### PR TITLE
subtile_is_diggable_for_player() improvement

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -752,7 +752,7 @@ long instf_first_person_do_imp_task(struct Thing *creatng, long *param)
         ahead_stl_y = creatng->mappos.y.stl.num;
         ahead_stl_x = creatng->mappos.x.stl.num + 1; 
     }
-    if ( (first_person_dig_claim_mode) || (!subtile_is_diggable_for_player(creatng->owner, ahead_stl_x, ahead_stl_y)) )
+    if ( (first_person_dig_claim_mode) || (!subtile_is_diggable_for_player(creatng->owner, ahead_stl_x, ahead_stl_y, false)) )
     {
         slb = get_slabmap_block(slb_x, slb_y);
         if ( check_place_to_convert_excluding(creatng, slb_x, slb_y) )

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -752,7 +752,7 @@ long instf_first_person_do_imp_task(struct Thing *creatng, long *param)
         ahead_stl_y = creatng->mappos.y.stl.num;
         ahead_stl_x = creatng->mappos.x.stl.num + 1; 
     }
-    if ( (first_person_dig_claim_mode) || (!subtile_is_diggable_for_player(creatng->owner, ahead_stl_x, ahead_stl_y, false)) )
+    if ( (first_person_dig_claim_mode) || (!subtile_is_diggable_for_player(creatng->owner, ahead_stl_x, ahead_stl_y, true)) )
     {
         slb = get_slabmap_block(slb_x, slb_y);
         if ( check_place_to_convert_excluding(creatng, slb_x, slb_y) )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3107,7 +3107,7 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     MapSlabCoord slb_y = subtile_slab_fast(stl_y);
     int floor_height_z = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
     TbBool allowed = false;
-    if (subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, true))
+    if (subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false))
     {
         allowed = true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3106,13 +3106,8 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     MapSlabCoord slb_x = subtile_slab_fast(stl_x);
     MapSlabCoord slb_y = subtile_slab_fast(stl_y);
     int floor_height_z = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
-    struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
-    struct SlabAttr* slbattr = get_slab_attrs(slb);
     TbBool allowed = false;
-    if ( (!subtile_revealed(stl_x, stl_y, plyr_idx)) || 
-         ( ((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0) && 
-           ( !(((slbattr->is_diggable) == 0) || 
-             ((slabmap_owner(slb) != plyr_idx) && ((slbattr->block_flags & SlbAtFlg_Filled) != 0))) ) ) )
+    if (subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, true))
     {
         allowed = true;
     }

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -711,10 +711,10 @@ TbBool subtile_is_door(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
  * @param plyr_idx The player to be checked.
  * @param stl_x Map subtile X coordinate.
  * @param stl_y Map subtile Y coordinate.
- * @param inc_enemy_walls Should other player's walls be treated as undiggable?
+ * @param enemy_wall_undiggable Should other player's walls be treated as undiggable?
  * @return True if the player can dig the subtile, false otherwise.
  */
-TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool inc_enemy_walls)
+TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool enemy_wall_undiggable)
 {
     struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
     if (slabmap_block_invalid(slb))
@@ -736,7 +736,7 @@ TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x
     struct SlabAttr* slbattr = get_slab_attrs(slb);
     if (((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0))
     {
-        if (!inc_enemy_walls)
+        if (!enemy_wall_undiggable)
         {
             return true;
         }

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -711,24 +711,41 @@ TbBool subtile_is_door(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
  * @param plyr_idx The player to be checked.
  * @param stl_x Map subtile X coordinate.
  * @param stl_y Map subtile Y coordinate.
+ * @param inc_enemy_walls Should other player's walls be treated as undiggable?
  * @return True if the player can dig the subtile, false otherwise.
  */
-TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool inc_enemy_walls)
 {
     struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
     if (slabmap_block_invalid(slb))
+    {
         return false;
+    }
     if (!subtile_revealed(stl_x, stl_y, plyr_idx))
+    {
         return true;
+    }
     //TODO DOOR Why magic door id different? This doesn't seem to be intended.
     if (slab_kind_is_nonmagic_door(slb->kind))
     {
         if (slabmap_owner(slb) == plyr_idx)
-          return false;
+        {
+            return false;
+        }
     }
     struct SlabAttr* slbattr = get_slab_attrs(slb);
-    if ((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0)
-      return true;
+    if (((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0))
+    {
+        if (!inc_enemy_walls)
+        {
+            return true;
+        }
+        if (!(((slbattr->is_diggable) == 0) || 
+        ((slabmap_owner(slb) != plyr_idx) && ((slbattr->block_flags & SlbAtFlg_Filled) != 0))))
+        {
+            return true;
+        }
+    }
     return false;
 }
 /******************************************************************************/

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -711,10 +711,10 @@ TbBool subtile_is_door(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
  * @param plyr_idx The player to be checked.
  * @param stl_x Map subtile X coordinate.
  * @param stl_y Map subtile Y coordinate.
- * @param enemy_wall_undiggable Should other player's walls be treated as undiggable?
+ * @param enemy_wall_diggable * If enemy walls can be selected for digging
  * @return True if the player can dig the subtile, false otherwise.
  */
-TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool enemy_wall_undiggable)
+TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool enemy_wall_diggable)
 {
     struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
     if (slabmap_block_invalid(slb))
@@ -736,7 +736,7 @@ TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x
     struct SlabAttr* slbattr = get_slab_attrs(slb);
     if (((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0))
     {
-        if (!enemy_wall_undiggable)
+        if (enemy_wall_diggable)
         {
             return true;
         }

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -127,8 +127,8 @@ TbBool subtile_is_player_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSub
 TbBool subtile_is_sellable_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool subtile_is_sellable_door_or_trap(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool subtile_is_door(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
-#define can_dig_here(stl_x, stl_y, plyr_idx, inc_enemy_walls) subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, inc_enemy_walls)
-TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool inc_enemy_walls);
+#define can_dig_here(stl_x, stl_y, plyr_idx, enemy_wall_undiggable) subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, enemy_wall_undiggable)
+TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool enemy_wall_undiggable);
 
 void clear_dig_for_map_rect(long plyr_idx,MapSubtlCoord start_x,MapSubtlCoord end_x,MapSubtlCoord start_y,MapSubtlCoord end_y);
 void clear_slab_dig(long a1, long a2, char a3);

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -127,8 +127,8 @@ TbBool subtile_is_player_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSub
 TbBool subtile_is_sellable_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool subtile_is_sellable_door_or_trap(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool subtile_is_door(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
-#define can_dig_here(stl_x, stl_y, plyr_idx) subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y)
-TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+#define can_dig_here(stl_x, stl_y, plyr_idx, inc_enemy_walls) subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, inc_enemy_walls)
+TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool inc_enemy_walls);
 
 void clear_dig_for_map_rect(long plyr_idx,MapSubtlCoord start_x,MapSubtlCoord end_x,MapSubtlCoord start_y,MapSubtlCoord end_y);
 void clear_slab_dig(long a1, long a2, char a3);

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -127,8 +127,8 @@ TbBool subtile_is_player_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSub
 TbBool subtile_is_sellable_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool subtile_is_sellable_door_or_trap(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool subtile_is_door(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
-#define can_dig_here(stl_x, stl_y, plyr_idx, enemy_wall_undiggable) subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, enemy_wall_undiggable)
-TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool enemy_wall_undiggable);
+#define can_dig_here(stl_x, stl_y, plyr_idx, enemy_wall_diggable) subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, enemy_wall_diggable)
+TbBool subtile_is_diggable_for_player(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool enemy_wall_diggable);
 
 void clear_dig_for_map_rect(long plyr_idx,MapSubtlCoord start_x,MapSubtlCoord end_x,MapSubtlCoord start_y,MapSubtlCoord end_y);
 void clear_slab_dig(long a1, long a2, char a3);

--- a/src/packets.c
+++ b/src/packets.c
@@ -529,7 +529,7 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
       }
       long i = thing_is_creature_special_digger(thing);
       if (can_drop_thing_here(stl_x, stl_y, player->id_number, i)
-        || !can_dig_here(stl_x, stl_y, player->id_number))
+        || !can_dig_here(stl_x, stl_y, player->id_number, false))
       {
         tag_cursor_blocks_thing_in_hand(player->id_number, stl_x, stl_y, i, player->full_slab_cursor);
       } else
@@ -798,7 +798,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
               } else
               if (dungeon->task_count < 300)
               {
-                if (can_dig_here(stl_x, stl_y, player->id_number))
+                if (can_dig_here(stl_x, stl_y, player->id_number, false))
                   tag_blocks_for_digging_in_rectangle_around(cx, cy, plyr_idx);
               } else
               if (is_my_player(player))

--- a/src/packets.c
+++ b/src/packets.c
@@ -1765,7 +1765,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
         {
             if (player->thing_under_hand > 0)
             {
-                struct Room* room = get_room_thing_is_on(thing);
+                room = get_room_thing_is_on(thing);
                 TbBool IsRoom = (!room_is_invalid(room));
                 switch(thing->class_id)
                 {

--- a/src/packets.c
+++ b/src/packets.c
@@ -529,7 +529,7 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
       }
       long i = thing_is_creature_special_digger(thing);
       if (can_drop_thing_here(stl_x, stl_y, player->id_number, i)
-        || !can_dig_here(stl_x, stl_y, player->id_number, false))
+        || !can_dig_here(stl_x, stl_y, player->id_number, true))
       {
         tag_cursor_blocks_thing_in_hand(player->id_number, stl_x, stl_y, i, player->full_slab_cursor);
       } else
@@ -798,7 +798,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
               } else
               if (dungeon->task_count < 300)
               {
-                if (can_dig_here(stl_x, stl_y, player->id_number, false))
+                if (can_dig_here(stl_x, stl_y, player->id_number, true))
                   tag_blocks_for_digging_in_rectangle_around(cx, cy, plyr_idx);
               } else
               if (is_my_player(player))


### PR DESCRIPTION
subtile_is_diggable_for_player() now (optionally) checks for fortified walls

subtile_is_diggable_for_player() used to return true for enemy/neutral fortified walls, now if the `enemy_wall_undiggable` parameter is set to true: it will deem fortified walls of other players to be undiggable.

Setting `enemy_wall_undiggable` to false is equivalent to the old behaviour of subtile_is_diggable_for_player().
Therefore, all existing calls to subtile_is_diggable_for_player(), and the synonymous can_dig_here(), have been modified to set `enemy_wall_undiggable` to false.
____
Now that subtile_is_diggable_for_player() will also return false for enemy/neutral fortified walls, **tag_cursor_blocks_dig()** can use that function instead of the convoluted IF statement it used before.