### PR TITLE
Remade PRINT and MESSAGE commands

### DIFF
--- a/src/config_campaigns.h
+++ b/src/config_campaigns.h
@@ -154,6 +154,7 @@ extern struct CampaignsList mappacks_list;
 extern const struct NamedCommand cmpgn_map_commands[];
 extern const struct NamedCommand cmpgn_map_cmnds_options[];
 extern const struct NamedCommand cmpgn_map_cmnds_kind[];
+extern const struct NamedCommand cmpgn_human_player_options[];
 /******************************************************************************/
 TbBool load_campaign(const char *cmpgn_fname,struct GameCampaign *campgn,unsigned short flags, short fgroup);
 TbBool free_campaign(struct GameCampaign *campgn);

--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -52,6 +52,7 @@ void message_draw(void)
         unsigned long spr_idx;
         if ((char)gameadd.messages[i].plyr_idx < 0)
         {
+            x -= (7 * units_per_pixel / 16);
             y -= (20 * units_per_pixel / 16);
             spr_idx = get_creature_model_graphics(((~gameadd.messages[i].plyr_idx) + 1), CGI_HandSymbol);
         }

--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -22,7 +22,7 @@
 #include "globals.h"
 #include "bflib_basics.h"
 #include "bflib_sprfnt.h"
-
+#include "creature_graphics.h"
 #include "gui_draw.h"
 #include "frontend.h"
 #include "game_legacy.h"
@@ -30,6 +30,7 @@
 #include "keeperfx.hpp"
 
 /******************************************************************************/
+
 void message_draw(void)
 {
     SYNCDBG(7,"Starting");
@@ -48,7 +49,17 @@ void message_draw(void)
         LbTextSetWindow(0, 0, MyScreenWidth, MyScreenHeight);
         set_flag_word(&lbDisplay.DrawFlags,Lb_TEXT_ONE_COLOR,false);
         LbTextDrawResized(x+32*units_per_pixel/16, y, tx_units_per_px, gameadd.messages[i].text);
-        draw_gui_panel_sprite_left(x, y, ps_units_per_px, 488+gameadd.messages[i].plyr_idx);
+        unsigned long spr_idx; // = ((char)gameadd.messages[i].plyr_idx < 0) ? get_creature_model_graphics(((~gameadd.messages[i].plyr_idx) + 1), CGI_HandSymbol) : 488+gameadd.messages[i].plyr_idx;
+        if ((char)gameadd.messages[i].plyr_idx < 0)
+        {
+            y -= 20;
+            spr_idx = get_creature_model_graphics(((~gameadd.messages[i].plyr_idx) + 1), CGI_HandSymbol);
+        }
+        else
+        {
+            spr_idx = 488+gameadd.messages[i].plyr_idx;
+        }
+        draw_gui_panel_sprite_left(x, y, ps_units_per_px, spr_idx);
         y += h*units_per_pixel/16;
     }
 }

--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -49,7 +49,7 @@ void message_draw(void)
         LbTextSetWindow(0, 0, MyScreenWidth, MyScreenHeight);
         set_flag_word(&lbDisplay.DrawFlags,Lb_TEXT_ONE_COLOR,false);
         LbTextDrawResized(x+32*units_per_pixel/16, y, tx_units_per_px, gameadd.messages[i].text);
-        unsigned long spr_idx; // = ((char)gameadd.messages[i].plyr_idx < 0) ? get_creature_model_graphics(((~gameadd.messages[i].plyr_idx) + 1), CGI_HandSymbol) : 488+gameadd.messages[i].plyr_idx;
+        unsigned long spr_idx;
         if ((char)gameadd.messages[i].plyr_idx < 0)
         {
             y -= (20 * units_per_pixel / 16);

--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -59,7 +59,10 @@ void message_draw(void)
         {
             spr_idx = 488+gameadd.messages[i].plyr_idx;
         }
-        draw_gui_panel_sprite_left(x, y, ps_units_per_px, spr_idx);
+        if (gameadd.messages[i].plyr_idx != 127)
+        {
+            draw_gui_panel_sprite_left(x, y, ps_units_per_px, spr_idx);
+        }
         y += h*units_per_pixel/16;
     }
 }

--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -65,7 +65,11 @@ void message_draw(void)
         {
             draw_gui_panel_sprite_left(x, y, ps_units_per_px, spr_idx);
         }
-        y += h*units_per_pixel/16 + ((20 * units_per_pixel / 16)*(unsigned char)NotPlayer);
+        y += h*units_per_pixel/16;
+        if (NotPlayer)
+        {
+            y += (20 * units_per_pixel / 16);
+        }        
     }
 }
 

--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -52,7 +52,7 @@ void message_draw(void)
         unsigned long spr_idx; // = ((char)gameadd.messages[i].plyr_idx < 0) ? get_creature_model_graphics(((~gameadd.messages[i].plyr_idx) + 1), CGI_HandSymbol) : 488+gameadd.messages[i].plyr_idx;
         if ((char)gameadd.messages[i].plyr_idx < 0)
         {
-            y -= 20;
+            y -= (20 * units_per_pixel / 16);
             spr_idx = get_creature_model_graphics(((~gameadd.messages[i].plyr_idx) + 1), CGI_HandSymbol);
         }
         else

--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -42,15 +42,16 @@ void message_draw(void)
         ps_units_per_px = (22 * units_per_pixel) / spr->SHeight;
     }
     int h = LbTextLineHeight();
-    long x = 148 * units_per_pixel / 16;
     long y = 28 * units_per_pixel / 16;
     for (int i = 0; i < game.active_messages_count; i++)
     {
+        long x = 148 * units_per_pixel / 16;
         LbTextSetWindow(0, 0, MyScreenWidth, MyScreenHeight);
         set_flag_word(&lbDisplay.DrawFlags,Lb_TEXT_ONE_COLOR,false);
         LbTextDrawResized(x+32*units_per_pixel/16, y, tx_units_per_px, gameadd.messages[i].text);
         unsigned long spr_idx;
-        if ((char)gameadd.messages[i].plyr_idx < 0)
+        TbBool NotPlayer = ((char)gameadd.messages[i].plyr_idx < 0);
+        if (NotPlayer)
         {
             x -= (7 * units_per_pixel / 16);
             y -= (20 * units_per_pixel / 16);
@@ -64,7 +65,7 @@ void message_draw(void)
         {
             draw_gui_panel_sprite_left(x, y, ps_units_per_px, spr_idx);
         }
-        y += h*units_per_pixel/16;
+        y += h*units_per_pixel/16 + ((20 * units_per_pixel / 16)*(unsigned char)NotPlayer);
     }
 }
 

--- a/src/gui_msgs.h
+++ b/src/gui_msgs.h
@@ -34,7 +34,7 @@ extern "C" {
 
 struct GuiMessage { // sizeof = 0x45 (69)
     char text[64];
-unsigned char plyr_idx;
+PlayerNumber plyr_idx;
 unsigned long creation_turn;
 };
 

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -6601,6 +6601,8 @@ const struct CommandDesc command_desc[] = {
   {"QUICK_OBJECTIVE_WITH_POS",          "NANN    ", Cmd_QUICK_OBJECTIVE_WITH_POS, NULL, NULL},
   {"QUICK_INFORMATION_WITH_POS",        "NANN    ", Cmd_QUICK_INFORMATION_WITH_POS, NULL, NULL},
   {"SWAP_CREATURE",                     "AC      ", Cmd_SWAP_CREATURE, NULL, NULL},
+  {"PRINT",                             "A       ", Cmd_PRINT, NULL, NULL},
+  {"MESSAGE",                           "A       ", Cmd_MESSAGE, NULL, NULL},
   {"PLAY_MESSAGE",                      "PAN     ", Cmd_PLAY_MESSAGE, NULL, NULL},
   {"ADD_GOLD_TO_PLAYER",                "PN      ", Cmd_ADD_GOLD_TO_PLAYER, NULL, NULL},
   {"SET_CREATURE_TENDENCIES",           "PAN     ", Cmd_SET_CREATURE_TENDENCIES, NULL, NULL},

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2935,7 +2935,7 @@ void command_message(const char *msgtext, unsigned char kind)
   SCRPTWRNLOG("Command '%s' is only supported in Dungeon Keeper Beta", cmd);
 }
 
-void command_printfx(int idx, const char *msgtext, const char *range_id)
+void command_quick_message(int idx, const char *msgtext, const char *range_id)
 {
   if ((idx < 0) || (idx >= QUICK_MESSAGES_COUNT))
   {
@@ -2973,7 +2973,7 @@ void command_printfx(int idx, const char *msgtext, const char *range_id)
         id = (~id) + 1;
     }           
   }
-  command_add_value(Cmd_PRINTFX, 0, id, idx, 0);
+  command_add_value(Cmd_QUICK_MESSAGE, 0, id, idx, 0);
 }
 
 void command_swap_creature(const char *ncrt_name, const char *crtr_name)
@@ -3550,8 +3550,8 @@ void script_add_command(const struct CommandDesc *cmd_desc, const struct ScriptL
     case Cmd_PRINT:
         command_message(scline->tp[0],80);
         break;
-    case Cmd_PRINTFX:
-        command_printfx(scline->np[0], scline->tp[1], scline->tp[2]);
+    case Cmd_QUICK_MESSAGE:
+        command_quick_message(scline->np[0], scline->tp[1], scline->tp[2]);
         break;
     case Cmd_MESSAGE:
         command_message(scline->tp[0],68);
@@ -6262,7 +6262,7 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
           intralvl.campaign_flags[i][val4] = get_condition_value(i, val2, val3);
       }
       break;
-  case Cmd_PRINTFX:
+  case Cmd_QUICK_MESSAGE:
   {
       message_add_fmt(val2, "%s", gameadd.quick_messages[val3]);
       break;
@@ -6613,7 +6613,7 @@ const struct CommandDesc command_desc[] = {
   {"CREATE_EFFECTS_LINE",               "LLNNNN  ", Cmd_CREATE_EFFECTS_LINE, &create_effects_line_check, &create_effects_line_process},
   {"IF_SLAB_OWNER",                     "NNP     ", Cmd_IF_SLAB_OWNER, NULL, NULL},
   {"IF_SLAB_TYPE",                      "NNS     ", Cmd_IF_SLAB_TYPE, NULL, NULL},
-  {"PRINT",                             "NAA     ", Cmd_PRINTFX, NULL, NULL},
+  {"QUICK_MESSAGE",                     "NAA     ", Cmd_QUICK_MESSAGE, NULL, NULL},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2956,10 +2956,10 @@ void command_quick_message(int idx, const char *msgtext, const char *range_id)
   command_add_value(Cmd_QUICK_MESSAGE, 0, id, idx, 0);
 }
 
-void command_messagefx(int msg_num, const char *range_id)
+void command_display_message(int msg_num, const char *range_id)
 {
     char id = get_player_number_from_value(range_id);
-    command_add_value(Cmd_MESSAGEFX, 0, id, msg_num, 0);
+    command_add_value(Cmd_DISPLAY_MESSAGE, 0, id, msg_num, 0);
 }
 
 void command_swap_creature(const char *ncrt_name, const char *crtr_name)
@@ -3539,8 +3539,8 @@ void script_add_command(const struct CommandDesc *cmd_desc, const struct ScriptL
     case Cmd_QUICK_MESSAGE:
         command_quick_message(scline->np[0], scline->tp[1], scline->tp[2]);
         break;
-    case Cmd_MESSAGEFX:
-        command_messagefx(scline->np[0], scline->tp[1]);
+    case Cmd_DISPLAY_MESSAGE:
+        command_display_message(scline->np[0], scline->tp[1]);
         break;
     case Cmd_MESSAGE:
         command_message(scline->tp[0],68);
@@ -6256,7 +6256,7 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       message_add_fmt(val2, "%s", gameadd.quick_messages[val3]);
       break;
   }
-  case Cmd_MESSAGEFX:
+  case Cmd_DISPLAY_MESSAGE:
   {
         message_add_fmt(val2, "%s", get_string(val3));
         break;        
@@ -6638,7 +6638,7 @@ const struct CommandDesc command_desc[] = {
   {"IF_SLAB_OWNER",                     "NNP     ", Cmd_IF_SLAB_OWNER, NULL, NULL},
   {"IF_SLAB_TYPE",                      "NNS     ", Cmd_IF_SLAB_TYPE, NULL, NULL},
   {"QUICK_MESSAGE",                     "NAA     ", Cmd_QUICK_MESSAGE, NULL, NULL},
-  {"MESSAGE",                           "NA      ", Cmd_MESSAGEFX, NULL, NULL},
+  {"DISPLAY_MESSAGE",                   "NA      ", Cmd_DISPLAY_MESSAGE, NULL, NULL},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -6597,8 +6597,6 @@ const struct CommandDesc command_desc[] = {
   {"QUICK_OBJECTIVE_WITH_POS",          "NANN    ", Cmd_QUICK_OBJECTIVE_WITH_POS, NULL, NULL},
   {"QUICK_INFORMATION_WITH_POS",        "NANN    ", Cmd_QUICK_INFORMATION_WITH_POS, NULL, NULL},
   {"SWAP_CREATURE",                     "AC      ", Cmd_SWAP_CREATURE, NULL, NULL},
-  {"PRINT",                             "A       ", Cmd_PRINT, NULL, NULL},
-  {"MESSAGE",                           "A       ", Cmd_MESSAGE, NULL, NULL},
   {"PLAY_MESSAGE",                      "PAN     ", Cmd_PLAY_MESSAGE, NULL, NULL},
   {"ADD_GOLD_TO_PLAYER",                "PN      ", Cmd_ADD_GOLD_TO_PLAYER, NULL, NULL},
   {"SET_CREATURE_TENDENCIES",           "PAN     ", Cmd_SET_CREATURE_TENDENCIES, NULL, NULL},

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2952,57 +2952,13 @@ void command_quick_message(int idx, const char *msgtext, const char *range_id)
   }
   strncpy(gameadd.quick_messages[idx], msgtext, MESSAGE_TEXT_LEN-1);
   gameadd.quick_messages[idx][MESSAGE_TEXT_LEN-1] = '\0';
-  char id;
-  if (strcasecmp(range_id, "None") == 0)
-  {
-      id = 127;
-  }
-  else
-  {
-    id = get_rid(player_desc, range_id);
-  }
-  if (id == -1)
-  {
-    id = get_rid(creature_desc, range_id);
-    if (id == -1)
-    {
-        id = atoi(range_id);
-    }
-    else
-    {
-        id = (~id) + 1;
-    }           
-  }
+  char id = get_player_number_from_value(range_id);
   command_add_value(Cmd_QUICK_MESSAGE, 0, id, idx, 0);
 }
 
 void command_messagefx(int msg_num, const char *range_id)
 {
-    char id;
-    if (strcasecmp(range_id, "None") == 0)
-    {
-        id = 127;
-    }
-    else
-    {
-        id = get_rid(player_desc, range_id);
-    }
-    if (id == -1)
-    {
-        id = get_rid(cmpgn_human_player_options, range_id);
-        if (id == -1)
-        {
-            id = get_rid(creature_desc, range_id);
-            if (id == -1)
-            {
-                id = atoi(range_id);
-            }
-            else
-            {
-                id = (~id) + 1;
-            }   
-        }        
-    }
+    char id = get_player_number_from_value(range_id);
     command_add_value(Cmd_MESSAGEFX, 0, id, msg_num, 0);
 }
 
@@ -6548,6 +6504,36 @@ void find_location_pos(long location, PlayerNumber plyr_idx, struct Coord3d *pos
       break;
   }
   SYNCDBG(15,"From %s; Location %ld, pos(%ld,%ld)",func_name, location, pos->x.stl.num, pos->y.stl.num);
+}
+
+char get_player_number_from_value(const char* txt)
+{
+    char id;
+    if (strcasecmp(txt, "None") == 0)
+    {
+        id = 127;
+    }
+    else
+    {
+        id = get_rid(player_desc, txt);
+    }
+    if (id == -1)
+    {
+        id = get_rid(cmpgn_human_player_options, txt);
+        if (id == -1)
+        {
+            id = get_rid(creature_desc, txt);
+            if (id == -1)
+            {
+                id = atoi(txt);
+            }
+            else
+            {
+                id = (~id) + 1;
+            }   
+        }        
+    }
+    return id;
 }
 /******************************************************************************/
 /**

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2976,26 +2976,6 @@ void command_printfx(int idx, const char *msgtext, const char *range_id)
   command_add_value(Cmd_PRINTFX, 0, id, idx, 0);
 }
 
-void command_messagefx(int idx, const char *msgtext, unsigned long nturns)
-{
-    if ((idx < 0) || (idx >= QUICK_MESSAGES_COUNT))
-    {
-        SCRPTERRLOG("Invalid information ID number (%d)", idx);
-        return;
-    }
-    if (strlen(msgtext) > MESSAGE_TEXT_LEN)
-    {
-        SCRPTWRNLOG("Information TEXT too long; truncating to %d characters", MESSAGE_TEXT_LEN-1);
-    }
-    if ((gameadd.quick_messages[idx][0] != '\0') && (strcmp(gameadd.quick_messages[idx],msgtext) != 0))
-    {
-        SCRPTWRNLOG("Quick Message no %d overwritten by different text", idx);
-    }
-    strncpy(gameadd.quick_messages[idx], msgtext, MESSAGE_TEXT_LEN-1);
-    gameadd.quick_messages[idx][MESSAGE_TEXT_LEN-1] = '\0';
-    command_add_value(Cmd_MESSAGEFX, 0, idx, nturns, 0);
-}
-
 void command_swap_creature(const char *ncrt_name, const char *crtr_name)
 {
     long ncrt_id = get_rid(newcrtr_desc, ncrt_name);
@@ -3575,9 +3555,6 @@ void script_add_command(const struct CommandDesc *cmd_desc, const struct ScriptL
         break;
     case Cmd_MESSAGE:
         command_message(scline->tp[0],68);
-        break;
-    case Cmd_MESSAGEFX:
-        command_messagefx(scline->np[0],scline->tp[1], scline->np[2]);
         break;
     case Cmd_PLAY_MESSAGE:
         command_play_message(scline->np[0], scline->tp[1], scline->np[2]);
@@ -6290,11 +6267,6 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       message_add_fmt(val2, "%s", gameadd.quick_messages[val3]);
       break;
   }
- case Cmd_MESSAGEFX:
-  {
-      show_onscreen_msg(val3, "%s", gameadd.quick_messages[val2]);
-      break;
-  }
   case Cmd_SET_GAME_RULE:
       switch (val2)
       {
@@ -6642,7 +6614,6 @@ const struct CommandDesc command_desc[] = {
   {"IF_SLAB_OWNER",                     "NNP     ", Cmd_IF_SLAB_OWNER, NULL, NULL},
   {"IF_SLAB_TYPE",                      "NNS     ", Cmd_IF_SLAB_TYPE, NULL, NULL},
   {"PRINT",                             "NAA     ", Cmd_PRINTFX, NULL, NULL},
-  {"MESSAGE",                           "NAN     ", Cmd_MESSAGEFX, NULL, NULL},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2952,7 +2952,15 @@ void command_printfx(int idx, const char *msgtext, const char *range_id)
   }
   strncpy(gameadd.quick_messages[idx], msgtext, MESSAGE_TEXT_LEN-1);
   gameadd.quick_messages[idx][MESSAGE_TEXT_LEN-1] = '\0';
-  char id = get_rid(player_desc, range_id);
+  char id;
+  if (strcasecmp(range_id, "None") == 0)
+  {
+      id = 127;
+  }
+  else
+  {
+    id = get_rid(player_desc, range_id);
+  }
   if (id == -1)
   {
     id = get_rid(creature_desc, range_id);

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2955,19 +2955,15 @@ void command_printfx(int idx, const char *msgtext, const char *range_id)
   char id = get_rid(player_desc, range_id);
   if (id == -1)
   {
-    id = get_rid(cmpgn_human_player_options, range_id);
+    id = get_rid(creature_desc, range_id);
     if (id == -1)
     {
-        id = get_rid(creature_desc, range_id);
-        if (id == -1)
-        {
-            id = atoi(range_id);
-        }
-        else
-        {
-            id = (~id) + 1;
-        }   
-    }        
+        id = atoi(range_id);
+    }
+    else
+    {
+        id = (~id) + 1;
+    }           
   }
   command_add_value(Cmd_PRINTFX, 0, id, idx, 0);
 }

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2976,6 +2976,36 @@ void command_quick_message(int idx, const char *msgtext, const char *range_id)
   command_add_value(Cmd_QUICK_MESSAGE, 0, id, idx, 0);
 }
 
+void command_messagefx(int msg_num, const char *range_id)
+{
+    char id;
+    if (strcasecmp(range_id, "None") == 0)
+    {
+        id = 127;
+    }
+    else
+    {
+        id = get_rid(player_desc, range_id);
+    }
+    if (id == -1)
+    {
+        id = get_rid(cmpgn_human_player_options, range_id);
+        if (id == -1)
+        {
+            id = get_rid(creature_desc, range_id);
+            if (id == -1)
+            {
+                id = atoi(range_id);
+            }
+            else
+            {
+                id = (~id) + 1;
+            }   
+        }        
+    }
+    command_add_value(Cmd_MESSAGEFX, 0, id, msg_num, 0);
+}
+
 void command_swap_creature(const char *ncrt_name, const char *crtr_name)
 {
     long ncrt_id = get_rid(newcrtr_desc, ncrt_name);
@@ -3552,6 +3582,9 @@ void script_add_command(const struct CommandDesc *cmd_desc, const struct ScriptL
         break;
     case Cmd_QUICK_MESSAGE:
         command_quick_message(scline->np[0], scline->tp[1], scline->tp[2]);
+        break;
+    case Cmd_MESSAGEFX:
+        command_messagefx(scline->np[0], scline->tp[1]);
         break;
     case Cmd_MESSAGE:
         command_message(scline->tp[0],68);
@@ -6267,6 +6300,11 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       message_add_fmt(val2, "%s", gameadd.quick_messages[val3]);
       break;
   }
+  case Cmd_MESSAGEFX:
+  {
+        message_add_fmt(val2, "%s", get_string(val3));
+        break;        
+  }
   case Cmd_SET_GAME_RULE:
       switch (val2)
       {
@@ -6614,6 +6652,7 @@ const struct CommandDesc command_desc[] = {
   {"IF_SLAB_OWNER",                     "NNP     ", Cmd_IF_SLAB_OWNER, NULL, NULL},
   {"IF_SLAB_TYPE",                      "NNS     ", Cmd_IF_SLAB_TYPE, NULL, NULL},
   {"QUICK_MESSAGE",                     "NAA     ", Cmd_QUICK_MESSAGE, NULL, NULL},
+  {"MESSAGE",                           "NA      ", Cmd_MESSAGEFX, NULL, NULL},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -143,6 +143,8 @@ enum TbScriptCommands {
     Cmd_SET_BOX_TOOLTIP                   = 122,
     Cmd_SET_BOX_TOOLTIP_ID                = 123,
     Cmd_CREATE_EFFECTS_LINE               = 124,
+    Cmd_MESSAGEFX                         = 125,
+    Cmd_CREATE_TEXT                       = 126,
 };
 
 enum ScriptVariables {

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -468,6 +468,7 @@ void process_win_and_lose_conditions(PlayerNumber plyr_idx);
 void script_process_new_creatures(PlayerNumber plyr_idx, long crtr_breed, long location, long copies_num, long carried_gold, long crtr_level);
 void process_check_new_creature_partys(void);
 void process_check_new_tunneller_partys(void);
+char get_player_number_from_value(const char* txt);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -144,7 +144,7 @@ enum TbScriptCommands {
     Cmd_SET_BOX_TOOLTIP_ID                = 123,
     Cmd_CREATE_EFFECTS_LINE               = 124,
     Cmd_MESSAGEFX                         = 125,
-    Cmd_CREATE_TEXT                       = 126,
+    Cmd_PRINTFX                           = 126,
 };
 
 enum ScriptVariables {

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -143,7 +143,7 @@ enum TbScriptCommands {
     Cmd_SET_BOX_TOOLTIP                   = 122,
     Cmd_SET_BOX_TOOLTIP_ID                = 123,
     Cmd_CREATE_EFFECTS_LINE               = 124,
-    Cmd_MESSAGEFX                         = 125,
+    Cmd_DISPLAY_MESSAGE                   = 125,
     Cmd_QUICK_MESSAGE                     = 126,
 };
 

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -144,7 +144,7 @@ enum TbScriptCommands {
     Cmd_SET_BOX_TOOLTIP_ID                = 123,
     Cmd_CREATE_EFFECTS_LINE               = 124,
     Cmd_MESSAGEFX                         = 125,
-    Cmd_PRINTFX                           = 126,
+    Cmd_QUICK_MESSAGE                     = 126,
 };
 
 enum ScriptVariables {


### PR DESCRIPTION
Commands send a chat message from a specific creature/player. Also accepts 'None' to have no icon.

```
QUICK_MESSAGE([message_ID], "[message text]", [creature/playername])

DISPLAY_MESSAGE([string number], [creature/playername])
```

