### PR TITLE
Added thing creating and slab placement commands.

### DIFF
--- a/src/config_campaigns.h
+++ b/src/config_campaigns.h
@@ -154,6 +154,7 @@ extern struct CampaignsList mappacks_list;
 extern const struct NamedCommand cmpgn_map_commands[];
 extern const struct NamedCommand cmpgn_map_cmnds_options[];
 extern const struct NamedCommand cmpgn_map_cmnds_kind[];
+extern const struct NamedCommand cmpgn_human_player_options[];
 /******************************************************************************/
 TbBool load_campaign(const char *cmpgn_fname,struct GameCampaign *campgn,unsigned short flags, short fgroup);
 TbBool free_campaign(struct GameCampaign *campgn);

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -624,9 +624,20 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                     pckt = get_packet_direct(player->packet_num);
                     pos.x.stl.num = coord_subtile(((unsigned short)pckt->pos_x));
                     pos.y.stl.num = coord_subtile(((unsigned short)pckt->pos_y));
-                    PlayerNumber id = get_player_number_for_command(pr4str);
-                    thing = create_thing(&pos, tngclass, tngmodel, id, -1);
-                    return (!thing_is_invalid(thing));
+                    if (!subtile_coords_invalid(pos.x.stl.num, pos.y.stl.num))
+                    {
+                        pos.z.stl.num = get_floor_height(pos.x.stl.num, pos.y.stl.num);
+                        PlayerNumber id = get_player_number_for_command(pr4str);
+                        thing = create_thing(&pos, tngclass, tngmodel, id, -1);
+                        if (!thing_is_invalid(thing))
+                        {
+                            if (thing_in_wall_at(thing, &thing->mappos))
+                            {
+                                move_creature_to_nearest_valid_position(thing);
+                            }
+                            return true;
+                        }
+                    }
                 }
             }
         }

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -331,7 +331,6 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
     char * pr5str = (pr4str != NULL) ? cmd_strtok(pr4str + 1) : NULL;
     struct PlayerInfo* player;
     struct Thing* thing;
-    struct Dungeon* dungeon;
     struct Room* room;
     struct Packet* pckt;
     struct SlabMap *slb;
@@ -409,7 +408,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
             return true;
         } else if (strcasecmp(parstr, "reveal") == 0)
         {
-            struct PlayerInfo* player = get_my_player();
+            player = get_my_player();
             reveal_whole_map(player);
             return true;
         } else if (strcasecmp(parstr, "comp.kill") == 0)
@@ -419,11 +418,10 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
             int id = atoi(pr2str);
             if (id < 0 || id > PLAYERS_COUNT)
                 return false;
-            struct Thing* thing = get_player_soul_container(id);
+            thing = get_player_soul_container(id);
             thing->health = 0;
         } else if (strcasecmp(parstr, "comp.me") == 0)
         {
-            struct PlayerInfo* player = get_player(plyr_idx);
             if (pr2str == NULL)
                 return false;
             if (!setup_a_computer_player(plyr_idx, atoi(pr2str))) {

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -496,8 +496,13 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 pos.y.stl.num = coord_subtile(((unsigned short)pckt->pos_y));
                 if (!subtile_coords_invalid(pos.x.stl.num, pos.y.stl.num))
                 {
+                    long ObjModel = get_rid(object_desc, pr2str);
+                    if (ObjModel == -1)
+                    {
+                        ObjModel = atoi(pr2str);
+                    }
                     PlayerNumber id = get_player_number_for_command(pr3str);
-                    thing = create_object(&pos, atoi(pr2str), id, -1);
+                    thing = create_object(&pos, ObjModel, id, -1);
                     if (thing_is_object(thing))
                     {
                         if (thing_in_wall_at(thing, &thing->mappos))

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -567,7 +567,8 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
         {
             if ( (pr2str != NULL) && (pr3str != NULL) )
             {
-                short tngclass, tngmodel = -1;
+                short tngclass = -1;
+                short tngmodel = -1;
                 if (strcasecmp(pr2str, "object") == 0)
                 {
                     tngclass = TCls_Object;

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -567,7 +567,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
         {
             if ( (pr2str != NULL) && (pr3str != NULL) )
             {
-                short tngclass, tngmodel;
+                short tngclass, tngmodel = -1;
                 if (strcasecmp(pr2str, "object") == 0)
                 {
                     tngclass = TCls_Object;

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -609,10 +609,6 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                     {
                         tngclass = atoi(pr2str);
                     }
-                    if (parameter_is_number(pr3str))
-                    {
-                        tngmodel = atoi(pr3str);
-                    }
                 }
                 if (tngmodel < 0)
                 {

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -505,7 +505,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                             ObjModel = atoi(pr2str);
                         }
                     }
-                    if (ObjNumber >= 0)
+                    if (ObjModel >= 0)
                     {
                         PlayerNumber id = get_player_number_for_command(pr3str);
                         thing = create_object(&pos, ObjModel, id, -1);

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -24,6 +24,7 @@
 #include "bflib_sound.h"
 #include "config.h"
 #include "config_campaigns.h"
+#include "config_effects.h"
 #include "config_magic.h"
 #include "config_rules.h"
 #include "config_terrain.h"
@@ -566,15 +567,70 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
         {
             if ( (pr2str != NULL) && (pr3str != NULL) )
             {
-                player = get_player(plyr_idx);
-                pckt = get_packet_direct(player->packet_num);
-                pos.x.stl.num = coord_subtile(((unsigned short)pckt->pos_x));
-                pos.y.stl.num = coord_subtile(((unsigned short)pckt->pos_y));
-                unsigned short tngclass = atoi(pr2str);
-                unsigned short tngmodel = atoi(pr3str);
-                PlayerNumber id = get_player_number_for_command(pr4str);
-                thing = create_thing(&pos, tngclass, tngmodel, id, -1);
-                return (!thing_is_invalid(thing));
+                short tngclass, tngmodel;
+                if (strcasecmp(pr2str, "object") == 0)
+                {
+                    tngclass = TCls_Object;
+                    tngmodel = get_rid(object_desc, pr3str);
+                }
+                else if (strcasecmp(pr2str, "corpse") == 0)
+                {
+                    tngclass = TCls_DeadCreature;
+                    tngmodel = get_creature_model_for_command(pr3str);
+                }
+                else if (strcasecmp(pr2str, "creature") == 0)
+                {
+                    tngclass = TCls_Creature;
+                    tngmodel = get_creature_model_for_command(pr3str);
+                }
+                else if (strcasecmp(pr2str, "trap") == 0)
+                {
+                    tngclass = TCls_Trap;
+                    tngmodel = get_trap_number_for_command(pr3str);
+                }
+                else if (strcasecmp(pr2str, "door") == 0)
+                {
+                    tngclass = TCls_Door;
+                    tngmodel = get_door_number_for_command(pr3str);
+                }
+                else if (strcasecmp(pr2str, "effect") == 0)
+                {
+                    tngclass = TCls_Effect;
+                    tngmodel = get_rid(effect_desc, pr3str);
+                }
+                else if (strcasecmp(pr2str, "shot") == 0)
+                {
+                    tngclass = TCls_Shot;
+                    tngmodel = get_rid(shot_desc, pr3str);
+                }
+                if (tngclass < 0)
+                {
+                    if (parameter_is_number(pr2str))
+                    {
+                        tngclass = atoi(pr2str);
+                    }
+                    if (parameter_is_number(pr3str))
+                    {
+                        tngmodel = atoi(pr3str);
+                    }
+                }
+                if (tngmodel < 0)
+                {
+                    if (parameter_is_number(pr2str))
+                    {
+                        tngmodel = atoi(pr2str);
+                    }
+                }
+                if ( (tngclass >= 0) && (tngmodel >= 0) )
+                {
+                    player = get_player(plyr_idx);
+                    pckt = get_packet_direct(player->packet_num);
+                    pos.x.stl.num = coord_subtile(((unsigned short)pckt->pos_x));
+                    pos.y.stl.num = coord_subtile(((unsigned short)pckt->pos_y));
+                    PlayerNumber id = get_player_number_for_command(pr4str);
+                    thing = create_thing(&pos, tngclass, tngmodel, id, -1);
+                    return (!thing_is_invalid(thing));
+                }
             }
         }
         else if ( (strcasecmp(parstr, "slab.place") == 0) || (strcasecmp(parstr, "place.slab") == 0) )
@@ -752,6 +808,58 @@ TbBool parameter_is_number(char* parstr)
         }
     }
     return true;
+}
+
+char get_trap_number_for_command(char* msg)
+{
+    char id = get_rid(trap_desc, msg);
+    if (id < 0)
+    {
+        if ( (strcasecmp(msg, "gas") == 0) || (strcasecmp(msg, "poison") == 0) || (strcasecmp(msg, "poisongas") == 0) )
+        {
+            id = 3;
+        }
+        else if ( (strcasecmp(msg, "word") == 0) || (strcasecmp(msg, "wordofpower") == 0) )
+        {
+            id = 5;
+        }
+        else
+        {
+            if (parameter_is_number(msg))
+            {
+                id = atoi(msg);
+            }
+        }
+    }
+    return id;
+}
+
+char get_door_number_for_command(char* msg)
+{
+    long id = get_rid(door_desc, msg);
+    if (id < 0)
+    {
+        if (strcasecmp(msg, "wooden") == 0)
+        {
+           id = 1;
+        }
+        else if (strcasecmp(msg, "iron") == 0)
+        {
+            id = 3;
+        }
+        else if (strcasecmp(msg, "magical") == 0)
+        {
+            id = 4;
+        }
+        else
+        {
+            if (parameter_is_number(msg))
+            {
+                id = atoi(msg);
+            }
+        }
+    }
+    return id;
 }
 
 #ifdef __cplusplus

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -583,7 +583,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 {
                     PlayerNumber id = (pr3str == NULL) ? slabmap_owner(slb) : get_player_number_for_command(pr3str);
                     short slbkind = get_rid(slab_desc, pr2str);
-                    if (slbkind <= 0)
+                    if (slbkind < 0)
                     {
                         long rid = get_rid(room_desc, pr2str);
                         if (rid > 0)
@@ -611,25 +611,30 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                             }
                             else
                             {
-                                slbkind = atoi(pr2str);
+                                if (parameter_is_number(pr2str))
+                                {
+                                    slbkind = atoi(pr2str);
+                                }
                             }
                         }
                     }
-                    if (subtile_is_room(stl_x, stl_y)) 
+                    if ( (slbkind >= 0) && (slbkind <= slab_conf.slab_types_count) )
                     {
-                        room = subtile_room_get(stl_x, stl_y);
-                        delete_room_slab(slb_x, slb_y, true);
+                        if (subtile_is_room(stl_x, stl_y)) 
+                        {
+                            delete_room_slab(slb_x, slb_y, true);
+                        }
+                        if (slab_kind_is_animated(slbkind))
+                        {
+                            place_animating_slab_type_on_map(slbkind, 0, stl_x, stl_y, id);  
+                        }
+                        else
+                        {
+                            place_slab_type_on_map(slbkind, stl_x, stl_y, id, 0);
+                        }
+                        do_slab_efficiency_alteration(slb_x, slb_y);
+                        return true;
                     }
-                    if (slab_kind_is_animated(slbkind))
-                    {
-                        place_animating_slab_type_on_map(slbkind, 0, stl_x, stl_y, id);  
-                    }
-                    else
-                    {
-                        place_slab_type_on_map(slbkind, stl_x, stl_y, id, 0);
-                    }
-                    do_slab_efficiency_alteration(slb_x, slb_y);
-                    return true;
                 }
             }
         }
@@ -726,6 +731,18 @@ PlayerNumber get_player_number_for_command(char *msg)
         }                            
     }
     return id;
+}
+
+TbBool parameter_is_number(char* parstr)
+{
+    for (int i = 0; parstr[i] != '\0'; i++)
+    {
+        if (!isdigit(parstr[i]))
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 #ifdef __cplusplus

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -457,7 +457,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
         {
             return script_set_pool(plyr_idx, pr2str, pr3str);
         }
-        else if (strcasecmp(parstr, "gold.create") == 0)
+        else if ( (strcasecmp(parstr, "gold.create") == 0) || (strcasecmp(parstr, "create.gold") == 0) )
         {
             if (pr2str != NULL)
             {
@@ -486,7 +486,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 }
             }           
         }
-        else if (strcasecmp(parstr, "object.create") == 0)
+        else if ( (strcasecmp(parstr, "object.create") == 0) || (strcasecmp(parstr, "create.object") == 0) )
         {
             if (pr2str != NULL)
             {
@@ -509,7 +509,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 }
             }
         }
-        else if (strcasecmp(parstr, "creature.create") == 0)
+        else if ( (strcasecmp(parstr, "creature.create") == 0) || (strcasecmp(parstr, "create.creature") == 0) )
         {
             if (pr2str != NULL)
             {
@@ -548,7 +548,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 }
             }
         }
-        else if (strcasecmp(parstr, "thing.create") == 0)
+        else if ( (strcasecmp(parstr, "thing.create") == 0) || (strcasecmp(parstr, "create.thing") == 0) )
         {
             if ( (pr2str != NULL) && (pr3str != NULL) )
             {
@@ -563,7 +563,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 return (!thing_is_invalid(thing));
             }
         }
-        else if (strcasecmp(parstr, "slab.place") == 0)
+        else if ( (strcasecmp(parstr, "slab.place") == 0) || (strcasecmp(parstr, "place.slab") == 0) )
         {
             if (pr2str != NULL)
             {

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -612,9 +612,9 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 }
                 if (tngmodel < 0)
                 {
-                    if (parameter_is_number(pr2str))
+                    if (parameter_is_number(pr3str))
                     {
-                        tngmodel = atoi(pr2str);
+                        tngmodel = atoi(pr3str);
                     }
                 }
                 if ( (tngclass >= 0) && (tngmodel >= 0) )

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -19,18 +19,48 @@
 #include "console_cmd.h"
 #include "globals.h"
 
+#include "actionpt.h"
 #include "bflib_datetm.h"
+#include "bflib_sound.h"
+#include "config.h"
+#include "config_campaigns.h"
+#include "config_magic.h"
+#include "config_rules.h"
+#include "config_terrain.h"
+#include "config_trapdoor.h"
+#include "creature_instances.h"
+#include "creature_jobs.h"
+#include "creature_states.h"
+#include "creature_states_hero.h"
 #include "dungeon_data.h"
 #include "frontend.h"
+#include "frontmenu_ingame_evnt.h"
 #include "frontmenu_ingame_tabs.h"
 #include "game_legacy.h"
 #include "game_merge.h"
 #include "gui_boxmenu.h"
 #include "gui_msgs.h"
+#include "gui_soundmsgs.h"
 #include "keeperfx.hpp"
+#include "map_blocks.h"
+#include "map_columns.h"
+#include "map_utils.h"
+#include "math.h"
+#include "music_player.h"
+#include "packets.h"
 #include "player_computer.h"
+#include "player_instances.h"
+#include "player_states.h"
+#include "player_utils.h"
+#include "room_data.h"
+#include "room_util.h"
 #include "slab_data.h"
-#include "creature_instances.h"
+#include "thing_factory.h"
+#include "thing_list.h"
+#include "thing_objects.h"
+#include "thing_navigate.h"
+#include "thing_physics.h"
+#include "version.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -293,33 +323,40 @@ static TbBool cmd_magic_instance(char* creature_str, const char*  slot_str, char
 TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
 {
     SYNCDBG(2,"Command %d: %s",(int)plyr_idx, msg);
-    const char * parstr = msg + 1;
-    const char * pr2str = cmd_strtok(msg + 1);
-    const char * pr3str = cmd_strtok((char*)pr2str);
-    const char * pr4str = cmd_strtok((char*)pr3str);
-
-    if (strcmp(parstr, "stats") == 0)
+    char * parstr = msg + 1;
+    char * pr2str = cmd_strtok(msg + 1);
+    char * pr3str = (pr2str != NULL) ? cmd_strtok(pr2str + 1) : NULL;
+    char * pr4str = (pr3str != NULL) ? cmd_strtok(pr3str + 1) : NULL;
+    char * pr5str = (pr4str != NULL) ? cmd_strtok(pr4str + 1) : NULL;
+    struct PlayerInfo* player;
+    struct Thing* thing;
+    struct Dungeon* dungeon;
+    struct Room* room;
+    struct Packet* pckt;
+    struct SlabMap *slb;
+    struct Coord3d pos;
+    if (strcasecmp(parstr, "stats") == 0)
     {
       message_add_fmt(plyr_idx, "Now time is %d, last loop time was %d",LbTimerClock(),last_loop_time);
       message_add_fmt(plyr_idx, "clock is %d, requested fps is %d",clock(),game.num_fps);
       return true;
-    } else if (strcmp(parstr, "quit") == 0)
+    } else if (strcasecmp(parstr, "quit") == 0)
     {
         quit_game = 1;
         exit_keeper = 1;
         return true;
-    } else if (strcmp(parstr, "turn") == 0)
+    } else if (strcasecmp(parstr, "turn") == 0)
     {
         message_add_fmt(plyr_idx, "turn %ld", game.play_gameturn);
         return true;
     } else if ((game.flags_font & FFlg_AlexCheat) != 0)
     {
-        if (strcmp(parstr, "compuchat") == 0)
+        if (strcasecmp(parstr, "compuchat") == 0)
         {
             if (pr2str == NULL)
                 return false;
 
-            if ((strcmp(pr2str,"scarce") == 0) || (strcmp(pr2str,"1") == 0))
+            if ((strcasecmp(pr2str,"scarce") == 0) || (strcasecmp(pr2str,"1") == 0))
             {
                 for (int i = 0; i < PLAYERS_COUNT; i++)
                 {
@@ -332,7 +369,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 }
                 gameadd.computer_chat_flags = CChat_TasksScarce;
             } else
-            if ((strcmp(pr2str,"frequent") == 0) || (strcmp(pr2str,"2") == 0))
+            if ((strcasecmp(pr2str,"frequent") == 0) || (strcasecmp(pr2str,"2") == 0))
             {
                 message_add_fmt(plyr_idx, "%s", pr2str);
                 gameadd.computer_chat_flags = CChat_TasksScarce|CChat_TasksFrequent;
@@ -342,7 +379,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 gameadd.computer_chat_flags = CChat_None;
             }
             return true;
-        } else if (strcmp(parstr, "comp.procs") == 0)
+        } else if (strcasecmp(parstr, "comp.procs") == 0)
         {
             if (pr2str == NULL)
                 return false;
@@ -351,7 +388,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 return false;
             cmd_comp_procs(id);
             return true;
-        } else if (strcmp(parstr, "comp.events") == 0)
+        } else if (strcasecmp(parstr, "comp.events") == 0)
         {
             if (pr2str == NULL)
                 return false;
@@ -360,7 +397,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 return false;
             cmd_comp_events(id);
             return true;
-        } else if (strcmp(parstr, "comp.checks") == 0)
+        } else if (strcasecmp(parstr, "comp.checks") == 0)
         {
             if (pr2str == NULL)
                 return false;
@@ -369,12 +406,12 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 return false;
             cmd_comp_checks(id);
             return true;
-        } else if (strcmp(parstr, "reveal") == 0)
+        } else if (strcasecmp(parstr, "reveal") == 0)
         {
             struct PlayerInfo* player = get_my_player();
             reveal_whole_map(player);
             return true;
-        } else if (strcmp(parstr, "comp.kill") == 0)
+        } else if (strcasecmp(parstr, "comp.kill") == 0)
         {
             if (pr2str == NULL)
                 return false;
@@ -383,7 +420,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 return false;
             struct Thing* thing = get_player_soul_container(id);
             thing->health = 0;
-        } else if (strcmp(parstr, "comp.me") == 0)
+        } else if (strcasecmp(parstr, "comp.me") == 0)
         {
             struct PlayerInfo* player = get_player(plyr_idx);
             if (pr2str == NULL)
@@ -393,10 +430,10 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
             } else
                 message_add_fmt(plyr_idx, "computer assistant is %d", atoi(pr2str));
             return true;
-        } else if (strcmp(parstr, "magic.instance") == 0)
+        } else if (strcasecmp(parstr, "magic.instance") == 0)
         {
             return cmd_magic_instance((char*)pr2str, pr3str, (char*)pr4str);
-        } else if (strcmp(parstr, "give.trap") == 0)
+        } else if (strcasecmp(parstr, "give.trap") == 0)
         {
             int id = atoi(pr2str);
             if (id <= 0 || id > trapdoor_conf.trap_types_count)
@@ -405,7 +442,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
             update_trap_tab_to_config();
             message_add(plyr_idx, "done!");
             return true;
-        } else if (strcmp(parstr, "give.door") == 0)
+        } else if (strcasecmp(parstr, "give.door") == 0)
         {
             int id = atoi(pr2str);
             if (id <= 0 || id > trapdoor_conf.door_types_count)
@@ -416,9 +453,180 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
             update_trap_tab_to_config();
             message_add(plyr_idx, "done!");
             return true;
-        } else if (strcmp(parstr, "map.pool") == 0)
+        } else if (strcasecmp(parstr, "map.pool") == 0)
         {
             return script_set_pool(plyr_idx, pr2str, pr3str);
+        }
+        else if (strcasecmp(parstr, "gold.create") == 0)
+        {
+            if (pr2str != NULL)
+            {
+                player = get_player(plyr_idx);
+                pckt = get_packet_direct(player->packet_num);
+                thing = create_gold_pot_at(pckt->pos_x, pckt->pos_y, plyr_idx);
+                if (!thing_is_invalid(thing))
+                {
+                    if (thing_in_wall_at(thing, &thing->mappos))
+                    {
+                        move_creature_to_nearest_valid_position(thing);
+                    }
+                    thing->valuable.gold_stored = atoi(pr2str);
+                    add_gold_to_pile(thing, 0);
+                    MapSubtlCoord stl_x = coord_subtile(((unsigned short)pckt->pos_x));
+                    MapSubtlCoord stl_y = coord_subtile(((unsigned short)pckt->pos_y));
+                    room = subtile_room_get(stl_x, stl_y);
+                    if (room_exists(room))
+                    {
+                        if (room->kind == RoK_TREASURE)
+                        {
+                            count_gold_hoardes_in_room(room);
+                        }
+                    }
+                    return true;
+                }
+            }           
+        }
+        else if (strcasecmp(parstr, "object.create") == 0)
+        {
+            if (pr2str != NULL)
+            {
+                player = get_player(plyr_idx);
+                pckt = get_packet_direct(player->packet_num);
+                pos.x.stl.num = coord_subtile(((unsigned short)pckt->pos_x));
+                pos.y.stl.num = coord_subtile(((unsigned short)pckt->pos_y));
+                if (!subtile_coords_invalid(pos.x.stl.num, pos.y.stl.num))
+                {
+                    PlayerNumber id = get_player_number_for_command(pr3str);
+                    thing = create_object(&pos, atoi(pr2str), id, -1);
+                    if (thing_is_object(thing))
+                    {
+                        if (thing_in_wall_at(thing, &thing->mappos))
+                        {
+                            move_creature_to_nearest_valid_position(thing);
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+        else if (strcasecmp(parstr, "creature.create") == 0)
+        {
+            if (pr2str != NULL)
+            {
+                long crmodel = get_creature_model_for_command(pr2str);
+                if (crmodel == -1)
+                {
+                    crmodel = atoi(pr2str);
+                }
+                if ( (crmodel > 0) && (crmodel <= 31) )
+                {
+                    player = get_player(plyr_idx);
+                    pckt = get_packet_direct(player->packet_num);
+                    MapSubtlCoord stl_x = coord_subtile(((unsigned short)pckt->pos_x));
+                    MapSubtlCoord stl_y = coord_subtile(((unsigned short)pckt->pos_y));
+                    PlayerNumber id = get_player_number_for_command(pr5str);
+                    if (!subtile_coords_invalid(stl_x, stl_y))
+                    {
+                        pos.x.stl.num = stl_x;
+                        pos.y.stl.num = stl_y;                 
+                        unsigned int count = (pr4str != NULL) ? atoi(pr4str) : 1;
+                        unsigned int i;
+                        for (i = 0; i < count; i++)
+                        {                            
+                            struct Thing* creatng = create_creature(&pos, crmodel, id);
+                            if (thing_is_creature(creatng))
+                            {
+                                if (thing_in_wall_at(creatng, &creatng->mappos))
+                                {
+                                    move_creature_to_nearest_valid_position(creatng);
+                                }
+                                set_creature_level(creatng, (atoi(pr3str) - (unsigned char)(pr3str != NULL)));
+                            }
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+        else if (strcasecmp(parstr, "thing.create") == 0)
+        {
+            if ( (pr2str != NULL) && (pr3str != NULL) )
+            {
+                player = get_player(plyr_idx);
+                pckt = get_packet_direct(player->packet_num);
+                pos.x.stl.num = coord_subtile(((unsigned short)pckt->pos_x));
+                pos.y.stl.num = coord_subtile(((unsigned short)pckt->pos_y));
+                unsigned short tngclass = atoi(pr2str);
+                unsigned short tngmodel = atoi(pr3str);
+                PlayerNumber id = get_player_number_for_command(pr4str);
+                thing = create_thing(&pos, tngclass, tngmodel, id, -1);
+                return (!thing_is_invalid(thing));
+            }
+        }
+        else if (strcasecmp(parstr, "slab.place") == 0)
+        {
+            if (pr2str != NULL)
+            {
+                player = get_player(plyr_idx);
+                pckt = get_packet_direct(player->packet_num);
+                MapSubtlCoord stl_x = coord_subtile(((unsigned short)pckt->pos_x));
+                MapSubtlCoord stl_y = coord_subtile(((unsigned short)pckt->pos_y));
+                MapSlabCoord slb_x = subtile_slab(stl_x);
+                MapSlabCoord slb_y = subtile_slab(stl_y);
+                slb = get_slabmap_block(slb_x, slb_y);
+                if (!slabmap_block_invalid(slb))
+                {
+                    PlayerNumber id = (pr3str == NULL) ? slabmap_owner(slb) : get_player_number_for_command(pr3str);
+                    short slbkind = get_rid(slab_desc, pr2str);
+                    if (slbkind <= 0)
+                    {
+                        long rid = get_rid(room_desc, pr2str);
+                        if (rid > 0)
+                        {
+                            struct RoomConfigStats *roomst = get_room_kind_stats(rid);
+                            slbkind = roomst->assigned_slab;
+                        }
+                        else
+                        {
+                            if (strcasecmp(pr2str, "Earth") == 0)
+                            {
+                                slbkind = rand() % (4 - 2) + 2;
+                            }
+                            else if ( (strcasecmp(pr2str, "Reinforced") == 0) || (strcasecmp(pr2str, "Fortified") == 0) )
+                            {
+                                slbkind = rand() % (9 - 4) + 4;
+                            }
+                            else if (strcasecmp(pr2str, "Claimed") == 0)
+                            {
+                                slbkind = SlbT_CLAIMED;
+                            }
+                            else if ( (strcasecmp(pr2str, "Rock") == 0) || (strcasecmp(pr2str, "Impenetrable") == 0) )
+                            {
+                                slbkind = SlbT_ROCK;
+                            }
+                            else
+                            {
+                                slbkind = atoi(pr2str);
+                            }
+                        }
+                    }
+                    if (subtile_is_room(stl_x, stl_y)) 
+                    {
+                        room = subtile_room_get(stl_x, stl_y);
+                        delete_room_slab(slb_x, slb_y, true);
+                    }
+                    if (slab_kind_is_animated(slbkind))
+                    {
+                        place_animating_slab_type_on_map(slbkind, 0, stl_x, stl_y, id);  
+                    }
+                    else
+                    {
+                        place_slab_type_on_map(slbkind, stl_x, stl_y, id, 0);
+                    }
+                    do_slab_efficiency_alteration(slb_x, slb_y);
+                    return true;
+                }
+            }
         }
     }
     return false;
@@ -446,6 +654,74 @@ static TbBool script_set_pool(PlayerNumber plyr_idx, const char *creature, const
   return true;
 }
 
+long get_creature_model_for_command(char *msg)
+{
+    long rid = get_rid(creature_desc, msg);
+    if (rid >= 1)
+    {
+        return rid;
+    }
+    else
+    {
+        if (strcasecmp(msg, "beetle") == 0)
+        {
+            return 24;
+        }
+        else if (strcasecmp(msg, "mistress") == 0)
+        {
+            return 20;
+        }
+        else if (strcasecmp(msg, "biledemon") == 0)
+        {
+            return 22;
+        }
+        else if (strcasecmp(msg, "hound") == 0)
+        {
+            return 27;
+        }
+        else if (strcasecmp(msg, "priestess") == 0)
+        {
+            return 9;
+        }
+        else if ( (strcasecmp(msg, "warlock") == 0) || (strcasecmp(msg, "sorcerer") == 0) )
+        {
+            return 21;
+        }
+        else if ( (strcasecmp(msg, "reaper") == 0) || (strcasecmp(msg, "hornedreaper") == 0) )
+        {
+            return 14;
+        }
+        else if ( (strcasecmp(msg, "dwarf") == 0) || (strcasecmp(msg, "mountaindwarf") == 0) )
+        {
+            return 5;
+        }
+        else if ( (strcasecmp(msg, "spirit") == 0) || (strcasecmp(msg, "floatingspirit") == 0) )
+        {
+            return 31;
+        }
+        else
+        {
+            return -1;
+        }    
+    }
+}
+
+PlayerNumber get_player_number_for_command(char *msg)
+{
+    PlayerNumber id = (msg == NULL) ? my_player_number : get_rid(cmpgn_human_player_options, msg);
+    if (id == -1)
+    {
+        if (strcasecmp(msg, "neutral") == 0)
+        {
+            id = game.neutral_player_num;
+        }
+        else
+        {
+            id = atoi(msg);
+        }                            
+    }
+    return id;
+}
 
 #ifdef __cplusplus
 }

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -459,7 +459,7 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
         }
         else if ( (strcasecmp(parstr, "gold.create") == 0) || (strcasecmp(parstr, "create.gold") == 0) )
         {
-            if (pr2str != NULL)
+            if ( (pr2str != NULL) && (parameter_is_number(pr2str)) )
             {
                 player = get_player(plyr_idx);
                 pckt = get_packet_direct(player->packet_num);
@@ -499,17 +499,23 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                     long ObjModel = get_rid(object_desc, pr2str);
                     if (ObjModel == -1)
                     {
-                        ObjModel = atoi(pr2str);
-                    }
-                    PlayerNumber id = get_player_number_for_command(pr3str);
-                    thing = create_object(&pos, ObjModel, id, -1);
-                    if (thing_is_object(thing))
-                    {
-                        if (thing_in_wall_at(thing, &thing->mappos))
+                        if (parameter_is_number(pr2str))
                         {
-                            move_creature_to_nearest_valid_position(thing);
+                            ObjModel = atoi(pr2str);
                         }
+                    }
+                    if (ObjNumber >= 0)
+                    {
+                        PlayerNumber id = get_player_number_for_command(pr3str);
+                        thing = create_object(&pos, ObjModel, id, -1);
+                        if (thing_is_object(thing))
+                        {
+                            if (thing_in_wall_at(thing, &thing->mappos))
+                            {
+                                move_creature_to_nearest_valid_position(thing);
+                            }
                         return true;
+                        }
                     }
                 }
             }
@@ -521,7 +527,10 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                 long crmodel = get_creature_model_for_command(pr2str);
                 if (crmodel == -1)
                 {
-                    crmodel = atoi(pr2str);
+                    if (parameter_is_number(pr2str))
+                    {
+                        crmodel = atoi(pr2str);
+                    }
                 }
                 if ( (crmodel > 0) && (crmodel <= 31) )
                 {

--- a/src/console_cmd.h
+++ b/src/console_cmd.h
@@ -27,6 +27,8 @@ extern "C" {
 #endif
 
 TbBool cmd_exec(PlayerNumber plyr_idx, char *msg);
+long get_creature_model_for_command(char *msg);
+PlayerNumber get_player_number_for_command(char *msg);
 
 #ifdef __cplusplus
 }

--- a/src/console_cmd.h
+++ b/src/console_cmd.h
@@ -29,6 +29,7 @@ extern "C" {
 TbBool cmd_exec(PlayerNumber plyr_idx, char *msg);
 long get_creature_model_for_command(char *msg);
 PlayerNumber get_player_number_for_command(char *msg);
+TbBool parameter_is_number(char* parstr);
 
 #ifdef __cplusplus
 }

--- a/src/console_cmd.h
+++ b/src/console_cmd.h
@@ -30,6 +30,8 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg);
 long get_creature_model_for_command(char *msg);
 PlayerNumber get_player_number_for_command(char *msg);
 TbBool parameter_is_number(char* parstr);
+char get_trap_number_for_command(char* msg);
+char get_door_number_for_command(char* msg);
 
 #ifdef __cplusplus
 }

--- a/src/packets.c
+++ b/src/packets.c
@@ -34,8 +34,8 @@
 #include "bflib_planar.h"
 
 #include "kjm_input.h"
+#include "front_input.h"
 #include "front_simple.h"
-#include "frontmenu_ingame_evnt.h"
 #include "front_landview.h"
 #include "front_network.h"
 #include "frontmenu_net.h"
@@ -84,7 +84,6 @@
 #include "net_sync.h"
 #include "game_legacy.h"
 #include "engine_redraw.h"
-#include "engine_render.h"
 #include "frontmenu_ingame_tabs.h"
 #include "vidfade.h"
 
@@ -397,8 +396,7 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
     struct Packet* pckt = get_packet_direct(player->packet_num);
-    unsigned char radius = 0;
-    TbBool even = false;
+    long keycode = 0;
     if ((pckt->control_flags & PCtr_MapCoordsValid) == 0)
     {
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->field_4AF != 0))
@@ -413,57 +411,13 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
     MapSubtlCoord stl_x = coord_subtile(x);
     MapSubtlCoord stl_y = coord_subtile(y);
     player->field_4A4 = 1;
-    MapSubtlCoord sellx;
-    MapSubtlCoord selly;
     if (is_my_player(player))
     {
-    if (is_key_pressed(KC_NUMPAD2, KMod_DONTCARE))
-    {
-        radius = 0;
-        even = true;
-    }
-    else if (is_key_pressed(KC_NUMPAD3, KMod_DONTCARE))
-    {
-        radius = 1;
-        even = false;
-    }
-    else if (is_key_pressed(KC_NUMPAD4, KMod_DONTCARE))
-    {
-        radius = 1;
-        even = true;
-    }
-    else if (is_key_pressed(KC_NUMPAD5, KMod_DONTCARE))
-    {
-        radius = 2;
-        even = false;
-    }
-    else if (is_key_pressed(KC_NUMPAD6, KMod_DONTCARE))
-    {
-        radius = 2;
-        even = true;
-    }
-    else if (is_key_pressed(KC_NUMPAD7, KMod_DONTCARE))
-    {
-        radius = 3;
-        even = false;
-    }
-    else if (is_key_pressed(KC_NUMPAD8, KMod_DONTCARE))
-    {
-        radius = 3;
-        even = true;
-    }
-    else if (is_key_pressed(KC_NUMPAD9, KMod_DONTCARE))
-    {
-        radius = 4;
-        even = false;
-    }
-    else
-    {
-        radius = 0;
-        even = false;
-    }
-      if (!game_is_busy_doing_gui())
-        tag_cursor_blocks_sell_area(player->id_number, stl_x, stl_y, player->field_4A4, (is_key_pressed(KC_LSHIFT, KMod_DONTCARE)), radius, even);
+        if (!game_is_busy_doing_gui())
+        {
+            get_dungeon_sell_user_roomspace(stl_x, stl_y);
+            tag_cursor_blocks_sell_area(player->id_number, stl_x, stl_y, player->field_4A4, (is_game_key_pressed(Gkey_SellTrapOnSubtile, &keycode, true)));
+        }
     }
     if ((pckt->control_flags & PCtr_LBtnClick) == 0)
     {
@@ -474,44 +428,52 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
       }
       return false;
     }
-    struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
-    if (slabmap_owner(slb) != plyr_idx)
+    if (!is_game_key_pressed(Gkey_SellTrapOnSubtile, &keycode, true))
     {
-        WARNLOG("Player %d can't sell item on %s owned by player %d at subtile (%d,%d).",(int)plyr_idx,slab_code_name(slb->kind),(int)slabmap_owner(slb),(int)stl_x,(int)stl_y);
-        unset_packet_control(pckt, PCtr_LBtnClick);
-        return false;
-    }
-    // Trying to sell room
-    int dist = radius * 3;
-    char evendist = even * 3;
-    if (!is_key_pressed(KC_LSHIFT, KMod_DONTCARE))
-    {
-        for (selly = stl_y - dist; selly <= stl_y + dist + evendist; selly += 3)
+        //Slab Mode
+        if (render_roomspace.slab_count > 1)
         {
-            for (sellx = stl_x - dist; sellx <= stl_x + dist + evendist; sellx += 3)
+            keeper_sell_roomspace(&render_roomspace);
+        }
+        else
+        {
+            struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
+            if (slabmap_owner(slb) != plyr_idx)
             {
-                if (subtile_is_sellable_room(plyr_idx, sellx, selly))
-                {
-                    player_sell_room_at_subtile(plyr_idx, sellx, selly);
-                } else
-                // Trying to sell door
-                if (player_sell_door_at_subtile(plyr_idx, sellx, selly))
-                {
-                // Nothing to do here - door already sold
-                } else
-                // Trying to sell trap
-                if (player_sell_trap_at_subtile(plyr_idx, sellx, selly))
-                {
-                // Nothing to do here - trap already sold
-                } else
-                {
-                    WARNLOG("Nothing to do for player %d request",(int)plyr_idx);
-                }
+                WARNLOG("Player %d can't sell item on %s owned by player %d at subtile (%d,%d).", (int)plyr_idx, slab_code_name(slb->kind), (int)slabmap_owner(slb), (int)stl_x, (int)stl_y);
+                unset_packet_control(pckt, PCtr_LBtnClick);
+                return false;
+            }
+            // Trying to sell room
+            if (subtile_is_sellable_room(plyr_idx, stl_x, stl_y))
+            {
+                player_sell_room_at_subtile(plyr_idx, stl_x, stl_y);
+            } else
+            // Trying to sell door
+            if (player_sell_door_at_subtile(plyr_idx, stl_x, stl_y))
+            {
+            // Nothing to do here - door already sold
+            } else
+            // Trying to sell trap
+            if (player_sell_trap_at_subtile(plyr_idx, stl_x, stl_y))
+            {
+            // Nothing to do here - trap already sold
+            } else
+            {
+                WARNLOG("Nothing to do for player %d request",(int)plyr_idx);
             }
         }
     }
     else
     {
+        struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
+        if (slabmap_owner(slb) != plyr_idx)
+        {
+            WARNLOG("Player %d can't sell item on %s owned by player %d at subtile (%d,%d).", (int)plyr_idx, slab_code_name(slb->kind), (int)slabmap_owner(slb), (int)stl_x, (int)stl_y);
+            unset_packet_control(pckt, PCtr_LBtnClick);
+            return false;
+        }
+        // Subtile Mode
         if (player_sell_trap_at_subtile(plyr_idx, stl_x, stl_y))
         {
             // Nothing to do here - trap already sold
@@ -609,15 +571,8 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     MapCoord y = ((unsigned short)pckt->pos_y);
     MapSubtlCoord stl_x = coord_subtile(x);
     MapSubtlCoord stl_y = coord_subtile(y);
-    MapSlabCoord slb_x = subtile_slab(stl_x);
-    MapSlabCoord slb_y = subtile_slab(stl_y);
-    int width = 1, height = 1;
-    int paintMode = 0;
-    int mode = -1;
-    if ((is_key_pressed(KC_LCONTROL, KMod_DONTCARE)) && ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld))
-    {
-        paintMode = 4;
-    }
+    int mode = box_placement_mode;
+    long keycode = 0;
     if ((pckt->control_flags & PCtr_MapCoordsValid) == 0)
     {
       if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->field_4AF != 0))
@@ -629,79 +584,22 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     }
     player->field_4A4 = 1;
     if (is_my_player(player))
+    {
         gui_room_type_highlighted = player->chosen_room_kind;
-    if (is_key_pressed(KC_NUMPAD1, KMod_DONTCARE))
-    {
-        mode = (0 | paintMode | 0);
     }
-    if (is_key_pressed(KC_NUMPAD2, KMod_DONTCARE))
-    {
-        //width = height = 2;
-        mode = (1 | paintMode | 0);
-    }
-    else if (is_key_pressed(KC_NUMPAD3, KMod_DONTCARE))
-    {
-        //width = height = 3;
-        mode = (2 | paintMode | 0);
-    }
-    else if (is_key_pressed(KC_NUMPAD4, KMod_DONTCARE))
-    {
-        //width = height = 4;
-        mode = (2 | paintMode | 8);
-    }
-    else if (is_key_pressed(KC_NUMPAD5, KMod_DONTCARE))
-    {
-        //width = height = 5;
-        //mode = (2 | paintMode | 8);
-    }
-    else if (is_key_pressed(KC_NUMPAD6, KMod_DONTCARE))
-    {
-        //width = height = 6;
-        //mode = (1 | paintMode | 0 | 16);
-    }
-    else if (is_key_pressed(KC_NUMPAD7, KMod_DONTCARE))
-    {
-        //width = height = 7;
-    }
-    else if (is_key_pressed(KC_NUMPAD8, KMod_DONTCARE))
-    {
-        //width = height = 8;
-    }
-    else if (is_key_pressed(KC_NUMPAD9, KMod_DONTCARE))
-    {
-        //width = height = 9;
-    }
-    else if (is_key_pressed(KC_LSHIFT, KMod_DONTCARE)) // Find biggest possible room (strict)
-    {
-        /*struct RoomStats* rstat = room_stats_get_for_kind(player->chosen_room_kind);
-        struct Dungeon* dungeon = get_players_dungeon(player);
-        find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned, 1 | paintMode | 0);*/
-        mode = (1 | paintMode | 0);
-    }
-    else if (is_key_pressed(KC_LALT, KMod_DONTCARE)) // Find biggest possible room (loose)
-    {
-        /*struct RoomStats* rstat = room_stats_get_for_kind(player->chosen_room_kind);
-        struct Dungeon* dungeon = get_players_dungeon(player);
-        find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned, 2 | paintMode | 8);*/
-        mode = (2 | paintMode | 8);
-    }
+    TbBool drag_check = ((is_game_key_pressed(Gkey_BestRoomSpace, &keycode, true) || is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true)) && ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld));
+    get_dungeon_build_user_roomspace(player->id_number, player->chosen_room_kind, stl_x, stl_y, &mode, drag_check);
+    long i = tag_cursor_blocks_place_room(player->id_number, stl_x, stl_y, player->field_4A4);
     
-    struct RoomStats* rstat = room_stats_get_for_kind(player->chosen_room_kind);
-    struct Dungeon* dungeon = get_players_dungeon(player);
-    if (mode != -1) find_biggest_room_dimensions(plyr_idx, player->chosen_room_kind, &slb_x, &slb_y, &width, &height, rstat->cost, dungeon->total_money_owned, mode);
-    
-    player->boxsize = can_build_room_of_dimensions(plyr_idx, player->chosen_room_kind, slb_x, slb_y, width, height, 0); //number of slabs to build, corrected for blocked tiles
-    long i = tag_cursor_blocks_place_room(player->id_number, (slb_x * 3), (slb_y * 3), player->field_4A4, width, height);
-    
-    if (paintMode == 0)
+    if (mode != drag_placement_mode) // allows the user to hold the left mouse to use "paint mode"
     {
         if ((pckt->control_flags & PCtr_LBtnClick) == 0)
         {
-        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->field_4AF != 0))
-        {
-            player->field_4AF = 0;
-            unset_packet_control(pckt, PCtr_LBtnRelease);
-        }
+            if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->field_4AF != 0))
+            {
+                player->field_4AF = 0;
+                unset_packet_control(pckt, PCtr_LBtnRelease);
+            }
             return false;
         }
     }
@@ -721,17 +619,9 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
       }
       return false;
     }
-    MapSlabCoord buildx;
-    MapSlabCoord buildy;
     if (player->boxsize > 0)
     {
-        for (buildy = slb_y - calc_distance_from_centre(height,0); buildy <= slb_y + calc_distance_from_centre(height,(height % 2 == 0)); buildy++)
-        {
-            for (buildx = slb_x - calc_distance_from_centre(width,0); buildx <= slb_x + calc_distance_from_centre(width,(width % 2 == 0)); buildx++)
-            {
-                keeper_build_room((buildx * 3), (buildy * 3), plyr_idx, player->chosen_room_kind);
-            }
-        }
+        keeper_build_roomspace(&render_roomspace);
     }
     else
     {
@@ -940,37 +830,33 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
             }
             unset_packet_control(pckt, PCtr_LBtnRelease);
         } else
-        //if ((player->thing_under_hand != 0) && (player->input_crtr_query != 0)
-          // && (dungeon->things_in_hand[0] != player->thing_under_hand)
-          // && can_thing_be_queried(thing, plyr_idx) )
-          if (player->input_crtr_query != 0)
+        if (player->input_crtr_query != 0)
         {
-        thing = get_creature_near(x, y);
-        if (!can_thing_be_queried(thing, plyr_idx))
-        {
-            player->thing_under_hand = 0;
-        }
-        else
-        {
-            player->thing_under_hand = thing->index;
-        }
-        if (player->thing_under_hand > 0)
-        {
-          if (player->thing_under_hand != player->controlled_thing_idx)
+          thing = get_creature_near(x, y);
+          if (!can_thing_be_queried(thing, plyr_idx))
           {
-            if (is_my_player(player))
-            {
-              turn_off_all_panel_menus();
-              turn_on_menu(GMnu_CREATURE_QUERY1);
-            }
-            player->influenced_thing_idx = player->thing_under_hand;
-            set_player_state(player, PSt_CreatrQuery, 0);
-            set_player_instance(player, PI_QueryCrtr, 0);
+              player->thing_under_hand = 0;
           }
-          unset_packet_control(pckt, PCtr_LBtnRelease);
-        }
-        }
-            else
+          else
+          {
+              player->thing_under_hand = thing->index;
+          }
+          if (player->thing_under_hand > 0)
+          {
+            if (player->thing_under_hand != player->controlled_thing_idx)
+            {
+              if (is_my_player(player))
+              {
+                turn_off_all_panel_menus();
+                turn_on_menu(GMnu_CREATURE_QUERY1);
+              }
+              player->influenced_thing_idx = player->thing_under_hand;
+              set_player_state(player, PSt_CreatrQuery, 0);
+              set_player_instance(player, PI_QueryCrtr, 0);
+            }
+            unset_packet_control(pckt, PCtr_LBtnRelease);
+          }
+        } else
         if (player->field_455 == player->field_454)
         {
           if (player->field_454 == P454_Unkn1)
@@ -1047,7 +933,6 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     } else
     if ((pckt->control_flags & PCtr_RBtnRelease) == 0)
     {
-      map_volume_box.field_17 = 1;
       player->boxsize = 1;
       player->field_4D6 = 0;
     }
@@ -1060,7 +945,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     short influence_own_creatures = false;
     struct SlabMap *slb;
     long i;
-    struct Room* room = NULL;
+    struct Room* room;
     MapSlabCoord slb_x = subtile_slab_fast(stl_x);
     MapSlabCoord slb_y = subtile_slab_fast(stl_y);
     switch (player->work_state)
@@ -1089,22 +974,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     case PSt_MkGoldPot:
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
         {
-            thing = create_gold_pot_at(x, y, player->id_number);
-            if (!thing_is_invalid(thing))
-            {
-                if (thing_in_wall_at(thing, &thing->mappos))
-                {
-                    move_creature_to_nearest_valid_position(thing);
-                }
-                room = subtile_room_get(stl_x, stl_y);
-                if (room_exists(room))
-                {
-                    if (room->kind == RoK_TREASURE)
-                    {
-                        count_gold_hoardes_in_room(room);
-                    }
-                }
-            }
+            create_gold_pot_at(x, y, player->id_number);
             unset_packet_control(pckt, PCtr_LBtnRelease);
         }
         break;
@@ -1192,28 +1062,10 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
         break;
     case PSt_CreatrQuery:
     case PSt_CreatrInfo:
-    case PSt_CreatrInfoAll:
     case PSt_CreatrQueryAll:
         influence_own_creatures = 1;
         thing = get_creature_near(x, y);
-        TbBool CanQuery = false;
-        TbBool All = ( (player->work_state == PSt_CreatrQueryAll) || (player->work_state == PSt_CreatrInfoAll) );
-        if (thing_is_creature(thing))
-        {
-            CanQuery = (All) ? true : (can_thing_be_queried(thing, plyr_idx));
-        }
-        else
-        {
-            if (All)
-            {
-                thing = get_nearest_thing_at_position(stl_x, stl_y);
-                CanQuery = (!thing_is_invalid(thing));
-                if (!CanQuery)
-                {
-                    room = subtile_room_get(stl_x, stl_y);
-                }
-            }
-        }
+        TbBool CanQuery = (player->work_state == PSt_CreatrQueryAll) ? (thing_is_creature(thing)) : (can_thing_be_queried(thing, plyr_idx));
         if (!CanQuery)
         {
             player->thing_under_hand = 0;
@@ -1226,32 +1078,21 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
         {
           if (player->thing_under_hand > 0)
           {
-            if (thing->class_id == TCls_Creature)
+            if (player->controlled_thing_idx != player->thing_under_hand)
             {
-                if (player->controlled_thing_idx != player->thing_under_hand)
-                {
-                    if (is_my_player(player))
-                    {
-                        turn_off_all_panel_menus();
-                        initialise_tab_tags_and_menu(GMnu_CREATURE_QUERY1);
-                        turn_on_menu(GMnu_CREATURE_QUERY1);
-                    }
-                    player->influenced_thing_idx = player->thing_under_hand;
-                    set_player_instance(player, PI_QueryCrtr, 0);
-                }
-            }
-            else
-            {
-                query_thing(thing);
+              if (is_my_player(player))
+              {
+                turn_off_all_panel_menus();
+                initialise_tab_tags_and_menu(GMnu_CREATURE_QUERY1);
+                turn_on_menu(GMnu_CREATURE_QUERY1);
+              }
+              player->influenced_thing_idx = player->thing_under_hand;
+              set_player_instance(player, PI_QueryCrtr, 0);
             }
             unset_packet_control(pckt, PCtr_LBtnRelease);
           }
-          else if ( (All) && (room_exists(room)) )
-          {
-             query_room(room);
-          }
         }
-        if ( (player->work_state == PSt_CreatrInfo) || (player->work_state == PSt_CreatrInfoAll) )
+        if (player->work_state == PSt_CreatrInfo)
         {
           thing = thing_get(player->controlled_thing_idx);
           if ((pckt->control_flags & PCtr_RBtnRelease) != 0)
@@ -1284,13 +1125,6 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             player->thing_under_hand = thing->index;
         if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
         {
-          if (player->thing_under_hand > 0)
-          {
-            if (player->controlled_thing_idx != player->thing_under_hand)
-            {
-                player->influenced_thing_idx = player->thing_under_hand;
-            }
-          }
           if ((player->controlled_thing_idx > 0) && (player->controlled_thing_idx < THINGS_COUNT))
           {
             if ((pckt->control_flags & PCtr_MapCoordsValid) != 0)
@@ -1580,14 +1414,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
                             pos.x.val = subtile_coord_center(slab_subtile_center(subtile_slab(stl_x)));
                             pos.y.val = subtile_coord_center(slab_subtile_center(subtile_slab(stl_y))); 
                             pos.z.val = subtile_coord_center(1);
-                            if (i == game.hero_player_num)
-                            {
-                                play_non_3d_sample(944);    
-                            }
-                            else
-                            {
-                                play_non_3d_sample(76);
-                            }
+                            play_non_3d_sample(76);
                             create_effect(&pos, imp_spangle_effects[i], i);
                         }
                         else
@@ -1627,7 +1454,6 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
         }
         break;
     case PSt_LevelCreatureUp:
-    case PSt_LevelCreatureDown:
         thing = get_creature_near(x, y);
         if (!thing_is_creature(thing))
         {
@@ -1641,23 +1467,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
         {
              if (player->thing_under_hand > 0)
              {
-                switch (player->work_state)
-                {
-                    case PSt_LevelCreatureUp:
-                    {
-                        creature_increase_level(thing);
-                        break;
-                    }
-                    case PSt_LevelCreatureDown:
-                    {
-                        struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-                        if (!creature_control_invalid(cctrl))
-                        {
-                            set_creature_level(thing, cctrl->explevel-1);
-                        }
-                        break;
-                    }
-                }
+                creature_increase_level(thing);
              }
         unset_packet_control(pckt, PCtr_LBtnRelease);    
         }
@@ -1670,7 +1480,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
               thing = get_player_soul_container(PlayerToKill->id_number);
               if (thing_is_dungeon_heart(thing))
               {
-                    thing->health = 0;
+                    thing->health = -1;
               }
           }
         break;
@@ -1878,68 +1688,6 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             }
         }
         unset_packet_control(pckt, PCtr_LBtnRelease);
-        break;
-    case PSt_DestroyThing:
-        thing = get_nearest_thing_at_position(stl_x, stl_y);
-        if (thing_is_invalid(thing))
-        {
-            player->thing_under_hand = 0;
-        }
-        else
-        {
-            player->thing_under_hand = thing->index;
-        }
-        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
-        {
-            if (player->thing_under_hand > 0)
-            {
-                struct Room* room = get_room_thing_is_on(thing);
-                TbBool IsRoom = (!room_is_invalid(room));
-                switch(thing->class_id)
-                {
-                    case TCls_Door:
-                    {
-                        destroy_door(thing);
-                        break;                    
-                    }
-                    case TCls_Effect:
-                    {
-                        destroy_effect_thing(thing);
-                        break;
-                    }
-                    default:
-                    {
-                        if (thing_is_spellbook(thing))
-                        {
-                            if (!is_neutral_thing(thing)) 
-                            {
-                                remove_power_from_player(book_thing_to_power_kind(thing), thing->owner);
-                            }
-                        }
-                        else if (thing_is_workshop_crate(thing))
-                        {
-                            if (!is_neutral_thing(thing)) 
-                            {
-                                ThingClass tngclass = crate_thing_to_workshop_item_class(thing);
-                                ThingModel tngmodel = crate_thing_to_workshop_item_model(thing);
-                                if (IsRoom)
-                                {
-                                    remove_workshop_item_from_amount_stored(thing->owner, tngclass, tngmodel, WrkCrtF_NoOffmap);
-                                }
-                                remove_workshop_item_from_amount_placeable(thing->owner, tngclass, tngmodel);                                
-                            }
-                        }
-                        destroy_object(thing);
-                        break;
-                    }
-                }
-                if (IsRoom)
-                {
-                    update_room_contents(room);
-                }
-            }
-            unset_packet_control(pckt, PCtr_LBtnRelease);    
-        }
         break;
     default:
         ERRORLOG("Unrecognized player %d work state: %d", (int)plyr_idx, (int)player->work_state);
@@ -2401,14 +2149,6 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
   case PckA_Unknown004:
       return 1;
   case PckA_FinishGame:
-  /*
-        if ( (timer_enabled()) && (player->victory_state == VicS_WonLevel) )
-        {
-          char msg[10];
-          sprintf(msg, "%ld", game.play_gameturn);
-          create_message_box(msg);
-        }
-        */
       if (is_my_player(player))
       {
         turn_off_all_menus();
@@ -2422,14 +2162,6 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       switch (player->victory_state)
       {
       case VicS_WonLevel:
-      /*
-        if ( timer_enabled() )
-        {
-          char msg[10];
-          sprintf(msg, "%ld", game.play_gameturn);
-          create_message_box(msg);
-        }
-        */
           complete_level(player);
           break;
       case VicS_LostLevel:
@@ -2453,14 +2185,10 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       if (player->mp_message_text[0] == '!')
       {
           if (!cmd_exec(player->id_number, player->mp_message_text))
-          {
               message_add(player->id_number, player->mp_message_text);
-          }
       }
       else if (player->mp_message_text[0] != '\0')
-      {
           message_add(player->id_number, player->mp_message_text);
-      }
       LbMemorySet(player->mp_message_text, 0, PLAYER_MP_MESSAGE_LEN);
       return 0;
   case PckA_PlyrMsgClear:

--- a/src/packets.c
+++ b/src/packets.c
@@ -2007,10 +2007,10 @@ TbBool message_text_key_add(char * message, long maxlen, TbKeyCode key, TbKeyMod
     if (((chr >= 'a') && (chr <= 'z')) ||
         ((chr >= 'A') && (chr <= 'Z')) ||
         ((chr >= '0') && (chr <= '9')) ||
-        (chr == ' ')  || (chr == '!') || (chr == ':') || (chr == ';') ||
-        (chr == '(') || (chr == ')') || (chr == '.') || (chr == '_') 
-        || (chr == "'") || (chr == '+') || (chr == '=') || (chr == '-')
-        || (chr == '"') || (chr == '?') || (chr == '/') || (chr == '#')
+        (chr == ' ')  || (chr == '!') || (chr == ':') || (chr == ';')
+        || (chr == '(') || (chr == ')') || (chr == '.') || (chr == '_') 
+        || (chr == '+') || (chr == '=') || (chr == '-')
+        || (chr == '?') || (chr == '/') || (chr == '#')
         || (chr == '<') || (chr == '>') || (chr == '^'))
     {
         if (chpos < maxlen)

--- a/src/packets.c
+++ b/src/packets.c
@@ -2008,7 +2008,10 @@ TbBool message_text_key_add(char * message, long maxlen, TbKeyCode key, TbKeyMod
         ((chr >= 'A') && (chr <= 'Z')) ||
         ((chr >= '0') && (chr <= '9')) ||
         (chr == ' ')  || (chr == '!') || (chr == ':') || (chr == ';') ||
-        (chr == '(') || (chr == ')') || (chr == '.'))
+        (chr == '(') || (chr == ')') || (chr == '.') || (chr == '_') 
+        || (chr == "'") || (chr == '+') || (chr == '=') || (chr == '-')
+        || (chr == '"') || (chr == '?') || (chr == '/') || (chr == '#')
+        || (chr == '<') || (chr == '>') || (chr == '^'))
     {
         if (chpos < maxlen)
         {

--- a/src/packets.c
+++ b/src/packets.c
@@ -2009,8 +2009,8 @@ TbBool message_text_key_add(char * message, long maxlen, TbKeyCode key, TbKeyMod
         ((chr >= '0') && (chr <= '9')) ||
         (chr == ' ')  || (chr == '!') || (chr == ':') || (chr == ';')
         || (chr == '(') || (chr == ')') || (chr == '.') || (chr == '_') 
-        || (chr == '+') || (chr == '=') || (chr == '-')
-        || (chr == '?') || (chr == '/') || (chr == '#')
+        || (chr == '\'') || (chr == '+') || (chr == '=') || (chr == '-')
+        || (chr == '"') || (chr == '?') || (chr == '/') || (chr == '#')
         || (chr == '<') || (chr == '>') || (chr == '^'))
     {
         if (chpos < maxlen)

--- a/src/room_data.h
+++ b/src/room_data.h
@@ -261,6 +261,8 @@ TbBool clear_dig_on_room_slabs(struct Room *room, PlayerNumber plyr_idx);
 void do_room_integration(struct Room *room);
 void destroy_dungeon_heart_room(PlayerNumber plyr_idx, const struct Thing *heartng);
 
+void count_gold_hoardes_in_room(struct Room *room);
+
 /* MOVE TO room_list.c/h */
 struct Room *find_nearest_room_for_thing_with_spare_item_capacity(struct Thing *thing, PlayerNumber plyr_idx, RoomKind rkind, unsigned char nav_flags);
 struct Room *find_random_room_for_thing(struct Thing *thing, PlayerNumber owner, RoomKind rkind, unsigned char nav_flags);

--- a/src/thing_factory.c
+++ b/src/thing_factory.c
@@ -111,7 +111,7 @@ struct Thing *create_thing(struct Coord3d *pos, unsigned short tngclass, unsigne
         thing = create_cave_in(pos, tngmodel, owner);
         break;
     case TCls_Door:
-        thing = create_door(pos, tngmodel, find_door_angle(pos->x.stl.num, pos->y.stl.num, owner), owner, 0);
+        thing = create_door(pos, tngmodel, find_door_angle(pos->x.stl.num, pos->y.stl.num, owner), owner, false);
         break;
     default:
         break;

--- a/src/thing_factory.c
+++ b/src/thing_factory.c
@@ -22,6 +22,7 @@
 #include "bflib_basics.h"
 
 #include "thing_data.h"
+#include "thing_doors.h"
 #include "thing_list.h"
 #include "thing_stats.h"
 #include "thing_effects.h"
@@ -108,6 +109,9 @@ struct Thing *create_thing(struct Coord3d *pos, unsigned short tngclass, unsigne
     case TCls_CaveIn:
         // for cave in, model is really a level
         thing = create_cave_in(pos, tngmodel, owner);
+        break;
+    case TCls_Door:
+        thing = create_door(pos, tngmodel, find_door_angle(pos->x.stl.num, pos->y.stl.num, owner), owner, 0);
         break;
     default:
         break;


### PR DESCRIPTION
This pull  has !thing.create, !object.create, !creature.create, !gold.create, and !slab.place. Object, gold, and slab takes only the type/amount as parameters. !create.thing takes 2 numbers, the [class](https://github.com/dkfans/keeperfx/blob/a07769e091ff842c93577baf9add33eebff8f5df/src/thing_list.h#L35) and model (I think in that order), and creature takes the creature, level, amount, and owner, the latter two of which are optional.

You can place any terrain, and create any thing, or specifically objects or creatures.