### PR TITLE
Added TabFall sound

### DIFF
--- a/src/bflib_sound.c
+++ b/src/bflib_sound.c
@@ -110,7 +110,7 @@ long S3DSetNumberOfSounds(long nMaxSounds)
     return true;
 }
 
-static struct SoundEmitter *S3DGetSoundEmitter(SoundEmitterID eidx)
+struct SoundEmitter* S3DGetSoundEmitter(SoundEmitterID eidx)
 {
     if ((eidx < 0) || (eidx >= SOUND_EMITTERS_MAX))
     {

--- a/src/bflib_sound.h
+++ b/src/bflib_sound.h
@@ -196,6 +196,10 @@ TbBool process_sound_samples(void);
 
 extern int atmos_sound_volume;
 
+struct SoundEmitter* S3DGetSoundEmitter(SoundEmitterID eidx);
+SoundEmitterID get_emitter_id(struct SoundEmitter *emit);
+void kick_out_sample(short smpl_id);
+
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/map_events.c
+++ b/src/map_events.c
@@ -36,6 +36,7 @@
 #include "room_workshop.h"
 #include "power_hand.h"
 #include "game_legacy.h"
+#include "player_states.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -371,7 +372,11 @@ void event_add_to_event_buttons_list_or_replace_button(struct Event *event, stru
             if (evidx == 0) {
                 if (is_my_player_number(dungeon->owner))
                 {
-                    play_non_3d_sample(947);
+                    struct PlayerInfo* player = get_player(dungeon->owner);
+                    if ( (game.play_gameturn > 10) && (player->view_type == PVT_DungeonTop) && ((game.operation_flags & GOF_ShowGui)) )
+                    {
+                        play_non_3d_sample(947);
+                    }
                 }
                 SYNCDBG(1,"New button at position %d",(int)i);
                 dungeon->event_button_index[i] = event->index;

--- a/src/map_events.c
+++ b/src/map_events.c
@@ -23,7 +23,7 @@
 #include "bflib_memory.h"
 #include "bflib_planar.h"
 #include "bflib_sound.h"
-
+#include "bflib_sndlib.h"
 #include "thing_objects.h"
 #include "thing_doors.h"
 #include "thing_traps.h"
@@ -369,6 +369,10 @@ void event_add_to_event_buttons_list_or_replace_button(struct Event *event, stru
         {
             evidx = dungeon->event_button_index[i];
             if (evidx == 0) {
+                if (is_my_player_number(dungeon->owner))
+                {
+                    play_non_3d_sample(947);
+                }
                 SYNCDBG(1,"New button at position %d",(int)i);
                 dungeon->event_button_index[i] = event->index;
                 break;
@@ -670,6 +674,8 @@ void maintain_my_event_list(struct Dungeon *dungeon)
                     if ((i == 1) || ((i >= 2) && dungeon->event_button_index[i-2] != 0))
                     {
                         if (is_my_player_number(dungeon->owner)) {
+                            struct SoundEmitter* emit = S3DGetSoundEmitter(Non3DEmitter);
+                            StopSample(get_emitter_id(emit), 947);
                             play_non_3d_sample(175);
                         }
                         unsigned char prev_ev_idx = dungeon->event_button_index[i - 1];


### PR DESCRIPTION
tabfall.wav should now play when you receive a message, but only when you in the top dungeon view and have the GUI enabled. It should stop when the tab hits to sound more natural.