### PR TITLE
Add roombuild keys to rebind menu

### DIFF
--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -5836,26 +5836,31 @@ msgid "Mouse Button"
 msgstr ""
 
 #: guitext:999
-msgctxt "One-Click Build"
+msgctxt "Game controls"
 msgid "Build Square Room"
 msgstr ""
 
 #: guitext:1000
-msgctxt "One-Click Build"
-msgid "Build Fancy Room"
+msgctxt "Game controls"
+msgid "Detect Room"
 msgstr ""
 
 #: guitext:1001
-msgctxt "One-Click Build"
+msgctxt "Game controls"
 msgid "Increase Room Size"
 msgstr ""
 
 #: guitext:1002
-msgctxt "One-Click Build"
+msgctxt "Game controls"
 msgid "Decrease Room Size"
 msgstr ""
 
 #: guitext:1003
-msgctxt "Traps on Subtiles"
-msgid "Sell Trap on Subtile"
+msgctxt "Game controls"
+msgid "Precision Sell"
+msgstr ""
+
+#: guitext:1004
+msgctxt "Game controls"
+msgid "Snap Camera"
 msgstr ""

--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -5834,3 +5834,28 @@ msgstr ""
 msgctxt "Mouse"
 msgid "Mouse Button"
 msgstr ""
+
+#: guitext:999
+msgctxt "One-Click Build"
+msgid "Build Square Room"
+msgstr ""
+
+#: guitext:1000
+msgctxt "One-Click Build"
+msgid "Build Fancy Room"
+msgstr ""
+
+#: guitext:1001
+msgctxt "One-Click Build"
+msgid "Increase Room Size"
+msgstr ""
+
+#: guitext:1002
+msgctxt "One-Click Build"
+msgid "Decrease Room Size"
+msgstr ""
+
+#: guitext:1003
+msgctxt "Traps on Subtiles"
+msgid "Sell Trap on Subtile"
+msgstr ""

--- a/pkg_lang.mk
+++ b/pkg_lang.mk
@@ -17,6 +17,7 @@
 #      (at your option) any later version.
 #
 #******************************************************************************
+LANGUAGE ?= eng
 
 NGTEXTDATS = \
 pkg/fxdata/gtext_chi.dat \
@@ -71,6 +72,9 @@ pkg-languages: lang-before $(NGTEXTDATS) $(NCTEXTDATS) pkg-before
 
 lang-before:
 	$(MKDIR) pkg/fxdata
+
+# Creation of Only single language engine language files from PO/POT files (for development)
+pkg-lang-single: lang-before pkg/fxdata/gtext_$(LANGUAGE).dat
 
 # Creation of engine language files from PO/POT files
 pkg/fxdata/gtext_jpn.dat: lang/gtext_jpn.po tools/po2ngdat/res/char_encoding_tbl_jp.txt $(POTONGDAT)

--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -200,7 +200,7 @@ TbBool clear_campaign(struct GameCampaign *campgn)
   LbMemorySet(campgn->movie_outro_fname,0,DISKPATH_SIZE);
   LbMemorySet(campgn->strings_fname,0,DISKPATH_SIZE);
   campgn->strings_data = NULL;
-  reset_strings(campgn->strings);
+  reset_strings(campgn->strings, STRINGS_MAX);
   LbMemorySet(campgn->hiscore_fname,0,DISKPATH_SIZE);
   campgn->hiscore_table = NULL;
   campgn->hiscore_count = 0;

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -36,6 +36,7 @@ extern "C" {
 #endif
 /******************************************************************************/
 unsigned char i_can_see_levels[] = {15, 20, 25, 30,};
+struct GameSettings settings;
 /******************************************************************************/
 #ifdef __cplusplus
 }
@@ -106,6 +107,28 @@ void setup_default_settings(void)
     }
 }
 
+void copy_settings_to_dk_settings(void)
+{
+    _DK_settings.field_0 = settings.field_0;
+    _DK_settings.video_shadows = settings.video_shadows;
+    _DK_settings.view_distance = settings.view_distance;
+    _DK_settings.video_rotate_mode = settings.video_rotate_mode;
+    _DK_settings.video_textures = settings.video_textures;
+    _DK_settings.video_cluedo_mode = settings.video_cluedo_mode;
+    _DK_settings.sound_volume = settings.sound_volume;
+    _DK_settings.redbook_volume = settings.redbook_volume;
+    _DK_settings.roomflags_on = settings.roomflags_on;
+    _DK_settings.gamma_correction = settings.gamma_correction;
+    _DK_settings.video_scrnmode = settings.video_scrnmode;
+    for (int i = 0; i < DK_GAME_KEYS_COUNT; i++)
+    {
+        _DK_settings.kbkeys[i] = settings.kbkeys[i];
+    }
+    _DK_settings.tooltips_on = settings.tooltips_on;
+    _DK_settings.first_person_move_invert = settings.first_person_move_invert;
+    _DK_settings.first_person_move_sensitivity = settings.first_person_move_sensitivity;
+}
+
 TbBool load_settings(void)
 {
     SYNCDBG(6,"Starting");
@@ -114,7 +137,10 @@ TbBool load_settings(void)
     if (len == sizeof(struct GameSettings))
     {
       if (LbFileLoadAt(fname, &settings) == sizeof(struct GameSettings))
+      { 
+          copy_settings_to_dk_settings();
           return true;
+      }
     }
     setup_default_settings();
     LbFileSaveAt(fname, &settings, sizeof(struct GameSettings));
@@ -123,6 +149,7 @@ TbBool load_settings(void)
 
 short save_settings(void)
 {
+    copy_settings_to_dk_settings();
     char* fname = prepare_file_path(FGrp_Save, "settings.dat");
     LbFileSaveAt(fname, &settings, sizeof(struct GameSettings));
     return true;

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -93,8 +93,8 @@ void setup_default_settings(void)
           {KC_E, KMod_NONE},        // Gkey_ToggleMessage
           {KC_LCONTROL, KMod_NONE},        // Gkey_SquareRoomSpace
           {KC_LSHIFT, KMod_NONE},          // Gkey_BestRoomSpace
-          {KC_MOUSEWHEEL_UP, KMod_NONE},   // Gkey_RoomSpaceIncSize
-          {KC_MOUSEWHEEL_DOWN, KMod_NONE}, // Gkey_RoomSpaceDecSize
+          {KC_MOUSEWHEEL_DOWN, KMod_NONE},   // Gkey_RoomSpaceIncSize
+          {KC_MOUSEWHEEL_UP, KMod_NONE}, // Gkey_RoomSpaceDecSize
           {KC_LALT, KMod_NONE},            // Gkey_SellTrapOnSubtile
      },                         // kbkeys
      1,                         // tooltips_on

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -91,6 +91,11 @@ void setup_default_settings(void)
           {KC_P, KMod_NONE},        // Gkey_TogglePause
           {KC_M, KMod_NONE},        // Gkey_SwitchToMap
           {KC_E, KMod_NONE},        // Gkey_ToggleMessage
+          {KC_LCONTROL, KMod_NONE},        // Gkey_SquareRoomSpace
+          {KC_LSHIFT, KMod_NONE},          // Gkey_BestRoomSpace
+          {KC_MOUSEWHEEL_UP, KMod_NONE},   // Gkey_RoomSpaceIncSize
+          {KC_MOUSEWHEEL_DOWN, KMod_NONE}, // Gkey_RoomSpaceDecSize
+          {KC_LALT, KMod_NONE},            // Gkey_SellTrapOnSubtile
      },                         // kbkeys
      1,                         // tooltips_on
      0,                         // first_person_move_invert

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -58,45 +58,45 @@ void setup_default_settings(void)
      0,                         // gamma_correction
      Lb_SCREEN_MODE_INVALID,    // Screen mode, set to correct value below
      {
-          {KC_W, KMod_NONE},        // Gkey_MoveUp
-          {KC_S, KMod_NONE},        // Gkey_MoveDown
-          {KC_A, KMod_NONE},        // Gkey_MoveLeft
-          {KC_D, KMod_NONE},        // Gkey_MoveRight
-          {KC_LCONTROL, KMod_NONE}, // Gkey_RotateMod
-          {KC_LSHIFT, KMod_NONE},   // Gkey_SpeedMod
-          {KC_DELETE, KMod_NONE},   // Gkey_RotateCW
-          {KC_PGDOWN, KMod_NONE},   // Gkey_RotateCCW
-          {KC_HOME, KMod_NONE},     // Gkey_ZoomIn
-          {KC_END, KMod_NONE},      // Gkey_ZoomOut
-          {KC_T, KMod_NONE},        // Gkey_ZoomRoom00
-          {KC_L, KMod_NONE},        // Gkey_ZoomRoom01
-          {KC_L, KMod_SHIFT},       // Gkey_ZoomRoom02
-          {KC_P, KMod_SHIFT},       // Gkey_ZoomRoom03
-          {KC_T, KMod_ALT},         // Gkey_ZoomRoom04
-          {KC_T, KMod_SHIFT},       // Gkey_ZoomRoom05
-          {KC_H, KMod_NONE},        // Gkey_ZoomRoom06
-          {KC_W, KMod_ALT},         // Gkey_ZoomRoom07
-          {KC_S, KMod_ALT},         // Gkey_ZoomRoom08
-          {KC_T, KMod_CONTROL},     // Gkey_ZoomRoom09
-          {KC_G, KMod_NONE},        // Gkey_ZoomRoom10
-          {KC_B, KMod_NONE},        // Gkey_ZoomRoom11
-          {KC_H, KMod_SHIFT},       // Gkey_ZoomRoom12
-          {KC_G, KMod_SHIFT},       // Gkey_ZoomRoom13
-          {KC_B, KMod_SHIFT},       // Gkey_ZoomRoom14
-          {KC_F, KMod_NONE},        // Gkey_ZoomToFight
-          {KC_A, KMod_ALT},         // Gkey_ZoomCrAnnoyed
-          {KC_LSHIFT, KMod_NONE},   // Gkey_CrtrContrlMod
-          {KC_Q, KMod_NONE},        // Gkey_CrtrQueryMod
-          {KC_BACK, KMod_NONE},     // Gkey_DumpToOldPos
-          {KC_P, KMod_NONE},        // Gkey_TogglePause
-          {KC_M, KMod_NONE},        // Gkey_SwitchToMap
-          {KC_E, KMod_NONE},        // Gkey_ToggleMessage
-          {KC_LCONTROL, KMod_NONE},          // Gkey_SquareRoomSpace
+          {KC_W, KMod_NONE},                 // Gkey_MoveUp
+          {KC_S, KMod_NONE},                 // Gkey_MoveDown
+          {KC_A, KMod_NONE},                 // Gkey_MoveLeft
+          {KC_D, KMod_NONE},                 // Gkey_MoveRight
+          {KC_LCONTROL, KMod_NONE},          // Gkey_RotateMod
+          {KC_LSHIFT, KMod_NONE},            // Gkey_SpeedMod
+          {KC_DELETE, KMod_NONE},            // Gkey_RotateCW
+          {KC_PGDOWN, KMod_NONE},            // Gkey_RotateCCW
+          {KC_HOME, KMod_NONE},              // Gkey_ZoomIn
+          {KC_END, KMod_NONE},               // Gkey_ZoomOut
+          {KC_T, KMod_NONE},                 // Gkey_ZoomRoom00
+          {KC_L, KMod_NONE},                 // Gkey_ZoomRoom01
+          {KC_L, KMod_SHIFT},                // Gkey_ZoomRoom02
+          {KC_P, KMod_SHIFT},                // Gkey_ZoomRoom03
+          {KC_T, KMod_ALT},                  // Gkey_ZoomRoom04
+          {KC_T, KMod_SHIFT},                // Gkey_ZoomRoom05
+          {KC_H, KMod_NONE},                 // Gkey_ZoomRoom06
+          {KC_W, KMod_ALT},                  // Gkey_ZoomRoom07
+          {KC_S, KMod_ALT},                  // Gkey_ZoomRoom08
+          {KC_T, KMod_CONTROL},              // Gkey_ZoomRoom09
+          {KC_G, KMod_NONE},                 // Gkey_ZoomRoom10
+          {KC_B, KMod_NONE},                 // Gkey_ZoomRoom11
+          {KC_H, KMod_SHIFT},                // Gkey_ZoomRoom12
+          {KC_G, KMod_SHIFT},                // Gkey_ZoomRoom13
+          {KC_B, KMod_SHIFT},                // Gkey_ZoomRoom14
+          {KC_F, KMod_NONE},                 // Gkey_ZoomToFight
+          {KC_A, KMod_ALT},                  // Gkey_ZoomCrAnnoyed
+          {KC_LSHIFT, KMod_NONE},            // Gkey_CrtrContrlMod
+          {KC_Q, KMod_NONE},                 // Gkey_CrtrQueryMod
+          {KC_BACK, KMod_NONE},              // Gkey_DumpToOldPos
+          {KC_P, KMod_NONE},                 // Gkey_TogglePause
+          {KC_M, KMod_NONE},                 // Gkey_SwitchToMap
+          {KC_E, KMod_NONE},                 // Gkey_ToggleMessage
+          {KC_MOUSE3, KMod_NONE},            // Gkey_SnapCamera
           {KC_LSHIFT, KMod_NONE},            // Gkey_BestRoomSpace
+          {KC_LCONTROL, KMod_NONE},          // Gkey_SquareRoomSpace
           {KC_MOUSEWHEEL_DOWN, KMod_NONE},   // Gkey_RoomSpaceIncSize
           {KC_MOUSEWHEEL_UP, KMod_NONE},     // Gkey_RoomSpaceDecSize
           {KC_LALT, KMod_NONE},              // Gkey_SellTrapOnSubtile
-          {KC_MOUSE3, KMod_NONE},            // Gkey_SnapCamera
      },                         // kbkeys
      1,                         // tooltips_on
      0,                         // first_person_move_invert

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -91,11 +91,12 @@ void setup_default_settings(void)
           {KC_P, KMod_NONE},        // Gkey_TogglePause
           {KC_M, KMod_NONE},        // Gkey_SwitchToMap
           {KC_E, KMod_NONE},        // Gkey_ToggleMessage
-          {KC_LCONTROL, KMod_NONE},        // Gkey_SquareRoomSpace
-          {KC_LSHIFT, KMod_NONE},          // Gkey_BestRoomSpace
+          {KC_LCONTROL, KMod_NONE},          // Gkey_SquareRoomSpace
+          {KC_LSHIFT, KMod_NONE},            // Gkey_BestRoomSpace
           {KC_MOUSEWHEEL_DOWN, KMod_NONE},   // Gkey_RoomSpaceIncSize
-          {KC_MOUSEWHEEL_UP, KMod_NONE}, // Gkey_RoomSpaceDecSize
-          {KC_LALT, KMod_NONE},            // Gkey_SellTrapOnSubtile
+          {KC_MOUSEWHEEL_UP, KMod_NONE},     // Gkey_RoomSpaceDecSize
+          {KC_LALT, KMod_NONE},              // Gkey_SellTrapOnSubtile
+          {KC_MOUSE3, KMod_NONE},            // Gkey_SnapCamera
      },                         // kbkeys
      1,                         // tooltips_on
      0,                         // first_person_move_invert

--- a/src/config_settings.h
+++ b/src/config_settings.h
@@ -23,7 +23,7 @@
 #include "bflib_basics.h"
 
 #define DK_GAME_KEYS_COUNT     32
-#define GAME_KEYS_COUNT        33
+#define GAME_KEYS_COUNT        38
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/config_settings.h
+++ b/src/config_settings.h
@@ -22,6 +22,7 @@
 #include "globals.h"
 #include "bflib_basics.h"
 
+#define DK_GAME_KEYS_COUNT     32
 #define GAME_KEYS_COUNT        33
 
 #ifdef __cplusplus
@@ -35,7 +36,25 @@ struct GameKey { // sizeof = 2
   unsigned char mods;
 };
 
-struct GameSettings { // sizeof = 0x52 (82)
+struct _DK_GameSettings { // sizeof = 0x52 (82)
+    unsigned char field_0;
+    unsigned char video_shadows;
+    unsigned char view_distance;
+    unsigned char video_rotate_mode;
+    unsigned char video_textures;
+    unsigned char video_cluedo_mode;
+    unsigned char sound_volume;
+    unsigned char redbook_volume;
+    unsigned char roomflags_on;
+    unsigned short gamma_correction;
+    int video_scrnmode;
+    struct GameKey kbkeys[DK_GAME_KEYS_COUNT];
+    unsigned char tooltips_on;
+    unsigned char first_person_move_invert;
+    unsigned char first_person_move_sensitivity;
+    };
+
+struct GameSettings { // KFX settings
     unsigned char field_0;
     unsigned char video_shadows;
     unsigned char view_distance;
@@ -52,12 +71,12 @@ struct GameSettings { // sizeof = 0x52 (82)
     unsigned char first_person_move_invert;
     unsigned char first_person_move_sensitivity;
     };
-
 #pragma pack()
 /******************************************************************************/
-DLLIMPORT extern struct GameSettings _DK_settings;
-#define settings _DK_settings
+DLLIMPORT extern struct _DK_GameSettings _DK_settings; // DK settings
+extern struct GameSettings settings; // KFX settings
 /******************************************************************************/
+void copy_settings_to_dk_settings(void);
 TbBool load_settings(void);
 short save_settings(void);
 

--- a/src/config_settings.h
+++ b/src/config_settings.h
@@ -23,7 +23,7 @@
 #include "bflib_basics.h"
 
 #define DK_GAME_KEYS_COUNT     32
-#define GAME_KEYS_COUNT        38
+#define GAME_KEYS_COUNT        39
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/config_strings.c
+++ b/src/config_strings.c
@@ -37,12 +37,12 @@ DLLIMPORT extern char *_DK_strings_data;
 DLLIMPORT extern char *_DK_strings[DK_STRINGS_MAX+1];
 /******************************************************************************/
 char *gui_strings_data;
-char *gui_strings[STRINGS_MAX+1];
+char *gui_strings[GUI_STRINGS_COUNT];
 /******************************************************************************/
-TbBool reset_strings(char **strings)
+TbBool reset_strings(char **strings, int max)
 {
     char** text_arr = strings;
-    int text_idx = STRINGS_MAX;
+    int text_idx = max;
     while (text_idx >= 0)
     {
         *text_arr = lbEmptyString;
@@ -52,10 +52,10 @@ TbBool reset_strings(char **strings)
   return true;
 }
 
-TbBool create_strings_list(char **strings,char *strings_data,char *strings_data_end)
+TbBool create_strings_list(char **strings,char *strings_data,char *strings_data_end, int max)
 {
     char** text_arr = strings;
-    int text_idx = STRINGS_MAX;
+    int text_idx = max;
     char* text_ptr = strings_data;
     while (text_idx >= 0)
     {
@@ -73,7 +73,7 @@ TbBool create_strings_list(char **strings,char *strings_data,char *strings_data_
     } while ((chr_prev != '\0') && (text_ptr < strings_data_end));
     text_idx--;
   }
-  return (text_idx < STRINGS_MAX);
+  return (text_idx < max);
 }
 
 /**
@@ -106,9 +106,9 @@ TbBool setup_gui_strings_data(void)
     return false;
   }
   // Resetting all values to empty strings
-  reset_strings(gui_strings);
+  reset_strings(gui_strings, GUI_STRINGS_COUNT-1);
   // Analyzing strings data and filling correct values
-  short result = create_strings_list(gui_strings, gui_strings_data, strings_data_end);
+  short result = create_strings_list(gui_strings, gui_strings_data, strings_data_end, GUI_STRINGS_COUNT-1);
   // Updating strings inside the DLL
   LbMemoryCopy(_DK_strings, gui_strings, DK_STRINGS_MAX*sizeof(char *));
   SYNCDBG(19,"Finished");
@@ -118,7 +118,7 @@ TbBool setup_gui_strings_data(void)
 TbBool free_gui_strings_data(void)
 {
   // Resetting all values to empty strings
-  reset_strings(gui_strings);
+  reset_strings(gui_strings, GUI_STRINGS_COUNT-1);
   // Freeing memory
   LbMemoryFree(gui_strings_data);
   gui_strings_data = NULL;
@@ -152,16 +152,16 @@ TbBool setup_campaign_strings_data(struct GameCampaign *campgn)
     return false;
   }
   // Resetting all values to empty strings
-  reset_strings(campgn->strings);
+  reset_strings(campgn->strings, STRINGS_MAX);
   // Analyzing strings data and filling correct values
-  short result = create_strings_list(campgn->strings, campgn->strings_data, strings_data_end);
+  short result = create_strings_list(campgn->strings, campgn->strings_data, strings_data_end, STRINGS_MAX);
   SYNCDBG(19,"Finished");
   return result;
 }
 
 const char * gui_string(unsigned int index)
 {
-    if (index >= STRINGS_MAX)
+    if (index >= GUI_STRINGS_COUNT)
         return lbEmptyString;
     return gui_strings[index];
 }

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -28,7 +28,7 @@ extern "C" {
 /******************************************************************************/
 #define STRINGS_MAX       1000
 #define DK_STRINGS_MAX     941
-#define GUI_STRINGS_COUNT  999
+#define GUI_STRINGS_COUNT 1004
 
 struct GameCampaign;
 
@@ -413,6 +413,11 @@ enum GUIStrings {
     GUIStr_MouseScrollWheelUp = STRINGS_MAX + 996,
     GUIStr_MouseScrollWheelDown = STRINGS_MAX + 997,
     GUIStr_MouseButton = STRINGS_MAX + 998,
+    GUIStr_SquareRoomSpace = STRINGS_MAX + 999,
+    GUIStr_BestRoomSpace = STRINGS_MAX + 1000,
+    GUIStr_RoomSpaceIncrease = STRINGS_MAX + 1001,
+    GUIStr_RoomSpaceDecrease = STRINGS_MAX + 1002,
+    GUIStr_SellTrapOnSubtile = STRINGS_MAX + 1003,
 };
 
 enum CampaignStrings {

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -28,7 +28,7 @@ extern "C" {
 /******************************************************************************/
 #define STRINGS_MAX       1000
 #define DK_STRINGS_MAX     941
-#define GUI_STRINGS_COUNT 1004
+#define GUI_STRINGS_COUNT 1005
 
 struct GameCampaign;
 
@@ -418,6 +418,7 @@ enum GUIStrings {
     GUIStr_RoomSpaceIncrease = STRINGS_MAX + 1001,
     GUIStr_RoomSpaceDecrease = STRINGS_MAX + 1002,
     GUIStr_SellTrapOnSubtile = STRINGS_MAX + 1003,
+    GUIStr_SnapCamera = STRINGS_MAX + 1004,
 };
 
 enum CampaignStrings {

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -28,6 +28,7 @@ extern "C" {
 /******************************************************************************/
 #define STRINGS_MAX       1000
 #define DK_STRINGS_MAX     941
+#define GUI_STRINGS_COUNT  999
 
 struct GameCampaign;
 
@@ -470,7 +471,7 @@ enum CampaignStrings {
 /******************************************************************************/
 TbBool setup_gui_strings_data(void);
 TbBool free_gui_strings_data(void);
-TbBool reset_strings(char **strings);
+TbBool reset_strings(char **strings, int max);
 const char * get_string(TextStringId stridx);
 TbBool setup_campaign_strings_data(struct GameCampaign *campgn);
 /******************************************************************************/

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -792,7 +792,7 @@ long get_dungeon_control_action_inputs(void)
           toggle_gui();
       }
       // Middle mouse camera actions for IsometricView
-      if (lbDisplay.MiddleButton >= 1)
+      if (is_game_key_pressed(Gkey_SnapCamera, &val, true))
       {
           struct Camera* cam = &player->cameras[CamIV_Isometric];
           struct Packet* pckt = get_packet(my_player_number);
@@ -867,8 +867,8 @@ long get_dungeon_control_action_inputs(void)
         {
             (angle = 0);
         }
-      set_packet_action(pckt,PckA_SetMapRotation,angle,0,0,0);
-      lbDisplay.MiddleButton = 0;
+        set_packet_action(pckt,PckA_SetMapRotation,angle,0,0,0);
+        clear_key_pressed(val);
       }
     }
     if (player->view_mode == PVM_FrontView)
@@ -883,7 +883,7 @@ long get_dungeon_control_action_inputs(void)
           toggle_gui();
       }
       // Middle mouse camera actions for FrontView
-      if (lbDisplay.MiddleButton >= 1)
+      if (is_game_key_pressed(Gkey_SnapCamera, &val, true))
       {
           struct Camera* cam = &player->cameras[CamIV_FrontView];
           struct Packet* pckt = get_packet(my_player_number);
@@ -916,7 +916,7 @@ long get_dungeon_control_action_inputs(void)
             }
         set_packet_action(pckt,PckA_SetMapRotation,angle,0,0,0);
         }
-      lbDisplay.MiddleButton = 0;
+        clear_key_pressed(val);
       }
     }
 

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -797,7 +797,7 @@ long get_dungeon_control_action_inputs(void)
           struct Camera* cam = &player->cameras[CamIV_Isometric];
           struct Packet* pckt = get_packet(my_player_number);
           int angle = cam->orient_a;
-          if (is_game_key_pressed(Gkey_RotateMod, NULL, false))
+          if (lbKeyOn[KC_LCONTROL])
           {
               if ((angle >= 0 && angle < 256) || angle == 2048)
               {
@@ -888,7 +888,7 @@ long get_dungeon_control_action_inputs(void)
           struct Camera* cam = &player->cameras[CamIV_FrontView];
           struct Packet* pckt = get_packet(my_player_number);
           int angle = cam->orient_a;
-          if (is_game_key_pressed(Gkey_RotateMod, NULL, false))
+          if (lbKeyOn[KC_LCONTROL])
           {
               set_packet_control(pckt, PCtr_ViewRotateCW);
         }

--- a/src/front_input.h
+++ b/src/front_input.h
@@ -63,6 +63,11 @@ enum GameKeys {
     Gkey_TogglePause, // 30
     Gkey_SwitchToMap,
     Gkey_ToggleMessage,
+    Gkey_SquareRoomSpace,
+    Gkey_BestRoomSpace,
+    Gkey_RoomSpaceIncSize,
+    Gkey_RoomSpaceDecSize,
+    Gkey_SellTrapOnSubtile,
 };
 
 enum TbButtonFrontendFlags {

--- a/src/front_input.h
+++ b/src/front_input.h
@@ -63,12 +63,12 @@ enum GameKeys {
     Gkey_TogglePause, // 30
     Gkey_SwitchToMap,
     Gkey_ToggleMessage,
-    Gkey_SquareRoomSpace,
+    Gkey_SnapCamera,
     Gkey_BestRoomSpace,
+    Gkey_SquareRoomSpace, // 35
     Gkey_RoomSpaceIncSize,
     Gkey_RoomSpaceDecSize,
     Gkey_SellTrapOnSubtile,
-    Gkey_SnapCamera,
 };
 
 enum TbButtonFrontendFlags {

--- a/src/front_input.h
+++ b/src/front_input.h
@@ -68,6 +68,7 @@ enum GameKeys {
     Gkey_RoomSpaceIncSize,
     Gkey_RoomSpaceDecSize,
     Gkey_SellTrapOnSubtile,
+    Gkey_SnapCamera,
 };
 
 enum TbButtonFrontendFlags {

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -76,6 +76,11 @@ const long definable_key_string[] = {
     GUIStr_Pause,
     GUIStr_Map,
     GUIStr_ToggleMessage,
+    GUIStr_SquareRoomSpace,
+    GUIStr_BestRoomSpace,
+    GUIStr_RoomSpaceIncrease,
+    GUIStr_RoomSpaceDecrease,
+    GUIStr_SellTrapOnSubtile,
 };
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -76,12 +76,12 @@ const long definable_key_string[] = {
     GUIStr_Pause,
     GUIStr_Map,
     GUIStr_ToggleMessage,
-    GUIStr_SquareRoomSpace,
+    GUIStr_SnapCamera,
     GUIStr_BestRoomSpace,
+    GUIStr_SquareRoomSpace,
     GUIStr_RoomSpaceIncrease,
     GUIStr_RoomSpaceDecrease,
     GUIStr_SellTrapOnSubtile,
-    GUIStr_SnapCamera,
 };
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -81,6 +81,7 @@ const long definable_key_string[] = {
     GUIStr_RoomSpaceIncrease,
     GUIStr_RoomSpaceDecrease,
     GUIStr_SellTrapOnSubtile,
+    GUIStr_SnapCamera,
 };
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -239,11 +239,13 @@ void frontend_draw_define_key(struct GuiButton *gbtn)
 void gui_video_shadows(struct GuiButton *gbtn)
 {
     settings.video_shadows = _DK_video_shadows;
+    copy_settings_to_dk_settings();
 }
 
 void gui_video_view_distance_level(struct GuiButton *gbtn)
 {
     settings.view_distance = video_view_distance_level;
+    copy_settings_to_dk_settings();
 }
 
 void gui_video_rotate_mode(struct GuiButton *gbtn)

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -304,11 +304,22 @@ unsigned short key_to_ascii(TbKeyCode key, TbKeyMods kmodif)
  */
 void clear_key_pressed(long key)
 {
-  if (key >= sizeof(lbKeyOn))
-    return;
-  lbKeyOn[key] = 0;
-  if (key == lbInkey)
-    lbInkey = KC_UNASSIGNED;
+    if (key >= sizeof(lbKeyOn))
+    {
+        return;
+    }
+    if ((key >= 0xF0) && (key <= 0xFC)) // This is a mouse button
+    {
+        if (key == KC_MOUSE3)
+        {
+            lbDisplay.MiddleButton = 0;
+        }
+    }
+    lbKeyOn[key] = 0;
+    if (key == lbInkey)
+    {
+        lbInkey = KC_UNASSIGNED;
+    }
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1389,6 +1389,7 @@ void reset_gui_based_on_player_mode(void)
         }
     }
     settings.video_cluedo_mode = player->video_cluedo_mode;
+    copy_settings_to_dk_settings();
     set_gui_visible(true);
 }
 
@@ -1886,6 +1887,7 @@ TbBool set_gamma(char corrlvl, TbBool do_set)
     if (corrlvl > 4)
       corrlvl = 4;
     settings.gamma_correction = corrlvl;
+    copy_settings_to_dk_settings();
     fname=prepare_file_fmtpath(FGrp_StdData,"pal%05d.dat",settings.gamma_correction);
     if (!LbFileExists(fname))
     {

--- a/src/packets.c
+++ b/src/packets.c
@@ -34,6 +34,7 @@
 #include "bflib_planar.h"
 
 #include "kjm_input.h"
+#include "front_input.h"
 #include "front_simple.h"
 #include "front_landview.h"
 #include "front_network.h"
@@ -395,6 +396,7 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
     struct Packet* pckt = get_packet_direct(player->packet_num);
+    long keycode = 0;
     if ((pckt->control_flags & PCtr_MapCoordsValid) == 0)
     {
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->field_4AF != 0))
@@ -414,7 +416,7 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
         if (!game_is_busy_doing_gui())
         {
             get_dungeon_sell_user_roomspace(stl_x, stl_y);
-            tag_cursor_blocks_sell_area(player->id_number, stl_x, stl_y, player->field_4A4, (is_key_pressed(KC_LALT, KMod_DONTCARE)));
+            tag_cursor_blocks_sell_area(player->id_number, stl_x, stl_y, player->field_4A4, (is_game_key_pressed(Gkey_SellTrapOnSubtile, &keycode, true)));
         }
     }
     if ((pckt->control_flags & PCtr_LBtnClick) == 0)
@@ -426,7 +428,7 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
       }
       return false;
     }
-    if (!is_key_pressed(KC_LALT, KMod_DONTCARE))
+    if (!is_game_key_pressed(Gkey_SellTrapOnSubtile, &keycode, true))
     {
         //Slab Mode
         if (render_roomspace.slab_count > 1)
@@ -563,6 +565,7 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     MapSubtlCoord stl_x = coord_subtile(x);
     MapSubtlCoord stl_y = coord_subtile(y);
     int mode = box_placement_mode;
+    long keycode = 0;
     if ((pckt->control_flags & PCtr_MapCoordsValid) == 0)
     {
       if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->field_4AF != 0))
@@ -577,7 +580,7 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     {
         gui_room_type_highlighted = player->chosen_room_kind;
     }
-    get_dungeon_build_user_roomspace(player->id_number, player->chosen_room_kind, stl_x, stl_y, &mode, (is_key_pressed(KC_LSHIFT, KMod_DONTCARE) || is_key_pressed(KC_LCONTROL, KMod_DONTCARE))  && ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld));
+    get_dungeon_build_user_roomspace(player->id_number, player->chosen_room_kind, stl_x, stl_y, &mode, (is_game_key_pressed(Gkey_BestRoomSpace, &keycode, true)) || (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true))  && ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld));
     long i = tag_cursor_blocks_place_room(player->id_number, stl_x, stl_y, player->field_4A4);
     
     if (mode != drag_placement_mode) // allows the user to hold the left mouse to use "paint mode"

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -729,6 +729,7 @@ long pinstfs_fade_to_map(struct PlayerInfo *player, long *n)
     {
         set_flag_byte(&player->field_1, 0x02, settings.tooltips_on);
         settings.tooltips_on = 0;
+        copy_settings_to_dk_settings();
         set_flag_byte(&player->field_1, 0x01, toggle_status_menu(0));
   }
   set_engine_view(player, PVM_ParchFadeIn);
@@ -746,6 +747,7 @@ long pinstfe_fade_to_map(struct PlayerInfo *player, long *n)
   set_player_mode(player, PVT_MapScreen);
   if (is_my_player(player))
     settings.tooltips_on = ((player->field_1 & 0x02) != 0);
+  copy_settings_to_dk_settings();
   player->allocflags &= ~PlaF_Unknown80;
   return 0;
 }
@@ -757,6 +759,7 @@ long pinstfs_fade_from_map(struct PlayerInfo *player, long *n)
   {
     set_flag_byte(&player->field_1, 0x02, settings.tooltips_on);
     settings.tooltips_on = 0;
+    copy_settings_to_dk_settings();
     game.operation_flags &= ~GOF_ShowPanel;
   }
   player->field_4BD = 32;
@@ -777,6 +780,7 @@ long pinstfe_fade_from_map(struct PlayerInfo *player, long *n)
     set_engine_view(player, player->view_mode_restore);
     if (player->id_number == myplyr->id_number) {
         settings.tooltips_on = ((player->field_1 & 2) != 0);
+        copy_settings_to_dk_settings();
         toggle_status_menu(player->field_1 & 1);
     }
     player->allocflags &= ~0x80;

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -22,6 +22,7 @@
 /******************************************************************************/
 #include "game_legacy.h"
 #include "kjm_input.h"
+#include "front_input.h"
 #include "player_utils.h"
 
 #ifdef __cplusplus
@@ -248,19 +249,20 @@ void reset_dungeon_build_room_ui_variables()
 
 void get_dungeon_sell_user_roomspace(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
+    long keycode = 0;
     int width = 1, height = 1;
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
-    if (is_key_pressed(KC_LCONTROL, KMod_DONTCARE)) // Define square room (mouse scroll-wheel changes size - default is 5x5)
+    if (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true)) // Define square room (mouse scroll-wheel changes size - default is 5x5)
     {
-        if (wheel_scrolled_down)
+        if (is_game_key_pressed(Gkey_RoomSpaceIncSize, &keycode, true))
         {
             if (user_defined_roomspace_width != MAX_USER_ROOMSPACE_WIDTH)
             {
                 user_defined_roomspace_width++;
             }
         }
-        if (wheel_scrolled_up)
+        if (is_game_key_pressed(Gkey_RoomSpaceDecSize, &keycode, true))
         {
             if (user_defined_roomspace_width != MIN_USER_ROOMSPACE_WIDTH)
             {
@@ -279,6 +281,7 @@ void get_dungeon_sell_user_roomspace(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 
 void get_dungeon_build_user_roomspace(PlayerNumber plyr_idx, RoomKind rkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y, int *mode, TbBool drag_check)
 {
+    long keycode = 0;
     struct PlayerInfo* player = get_player(plyr_idx);
     MapSlabCoord slb_x = subtile_slab_fast(stl_x);
     MapSlabCoord slb_y = subtile_slab_fast(stl_y);
@@ -291,9 +294,9 @@ void get_dungeon_build_user_roomspace(PlayerNumber plyr_idx, RoomKind rkind, Map
             (*mode) = drag_placement_mode;
         }
     }
-    else if (is_key_pressed(KC_LSHIFT, KMod_DONTCARE)) // Find "best" room
+    else if (is_game_key_pressed(Gkey_BestRoomSpace, &keycode, true)) // Find "best" room
     {
-        if (wheel_scrolled_down)
+        if (is_game_key_pressed(Gkey_RoomSpaceIncSize, &keycode, true))
         {
             if (roomspace_detection_looseness < tolerate_gold && roomspace_detection_looseness >=disable_tolerance_layers)
             {
@@ -304,7 +307,7 @@ void get_dungeon_build_user_roomspace(PlayerNumber plyr_idx, RoomKind rkind, Map
                 roomspace_detection_looseness = tolerate_rock;
             }
         }
-        if (wheel_scrolled_up)
+        if (is_game_key_pressed(Gkey_RoomSpaceDecSize, &keycode, true))
         {
             if (roomspace_detection_looseness == tolerate_rock)
             {
@@ -317,16 +320,16 @@ void get_dungeon_build_user_roomspace(PlayerNumber plyr_idx, RoomKind rkind, Map
         }
         (*mode) = roomspace_detection_mode;
     }
-    else if (is_key_pressed(KC_LCONTROL, KMod_DONTCARE)) // Define square room (mouse scroll-wheel changes size - default is 5x5)
+    else if (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true)) // Define square room (mouse scroll-wheel changes size - default is 5x5)
     {
-        if (wheel_scrolled_down)
+        if (is_game_key_pressed(Gkey_RoomSpaceIncSize, &keycode, true))
         {
             if (user_defined_roomspace_width != MAX_USER_ROOMSPACE_WIDTH)
             {
                 user_defined_roomspace_width++;
             }
         }
-        if (wheel_scrolled_up)
+        if (is_game_key_pressed(Gkey_RoomSpaceDecSize, &keycode, true))
         {
             if (user_defined_roomspace_width != MIN_USER_ROOMSPACE_WIDTH)
             {

--- a/src/vidmode.c
+++ b/src/vidmode.c
@@ -869,6 +869,7 @@ TbScreenMode reenter_video_mode(void)
     if (setup_screen_mode(scrmode))
     {
         settings.video_scrnmode = scrmode;
+        copy_settings_to_dk_settings();
   } else
   {
       SYNCLOG("Can't enter %s (mode %d), falling to failsafe mode",


### PR DESCRIPTION
- Removed limit of 1001 GUI strings **(GUI_STRINGS_COUNT must now be increase as new strings are added)**
- _DK_GameSettings added and GameSettings expanded _(need to check what in DLL is dependent on GameSettings)_
- Added `make pkg-lang-single LANGUAGE=eng` to just build the .dat file for a single language (works for any language)
- Added One-Click Build, Single Subtile selling, and Snap Camera keys to keybind menu
- Replaced in-game usage of One-Click Build, Single Subtile selling, and Snap Camera to use the above game key bindings rather than the hard-coded keys