### PR TITLE
New script commands: USE_SPECIAL_...

### DIFF
--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -130,6 +130,10 @@ enum TbScriptCommands {
     Cmd_USE_POWER                         = 110,
     Cmd_USE_POWER_AT_LOCATION             = 111,
     Cmd_ADD_OBJECT_TO_LEVEL               = 112,
+    Cmd_USE_SPECIAL_INCREASE_LEVEL        = 113,
+    Cmd_USE_SPECIAL_MULTIPLY_CREATURES    = 114,
+    Cmd_USE_SPECIAL_MAKE_SAFE             = 115,
+    Cmd_USE_SPECIAL_LOCATE_HIDDEN_WORLD   = 116,
 };
 
 enum ScriptVariables {

--- a/src/power_specials.c
+++ b/src/power_specials.c
@@ -114,7 +114,7 @@ void multiply_creatures(struct PlayerInfo *player)
     multiply_creatures_in_dungeon_list(dungeon, dungeon->digger_list_start);
 }
 
-void increase_level(struct PlayerInfo *player)
+void increase_level(struct PlayerInfo *player, int count)
 {
     struct CreatureControl *cctrl;
     struct Thing *thing;
@@ -133,7 +133,8 @@ void increase_level(struct PlayerInfo *player)
         }
         i = cctrl->players_next_creature_idx;
         // Thing list loop body
-        creature_increase_level(thing);
+        if (count > 1) creature_increase_multiple_levels(thing, count);
+        else creature_increase_level(thing);
         // Thing list loop body ends
         k++;
         if (k > CREATURES_COUNT)
@@ -156,7 +157,8 @@ void increase_level(struct PlayerInfo *player)
         }
         i = cctrl->players_next_creature_idx;
         // Thing list loop body
-        creature_increase_level(thing);
+        if (count > 1) creature_increase_multiple_levels(thing, count);
+        else creature_increase_level(thing);
         // Thing list loop body ends
         k++;
         if (k > CREATURES_COUNT)
@@ -420,7 +422,7 @@ void activate_dungeon_special(struct Thing *cratetng, struct PlayerInfo *player)
           delete_thing_structure(cratetng, 0);
           break;
         case 91:
-          increase_level(player);
+          increase_level(player, 1);
           remove_events_thing_is_attached_to(cratetng);
           used = 1;
           delete_thing_structure(cratetng, 0);

--- a/src/power_specials.h
+++ b/src/power_specials.h
@@ -65,7 +65,7 @@ DLLIMPORT struct SpecialDesc _DK_special_desc[8];
 #pragma pack()
 /******************************************************************************/
 void multiply_creatures(struct PlayerInfo *player);
-void increase_level(struct PlayerInfo *player);
+void increase_level(struct PlayerInfo *player, int count);
 TbBool steal_hero(struct PlayerInfo *player, struct Coord3d *pos);
 void make_safe(struct PlayerInfo *player);
 TbBool activate_bonus_level(struct PlayerInfo *player);


### PR DESCRIPTION
Triggers a special action as if the player used a dungeon special box.

USE_SPECIAL_INCREASE_LEVEL([player], [count])
USE_SPECIAL_MULTIPLY_CREATURES([player], [count])
USE_SPECIAL_MAKE_SAFE([player])
where player is target player and count is how many times the special should be used.
count should be between 1-9, otherwise is adjusted