### PR TITLE
Adding missing Mentor dialogue

### DIFF
--- a/src/creature_states_spdig.c
+++ b/src/creature_states_spdig.c
@@ -1475,6 +1475,7 @@ short creature_picks_up_crate_for_workshop(struct Thing *creatng)
         set_start_state(creatng);
         return 0;
     }
+    update_workshop_object_pickup_event(creatng, cratetng);
     creature_drag_object(creatng, cratetng);
     creatng->continue_state = CrSt_CreatureDropsCrateInWorkshop;
     return 1;

--- a/src/gui_soundmsgs.h
+++ b/src/gui_soundmsgs.h
@@ -40,6 +40,7 @@ extern "C" {
 #define MESSAGE_DELAY_CRTR_MOOD     500
 #define MESSAGE_DELAY_SPECIAL       100
 #define MESSAGE_DELAY_LORD          100
+#define MESSAGE_DELAY_CRTR_JOINED   500
 
 enum TbSpeechMessages {
         SMsg_None = 0,

--- a/src/room_library.c
+++ b/src/room_library.c
@@ -105,16 +105,21 @@ EventIndex update_library_object_pickup_event(struct Thing *creatng, struct Thin
         // Only play speech message if new event was created
         if (evidx > 0)
         {
-            long speech_idx;
             if ( (is_my_player_number(picktng->owner)) && (!is_my_player_number(creatng->owner)) )
             {
-                speech_idx = SMsg_SpellbookStolen;
+                output_message(SMsg_SpellbookStolen, 0, true);
             } 
             else if ( (is_my_player_number(creatng->owner)) && (!is_my_player_number(picktng->owner)) )
             {
-                speech_idx = (picktng->owner == game.neutral_player_num) ? SMsg_DiscoveredSpell : SMsg_SpellbookTaken;
+                if (picktng->owner == game.neutral_player_num)
+                {
+                   output_message(SMsg_DiscoveredSpell, 0, true); 
+                }
+                else
+                {
+                   output_message(SMsg_SpellbookTaken, 0, true); 
+                }
             }
-            output_message(speech_idx, 0, true);
         }
     } else
     if (thing_is_special_box(picktng))

--- a/src/room_library.c
+++ b/src/room_library.c
@@ -103,11 +103,18 @@ EventIndex update_library_object_pickup_event(struct Thing *creatng, struct Thin
             picktng->mappos.x.val, picktng->mappos.y.val,
             EvKind_SpellPickedUp, creatng->owner, picktng->index);
         // Only play speech message if new event was created
-        if ((evidx > 0) && is_my_player_number(picktng->owner) && !is_my_player_number(creatng->owner)) {
-            output_message(SMsg_SpellbookStolen, 0, true);
-        } else
-        if ((evidx > 0) && is_my_player_number(creatng->owner) && !is_my_player_number(picktng->owner)) {
-            output_message(SMsg_SpellbookTaken, 0, true);
+        if (evidx > 0)
+        {
+            long speech_idx;
+            if ( (is_my_player_number(picktng->owner)) && (!is_my_player_number(creatng->owner)) )
+            {
+                speech_idx = SMsg_SpellbookStolen;
+            } 
+            else if ( (is_my_player_number(creatng->owner)) && (!is_my_player_number(picktng->owner)) )
+            {
+                speech_idx = (picktng->owner == game.neutral_player_num) ? SMsg_DiscoveredSpell : SMsg_SpellbookTaken;
+            }
+            output_message(speech_idx, 0, true);
         }
     } else
     if (thing_is_special_box(picktng))

--- a/src/room_workshop.c
+++ b/src/room_workshop.c
@@ -674,4 +674,48 @@ short process_player_manufacturing(PlayerNumber plyr_idx)
     get_next_manufacture(dungeon);
     return true;
 }
+
+EventIndex update_workshop_object_pickup_event(struct Thing *creatng, struct Thing *picktng)
+{
+    EventIndex evidx;
+    ThingClass tngclass = crate_thing_to_workshop_item_class(picktng);
+    if (tngclass == TCls_Trap)
+    {
+        evidx = event_create_event_or_update_nearby_existing_event(
+            picktng->mappos.x.val, picktng->mappos.y.val,
+            EvKind_TrapCrateFound, creatng->owner, picktng->index);
+            if ( (is_my_player_number(picktng->owner)) && (!is_my_player_number(creatng->owner)) )
+            {
+                output_message(SMsg_TrapStolen, 0, true);
+            } 
+            else if ( (is_my_player_number(creatng->owner)) && (!is_my_player_number(picktng->owner)) )
+            {
+                if (picktng->owner != game.neutral_player_num)
+                {
+                    output_message(SMsg_TrapTaken, 0, true);
+                }
+            }
+    } else if (tngclass == TCls_Door)
+    {
+       evidx = event_create_event_or_update_nearby_existing_event(
+            picktng->mappos.x.val, picktng->mappos.y.val,
+            EvKind_DoorCrateFound, creatng->owner, picktng->index);
+            if ( (is_my_player_number(picktng->owner)) && (!is_my_player_number(creatng->owner)) )
+            {
+                output_message(SMsg_DoorStolen, 0, true);
+            } 
+            else if ( (is_my_player_number(creatng->owner)) && (!is_my_player_number(picktng->owner)) )
+            {
+                if (picktng->owner != game.neutral_player_num)
+                {
+                    output_message(SMsg_DoorTaken, 0, true);
+                }
+            }
+    } else
+    {
+        WARNLOG("Strange pickup (model %d) - no event",(int)picktng->model);
+        evidx = 0;
+    }
+    return evidx;
+}
 /******************************************************************************/

--- a/src/room_workshop.h
+++ b/src/room_workshop.h
@@ -76,6 +76,7 @@ TbBool remove_workshop_object_from_player(PlayerNumber owner, ThingModel objmode
 long get_doable_manufacture_with_minimal_amount_available(const struct Dungeon *dungeon, int * mnfctr_class, int * mnfctr_kind);
 TbBool get_next_manufacture(struct Dungeon *dungeon);
 short process_player_manufacturing(PlayerNumber plyr_idx);
+EventIndex update_workshop_object_pickup_event(struct Thing *creatng, struct Thing *picktng);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -2794,19 +2794,12 @@ long check_out_worker_pickup_trap_for_workshop(struct Thing *thing, struct Digge
           EvKind_TrapCrateFound, thing->owner, sectng->index);
         if (evidx > 0)
         {
-            if ( (is_my_player_number(sectng->owner)) && (!is_my_player_number(thing->owner)) )
-            {
-                output_message(SMsg_TrapStolen, 0, true);
-            } 
-            else if ( (is_my_player_number(thing->owner)) && (!is_my_player_number(sectng->owner)) )
+
+            if ( (is_my_player_number(thing->owner)) && (!is_my_player_number(sectng->owner)) )
             {
                 if (sectng->owner == game.neutral_player_num)
                 {
                     output_message(SMsg_DiscoveredTrap, 0, true);
-                }
-                else
-                {
-                    output_message(SMsg_TrapTaken, 0, true); 
                 }
             }
         }
@@ -2818,19 +2811,11 @@ long check_out_worker_pickup_trap_for_workshop(struct Thing *thing, struct Digge
           EvKind_DoorCrateFound, thing->owner, sectng->index);
         if (evidx > 0)
         {
-            if ( (is_my_player_number(sectng->owner)) && (!is_my_player_number(thing->owner)) )
-            {
-                output_message(SMsg_DoorStolen, 0, true);
-            } 
-            else if ( (is_my_player_number(thing->owner)) && (!is_my_player_number(sectng->owner)) )
+            if ( (is_my_player_number(thing->owner)) && (!is_my_player_number(sectng->owner)) )
             {
                 if (sectng->owner == game.neutral_player_num)
                 {
                     output_message(SMsg_DiscoveredDoor, 0, true);
-                }
-                else
-                {
-                    output_message(SMsg_DoorTaken, 0, true); 
                 }
             }
         }

--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -2785,18 +2785,45 @@ long check_out_worker_pickup_trap_for_workshop(struct Thing *thing, struct Digge
         // Do not delete the task - another digger might be able to reach it
         return 0;
     }
+    EventIndex evidx;
     i = crate_thing_to_workshop_item_class(sectng);
     if (i == TCls_Trap)
     {
-      event_create_event_or_update_nearby_existing_event(
+      evidx = event_create_event_or_update_nearby_existing_event(
           subtile_coord_center(stl_x), subtile_coord_center(stl_y),
           EvKind_TrapCrateFound, thing->owner, sectng->index);
+        if (evidx > 0)
+        {
+            long speech_idx;
+            if ( (is_my_player_number(sectng->owner)) && (!is_my_player_number(thing->owner)) )
+            {
+                speech_idx = SMsg_TrapStolen;
+            } 
+            else if ( (is_my_player_number(thing->owner)) && (!is_my_player_number(sectng->owner)) )
+            {
+                speech_idx = (sectng->owner == game.neutral_player_num) ? SMsg_DiscoveredTrap : SMsg_TrapTaken;
+            }
+            output_message(speech_idx, 0, true);
+        }
     } else
     if (i == TCls_Door)
     {
-      event_create_event_or_update_nearby_existing_event(
+      evidx = event_create_event_or_update_nearby_existing_event(
           subtile_coord_center(stl_x), subtile_coord_center(stl_y),
           EvKind_DoorCrateFound, thing->owner, sectng->index);
+        if (evidx > 0)
+        {
+            long speech_idx;
+            if ( (is_my_player_number(sectng->owner)) && (!is_my_player_number(thing->owner)) )
+            {
+                speech_idx = SMsg_DoorStolen;
+            } 
+            else if ( (is_my_player_number(thing->owner)) && (!is_my_player_number(sectng->owner)) )
+            {
+                speech_idx = (sectng->owner == game.neutral_player_num) ? SMsg_DiscoveredDoor : SMsg_DoorTaken;
+            }
+            output_message(speech_idx, 0, true);
+        }
     } else
     {
         WARNLOG("Strange pickup (class %d) - no event",(int)i);

--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -2794,16 +2794,21 @@ long check_out_worker_pickup_trap_for_workshop(struct Thing *thing, struct Digge
           EvKind_TrapCrateFound, thing->owner, sectng->index);
         if (evidx > 0)
         {
-            long speech_idx;
             if ( (is_my_player_number(sectng->owner)) && (!is_my_player_number(thing->owner)) )
             {
-                speech_idx = SMsg_TrapStolen;
+                output_message(SMsg_TrapStolen, 0, true);
             } 
             else if ( (is_my_player_number(thing->owner)) && (!is_my_player_number(sectng->owner)) )
             {
-                speech_idx = (sectng->owner == game.neutral_player_num) ? SMsg_DiscoveredTrap : SMsg_TrapTaken;
+                if (sectng->owner == game.neutral_player_num)
+                {
+                    output_message(SMsg_DiscoveredTrap, 0, true);
+                }
+                else
+                {
+                    output_message(SMsg_TrapTaken, 0, true); 
+                }
             }
-            output_message(speech_idx, 0, true);
         }
     } else
     if (i == TCls_Door)
@@ -2813,16 +2818,21 @@ long check_out_worker_pickup_trap_for_workshop(struct Thing *thing, struct Digge
           EvKind_DoorCrateFound, thing->owner, sectng->index);
         if (evidx > 0)
         {
-            long speech_idx;
             if ( (is_my_player_number(sectng->owner)) && (!is_my_player_number(thing->owner)) )
             {
-                speech_idx = SMsg_DoorStolen;
+                output_message(SMsg_DoorStolen, 0, true);
             } 
             else if ( (is_my_player_number(thing->owner)) && (!is_my_player_number(sectng->owner)) )
             {
-                speech_idx = (sectng->owner == game.neutral_player_num) ? SMsg_DiscoveredDoor : SMsg_DoorTaken;
+                if (sectng->owner == game.neutral_player_num)
+                {
+                    output_message(SMsg_DiscoveredDoor, 0, true);
+                }
+                else
+                {
+                    output_message(SMsg_DoorTaken, 0, true); 
+                }
             }
-            output_message(speech_idx, 0, true);
         }
     } else
     {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -5223,6 +5223,7 @@ int claim_neutral_creatures_in_sight(struct Thing *creatng, struct Coord3d *pos,
 				{
 				change_creature_owner(thing, creatng->owner);
                 mark_creature_joined_dungeon(thing);
+                output_message(SMsg_CreaturesJoinedYou, 500, true);
                 n++;
 				}
             }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -5223,7 +5223,7 @@ int claim_neutral_creatures_in_sight(struct Thing *creatng, struct Coord3d *pos,
 				{
 				change_creature_owner(thing, creatng->owner);
                 mark_creature_joined_dungeon(thing);
-                output_message(SMsg_CreaturesJoinedYou, 500, true);
+                output_message(SMsg_CreaturesJoinedYou, MESSAGE_DELAY_CRTR_JOINED, true);
                 n++;
 				}
             }


### PR DESCRIPTION
The Mentor should now tell you when:

*Neutral creatures join your dungeon
*A door or trap crate is discovered or taken.

The Mentor now says that a spell has been discovered, rather than taken, if the spell book is neutral-owned.