### PR TITLE
fixed a mistake with bracket usage

### DIFF
--- a/src/packets.c
+++ b/src/packets.c
@@ -580,7 +580,8 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     {
         gui_room_type_highlighted = player->chosen_room_kind;
     }
-    get_dungeon_build_user_roomspace(player->id_number, player->chosen_room_kind, stl_x, stl_y, &mode, (is_game_key_pressed(Gkey_BestRoomSpace, &keycode, true)) || (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true))  && ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld));
+    TbBool drag_check = ((is_game_key_pressed(Gkey_BestRoomSpace, &keycode, true) || is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true)) && ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld));
+    get_dungeon_build_user_roomspace(player->id_number, player->chosen_room_kind, stl_x, stl_y, &mode, drag_check);
     long i = tag_cursor_blocks_place_room(player->id_number, stl_x, stl_y, player->field_4A4);
     
     if (mode != drag_placement_mode) // allows the user to hold the left mouse to use "paint mode"


### PR DESCRIPTION
compounded conditional statement moved to a new boolean - drag_check.

Before this fix, it was checking for SHIFT only or CTRL and hold left mouse button to paint a bridge. 

Now it checks for (SHIFT or CTRL) and hold left mouse button to paint a bridge. 