### PR TITLE
Ami/lvl7 init vampire trigger bugfix

### DIFF
--- a/campgns/ami2019/MAP10007.txt
+++ b/campgns/ami2019/MAP10007.txt
@@ -150,7 +150,7 @@ REVEAL_MAP_LOCATION(PLAYER0,6,25)
 REVEAL_MAP_LOCATION(PLAYER0,2,33)
 REVEAL_MAP_LOCATION(PLAYER0,1,15)
 
-ADD_CREATURE_TO_LEVEL(PLAYER0,VAMPIRE,3,IMPORT(PLAYER0,CAMPAIGN_FLAG1),1,0)
+ADD_CREATURE_TO_LEVEL(PLAYER0,VAMPIRE,-2,IMPORT(PLAYER0,CAMPAIGN_FLAG1),1,0)
 
 REM	QUICK_OBJECTIVE(1,"Back when the land was still settled by wizards before they were burned alive by the Polish, a keeper retreated to the northern caverns. Although discovered and defeated, he left behind a fascinating relic: a spell that is said to eliminate every living being recently exposed to sunlight. Let's find it. But first, some bad news: only allied blue keeper can attract creatures through a portal in this land. However, there are 2 scavengers capable of summoning heroes, but the powerful one has already been taken by the green keeper and the remaining one is guarded by dragons.",ALL_PLAYERS)
 DISPLAY_OBJECTIVE(73,PLAYER0)


### PR DESCRIPTION
Assmist Isle Level 7 initial vampire trigger fix.
If player has completed bonus task in the previous level, two vampires spawn at action point 3, triggering it. Shows at the beginning of: https://www.youtube.com/watch?v=HULlXwKbt94
This is a script bug and makes the level easier.
This commit makes the vampires to spawn at hero gate two, located at ally player.