### PR TITLE
Fix #919 - Boulders ineffective in Hatchery

### DIFF
--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -285,6 +285,13 @@ long get_floor_height_at(const struct Coord3d *pos)
     return get_map_floor_height(mapblk);
 }
 
+long get_floor_height(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    struct Map *mapblk;
+    mapblk = get_map_block_at(stl_x, stl_y);
+    return get_map_floor_height(mapblk);
+}
+
 long get_map_ceiling_height(const struct Map *mapblk)
 {
     const struct Column *colmn;
@@ -304,6 +311,13 @@ long get_ceiling_height_at(const struct Coord3d *pos)
 {
     struct Map *mapblk;
     mapblk = get_map_block_at(pos->x.val >> 8, pos->y.val >> 8);
+    return get_map_ceiling_height(mapblk);
+}
+
+long get_ceiling_height_at_subtile(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    struct Map *mapblk;
+    mapblk = get_map_block_at(stl_x, stl_y);
     return get_map_ceiling_height(mapblk);
 }
 

--- a/src/map_columns.h
+++ b/src/map_columns.h
@@ -86,6 +86,7 @@ long get_floor_height(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 long get_floor_height_at(const struct Coord3d *pos);
 long get_map_ceiling_height(const struct Map *mapblk);
 long get_ceiling_height_at(const struct Coord3d *pos);
+long get_ceiling_height_at_subtile(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 TbBool cube_is_water(long cube_id);
 TbBool cube_is_lava(long cube_id);

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -306,8 +306,8 @@ TbBool set_coords_with_range_check(struct Coord3d *pos, MapCoord cor_x, MapCoord
         if (flags & MapCoord_ClipY) cor_y = subtile_coord(map_subtiles_y,255);
         corrected = true;
     }
-    if (cor_z >= subtile_coord(map_subtiles_z,255)) {
-        if (flags & MapCoord_ClipZ) cor_z = subtile_coord(map_subtiles_z,255);
+    if (cor_z > subtile_coord(map_subtiles_z,8)) {
+        if (flags & MapCoord_ClipZ) cor_z = subtile_coord(map_subtiles_z,8);
         corrected = true;
     }
     if (cor_x < subtile_coord(0,0)) {
@@ -318,9 +318,12 @@ TbBool set_coords_with_range_check(struct Coord3d *pos, MapCoord cor_x, MapCoord
         if (flags & MapCoord_ClipY) cor_y = subtile_coord(0,0);
         corrected = true;
     }
-    if (cor_z < subtile_coord(0,0)) {
-        if (flags & MapCoord_ClipZ) cor_z = subtile_coord(0,0);
-        corrected = true;
+    if ( (!subtile_has_water_on_top(coord_subtile(cor_x), coord_subtile(cor_y))) && (!subtile_has_lava_on_top(coord_subtile(cor_x), coord_subtile(cor_y))) )
+    {
+        if (cor_z < subtile_coord(0,0)) {
+            if (flags & MapCoord_ClipZ) cor_z = subtile_coord(0,0);
+            corrected = true;
+        }
     }
     pos->x.val = cor_x;
     pos->y.val = cor_y;

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -322,7 +322,9 @@ TbBool set_coords_with_range_check(struct Coord3d *pos, MapCoord cor_x, MapCoord
         if (flags & MapCoord_ClipY) cor_y = subtile_coord(0,0);
         corrected = true;
     }
-    if ( (!subtile_has_water_on_top(stl_x, stl_y)) && (!subtile_has_lava_on_top(stl_x, stl_y)) && (!slab_is_wall(subtile_slab(stl_x), subtile_slab(stl_y))) )
+    MapSlabCoord slb_x = subtile_slab(stl_x);
+    MapSlabCoord slb_y = subtile_slab(stl_y);
+    if ( (!slab_is_liquid(slb_x, slb_y)) && (!slab_is_door(slb_x, slb_y)) && (!slab_is_wall(slb_x, slb_y)) )
     {
         height = get_floor_height(stl_x, stl_y);
         if (cor_z < height)

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -18,7 +18,7 @@
 /******************************************************************************/
 #include "map_data.h"
 #include "globals.h"
-
+#include "map_columns.h"
 #include "bflib_math.h"
 #include "bflib_memory.h"
 #include "slab_data.h"
@@ -306,9 +306,13 @@ TbBool set_coords_with_range_check(struct Coord3d *pos, MapCoord cor_x, MapCoord
         if (flags & MapCoord_ClipY) cor_y = subtile_coord(map_subtiles_y,255);
         corrected = true;
     }
-    if (cor_z > subtile_coord(map_subtiles_z,8)) {
-        if (flags & MapCoord_ClipZ) cor_z = subtile_coord(map_subtiles_z,8);
-        corrected = true;
+    MapSubtlCoord stl_x = coord_subtile(cor_x);
+    MapSubtlCoord stl_y = coord_subtile(cor_y);
+    MapCoord height = get_ceiling_height_at_subtile(stl_x, stl_y);
+    if (cor_z > height)
+    {
+        if (flags & MapCoord_ClipZ) cor_z = height;
+        corrected = true;  
     }
     if (cor_x < subtile_coord(0,0)) {
         if (flags & MapCoord_ClipX) cor_x = subtile_coord(0,0);
@@ -318,11 +322,13 @@ TbBool set_coords_with_range_check(struct Coord3d *pos, MapCoord cor_x, MapCoord
         if (flags & MapCoord_ClipY) cor_y = subtile_coord(0,0);
         corrected = true;
     }
-    if ( (!subtile_has_water_on_top(coord_subtile(cor_x), coord_subtile(cor_y))) && (!subtile_has_lava_on_top(coord_subtile(cor_x), coord_subtile(cor_y))) )
+    if ( (!subtile_has_water_on_top(stl_x, stl_y)) && (!subtile_has_lava_on_top(stl_x, stl_y)) )
     {
-        if (cor_z < subtile_coord(0,0)) {
-            if (flags & MapCoord_ClipZ) cor_z = subtile_coord(0,0);
-            corrected = true;
+        height = get_floor_height(stl_x, stl_y);
+        if (cor_z < height)
+        {
+            if (flags & MapCoord_ClipZ) cor_z = height;
+            corrected = true;   
         }
     }
     pos->x.val = cor_x;

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -312,7 +312,7 @@ TbBool set_coords_with_range_check(struct Coord3d *pos, MapCoord cor_x, MapCoord
     if (cor_z > height)
     {
         if (flags & MapCoord_ClipZ) cor_z = height;
-        corrected = true;  
+        corrected = true;
     }
     if (cor_x < subtile_coord(0,0)) {
         if (flags & MapCoord_ClipX) cor_x = subtile_coord(0,0);
@@ -322,13 +322,13 @@ TbBool set_coords_with_range_check(struct Coord3d *pos, MapCoord cor_x, MapCoord
         if (flags & MapCoord_ClipY) cor_y = subtile_coord(0,0);
         corrected = true;
     }
-    if ( (!subtile_has_water_on_top(stl_x, stl_y)) && (!subtile_has_lava_on_top(stl_x, stl_y)) )
+    if ( (!subtile_has_water_on_top(stl_x, stl_y)) && (!subtile_has_lava_on_top(stl_x, stl_y)) && (!slab_is_wall(subtile_slab(stl_x), subtile_slab(stl_y))) )
     {
         height = get_floor_height(stl_x, stl_y);
         if (cor_z < height)
         {
             if (flags & MapCoord_ClipZ) cor_z = height;
-            corrected = true;   
+            corrected = true;
         }
     }
     pos->x.val = cor_x;

--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -21,7 +21,7 @@
 
 #include "globals.h"
 #include "bflib_basics.h"
-
+#include "thing_shots.h"
 #include "thing_data.h"
 #include "thing_stats.h"
 #include "thing_creature.h"
@@ -344,6 +344,13 @@ long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
  */
 TbBool get_thing_next_position(struct Coord3d *pos, const struct Thing *thing)
 {
+    if (thing_is_shot(thing))
+    {
+        if (shot_is_boulder(thing))
+        {
+            return set_coords_add_velocity(pos, &thing->mappos, &thing->velocity, MapCoord_ClipX|MapCoord_ClipY|MapCoord_ClipZ);   
+        }
+    }
     // Don't clip the Z coord - clipping would make impossible to hit base ground (ie. water drip over water)
     return set_coords_add_velocity(pos, &thing->mappos, &thing->velocity, MapCoord_ClipX|MapCoord_ClipY);
 }
@@ -631,7 +638,7 @@ TbBool things_collide_while_first_moves_to(const struct Thing *firstng, const st
     struct CoordDelta3d dt;
     dt.x.val = dstpos->x.val - (MapCoordDelta)firstng->mappos.x.val;
     dt.y.val = dstpos->y.val - (MapCoordDelta)firstng->mappos.y.val;
-    dt.z.val = dstpos->y.val - (MapCoordDelta)firstng->mappos.y.val;
+    dt.z.val = dstpos->z.val - (MapCoordDelta)firstng->mappos.z.val;
     // Compute amount of interpoints for collision check
     int interpoints;
     {

--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -344,15 +344,8 @@ long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
  */
 TbBool get_thing_next_position(struct Coord3d *pos, const struct Thing *thing)
 {
-    if (thing_is_shot(thing))
-    {
-        if (shot_is_boulder(thing))
-        {
-            return set_coords_add_velocity(pos, &thing->mappos, &thing->velocity, MapCoord_ClipX|MapCoord_ClipY|MapCoord_ClipZ);   
-        }
-    }
     // Don't clip the Z coord - clipping would make impossible to hit base ground (ie. water drip over water)
-    return set_coords_add_velocity(pos, &thing->mappos, &thing->velocity, MapCoord_ClipX|MapCoord_ClipY);
+    return set_coords_add_velocity(pos, &thing->mappos, &thing->velocity, MapCoord_ClipX|MapCoord_ClipY|MapCoord_ClipZ);
 }
 
 long get_thing_height_at(const struct Thing *thing, const struct Coord3d *pos)

--- a/src/thing_shots.h
+++ b/src/thing_shots.h
@@ -82,6 +82,7 @@ TbBool shot_is_slappable(const struct Thing *thing, PlayerNumber plyr_idx);
 TbBool shot_model_is_navigable(long tngmodel);
 TbBool shot_model_makes_flesh_explosion(long shot_model);
 TbBool detonate_shot(struct Thing *shotng);
+TbBool shot_is_boulder(const struct Thing *shotng);
 
 struct Thing *get_thing_collided_with_at_satisfying_filter(struct Thing *thing, struct Coord3d *pos, Thing_Collide_Func filter, long a4, long a5);
 /******************************************************************************/


### PR DESCRIPTION
Also seems to enable you to avoid boulders in possession by flying over them.