### PR TITLE
USE_POWER_AT_LOCATION renamed to ..._AT_SUBTILE; added ..._AT_LOCATION

### DIFF
--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -126,8 +126,9 @@ enum TbScriptCommands {
     Cmd_SET_CREATURE_PROPERTY             = 106,
     Cmd_SET_CREATURE_FEARSOME_FACTOR      = 107,
     Cmd_USE_POWER_ON_CREATURE             = 108,
-    Cmd_USE_POWER_AT_LOCATION             = 109,
+    Cmd_USE_POWER_AT_SUBTILE              = 109,
     Cmd_USE_POWER                         = 110,
+    Cmd_USE_POWER_AT_LOCATION             = 111,
 };
 
 enum ScriptVariables {


### PR DESCRIPTION
USE_POWER_AT_LOCATION renamed to USE_POWER_AT_SUBTILE; added USE_POWER_AT_LOCATION

Would be great having the option to use action points or hero doors for spell casts.
- use power at location now takes one action point/hero door argument instead of former subtiles x,y
- former USE_POWER_AT_LOCATION renamed to ..._at_subtile