### PR TITLE
 Add mouse3 and mouse wheel to bindable keys [Patch]

### DIFF
--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -5819,3 +5819,18 @@ msgstr ""
 msgctxt "Door name"
 msgid "Hidden Door"
 msgstr ""
+
+#: guitext:996
+msgctxt "Mouse"
+msgid "SCROLL WHEEL UP"
+msgstr ""
+
+#: guitext:997
+msgctxt "Mouse"
+msgid "SCROLL WHEEL DOWN"
+msgstr ""
+
+#: guitext:998
+msgctxt "Mouse"
+msgid "MOUSE BUTTON"
+msgstr ""

--- a/src/bflib_keybrd.h
+++ b/src/bflib_keybrd.h
@@ -166,6 +166,13 @@ enum KeyCodes {
         KC_POWER       = 0xDE,    // System Power
         KC_SLEEP       = 0xDF,    // System Sleep
         KC_WAKE        = 0xE3,    // System Wake
+    // Add mouse buttons couting backwards from 0xFE
+    // This allows them to be used as a bindable "key" [mouse buttons as keybinds - quick fix]
+        KC_MOUSEWHEEL_DOWN = 0xFA,    // Mouse Wheel Scroll down
+        KC_MOUSEWHEEL_UP   = 0xFB,    // Mouse Wheel Scroll up
+        KC_MOUSE3          = 0xFC,    // Middle Mouse button
+      //KC_MOUSE2          = 0xFD,    // Right Mouse button (don't use for binding, there will likely be conflicts)
+      //KC_MOUSE1          = 0xFE,    // Left Mouse button (don't use for binding, there will likely be conflicts)
 };
 
 enum KeyAction {

--- a/src/bflib_keybrd.h
+++ b/src/bflib_keybrd.h
@@ -166,7 +166,7 @@ enum KeyCodes {
         KC_POWER       = 0xDE,    // System Power
         KC_SLEEP       = 0xDF,    // System Sleep
         KC_WAKE        = 0xE3,    // System Wake
-    // Add mouse buttons couting backwards from 0xFE
+    // Add mouse buttons counting backwards from 0xFE
     // This allows them to be used as a bindable "key" [mouse buttons as keybinds - quick fix]
         KC_MOUSEWHEEL_DOWN = 0xFA,    // Mouse Wheel Scroll down
         KC_MOUSEWHEEL_UP   = 0xFB,    // Mouse Wheel Scroll up

--- a/src/bflib_keybrd.h
+++ b/src/bflib_keybrd.h
@@ -167,12 +167,18 @@ enum KeyCodes {
         KC_SLEEP       = 0xDF,    // System Sleep
         KC_WAKE        = 0xE3,    // System Wake
     // Add mouse buttons counting backwards from 0xFE
-    // This allows them to be used as a bindable "key" [mouse buttons as keybinds - quick fix]
-        KC_MOUSEWHEEL_DOWN = 0xFA,    // Mouse Wheel Scroll down
-        KC_MOUSEWHEEL_UP   = 0xFB,    // Mouse Wheel Scroll up
-        KC_MOUSE3          = 0xFC,    // Middle Mouse button
-      //KC_MOUSE2          = 0xFD,    // Right Mouse button (don't use for binding, there will likely be conflicts)
-      //KC_MOUSE1          = 0xFE,    // Left Mouse button (don't use for binding, there will likely be conflicts)
+    // This allows them to be used as a bindable "key" by adding them to key_to_string_init[] [mouse buttons as keybinds - quick fix]
+        KC_MOUSE9          = 0xF4,    // Mouse button #9 (not yet supported by KFX)
+        KC_MOUSE8          = 0xF5,    // Mouse button #8 (not yet supported by KFX)
+        KC_MOUSE7          = 0xF6,    // Mouse button #7 (not yet supported by KFX)
+        KC_MOUSE6          = 0xF7,    // Mouse button #6 (not yet supported by KFX)
+        KC_MOUSE5          = 0xF8,    // Mouse button #5 (not yet supported by KFX)
+        KC_MOUSE4          = 0xF9,    // Mouse button #4 (not yet supported by KFX)
+        KC_MOUSE3          = 0xFA,    // Middle Mouse button
+        KC_MOUSE2          = 0xFB,    // Right Mouse button (don't use for binding, there will likely be conflicts)
+        KC_MOUSE1          = 0xFC,    // Left Mouse button (don't use for binding, there will likely be conflicts)
+        KC_MOUSEWHEEL_DOWN = 0xFD,    // Mouse Wheel Scroll down
+        KC_MOUSEWHEEL_UP   = 0xFE,    // Mouse Wheel Scroll up
 };
 
 enum KeyAction {

--- a/src/bflib_mouse.cpp
+++ b/src/bflib_mouse.cpp
@@ -255,6 +255,7 @@ void mouseControl(unsigned int action, struct TbPoint *pos)
             lbDisplay.RMouseX = lbDisplay.MMouseX;
             lbDisplay.RMouseY = lbDisplay.MMouseY;
             lbDisplay.RMiddleButton = 1;
+            lbDisplay.MiddleButton = 0; // lbDisplay.MiddleButton is not handled as well as lbDisplay.LeftButton and lbDisplay.RightButton, so reset it here
         }
         break;
     case MActn_WHEELMOVEUP:

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -409,6 +409,9 @@ enum GUIStrings {
     GUIStr_MnuMapPacks = STRINGS_MAX + 969,
     GUIStr_MnuDungeonKeeperLevels = STRINGS_MAX+970, // range 970..975
     GUIStr_TrapDoorNames = STRINGS_MAX + 981, // range 981..995
+    GUIStr_MouseScrollWheelUp = STRINGS_MAX + 996,
+    GUIStr_MouseScrollWheelDown = STRINGS_MAX + 997,
+    GUIStr_MouseButton = STRINGS_MAX + 998,
 };
 
 enum CampaignStrings {

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -197,14 +197,18 @@ void frontend_draw_define_key(struct GuiButton *gbtn)
         keytext = get_string(GUIStr_KeyAlt);
         break;
       case KC_MOUSE3:
-        keytext = "Mouse 3";
+      {
+        char mouse_button_label[255] = "";
+        const char* mouse_gui_string = get_string(key_to_string[(long)code]);
+        int mouse_button_number = (KC_MOUSE1 + 1 - code);
+        char mouse_button_number_string[8];
+        itoa(mouse_button_number, mouse_button_number_string, 10);
+        strcat(mouse_button_label, mouse_gui_string);
+        strcat(mouse_button_label, " ");
+        strcat(mouse_button_label, mouse_button_number_string);
+        keytext = mouse_button_label;
         break;
-      case KC_MOUSEWHEEL_UP:
-        keytext = "Mouse Wheel Up";
-        break;
-      case KC_MOUSEWHEEL_DOWN:
-        keytext = "Mouse Wheel Down";
-        break;
+      }
       default:
       {
         long i = key_to_string[code];

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -196,7 +196,15 @@ void frontend_draw_define_key(struct GuiButton *gbtn)
       case KC_RALT:
         keytext = get_string(GUIStr_KeyAlt);
         break;
+      case KC_MOUSE9:
+      case KC_MOUSE8:
+      case KC_MOUSE7:
+      case KC_MOUSE6:
+      case KC_MOUSE5:
+      case KC_MOUSE4:
       case KC_MOUSE3:
+      case KC_MOUSE2:
+      case KC_MOUSE1:
       {
         char mouse_button_label[255] = "";
         const char* mouse_gui_string = get_string(key_to_string[(long)code]);

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -166,17 +166,17 @@ void frontend_draw_define_key(struct GuiButton *gbtn)
     if (mods & KMod_CONTROL)
     {
         strcat(text, get_string(GUIStr_KeyControl));
-        strcat(text, " ");
+        strcat(text, " + ");
     }
     if (mods & KMod_ALT)
     {
         strcat(text, get_string(GUIStr_KeyAlt));
-        strcat(text, " ");
+        strcat(text, " + ");
     }
     if (mods & KMod_SHIFT)
     {
         strcat(text, get_string(GUIStr_KeyShift));
-        strcat(text, " ");
+        strcat(text, " + ");
     }
 
     unsigned char code = settings.kbkeys[key_id].code;

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -196,6 +196,15 @@ void frontend_draw_define_key(struct GuiButton *gbtn)
       case KC_RALT:
         keytext = get_string(GUIStr_KeyAlt);
         break;
+      case KC_MOUSE3:
+        keytext = "Mouse 3";
+        break;
+      case KC_MOUSEWHEEL_UP:
+        keytext = "Mouse Wheel Up";
+        break;
+      case KC_MOUSEWHEEL_DOWN:
+        keytext = "Mouse Wheel Down";
+        break;
       default:
       {
         long i = key_to_string[code];

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -114,6 +114,10 @@ struct KeyToStringInit key_to_string_init[] = {
   {KC_RIGHT,  GUIStr_KeyRight},
   {KC_LALT,   GUIStr_KeyLeftAlt},
   {KC_RALT,   GUIStr_KeyRightAlt},
+// [mouse buttons as keybinds - quick fix]
+  {KC_MOUSE3, GUIStr_Mouse},
+  {KC_MOUSEWHEEL_UP, GUIStr_Mouse},
+  {KC_MOUSEWHEEL_DOWN, GUIStr_Mouse},
   {  0,     0},
 };
 
@@ -260,6 +264,12 @@ void update_mouse(void)
   lbDisplay.RightButton = 0;
   lbDisplayEx.WhellMoveUp = 0;
   lbDisplayEx.WhellMoveDown = 0;
+  // [mouse buttons as keybinds - quick fix]
+  lbKeyOn[KC_MOUSE3] = lbDisplay.MiddleButton;
+  lbKeyOn[KC_MOUSEWHEEL_UP] = wheel_scrolled_up;
+  lbKeyOn[KC_MOUSEWHEEL_DOWN] = wheel_scrolled_down;
+  lbInkey = lbDisplay.MiddleButton ? KC_MOUSE3 : wheel_scrolled_down ? KC_MOUSEWHEEL_DOWN : wheel_scrolled_up ? KC_MOUSEWHEEL_UP : lbInkey;
+
 }
 
 /**
@@ -467,6 +477,8 @@ void define_key_input(void)
       update_key_modifiers();
       if ( set_game_key(defining_a_key_id, lbInkey, key_modifiers) )
         defining_a_key = 0;
+      if (lbInkey == KC_MOUSE3) // [mouse buttons as keybinds - quick fix]
+        lbDisplay.MiddleButton = 0; // lbDisplay.MiddleButton is not handled as well as lbDisplay.LeftButton and lbDisplay.RightButton, so reset it here
       lbInkey = KC_UNASSIGNED;
   }
 }

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -115,9 +115,9 @@ struct KeyToStringInit key_to_string_init[] = {
   {KC_LALT,   GUIStr_KeyLeftAlt},
   {KC_RALT,   GUIStr_KeyRightAlt},
 // [mouse buttons as keybinds - quick fix]
-  {KC_MOUSE3, GUIStr_Mouse},
-  {KC_MOUSEWHEEL_UP, GUIStr_Mouse},
-  {KC_MOUSEWHEEL_DOWN, GUIStr_Mouse},
+  {KC_MOUSE3,          GUIStr_MouseButton},
+  {KC_MOUSEWHEEL_UP,   GUIStr_MouseScrollWheelUp},
+  {KC_MOUSEWHEEL_DOWN, GUIStr_MouseScrollWheelDown},
   {  0,     0},
 };
 

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -477,8 +477,6 @@ void define_key_input(void)
       update_key_modifiers();
       if ( set_game_key(defining_a_key_id, lbInkey, key_modifiers) )
         defining_a_key = 0;
-      if (lbInkey == KC_MOUSE3) // [mouse buttons as keybinds - quick fix]
-        lbDisplay.MiddleButton = 0; // lbDisplay.MiddleButton is not handled as well as lbDisplay.LeftButton and lbDisplay.RightButton, so reset it here
       lbInkey = KC_UNASSIGNED;
   }
 }


### PR DESCRIPTION
**_This is not a good/proper implementation, but a decent interim one._**

Middle mouse button (Mouse 3) and mouse wheel up/down can be bound in the key binding menu to an in-game action.

If bound to an action, the action will trigger when the user presses one of the mouse buttons in-game.

- The fact the mouse buttons work as  a binding for in-game actions is because of the use of `lbKeyOn[]`.

- The use of `lbInkey` lets the user bind the mouse buttons in the key bind menu.

~~**Currently uses hardcoded strings for the mouse buttons when shown on the key binding menu, appropriate new ones should probably be added to the .dat file.** _Other than the strings, this is good to go._~~ GUI Strings are now used