### PR TITLE
Fixed flying units falling really slow when dropped

### DIFF
--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -770,7 +770,7 @@ void drop_gold_coins(const struct Coord3d *pos, long value, long plyr_idx)
             break;
         if (i > 0)
         {
-            thing->fall_speed += ACTION_RANDOM(thing->fall_speed) - thing->fall_speed / 2;
+            thing->fall_acceleration += ACTION_RANDOM(thing->fall_acceleration) - thing->fall_acceleration / 2;
             thing->valuable.gold_stored = 0;
         } else
         {

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -770,7 +770,7 @@ void drop_gold_coins(const struct Coord3d *pos, long value, long plyr_idx)
             break;
         if (i > 0)
         {
-            thing->field_20 += ACTION_RANDOM(thing->field_20) - thing->field_20 / 2;
+            thing->fall_speed += ACTION_RANDOM(thing->fall_speed) - thing->fall_speed / 2;
             thing->valuable.gold_stored = 0;
         } else
         {

--- a/src/thing_corpses.c
+++ b/src/thing_corpses.c
@@ -398,7 +398,7 @@ struct Thing *create_dead_creature(const struct Coord3d *pos, ThingModel model, 
     thing->clipbox_size_yz = 0;
     thing->solid_size_xy = 0;
     thing->solid_size_yz = 0;
-    thing->field_20 = 16;
+    thing->fall_speed = 16;
     thing->field_23 = 204;
     thing->field_24 = 51;
     thing->field_22 = 0;

--- a/src/thing_corpses.c
+++ b/src/thing_corpses.c
@@ -398,7 +398,7 @@ struct Thing *create_dead_creature(const struct Coord3d *pos, ThingModel model, 
     thing->clipbox_size_yz = 0;
     thing->solid_size_xy = 0;
     thing->solid_size_yz = 0;
-    thing->fall_speed = 16;
+    thing->fall_acceleration = 16;
     thing->field_23 = 204;
     thing->field_24 = 51;
     thing->field_22 = 0;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3477,7 +3477,7 @@ struct Thing *create_creature(struct Coord3d *pos, ThingModel model, PlayerNumbe
     crtng->clipbox_size_yz = crstat->size_yz;
     crtng->solid_size_xy = crstat->thing_size_xy;
     crtng->solid_size_yz = crstat->thing_size_yz;
-    crtng->field_20 = 32;
+    crtng->fall_speed = 32;
     crtng->field_22 = 0;
     crtng->field_23 = 32;
     crtng->field_24 = 8;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3477,7 +3477,7 @@ struct Thing *create_creature(struct Coord3d *pos, ThingModel model, PlayerNumbe
     crtng->clipbox_size_yz = crstat->size_yz;
     crtng->solid_size_xy = crstat->thing_size_xy;
     crtng->solid_size_yz = crstat->thing_size_yz;
-    crtng->fall_speed = 32;
+    crtng->fall_acceleration = 32;
     crtng->field_22 = 0;
     crtng->field_23 = 32;
     crtng->field_24 = 8;

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -195,7 +195,7 @@ struct Thing {
      */
     short parent_idx;
     unsigned char class_id;
-    unsigned char field_20;
+    unsigned char fall_speed;
 unsigned char field_21;
 unsigned char field_22;
     unsigned char field_23;

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -195,7 +195,7 @@ struct Thing {
      */
     short parent_idx;
     unsigned char class_id;
-    unsigned char fall_speed;
+    unsigned char fall_acceleration;
 unsigned char field_21;
 unsigned char field_22;
     unsigned char field_23;

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -554,7 +554,7 @@ struct Thing *create_effect_element(const struct Coord3d *pos, unsigned short ee
         set_flag_byte(&thing->field_4F,TF4F_Unknown01,true);
     }
 
-    thing->fall_speed = eestat->field_18;
+    thing->fall_acceleration = eestat->field_18;
     thing->field_23 = eestat->field_1A;
     thing->field_24 = eestat->field_1C;
     thing->movement_flags |= TMvF_Unknown08;
@@ -826,7 +826,7 @@ void change_effect_element_into_another(struct Thing *thing, long nmodel)
     set_thing_draw(thing, eestat->sprite_idx, speed, scale, eestat->field_D, 0, 2);
     thing->field_4F ^= (thing->field_4F ^ 0x02 * eestat->field_13) & TF4F_Unknown02;
     thing->field_4F ^= (thing->field_4F ^ 0x10 * eestat->field_14) & (TF4F_Transpar_Flags);
-    thing->fall_speed = eestat->field_18;
+    thing->fall_acceleration = eestat->field_18;
     thing->field_23 = eestat->field_1A;
     thing->field_24 = eestat->field_1C;
     if (eestat->numfield_3 <= 0) {
@@ -1203,7 +1203,7 @@ struct Thing *create_effect(const struct Coord3d *pos, ThingModel effmodel, Play
     thing->next_on_mapblk = 0;
     thing->owner = owner;
     thing->parent_idx = thing->index;
-    thing->fall_speed = 0;
+    thing->fall_acceleration = 0;
     thing->field_23 = 0;
     thing->field_24 = 0;
     thing->field_4F |= TF4F_Unknown01;

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -554,7 +554,7 @@ struct Thing *create_effect_element(const struct Coord3d *pos, unsigned short ee
         set_flag_byte(&thing->field_4F,TF4F_Unknown01,true);
     }
 
-    thing->field_20 = eestat->field_18;
+    thing->fall_speed = eestat->field_18;
     thing->field_23 = eestat->field_1A;
     thing->field_24 = eestat->field_1C;
     thing->movement_flags |= TMvF_Unknown08;
@@ -826,7 +826,7 @@ void change_effect_element_into_another(struct Thing *thing, long nmodel)
     set_thing_draw(thing, eestat->sprite_idx, speed, scale, eestat->field_D, 0, 2);
     thing->field_4F ^= (thing->field_4F ^ 0x02 * eestat->field_13) & TF4F_Unknown02;
     thing->field_4F ^= (thing->field_4F ^ 0x10 * eestat->field_14) & (TF4F_Transpar_Flags);
-    thing->field_20 = eestat->field_18;
+    thing->fall_speed = eestat->field_18;
     thing->field_23 = eestat->field_1A;
     thing->field_24 = eestat->field_1C;
     if (eestat->numfield_3 <= 0) {
@@ -1203,7 +1203,7 @@ struct Thing *create_effect(const struct Coord3d *pos, ThingModel effmodel, Play
     thing->next_on_mapblk = 0;
     thing->owner = owner;
     thing->parent_idx = thing->index;
-    thing->field_20 = 0;
+    thing->fall_speed = 0;
     thing->field_23 = 0;
     thing->field_24 = 0;
     thing->field_4F |= TF4F_Unknown01;

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2738,7 +2738,7 @@ TbBool update_thing(struct Thing *thing)
                 thing->veloc_base.y.val = thing->veloc_base.y.val * (256 - (int)thing->field_24) / 256;
             if ((thing->movement_flags & TMvF_Flying) == 0)
             {
-                thing->veloc_push_add.z.val -= thing->fall_speed;
+                thing->veloc_push_add.z.val -= thing->fall_acceleration;
                 thing->state_flags |= TF1_PushAdd;
             } else
             {
@@ -2751,7 +2751,7 @@ TbBool update_thing(struct Thing *thing)
                 {
                     if (thing_above_flight_altitude(thing))
                     {
-                        thing->veloc_push_add.z.val -= thing->fall_speed;
+                        thing->veloc_push_add.z.val -= thing->fall_acceleration;
                         thing->state_flags |= TF1_PushAdd;
                     }
                 }

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2738,13 +2738,23 @@ TbBool update_thing(struct Thing *thing)
                 thing->veloc_base.y.val = thing->veloc_base.y.val * (256 - (int)thing->field_24) / 256;
             if ((thing->movement_flags & TMvF_Flying) == 0)
             {
-                thing->veloc_push_add.z.val -= thing->field_20;
+                thing->veloc_push_add.z.val -= thing->fall_speed;
                 thing->state_flags |= TF1_PushAdd;
             } else
             {
                 // For flying creatures, the Z velocity should also decrease over time
                 if (thing->veloc_base.z.val != 0)
+                {
                     thing->veloc_base.z.val = thing->veloc_base.z.val * (256 - (int)thing->field_24) / 256;
+                }
+                else 
+                {
+                    if (thing_above_flight_altitude(thing))
+                    {
+                        thing->veloc_push_add.z.val -= thing->fall_speed;
+                        thing->state_flags |= TF1_PushAdd;
+                    }
+                }
             }
         } else
         {

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -421,7 +421,7 @@ struct Thing *create_object(const struct Coord3d *pos, unsigned short model, uns
     thing->solid_size_xy = objdat->size_xy;
     thing->solid_size_yz = objdat->size_yz;
     thing->health = saturate_set_signed(objconf->health,16);
-    thing->fall_speed = objconf->field_4;
+    thing->fall_acceleration = objconf->field_4;
     thing->field_23 = 204;
     thing->field_24 = 51;
     thing->field_22 = 0;

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -421,7 +421,7 @@ struct Thing *create_object(const struct Coord3d *pos, unsigned short model, uns
     thing->solid_size_xy = objdat->size_xy;
     thing->solid_size_yz = objdat->size_yz;
     thing->health = saturate_set_signed(objconf->health,16);
-    thing->field_20 = objconf->field_4;
+    thing->fall_speed = objconf->field_4;
     thing->field_23 = 204;
     thing->field_24 = 51;
     thing->field_22 = 0;

--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -61,6 +61,12 @@ TbBool thing_touching_flight_altitude(const struct Thing *thing)
         && (thing->mappos.z.val <= floor_height + 19*NORMAL_FLYING_ALTITUDE/17);
 }
 
+TbBool thing_above_flight_altitude(const struct Thing* thing)
+{
+    int floor_height = get_floor_height_under_thing_at(thing, &thing->mappos);
+    return (thing->mappos.z.val > floor_height + 19 * NORMAL_FLYING_ALTITUDE / 17);
+}
+
 void slide_thing_against_wall_at(struct Thing *thing, struct Coord3d *pos, long a3)
 {
     _DK_slide_thing_against_wall_at(thing, pos, a3); return;

--- a/src/thing_physics.h
+++ b/src/thing_physics.h
@@ -52,6 +52,7 @@ struct ComponentVector;
 /******************************************************************************/
 TbBool thing_touching_floor(const struct Thing *thing);
 TbBool thing_touching_flight_altitude(const struct Thing *thing);
+TbBool thing_above_flight_altitude(const struct Thing* thing);
 
 TbBool thing_on_thing_at(const struct Thing *firstng, const struct Coord3d *pos, const struct Thing *sectng);
 TbBool things_collide_while_first_moves_to(const struct Thing *firstng, const struct Coord3d *dstpos, const struct Thing *sectng);

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -768,7 +768,7 @@ TbBool shot_kill_creature(struct Thing *shotng, struct Thing *creatng)
 long melee_shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coord3d *pos)
 {
     struct ShotConfigStats* shotst = get_shot_model_stats(shotng->model);
-    //throw_strength = shotng->field_20; //this seems to be always 0, this is why it didn't work;
+    //throw_strength = shotng->fall_speed; //this seems to be always 0, this is why it didn't work;
     long throw_strength = shotst->old->push_on_hit;
     if (trgtng->health < 0)
         return 0;
@@ -849,7 +849,7 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
     long i;
     long n;
     struct ShotConfigStats* shotst = get_shot_model_stats(shotng->model);
-    //amp = shotng->field_20;
+    //amp = shotng->fall_speed;
     long amp = shotst->old->push_on_hit;
     struct Thing* shooter = INVALID_THING;
     if (shotng->parent_idx != shotng->index) {
@@ -1425,7 +1425,7 @@ struct Thing *create_shot(struct Coord3d *pos, unsigned short model, unsigned sh
     thing->parent_idx = thing->index;
     thing->owner = owner;
     thing->field_22 = shotst->old->field_D;
-    thing->field_20 = shotst->old->field_F;
+    thing->fall_speed = shotst->old->field_F;
     thing->field_21 = shotst->old->field_10;
     thing->field_23 = shotst->old->field_11;
     thing->field_24 = shotst->old->field_12;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -768,7 +768,7 @@ TbBool shot_kill_creature(struct Thing *shotng, struct Thing *creatng)
 long melee_shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coord3d *pos)
 {
     struct ShotConfigStats* shotst = get_shot_model_stats(shotng->model);
-    //throw_strength = shotng->fall_speed; //this seems to be always 0, this is why it didn't work;
+    //throw_strength = shotng->fall_acceleration; //this seems to be always 0, this is why it didn't work;
     long throw_strength = shotst->old->push_on_hit;
     if (trgtng->health < 0)
         return 0;
@@ -849,7 +849,7 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
     long i;
     long n;
     struct ShotConfigStats* shotst = get_shot_model_stats(shotng->model);
-    //amp = shotng->fall_speed;
+    //amp = shotng->fall_acceleration;
     long amp = shotst->old->push_on_hit;
     struct Thing* shooter = INVALID_THING;
     if (shotng->parent_idx != shotng->index) {
@@ -1425,7 +1425,7 @@ struct Thing *create_shot(struct Coord3d *pos, unsigned short model, unsigned sh
     thing->parent_idx = thing->index;
     thing->owner = owner;
     thing->field_22 = shotst->old->field_D;
-    thing->fall_speed = shotst->old->field_F;
+    thing->fall_acceleration = shotst->old->field_F;
     thing->field_21 = shotst->old->field_10;
     thing->field_23 = shotst->old->field_11;
     thing->field_24 = shotst->old->field_12;


### PR DESCRIPTION
Dropping flying units (fairy, fly, vampire with flight spell enabled) into battle they should now drop at a reasonable speed towards their normal altitude.

To see the new behavior simply drop a fairy or vampire and some non-flying units into a party of enemies and compare their drops.