### PR TITLE
Translatable level names for mappacks

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1363,6 +1363,17 @@ short set_level_info_text_name(LevelNumber lvnum, char *name, unsigned long lvop
     struct LevelInformation* lvinfo = get_or_create_level_info(lvnum, lvoptions);
     if (lvinfo == NULL)
         return false;
+    // Check if 'NAME_ID' is in use
+    //if (name[0] == "#")
+    //{
+        name++;
+        int k = atoi(name);
+        if (k > 0)
+        {
+            lvinfo->name_stridx = k;
+        }
+        name--;
+    //}
     strncpy(lvinfo->name, name, LINEMSG_SIZE - 1);
     lvinfo->name[LINEMSG_SIZE - 1] = '\0';
     if ((lvoptions & LvOp_IsFree) != 0)

--- a/src/config.c
+++ b/src/config.c
@@ -1356,6 +1356,22 @@ struct LevelInformation *get_prev_level_info(struct LevelInformation *nextinfo)
   return &campaign.lvinfos[i];
 }
 
+short set_level_info_string_index(LevelNumber lvnum, char *stridx, unsigned long lvoptions)
+{
+    if (campaign.lvinfos == NULL)
+        init_level_info_entries(&campaign, 0);
+    struct LevelInformation* lvinfo = get_or_create_level_info(lvnum, lvoptions);
+    if (lvinfo == NULL)
+        return false;
+    int k = atoi(stridx);
+    if (k > 0)
+    {
+        lvinfo->name_stridx = k;
+        return true;
+    }
+  return false;
+}
+
 short set_level_info_text_name(LevelNumber lvnum, char *name, unsigned long lvoptions)
 {
     if (campaign.lvinfos == NULL)
@@ -1363,17 +1379,6 @@ short set_level_info_text_name(LevelNumber lvnum, char *name, unsigned long lvop
     struct LevelInformation* lvinfo = get_or_create_level_info(lvnum, lvoptions);
     if (lvinfo == NULL)
         return false;
-    // Check if 'NAME_ID' is in use
-    //if (name[0] == "#")
-    //{
-        name++;
-        int k = atoi(name);
-        if (k > 0)
-        {
-            lvinfo->name_stridx = k;
-        }
-        name--;
-    //}
     strncpy(lvinfo->name, name, LINEMSG_SIZE - 1);
     lvinfo->name[LINEMSG_SIZE - 1] = '\0';
     if ((lvoptions & LvOp_IsFree) != 0)

--- a/src/config.h
+++ b/src/config.h
@@ -251,6 +251,7 @@ struct LevelInformation *get_last_level_info(void);
 struct LevelInformation *get_next_level_info(struct LevelInformation *previnfo);
 struct LevelInformation *get_prev_level_info(struct LevelInformation *nextinfo);
 short set_level_info_text_name(LevelNumber lvnum, char *name, unsigned long lvoptions);
+short set_level_info_string_index(LevelNumber lvnum, char *stridx, unsigned long lvoptions);
 short get_level_fgroup(LevelNumber lvnum);
 const char *get_current_language_str(void);
 const char *get_language_lwrstr(int lang_id);

--- a/src/frontmenu_select.c
+++ b/src/frontmenu_select.c
@@ -115,7 +115,14 @@ void frontend_draw_level_select_button(struct GuiButton *gbtn)
     int tx_units_per_px = (gbtn->height * 13 / 11) * 16 / LbTextLineHeight();
     i = LbTextLineHeight() * tx_units_per_px / 16;
     LbTextSetWindow(gbtn->scr_pos_x, gbtn->scr_pos_y, gbtn->width, i);
-    LbTextDrawResized(0, 0, tx_units_per_px, lvinfo->name);
+    if (lvinfo->name_stridx > 0)
+    {
+        LbTextDrawResized(0, 0, tx_units_per_px, get_string(lvinfo->name_stridx));
+    }
+    else
+    {
+        LbTextDrawResized(0, 0, tx_units_per_px, lvinfo->name);
+    }
 }
 
 void frontend_draw_levels_scroll_tab(struct GuiButton *gbtn)

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -128,7 +128,25 @@ long level_lif_entry_parse(char *fname, char *buf)
   // Skip spaces and control chars
   while (buf[i] != '\0')
   {
-    if (!isspace(buf[i]) && (buf[i] != ',') && (buf[i] != ';') && (buf[i] != ':'))
+    // Check for commented-out lines
+    if (buf[i] == ';')
+    {
+      // Loop through the entire commented-out line
+      while (buf[i] != '\0')
+      {
+        if ((buf[i] == '\n') || (buf[i] == '\r'))
+        {
+          break;
+        }
+        i++;
+        if (i >= 10000) // arbritarily big number to prevent an infinte loop if last line is a comment that doesn't have a new line at the end
+        {
+          WARNMSG("commented-out line from \"%s\" is too long at %d characters", fname,i);
+          return 0;
+        }
+      }
+    }
+    if (!isspace(buf[i]) && (buf[i] != ',') && (buf[i] != ';') && (buf[i] != ':') && (buf[i] != '\n') && (buf[i] != '\r'))
       break;
     i++;
   }

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -150,6 +150,9 @@ long level_lif_entry_parse(char *fname, char *buf)
       break;
     i++;
   }
+  // when the last line of a .lif is a comment, we check here if the end of the file has been reached (and we should exit the function)
+  if (buf[i] == '\0')
+    return 0;
   // Get level number
   char* cbuf;
   long lvnum = strtol(&buf[i], &cbuf, 0);

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -204,7 +204,7 @@ long level_lif_entry_parse(char *fname, char *buf)
   // Store level name
   if (add_freeplay_level_to_campaign(&campaign,lvnum) < 0)
   {
-    WARNMSG("Can't add freeplay level from \"%s\" to campaign", fname);
+    WARNMSG("Can't add freeplay level from \"%s\" to campaign \"%s\"", fname, campaign.name);
     return 0;
   }
   if (!set_level_info_text_name(lvnum,cbuf,LvOp_IsFree))

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -166,6 +166,16 @@ long level_lif_entry_parse(char *fname, char *buf)
       break;
     cbuf++;
   }
+  // IF the next field starts with a "#" then treat it as a string ID for the level's name
+    if (cbuf[0] == '#')
+    {
+      cbuf++;
+      if (!set_level_info_string_index(lvnum,cbuf,LvOp_IsFree))
+      {
+        WARNMSG("Can't set string index of level %d from file \"%s\"", lvnum, fname);
+      }
+      cbuf--;
+    }
   // Find length of level name; make it null-terminated
   i = 0;
   while (cbuf[i] != '\0')


### PR DESCRIPTION
Proof of concept …

Using e.g. #201 as the level name in a .lif file will set `lvinfo->name_stridx` to 201.

`lvinfo->name_stridx` is then used on the Map screen to show the level name. (through existing code)

`lvinfo->name_stridx` is also used on the Level select screen to show the correct level names (added in ec62600)