### PR TITLE
Added GOOD_CREATURES_CONVERTED and EVIL_CREATURES_CONVERTED script variables

### DIFF
--- a/src/creature_states_tortr.c
+++ b/src/creature_states_tortr.c
@@ -305,8 +305,21 @@ void convert_tortured_creature_owner(struct Thing *creatng, PlayerNumber new_own
     change_creature_owner(creatng, new_owner);
     anger_set_creature_anger_all_types(creatng, 0);
     struct Dungeon* dungeon = get_dungeon(new_owner);
-    if (!dungeon_invalid(dungeon)) {
+    struct DungeonAdd* dungeonadd = get_dungeon(new_owner);
+    if (!dungeon_invalid(dungeon)) 
+    {
         dungeon->lvstats.creatures_converted++;
+        if (((get_creature_model_flags(creatng) & CMF_IsSpectator) == 0) && ((get_creature_model_flags(creatng) & CMF_IsSpecDigger) == 0))
+        {
+            if (get_creature_model_flags(creatng) & CMF_IsEvil)
+            {
+                dungeonadd->evil_creatures_converted++;
+            }
+            else
+            {
+                dungeonadd->good_creatures_converted++;
+            }
+        }
     }
 }
 

--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -305,6 +305,8 @@ struct DungeonAdd
     int                   creature_awarded[CREATURE_TYPES_COUNT];
     struct RoomSpace      roomspace;
     unsigned char         creature_entrance_level;
+    unsigned long         evil_creatures_converted;
+    unsigned long         good_creatures_converted;
 };
 /******************************************************************************/
 extern struct Dungeon bad_dungeon;

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -134,6 +134,8 @@ const struct NamedCommand variable_desc[] = {
     {"SKELETONS_RAISED",            SVar_SKELETONS_RAISED},
     {"VAMPIRES_RAISED",             SVar_VAMPIRES_RAISED},
     {"CREATURES_CONVERTED",         SVar_CREATURES_CONVERTED},
+    {"EVIL_CREATURES_CONVERTED",    SVar_EVIL_CREATURES_CONVERTED},
+    {"GOOD_CREATURES_CONVERTED",    SVar_GOOD_CREATURES_CONVERTED},
     {"TIMES_ANNOYED_CREATURE",      SVar_TIMES_ANNOYED_CREATURE},
     {"TIMES_TORTURED_CREATURE",     SVar_TIMES_TORTURED_CREATURE},
     {"TOTAL_DOORS_MANUFACTURED",    SVar_TOTAL_DOORS_MANUFACTURED},
@@ -5632,6 +5634,12 @@ long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, unsigned 
     case SVar_REWARDED:
         dungeonadd = get_dungeonadd(plyr_idx);
         return dungeonadd->creature_awarded[validx];
+    case SVar_EVIL_CREATURES_CONVERTED:
+        dungeonadd = get_dungeon(plyr_idx);
+        return dungeonadd->evil_creatures_converted;
+    case SVar_GOOD_CREATURES_CONVERTED:
+        dungeonadd = get_dungeon(plyr_idx);
+        return dungeonadd->good_creatures_converted;
     default:
         break;
     };

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -218,6 +218,8 @@ enum ScriptVariables {
   SVar_BOX_ACTIVATED                   = 66,
   SVar_SACRIFICED                      = 67,  // Per model
   SVar_REWARDED                        = 68,  // Per model
+  SVar_EVIL_CREATURES_CONVERTED        = 69,
+  SVar_GOOD_CREATURES_CONVERTED        = 70,
  };
 
 enum MapLocationTypes {


### PR DESCRIPTION
Does not count special diggers. This is consistent with the GOOD_CREATURES and EVIL_CREATURES variables.

Works like this:
```
IF(PLAYER0,EVIL_CREATURES_CONVERTED >= 1)
	QUICK_OBJECTIVE(11," 1 evil creature converted",ALL_PLAYERS)
ENDIF
IF(PLAYER0,GOOD_CREATURES_CONVERTED >= 2)
	QUICK_OBJECTIVE(13," 2 heroes converted",ALL_PLAYERS)
ENDIF
```

Can be used to detect how many creatures/heroes a player has converted, and tweak the specific conversion rates based on this.