### PR TITLE
New script command: CHANGE_CREATURES_ANNOYANCE

### DIFF
--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -37,6 +37,8 @@
 #include "config_magic.h"
 #include "config_creature.h"
 #include "config_effects.h"
+#include "creature_states_mood.h"
+#include "creature_control.h"
 #include "gui_soundmsgs.h"
 #include "frontmenu_ingame_tabs.h"
 #include "player_instances.h"
@@ -151,6 +153,7 @@ const struct CommandDesc command_desc[] = {
   {"USE_SPECIAL_MULTIPLY_CREATURES",    "PN      ", Cmd_USE_SPECIAL_MULTIPLY_CREATURES},
   {"USE_SPECIAL_MAKE_SAFE",             "P       ", Cmd_USE_SPECIAL_MAKE_SAFE},
   {"USE_SPECIAL_LOCATE_HIDDEN_WORLD",   "        ", Cmd_USE_SPECIAL_LOCATE_HIDDEN_WORLD},
+  {"CHANGE_CREATURES_ANNOYANCE",        "PAN     ", Cmd_CHANGE_CREATURES_ANNOYANCE},
   {"ADD_TO_FLAG",                       "PAN     ", Cmd_ADD_TO_FLAG},
   {"SET_CAMPAIGN_FLAG",                 "PAN     ", Cmd_SET_CAMPAIGN_FLAG},
   {"ADD_TO_CAMPAIGN_FLAG",              "PAN     ", Cmd_ADD_TO_CAMPAIGN_FLAG},
@@ -2883,6 +2886,20 @@ void command_use_special_locate_hidden_world()
     command_add_value(Cmd_USE_SPECIAL_LOCATE_HIDDEN_WORLD, 0, 0, 0, 0);
 }
 
+void command_change_creatures_annoyance(long plr_range_id, const char *operation, long anger)
+{
+    long op_id = 255;
+    if(strcasecmp("set", operation) == 0) op_id = 0;
+    if(strcasecmp("increase", operation) == 0) op_id = 1;
+    if(strcasecmp("decrease", operation) == 0) op_id = -1;
+    if (op_id == 255)
+    {
+        SCRPTWRNLOG("Invalid operation for changing creatures' annoyance: '%s', setting to SET.", operation);
+        op_id = 0;
+    }
+    command_add_value(Cmd_CHANGE_CREATURES_ANNOYANCE, plr_range_id, op_id, anger, 0);
+}
+
 void command_change_creature_owner(long origin_plyr_idx, const char *crtr_name, const char *criteria, long dest_plyr_idx)
 {
     SCRIPTDBG(11, "Starting");
@@ -3204,6 +3221,9 @@ void script_add_command(const struct CommandDesc *cmd_desc, const struct ScriptL
         break;
     case Cmd_USE_SPECIAL_LOCATE_HIDDEN_WORLD:
         command_use_special_locate_hidden_world();
+        break;
+    case Cmd_CHANGE_CREATURES_ANNOYANCE:
+        command_change_creatures_annoyance(scline->np[0], scline->tp[1], scline->np[2]);
         break;
     case Cmd_CHANGE_CREATURE_OWNER:
         command_change_creature_owner(scline->np[0], scline->tp[1], scline->tp[2], scline->np[3]);
@@ -4602,6 +4622,47 @@ void script_use_special_make_safe(PlayerNumber plyr_idx)
 }
 
 /**
+ * Modifies player's creatures' anger.
+ * @param plyr_idx target player
+ * @param anger anger value. Use double AnnoyLevel (from creature's config file) to fully piss creature. More for longer calm time
+ * @param operation 1 to add anger, -1 to reduce, 0 to set
+ */
+TbBool script_change_creatures_annoyance(PlayerNumber plyr_idx, long operation, long anger)
+{
+    SYNCDBG(8,"Starting");
+    struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
+    unsigned long k = 0;
+    int i = dungeon->creatr_list_start;
+    while (i != 0)
+    {
+        struct Thing* thing = thing_get(i);
+        TRACE_THING(thing);
+        struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
+        if (thing_is_invalid(thing) || creature_control_invalid(cctrl))
+        {
+            ERRORLOG("Jump to invalid creature detected");
+            break;
+        }
+        i = cctrl->players_next_creature_idx;
+        if (!operation) anger_set_creature_anger(thing, anger, AngR_Other);
+        else
+        {
+            if (operation > 0) anger_increase_creature_anger(thing, anger, AngR_Other);
+            else anger_reduce_creature_anger(thing, -anger, AngR_Other);
+        }
+        // Thing list loop body ends
+        k++;
+        if (k > CREATURES_COUNT)
+        {
+            ERRORLOG("Infinite loop detected when sweeping creatures list");
+            break;
+        }
+    }
+    SYNCDBG(19,"Finished");
+    return true;
+}
+
+/**
  * Enables bonus level for current player.
  */
 TbBool script_use_special_locate_hidden_world()
@@ -5644,6 +5705,12 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       break;
     case Cmd_USE_SPECIAL_LOCATE_HIDDEN_WORLD:
       script_use_special_locate_hidden_world();
+      break;
+    case Cmd_CHANGE_CREATURES_ANNOYANCE:
+      for (i=plr_start; i < plr_end; i++)
+      {
+          script_change_creatures_annoyance(i, val2, val3);
+      }
       break;
     case Cmd_CHANGE_CREATURE_OWNER:
       for (i=plr_start; i < plr_end; i++)

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2894,8 +2894,8 @@ void command_change_creatures_annoyance(long plr_range_id, const char *operation
     if(strcasecmp("decrease", operation) == 0) op_id = -1;
     if (op_id == 255)
     {
-        SCRPTWRNLOG("Invalid operation for changing creatures' annoyance: '%s', setting to SET.", operation);
-        op_id = 0;
+        SCRPTERRLOG("Invalid operation for changing creatures' annoyance: '%s'", operation);
+        return;
     }
     command_add_value(Cmd_CHANGE_CREATURES_ANNOYANCE, plr_range_id, op_id, anger, 0);
 }

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2888,11 +2888,8 @@ void command_use_special_locate_hidden_world()
 
 void command_change_creatures_annoyance(long plr_range_id, const char *operation, long anger)
 {
-    long op_id = 255;
-    if(strcasecmp("set", operation) == 0) op_id = 0;
-    if(strcasecmp("increase", operation) == 0) op_id = 1;
-    if(strcasecmp("decrease", operation) == 0) op_id = -1;
-    if (op_id == 255)
+    long op_id = get_rid(script_operator_desc, operation);
+    if (op_id == -1)
     {
         SCRPTERRLOG("Invalid operation for changing creatures' annoyance: '%s'", operation);
         return;
@@ -4625,7 +4622,6 @@ void script_use_special_make_safe(PlayerNumber plyr_idx)
  * Modifies player's creatures' anger.
  * @param plyr_idx target player
  * @param anger anger value. Use double AnnoyLevel (from creature's config file) to fully piss creature. More for longer calm time
- * @param operation 1 to add anger, -1 to reduce, 0 to set
  */
 TbBool script_change_creatures_annoyance(PlayerNumber plyr_idx, long operation, long anger)
 {
@@ -4644,11 +4640,17 @@ TbBool script_change_creatures_annoyance(PlayerNumber plyr_idx, long operation, 
             break;
         }
         i = cctrl->players_next_creature_idx;
-        if (!operation) anger_set_creature_anger(thing, anger, AngR_Other);
-        else
+        if (operation == SOpr_SET)
         {
-            if (operation > 0) anger_increase_creature_anger(thing, anger, AngR_Other);
-            else anger_reduce_creature_anger(thing, -anger, AngR_Other);
+            anger_set_creature_anger(thing, anger, AngR_Other);
+        }
+        else if (operation == SOpr_INCREASE)
+        {
+            anger_increase_creature_anger(thing, anger, AngR_Other);
+        }
+        else if (operation == SOpr_DECREASE)
+        {
+            anger_reduce_creature_anger(thing, -anger, AngR_Other);
         }
         // Thing list loop body ends
         k++;

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -482,6 +482,13 @@ const struct NamedCommand campaign_flag_desc[] = {
   {NULL,     0},
 };
 
+const struct NamedCommand script_operator_desc[] = {
+  {"SET",         1},
+  {"INCREASE",    2},
+  {"DECREASE",    3},
+  {NULL,          0},
+};
+
 /******************************************************************************/
 static struct Thing *script_process_new_object(long crmodel, TbMapLocation location, long arg);
 

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -4667,7 +4667,7 @@ TbBool script_change_creatures_annoyance(PlayerNumber plyr_idx, long operation, 
  */
 TbBool script_use_special_locate_hidden_world()
 {
-    return activate_bonus_level(my_player_number);
+    return activate_bonus_level(get_player(my_player_number));
 }
 
 /**

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -224,6 +224,12 @@ enum MetaLocation {
   MML_RECENT_COMBAT,
 };
 
+enum ScriptOperator {
+    SOpr_SET = 1,
+    SOpr_INCREASE,
+    SOpr_DECREASE,
+};
+
 enum {
     CurrentPlayer = 15
 };

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -134,6 +134,7 @@ enum TbScriptCommands {
     Cmd_USE_SPECIAL_MULTIPLY_CREATURES    = 114,
     Cmd_USE_SPECIAL_MAKE_SAFE             = 115,
     Cmd_USE_SPECIAL_LOCATE_HIDDEN_WORLD   = 116,
+    Cmd_CHANGE_CREATURES_ANNOYANCE        = 117,
 };
 
 enum ScriptVariables {


### PR DESCRIPTION
New script command: ALTER_CREATURES_ANGER([player],[anger],[operation])
Annoys/calms all player's creatures.
* player is target player
* anger is anger value: refer to AnnoyLevel in creature's config
* operation: whether anger should be added to current anger for every creature(1), reduced(-1), or set(0)