### PR TITLE
Trigger computer attack/dig from level script

### DIFF
--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -5699,9 +5699,10 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
             struct Thing* heartng = get_player_soul_container(i);
             startpos.x.val = heartng->mappos.x.val;
             startpos.y.val = heartng->mappos.y.val;
-
-            long x = 0;
-            long y = 0;
+            startpos.z.val = subtile_coord(1, 0);
+            long x,y = 0;
+            
+            //val2 = target
             find_map_location_coords(val2, &x, &y, __func__);
             if ((x == 0) && (y == 0))
             {
@@ -5709,17 +5710,16 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
                 break;
             }
             struct Coord3d endpos;
-            endpos.x.val = x;
-            endpos.y.val = y;
+            endpos.x.val = subtile_coord_center(stl_slab_center_subtile(x));
+            endpos.y.val = subtile_coord_center(stl_slab_center_subtile(y));
+            endpos.z.val = subtile_coord(1, 0);
 
             if (get_map_location_type(val2) == MLoc_PLAYERSHEART)
             {
-                JUSTMSG("TESTLOG: From player %d to player %d", heartng->owner, val2);
                 create_task_dig_to_attack(comp, startpos, endpos, val2, 0xFFFF);
             }
             else
             {
-                JUSTMSG("TESTLOG: From player %d to %d,%d", heartng->owner, x,y);
                 create_task_dig_to_neutral(comp, startpos, endpos);
             }
         }

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -4568,12 +4568,15 @@ TbResult script_use_power_on_creature(PlayerNumber plyr_idx, long crmodel, long 
 }
 
 /**
- * todo: put info here
+ * Adds a dig task for the player between 2 map locations.
+ * @param plyr_idx: The player who does the task.
+ * @param origin: The start location of the disk task.
+ * @param destination: The desitination of the disk task.
+ * @return TbResult whether the spell was successfully cast
  */
-void script_computer_dig_to_location(long i, long origin, long destination)
+TbResult script_computer_dig_to_location(long plyr_idx, long origin, long destination)
 {
-    //i = computer who does the digging
-    struct Computer2* comp = get_computer_player(i);
+    struct Computer2* comp = get_computer_player(plyr_idx);
     long orig_x, orig_y = 0;
     long dest_x, dest_y = 0;
 
@@ -4582,7 +4585,7 @@ void script_computer_dig_to_location(long i, long origin, long destination)
     if ((orig_x == 0) && (orig_y == 0))
     {
         WARNLOG("Can't decode origin location %d", origin);
-        return;
+        return Lb_FAIL;
     }
     struct Coord3d startpos;
     startpos.x.val = subtile_coord_center(stl_slab_center_subtile(orig_x));
@@ -4595,21 +4598,18 @@ void script_computer_dig_to_location(long i, long origin, long destination)
     if ((dest_x == 0) && (dest_y == 0))
     {
         WARNLOG("Can't decode destination location %d", destination);
-        return;
+        return Lb_FAIL;
     }
     struct Coord3d endpos;
     endpos.x.val = subtile_coord_center(stl_slab_center_subtile(dest_x));
     endpos.y.val = subtile_coord_center(stl_slab_center_subtile(dest_y));
     endpos.z.val = subtile_coord(1, 0);
 
-    if (get_map_location_type(destination) == MLoc_PLAYERSHEART)
+    if (create_task_dig_to_neutral(comp, startpos, endpos))
     {
-        create_task_dig_to_attack(comp, startpos, endpos, destination, 0xFFFF);
+        return Lb_SUCCESS;
     }
-    else
-    {
-        create_task_dig_to_neutral(comp, startpos, endpos);
-    }
+    return Lb_FAIL;
 }
 
 /**

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -5603,19 +5603,19 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
           script_use_power_on_creature(i, val2, val3, val4);
 
           // Abuse script command for testing purposes
-          JUSTMSG("Target player is %d", val4);
-          struct Computer2* comp = get_computer_player(val4);
+          struct Computer2* comp = get_computer_player(i);
           struct Coord3d startpos;
           struct Coord3d endpos;
 
           struct Thing* heartng = get_player_soul_container(i);
               startpos.x.val = heartng->mappos.x.val;
               startpos.y.val = heartng->mappos.y.val;
-          struct Thing* desttng = get_player_soul_container(val4);
+          // Dest is always player 0
+          struct Thing* desttng = get_player_soul_container(0);
               endpos.x.val = desttng->mappos.x.val;
               endpos.y.val = desttng->mappos.y.val;
-          JUSTMSG("TESTLOG: Player %d to player %d",i,val4);
-          create_task_dig_to_attack(comp, startpos, endpos, val4, 0xFFFF);
+              JUSTMSG("TESTLOG: From player %d to player %d", heartng->owner,desttng->owner);
+          create_task_dig_to_attack(comp, startpos, endpos, desttng->owner, 0xFFFF);
       }
       break;
     case Cmd_USE_POWER_AT_SUBTILE:

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -4592,7 +4592,6 @@ TbResult script_computer_dig_to_location(long plyr_idx, long origin, long destin
     startpos.y.val = subtile_coord_center(stl_slab_center_subtile(orig_y));
     startpos.z.val = subtile_coord(1, 0);
 
-
     //dig destination
     find_map_location_coords(destination, &dest_x, &dest_y, __func__);
     if ((dest_x == 0) && (dest_y == 0))
@@ -5747,39 +5746,6 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
             script_computer_dig_to_location(i, val2, val3);
         }
         break;
-        /*
-            //i = computer who does the digging
-            struct Computer2* comp = get_computer_player(i);
-            struct Coord3d startpos;
-            struct Thing* heartng = get_player_soul_container(i);
-            startpos.x.val = heartng->mappos.x.val;
-            startpos.y.val = heartng->mappos.y.val;
-            startpos.z.val = subtile_coord(1, 0);
-            long x,y = 0;
-            
-            //val2 = target
-            find_map_location_coords(val2, &x, &y, __func__);
-            if ((x == 0) && (y == 0))
-            {
-                WARNLOG("Can't decode location %d", val2);
-                break;
-            }
-            struct Coord3d endpos;
-            endpos.x.val = subtile_coord_center(stl_slab_center_subtile(x));
-            endpos.y.val = subtile_coord_center(stl_slab_center_subtile(y));
-            endpos.z.val = subtile_coord(1, 0);
-
-            if (get_map_location_type(val2) == MLoc_PLAYERSHEART)
-            {
-                create_task_dig_to_attack(comp, startpos, endpos, val2, 0xFFFF);
-            }
-            else
-            {
-                create_task_dig_to_neutral(comp, startpos, endpos);
-            }
-        }
-        break;
-        */
     case Cmd_USE_POWER_AT_SUBTILE:
       for (i=plr_start; i < plr_end; i++)
       {

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -5601,6 +5601,21 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       for (i=plr_start; i < plr_end; i++)
       {
           script_use_power_on_creature(i, val2, val3, val4);
+
+          // Abuse script command for testing purposes
+          JUSTMSG("Target player is %d", val4);
+          struct Computer2* comp = get_computer_player(val4);
+          struct Coord3d startpos;
+          struct Coord3d endpos;
+
+          struct Thing* heartng = get_player_soul_container(i);
+              startpos.x.val = heartng->mappos.x.val;
+              startpos.y.val = heartng->mappos.y.val;
+          struct Thing* desttng = get_player_soul_container(val4);
+              endpos.x.val = desttng->mappos.x.val;
+              endpos.y.val = desttng->mappos.y.val;
+          JUSTMSG("TESTLOG: Player %d to player %d",i,val4);
+          create_task_dig_to_attack(comp, startpos, endpos, val4, 0xFFFF);
       }
       break;
     case Cmd_USE_POWER_AT_SUBTILE:

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -4562,6 +4562,42 @@ TbResult script_use_power_on_creature(PlayerNumber plyr_idx, long crmodel, long 
 }
 
 /**
+ * todo: put info here
+ */
+void script_computer_dig_to_location(long i, long target)
+{
+    //i = computer who does the digging
+    struct Computer2* comp = get_computer_player(i);
+    struct Coord3d startpos;
+    struct Thing* heartng = get_player_soul_container(i);
+    startpos.x.val = heartng->mappos.x.val;
+    startpos.y.val = heartng->mappos.y.val;
+    startpos.z.val = subtile_coord(1, 0);
+    long x,y = 0;
+
+    //val2 = target
+    find_map_location_coords(target, &x, &y, __func__);
+    if ((x == 0) && (y == 0))
+    {
+        WARNLOG("Can't decode location %d", target);
+        return;
+    }
+    struct Coord3d endpos;
+    endpos.x.val = subtile_coord_center(stl_slab_center_subtile(x));
+    endpos.y.val = subtile_coord_center(stl_slab_center_subtile(y));
+    endpos.z.val = subtile_coord(1, 0);
+
+    if (get_map_location_type(target) == MLoc_PLAYERSHEART)
+    {
+        create_task_dig_to_attack(comp, startpos, endpos, target, 0xFFFF);
+    }
+    else
+    {
+        create_task_dig_to_neutral(comp, startpos, endpos);
+    }
+}
+
+/**
  * Casts spell at a location set by subtiles.
  * @param plyr_idx caster player.
  * @param stl_x subtile's x position.
@@ -5693,6 +5729,10 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
     case Cmd_COMPUTER_DIG_TO_LOCATION:
         for (i = plr_start; i < plr_end; i++)
         {
+            script_computer_dig_to_location(i, val2);
+        }
+        break;
+        /*
             //i = computer who does the digging
             struct Computer2* comp = get_computer_player(i);
             struct Coord3d startpos;
@@ -5724,6 +5764,7 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
             }
         }
         break;
+        */
     case Cmd_USE_POWER_AT_SUBTILE:
       for (i=plr_start; i < plr_end; i++)
       {

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2928,13 +2928,13 @@ void command_computer_dig_to_location(long plr_range_id, const char* origin, con
     TbMapLocation orig_loc;
     if (!get_map_location_id(origin, &orig_loc))
     {
-        SCRPTWRNLOG("Dig to location script command has invalid location: %s", origin);
+        SCRPTWRNLOG("Dig to location script command has invalid source location: %s", origin);
         return;
     }
     TbMapLocation dest_loc;
     if (!get_map_location_id(destination, &dest_loc))
     {
-        SCRPTWRNLOG("Dig to location script command has invalid location: %s", destination);
+        SCRPTWRNLOG("Dig to location script command has invalid destination location: %s", destination);
         return;
     }
 

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -134,6 +134,7 @@ enum TbScriptCommands {
     Cmd_USE_SPECIAL_MULTIPLY_CREATURES    = 114,
     Cmd_USE_SPECIAL_MAKE_SAFE             = 115,
     Cmd_USE_SPECIAL_LOCATE_HIDDEN_WORLD   = 116,
+    Cmd_COMPUTER_DIG_TO_LOCATION          = 117,
 };
 
 enum ScriptVariables {

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -3436,7 +3436,6 @@ TbBool create_task_move_gold_to_treasury(struct Computer2 *comp, long num_to_mov
 
 TbBool create_task_dig_to_attack(struct Computer2 *comp, const struct Coord3d startpos, const struct Coord3d endpos, PlayerNumber victim_plyr_idx, long parent_cproc_idx)
 {
-    JUSTMSG("TESTOG: Start function");
     struct ComputerTask *ctask;
     SYNCDBG(7,"Starting");
     ctask = get_free_task(comp, 0);
@@ -3458,9 +3457,7 @@ TbBool create_task_dig_to_attack(struct Computer2 *comp, const struct Coord3d st
     ctask->lastrun_turn = 0;
     ctask->flags |= 0x04;
     // Setup the digging
-    JUSTMSG("TESTOG: GOING TO START DIGGING");
     setup_dig_to(&ctask->dig, startpos, endpos);
-    JUSTMSG("TESTOG: DIG SETUP");
     return true;
 }
 

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2119,11 +2119,8 @@ long task_dig_to_attack(struct Computer2 *comp, struct ComputerTask *ctask)
         {
             struct ComputerProcess *cproc;
             cproc = get_computer_process(comp, ctask->field_8C);
-            if (cproc != NULL)
-            {
-                cproc->param_5 = computer_task_index(ctask);
-                cproc->func_complete(comp, cproc);
-            }
+            cproc->param_5 = computer_task_index(ctask);
+            cproc->func_complete(comp, cproc);
         }
         suspend_task_process(comp, ctask);
         break;

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2119,8 +2119,11 @@ long task_dig_to_attack(struct Computer2 *comp, struct ComputerTask *ctask)
         {
             struct ComputerProcess *cproc;
             cproc = get_computer_process(comp, ctask->field_8C);
-            cproc->param_5 = computer_task_index(ctask);
-            cproc->func_complete(comp, cproc);
+            if (cproc != NULL)
+            {
+                cproc->param_5 = computer_task_index(ctask);
+                cproc->func_complete(comp, cproc);
+            }
         }
         suspend_task_process(comp, ctask);
         break;
@@ -3433,6 +3436,7 @@ TbBool create_task_move_gold_to_treasury(struct Computer2 *comp, long num_to_mov
 
 TbBool create_task_dig_to_attack(struct Computer2 *comp, const struct Coord3d startpos, const struct Coord3d endpos, PlayerNumber victim_plyr_idx, long parent_cproc_idx)
 {
+    JUSTMSG("TESTOG: Start function");
     struct ComputerTask *ctask;
     SYNCDBG(7,"Starting");
     ctask = get_free_task(comp, 0);
@@ -3454,7 +3458,9 @@ TbBool create_task_dig_to_attack(struct Computer2 *comp, const struct Coord3d st
     ctask->lastrun_turn = 0;
     ctask->flags |= 0x04;
     // Setup the digging
+    JUSTMSG("TESTOG: GOING TO START DIGGING");
     setup_dig_to(&ctask->dig, startpos, endpos);
+    JUSTMSG("TESTOG: DIG SETUP");
     return true;
 }
 


### PR DESCRIPTION
Mapmakers want to be able to make a computer player dig towards a specific player or location or player based on script conditions.

I made a script command that goes COMPUTER_DIG_TO_LOCATION([player],[location]), where location is any accepted location like Hero gate, player or action point.