### PR TITLE
Fixed dropping flying units

### DIFF
--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -408,7 +408,7 @@ unsigned char field_27F;
     unsigned char joining_age;
     unsigned char blood_type;
     struct Coord3d flee_pos;
-    long start_turn_28E;
+    long flee_start_turn;
     struct MemberPos followers_pos[GROUP_MEMBERS_COUNT];
     unsigned short next_in_room;
     unsigned short prev_in_room;//field_2AC

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -1391,7 +1391,7 @@ short creature_being_dropped(struct Thing *creatng)
     MapSubtlCoord stl_y = creatng->mappos.y.stl.num;
     struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
     // If dropping still in progress, do nothing
-    if ( !thing_touching_floor(creatng) && ((creatng->movement_flags & TMvF_Flying) == 0) )
+    if ( !(thing_touching_floor(creatng) || (((creatng->movement_flags & TMvF_Flying) != 0) && thing_touching_flight_altitude(creatng))))
     {
         // Note that the creature should have no self control while dropping - after all, it was in hand moments ago
         SYNCDBG(17,"The %s index %d owner %d dropped at (%d,%d) isn't touching ground yet",thing_model_name(creatng),(int)creatng->index,(int)creatng->owner,(int)stl_x,(int)stl_y);

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1253,7 +1253,7 @@ CrAttackType check_for_possible_combat_within_distance(struct Thing *creatng, st
 short creature_combat_flee(struct Thing *creatng)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
-    GameTurnDelta turns_in_flee = game.play_gameturn - (GameTurnDelta)cctrl->start_turn_28E;
+    GameTurnDelta turns_in_flee = game.play_gameturn - (GameTurnDelta)cctrl->flee_start_turn;
     if (get_2d_box_distance(&creatng->mappos, &cctrl->flee_pos) >= 1536)
     {
         SYNCDBG(8,"Starting distant flee for %s index %d",thing_model_name(creatng),(int)creatng->index);
@@ -1266,7 +1266,7 @@ short creature_combat_flee(struct Thing *creatng)
                 cctrl->flee_pos.y.val = creatng->mappos.y.val;
                 cctrl->flee_pos.z.val = creatng->mappos.z.val;
             }
-            cctrl->start_turn_28E = game.play_gameturn;
+            cctrl->flee_start_turn = game.play_gameturn;
         } else
         if (turns_in_flee <= game.game_turns_in_flee)
         {
@@ -2614,7 +2614,7 @@ short creature_in_combat(struct Thing *creatng)
             ERRORLOG("Cannot get %s index %d into flee",thing_model_name(creatng),(int)creatng->index);
             return 0;
         }
-        cctrl->start_turn_28E = game.play_gameturn;
+        cctrl->flee_start_turn = game.play_gameturn;
         return 0;
     }
     CombatState combat_func;
@@ -2767,7 +2767,7 @@ TbBool creature_look_for_combat(struct Thing *creatng)
             return false;
         }
         setup_combat_flee_position(creatng);
-        cctrl->start_turn_28E = game.play_gameturn;
+        cctrl->flee_start_turn = game.play_gameturn;
         return true;
     }
 
@@ -2808,7 +2808,7 @@ TbBool creature_look_for_combat(struct Thing *creatng)
         return false;
     }
     setup_combat_flee_position(creatng);
-    cctrl->start_turn_28E = game.play_gameturn;
+    cctrl->flee_start_turn = game.play_gameturn;
     return true;
 }
 


### PR DESCRIPTION
creatures would start looking around before the drop was finished, causing them to flee too fast, and possibly other issues.