### PR TITLE
Assign keys already in use

### DIFF
--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -57,39 +57,39 @@ void setup_default_settings(void)
      0,                         // gamma_correction
      Lb_SCREEN_MODE_INVALID,    // Screen mode, set to correct value below
      {
-          {KC_W, KMod_NONE},   // Gkey_MoveUp
-          {KC_S, KMod_NONE}, // Gkey_MoveDown
-          {KC_A, KMod_NONE}, // Gkey_MoveLeft
-          {KC_D, KMod_NONE},// Gkey_MoveRight
-          {KC_LCONTROL, KMod_NONE},//Gkey_RotateMod
-          {KC_LSHIFT, KMod_NONE},//Gkey_SpeedMod
-          {KC_DELETE, KMod_NONE},//Gkey_RotateCW
-          {KC_PGDOWN, KMod_NONE},//Gkey_RotateCCW
-          {KC_HOME, KMod_NONE}, // Gkey_ZoomIn
-          {KC_END, KMod_NONE},  // Gkey_ZoomOut
-          {KC_T, KMod_NONE},    // Gkey_ZoomRoom00
-          {KC_L, KMod_NONE},    // Gkey_ZoomRoom01
-          {KC_L, KMod_SHIFT},   // Gkey_ZoomRoom02
-          {KC_P, KMod_SHIFT},   // Gkey_ZoomRoom03
-          {KC_T, KMod_ALT},     // Gkey_ZoomRoom04
-          {KC_T, KMod_SHIFT},   // Gkey_ZoomRoom05
-          {KC_H, KMod_NONE},    // Gkey_ZoomRoom06
-          {KC_W, KMod_ALT},		// Gkey_ZoomRoom07
-          {KC_S, KMod_ALT},		// Gkey_ZoomRoom08
-          {KC_T, KMod_CONTROL}, // Gkey_ZoomRoom09
-          {KC_G, KMod_NONE},    // Gkey_ZoomRoom10
-          {KC_B, KMod_NONE},    // Gkey_ZoomRoom11
-          {KC_H, KMod_SHIFT},   // Gkey_ZoomRoom12
-          {KC_G, KMod_SHIFT},   // Gkey_ZoomRoom13
-          {KC_B, KMod_SHIFT},   // Gkey_ZoomRoom14
-          {KC_F, KMod_NONE},    // Gkey_ZoomToFight
-          {KC_A, KMod_ALT},		// Gkey_ZoomCrAnnoyed
-          {KC_LSHIFT, KMod_NONE},//Gkey_CrtrContrlMod
-          {KC_Q, KMod_NONE},	//Gkey_CrtrQueryMod
-          {KC_BACK, KMod_NONE}, // Gkey_DumpToOldPos
-          {KC_P, KMod_NONE},    // Gkey_TogglePause
-          {KC_M, KMod_NONE},    // Gkey_SwitchToMap
-          {KC_E, KMod_NONE},    // Gkey_ToggleMessage
+          {KC_W, KMod_NONE},        // Gkey_MoveUp
+          {KC_S, KMod_NONE},        // Gkey_MoveDown
+          {KC_A, KMod_NONE},        // Gkey_MoveLeft
+          {KC_D, KMod_NONE},        // Gkey_MoveRight
+          {KC_LCONTROL, KMod_NONE}, // Gkey_RotateMod
+          {KC_LSHIFT, KMod_NONE},   // Gkey_SpeedMod
+          {KC_DELETE, KMod_NONE},   // Gkey_RotateCW
+          {KC_PGDOWN, KMod_NONE},   // Gkey_RotateCCW
+          {KC_HOME, KMod_NONE},     // Gkey_ZoomIn
+          {KC_END, KMod_NONE},      // Gkey_ZoomOut
+          {KC_T, KMod_NONE},        // Gkey_ZoomRoom00
+          {KC_L, KMod_NONE},        // Gkey_ZoomRoom01
+          {KC_L, KMod_SHIFT},       // Gkey_ZoomRoom02
+          {KC_P, KMod_SHIFT},       // Gkey_ZoomRoom03
+          {KC_T, KMod_ALT},         // Gkey_ZoomRoom04
+          {KC_T, KMod_SHIFT},       // Gkey_ZoomRoom05
+          {KC_H, KMod_NONE},        // Gkey_ZoomRoom06
+          {KC_W, KMod_ALT},         // Gkey_ZoomRoom07
+          {KC_S, KMod_ALT},         // Gkey_ZoomRoom08
+          {KC_T, KMod_CONTROL},     // Gkey_ZoomRoom09
+          {KC_G, KMod_NONE},        // Gkey_ZoomRoom10
+          {KC_B, KMod_NONE},        // Gkey_ZoomRoom11
+          {KC_H, KMod_SHIFT},       // Gkey_ZoomRoom12
+          {KC_G, KMod_SHIFT},       // Gkey_ZoomRoom13
+          {KC_B, KMod_SHIFT},       // Gkey_ZoomRoom14
+          {KC_F, KMod_NONE},        // Gkey_ZoomToFight
+          {KC_A, KMod_ALT},         // Gkey_ZoomCrAnnoyed
+          {KC_LSHIFT, KMod_NONE},   // Gkey_CrtrContrlMod
+          {KC_Q, KMod_NONE},        // Gkey_CrtrQueryMod
+          {KC_BACK, KMod_NONE},     // Gkey_DumpToOldPos
+          {KC_P, KMod_NONE},        // Gkey_TogglePause
+          {KC_M, KMod_NONE},        // Gkey_SwitchToMap
+          {KC_E, KMod_NONE},        // Gkey_ToggleMessage
      },                         // kbkeys
      1,                         // tooltips_on
      0,                         // first_person_move_invert

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -147,6 +147,8 @@ void frontend_draw_define_key(struct GuiButton *gbtn)
     }
     if (frontend_mouse_over_button == content) {
         LbTextSetFont(frontend_font[2]);
+    } else if (defined_keys_that_have_been_swapped[key_id]) {
+        LbTextSetFont(frontend_font[3]);
     } else {
         LbTextSetFont(frontend_font[1]);
     }

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -432,6 +432,7 @@ void define_key_input(void)
 {
   if (lbInkey == KC_ESCAPE)
   {
+      lbKeyOn[KC_ESCAPE] = 0;
       lbInkey = KC_UNASSIGNED;
       defining_a_key = 0;
   } else

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -310,6 +310,16 @@ void update_key_modifiers(void)
   key_modifiers = key_mods;
 }
 
+void swap_assigned_keys(struct GameKey* current_kbk, long new_key_id, unsigned char new_key, unsigned int new_mods)
+{
+    struct GameKey* kbk_swap = current_kbk;
+    current_kbk = &settings.kbkeys[new_key_id];
+    kbk_swap->code = current_kbk->code;
+    kbk_swap->mods = current_kbk->mods;
+    current_kbk->code = new_key;
+    current_kbk->mods = new_mods; 
+}
+
 void assign_key(long key_id, unsigned char key, unsigned int mods)
 {
     struct GameKey* kbk = &settings.kbkeys[key_id];
@@ -351,6 +361,10 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
             {
                 assign_key(key_id, ncode, 0);
             }
+            else
+            {
+                swap_assigned_keys(kbk, key_id, ncode, 0);
+            }
             return 1;
         }
         else
@@ -386,6 +400,10 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
             {
                 assign_key(key_id, ncode, 0);
             }
+            else
+            {
+                swap_assigned_keys(kbk, key_id, ncode, 0);
+            }
             return 1;
         }
         else
@@ -396,7 +414,8 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
                 kbk = &settings.kbkeys[i];
                 if ((i != key_id) && (kbk->code == key) && (kbk->mods == mods))
                 {
-                    return 0;
+                    swap_assigned_keys(kbk, key_id, key, 0);
+                    return 1;
                 }
             }
             assign_key(key_id, key, 0);
@@ -422,7 +441,8 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
             kbk = &settings.kbkeys[i];
             if ((i != key_id) && (kbk->code == key) && (kbk->mods == mods))
             {
-                return 0;
+                swap_assigned_keys(kbk, key_id, key, mods & (KMod_SHIFT|KMod_CONTROL|KMod_ALT));
+                return 1;
             }
         }
         assign_key(key_id, key, mods & (KMod_SHIFT|KMod_CONTROL|KMod_ALT));

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -112,6 +112,8 @@ struct KeyToStringInit key_to_string_init[] = {
   {KC_DOWN,   GUIStr_KeyDown},
   {KC_LEFT,   GUIStr_KeyLeft},
   {KC_RIGHT,  GUIStr_KeyRight},
+  {KC_LALT,   GUIStr_KeyLeftAlt},
+  {KC_RALT,   GUIStr_KeyRightAlt},
   {  0,     0},
 };
 
@@ -351,6 +353,10 @@ int mod_key_to_normal_key(unsigned int mods)
     {
         ncode = KC_LCONTROL;
     }
+    else if (mods & KMod_ALT)
+    {
+        ncode = KC_LALT;
+    }
     else
     {
         ERRORLOG("Reached a place we should not be able");
@@ -400,7 +406,7 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
     // Rotate & speed - allow lone modifiers and normal keys
     if (key_id == Gkey_RotateMod || key_id == Gkey_SpeedMod)
     {
-        if ((mods & KMod_SHIFT) || (mods & KMod_CONTROL))
+        if ((mods & KMod_SHIFT) || (mods & KMod_CONTROL) || (mods & KMod_ALT))
         {
             check_and_assign_mod_keys(key_id, mods, Gkey_RotateMod);
             return 1;
@@ -414,7 +420,7 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
     // Possess & query - allow lone modifiers and normal keys
     if (key_id == Gkey_CrtrContrlMod || key_id == Gkey_CrtrQueryMod)
     {
-        if ((mods & KMod_SHIFT) || (mods & KMod_CONTROL))
+        if ((mods & KMod_SHIFT) || (mods & KMod_CONTROL) || (mods & KMod_ALT))
         {
             check_and_assign_mod_keys(key_id, mods, Gkey_CrtrContrlMod);
             return 1;
@@ -426,7 +432,7 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
         }
     }
     // Single control keys - just ignore these keystrokes
-    if ( key == KC_LSHIFT || key == KC_RSHIFT || key == KC_LCONTROL || key == KC_RCONTROL )
+    if ( key == KC_LSHIFT || key == KC_RSHIFT || key == KC_LCONTROL || key == KC_RCONTROL  || key == KC_LALT || key == KC_RALT )
     {
         return 0;
     }

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -310,6 +310,13 @@ void update_key_modifiers(void)
   key_modifiers = key_mods;
 }
 
+void assign_key(long key_id, unsigned char key, unsigned int mods)
+{
+    struct GameKey* kbk = &settings.kbkeys[key_id];
+    kbk->code = key;
+    kbk->mods = mods;
+}
+
 long set_game_key(long key_id, unsigned char key, unsigned int mods)
 {
     if (!key_to_string[key])
@@ -342,9 +349,7 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
             struct GameKey* kbk = &settings.kbkeys[((unsigned int)(key_id - Gkey_RotateMod) < 1) + Gkey_RotateMod];
             if (kbk->code != ncode)
             {
-                kbk = &settings.kbkeys[key_id];
-                kbk->code = ncode;
-                kbk->mods = 0;
+                assign_key(key_id, ncode, 0);
             }
             return 1;
         }
@@ -379,9 +384,7 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
             struct GameKey* kbk = &settings.kbkeys[((unsigned int)(key_id - Gkey_CrtrContrlMod) < 1) + Gkey_CrtrContrlMod];
             if (kbk->code != ncode)
             {
-                kbk = &settings.kbkeys[key_id];
-                kbk->code = ncode;
-                kbk->mods = 0;
+                assign_key(key_id, ncode, 0);
             }
             return 1;
         }
@@ -396,9 +399,7 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
                     return 0;
                 }
             }
-            kbk = &settings.kbkeys[key_id];
-            kbk->code = key;
-            kbk->mods = 0;
+            assign_key(key_id, key, 0);
             return 1;
         }
     }
@@ -424,9 +425,7 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
                 return 0;
             }
         }
-        kbk = &settings.kbkeys[key_id];
-        kbk->code = key;
-        kbk->mods = mods & (KMod_SHIFT|KMod_CONTROL|KMod_ALT);
+        assign_key(key_id, key, mods & (KMod_SHIFT|KMod_CONTROL|KMod_ALT));
         return 1;
     }
 }

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -312,7 +312,8 @@ void update_key_modifiers(void)
 
 long set_game_key(long key_id, unsigned char key, unsigned int mods)
 {
-    if (!key_to_string[key]) {
+    if (!key_to_string[key])
+    {
       return 0;
     }
     // Rotate & speed - allow only lone modifiers
@@ -321,14 +322,21 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
         if ((mods & KMod_SHIFT) || (mods & KMod_CONTROL))
         {
             int ncode;
-            if (mods & KMod_SHIFT) {
+            if (mods & KMod_SHIFT)
+            {
                 ncode = KC_LSHIFT;
-            } else
-            if (mods & KMod_CONTROL) {
-                ncode = KC_LCONTROL;
-            } else {
-                ERRORLOG("Reached a place we should not be able");
-                ncode = KC_UNASSIGNED;
+            }
+            else
+            {
+                if (mods & KMod_CONTROL)
+                {
+                    ncode = KC_LCONTROL;
+                }
+                else
+                {
+                    ERRORLOG("Reached a place we should not be able");
+                    ncode = KC_UNASSIGNED;
+                }
             }
             // Do not allow the key if it is used as other mod key
             struct GameKey* kbk = &settings.kbkeys[((unsigned int)(key_id - Gkey_RotateMod) < 1) + Gkey_RotateMod];
@@ -339,7 +347,8 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
                 kbk->mods = 0;
             }
             return 1;
-        } else
+        }
+        else
         {
             return 0;
         }
@@ -350,14 +359,21 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
         if ((mods & KMod_SHIFT) || (mods & KMod_CONTROL))
         {
             int ncode;
-            if (mods & KMod_SHIFT) {
+            if (mods & KMod_SHIFT)
+            {
                 ncode = KC_LSHIFT;
-            } else
-            if (mods & KMod_CONTROL) {
-                ncode = KC_LCONTROL;
-            } else {
-                ERRORLOG("Reached a place we should not be able");
-                ncode = KC_UNASSIGNED;
+            }
+            else
+            {
+                if (mods & KMod_CONTROL)
+                {
+                    ncode = KC_LCONTROL;
+                }
+                else
+                {
+                    ERRORLOG("Reached a place we should not be able");
+                    ncode = KC_UNASSIGNED;
+                }
             }
             // Do not allow the key if it is used as other mod key
             struct GameKey* kbk = &settings.kbkeys[((unsigned int)(key_id - Gkey_CrtrContrlMod) < 1) + Gkey_CrtrContrlMod];
@@ -368,13 +384,15 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
                 kbk->mods = 0;
             }
             return 1;
-        } else
+        }
+        else
         {
             struct GameKey  *kbk;
             for (long i = 0; i < GAME_KEYS_COUNT; i++)
             {
                 kbk = &settings.kbkeys[i];
-                if ((i != key_id) && (kbk->code == key) && (kbk->mods == mods)) {
+                if ((i != key_id) && (kbk->code == key) && (kbk->mods == mods))
+                {
                     return 0;
                 }
             }
@@ -393,14 +411,16 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
     {
         if (((mods & KMod_SHIFT) && (mods & KMod_CONTROL))
          || ((mods & KMod_SHIFT) && (mods & KMod_ALT))
-         || ((mods & KMod_CONTROL) && (mods & KMod_ALT))) {
+         || ((mods & KMod_CONTROL) && (mods & KMod_ALT)))
+        {
             return 0;
         }
         struct GameKey *kbk;
         for (long i = 0; i < GAME_KEYS_COUNT; i++)
         {
             kbk = &settings.kbkeys[i];
-            if ((i != key_id) && (kbk->code == key) && (kbk->mods == mods)) {
+            if ((i != key_id) && (kbk->code == key) && (kbk->mods == mods))
+            {
                 return 0;
             }
         }

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -397,7 +397,7 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
     {
       return 0;
     }
-    // Rotate & speed - allow only lone modifiers
+    // Rotate & speed - allow lone modifiers and normal keys
     if (key_id == Gkey_RotateMod || key_id == Gkey_SpeedMod)
     {
         if ((mods & KMod_SHIFT) || (mods & KMod_CONTROL))
@@ -407,7 +407,8 @@ long set_game_key(long key_id, unsigned char key, unsigned int mods)
         }
         else
         {
-            return 0;
+            check_and_assign_normal_keys(key_id, key, mods, 0);
+            return 1;
         }
     }
     // Possess & query - allow lone modifiers and normal keys

--- a/src/kjm_input.h
+++ b/src/kjm_input.h
@@ -99,6 +99,7 @@ DLLIMPORT long _DK_key_to_string[256];
 
 #pragma pack()
 /******************************************************************************/
+extern TbBool defined_keys_that_have_been_swapped[];
 extern TbBool wheel_scrolled_up;
 extern TbBool wheel_scrolled_down;
 


### PR DESCRIPTION
In response to #810.

This allows the assignment of key combos that are already in use. When this occurs:
- the key with the matching key combo takes on the key combo of the currently chosen key
- and the currently chosen key takes on the currently chosen key combo

i.e. they are swapped. 

The "other" key involved in the swap, i.e. the one the player didn't choose to change, is "highlighted" in the deep red colour in the Define Keys Menu. This colour is cleared when the user sets the key manually.
![image](https://user-images.githubusercontent.com/1984342/95003647-17301000-05d9-11eb-852f-1780d41c5d00.png)
_(Note that this is a grey colour in CJK fonts.)_

Also:
- ALT can be used as a single modifer key for Rotate/Speed and Possess/Query
- Rotate/Speed can also now use any valid single key
- [bugfix] Pressing Escape no longer returns to the Options Menu when you cancel a key assignment

Any further improvement to the key configuration/mapping system should be started as a rewrite, in line with suggestions from Sim here: https://github.com/Loobinex/keeperfx-unofficial/pull/181