### PR TITLE
New script command: SUMMON_CREATURE_AT_CREATURE

### DIFF
--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -135,6 +135,7 @@ enum TbScriptCommands {
     Cmd_USE_SPECIAL_MAKE_SAFE             = 115,
     Cmd_USE_SPECIAL_LOCATE_HIDDEN_WORLD   = 116,
     Cmd_CHANGE_CREATURES_ANNOYANCE        = 117,
+    Cmd_SUMMON_CREATURE_AT_CREATURE       = 118
 };
 
 enum ScriptVariables {


### PR DESCRIPTION
A script command I personally needed many times. This enables a mapmaker to spawn creatures not at predefined locations, but dynamically, based on other creatures' location. The creature gets summoned with the same spell effect as in 'summon imp' spell.
Also, it does not take up ADD_CREATURE_TO_LEVEL slot.
Would be glad if anyone suggested a better name for this as I don't like it much

SUMMON_CREATURE_AT_CREATURE([player],[creature],[criteria],[owner_player],[summoned_creature],[copies],[experience])
where:
first three args are the same as in KILL_CREATURE
owner_player - owner of summoned creature
summoned_creature - type of summoned creature
copies - how many creatures should be summoned
experience - level of new creatures