### PR TITLE
One-click Highlight (Square Brush mode)

### DIFF
--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -307,7 +307,7 @@ struct DungeonAdd
     unsigned char         creature_entrance_level;
     unsigned long         evil_creatures_converted;
     unsigned long         good_creatures_converted;
-    TbBool                painter_build_mode; // this is not ideal, but I do not know how else to track what I need
+    TbBool                one_click_lock_cursor;
 };
 /******************************************************************************/
 extern struct Dungeon bad_dungeon;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -2337,8 +2337,8 @@ void create_fancy_map_volume_box(struct RoomSpace roomspace, long x, long y, lon
 
 void process_isometric_map_volume_box(long x, long y, long z)
 {
-    int default_color = map_volume_box.color;
-    int line_color = default_color;
+    unsigned char default_color = map_volume_box.color;
+    unsigned char line_color = default_color;
     struct DungeonAdd *dungeonadd = get_dungeonadd(render_roomspace.plyr_idx);
     struct PlayerInfo* current_player = get_player(render_roomspace.plyr_idx);
     // Check if a roomspace is currently being built
@@ -6735,8 +6735,8 @@ void create_fancy_frontview_map_volume_box(struct RoomSpace roomspace, struct Ca
 
 void process_frontview_map_volume_box(struct Camera *cam, unsigned char stl_width)
 {
-    int default_color = map_volume_box.color;
-    int line_color = default_color;
+    unsigned char default_color = map_volume_box.color;
+    unsigned char line_color = default_color;
     struct DungeonAdd *dungeonadd = get_dungeonadd(render_roomspace.plyr_idx);
     struct PlayerInfo* current_player = get_player(render_roomspace.plyr_idx);
     // Check if a roomspace is currently being built

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -141,7 +141,7 @@ void update_gui_layer()
     if ( ((player->work_state == PSt_Sell) || (player->work_state == PSt_BuildRoom) || (render_roomspace.highlight_mode))  &&
          (is_game_key_pressed(Gkey_BestRoomSpace, NULL, true) || is_game_key_pressed(Gkey_SquareRoomSpace, NULL, true)) )
     {
-        if (dungeonadd->painter_build_mode)
+        if (render_roomspace.one_click_mode_exclusive)
         {
             // Is the user in "one-click bridge building" mode
             set_current_gui_layer(GuiLayer_OneClickBridgeBuild);
@@ -1801,6 +1801,7 @@ TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *context
   unsigned long x;
   unsigned long y;
   struct PlayerInfo* player = get_my_player();
+  struct DungeonAdd* dungeonadd = get_dungeonadd(player->id_number);
   if ((pointer_x < 0) || (pointer_y < 0)
    || (pointer_x >= player->engine_window_width/pixel_size)
    || (pointer_y >= player->engine_window_height/pixel_size))
@@ -1841,7 +1842,7 @@ TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *context
     pos->x.val = (block_pointed_at_x<<8) + pointed_at_frac_x;
     pos->y.val = (block_pointed_at_y<<8) + pointed_at_frac_y;
   } else
-  if ((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0)
+  if (((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0) || dungeonadd->one_click_lock_cursor == 1)
   {
     *context = CSt_PickAxe;
     pos->x.val = (x<<8) + top_pointed_at_frac_x;

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -138,7 +138,7 @@ void update_gui_layer()
 
     struct PlayerInfo* player = get_my_player();
     struct DungeonAdd *dungeonadd = get_dungeonadd(player->id_number);
-    if ( ((player->work_state == PSt_Sell) || (player->work_state == PSt_BuildRoom))  &&
+    if ( ((player->work_state == PSt_Sell) || (player->work_state == PSt_BuildRoom) || (render_roomspace.highlight_mode))  &&
          (is_game_key_pressed(Gkey_BestRoomSpace, NULL, true) || is_game_key_pressed(Gkey_SquareRoomSpace, NULL, true)) )
     {
         if (dungeonadd->painter_build_mode)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3106,7 +3106,11 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     MapSlabCoord slb_y = subtile_slab_fast(stl_y);
     int floor_height_z = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
     TbBool allowed = false;
-    if (subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false))
+    if (render_roomspace.slab_count > 0 && full_slab) ///if roomspace is not empty
+    {
+        allowed = true;
+    }
+    else if (subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false)) // else if not using roomspace, is current slab diggable
     {
         allowed = true;
     }
@@ -3114,22 +3118,18 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     {
         map_volume_box.visible = 1;
         map_volume_box.color = allowed;
-        map_volume_box.beg_x = (!full_slab ? (subtile_coord(stl_x, 0)) : subtile_coord((slb_x * STL_PER_SLB), 0));
-        map_volume_box.beg_y = (!full_slab ? (subtile_coord(stl_y, 0)) : subtile_coord((slb_y * STL_PER_SLB), 0));
-        map_volume_box.end_x = (!full_slab ? (subtile_coord(stl_x + 1, 0)) : subtile_coord(((slb_x + 1) * STL_PER_SLB), 0));
-        map_volume_box.end_y = (!full_slab ? (subtile_coord(stl_y + 1, 0)) : subtile_coord(((slb_y + 1) * STL_PER_SLB), 0));
+        map_volume_box.beg_x = (!full_slab ? (subtile_coord(stl_x, 0)) : subtile_coord(((render_roomspace.centreX - calc_distance_from_roomspace_centre(render_roomspace.width,0)) * STL_PER_SLB), 0));
+        map_volume_box.beg_y = (!full_slab ? (subtile_coord(stl_y, 0)) : subtile_coord(((render_roomspace.centreY - calc_distance_from_roomspace_centre(render_roomspace.height,0)) * STL_PER_SLB), 0));
+        map_volume_box.end_x = (!full_slab ? (subtile_coord(stl_x + 1, 0)) : subtile_coord((((render_roomspace.centreX + calc_distance_from_roomspace_centre(render_roomspace.width,(render_roomspace.width % 2 == 0))) + 1) * STL_PER_SLB), 0));
+        map_volume_box.end_y = (!full_slab ? (subtile_coord(stl_y + 1, 0)) : subtile_coord((((render_roomspace.centreY + calc_distance_from_roomspace_centre(render_roomspace.height,(render_roomspace.height % 2 == 0))) + 1) * STL_PER_SLB), 0));
         map_volume_box.floor_height_z = floor_height_z;
         render_roomspace.is_roomspace_a_single_subtile = !full_slab;
-        render_roomspace.is_roomspace_a_box = true;
-        render_roomspace.render_roomspace_as_box = true;
     }
 }
 
 void tag_cursor_blocks_thing_in_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, int is_special_digger, long full_slab)
 {
   SYNCDBG(7,"Starting");
-  render_roomspace.is_roomspace_a_box = true;
-  render_roomspace.render_roomspace_as_box = true;
   _DK_tag_cursor_blocks_thing_in_hand(plyr_idx, stl_x, stl_y, is_special_digger, full_slab);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3106,7 +3106,7 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     MapSlabCoord slb_y = subtile_slab_fast(stl_y);
     int floor_height_z = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
     TbBool allowed = false;
-    if (render_roomspace.slab_count > 0 && full_slab) ///if roomspace is not empty
+    if (render_roomspace.slab_count > 0 && full_slab) // if roomspace is not empty
     {
         allowed = true;
     }
@@ -3114,10 +3114,15 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     {
         allowed = true;
     }
+    unsigned char line_color = allowed;
+    if (render_roomspace.untag_mode && allowed)
+    {
+        line_color = SLC_YELLOW;
+    }
     if (is_my_player_number(plyr_idx) && !game_is_busy_doing_gui() && (game.small_map_state != 2))
     {
         map_volume_box.visible = 1;
-        map_volume_box.color = allowed;
+        map_volume_box.color = line_color;
         map_volume_box.beg_x = (!full_slab ? (subtile_coord(stl_x, 0)) : subtile_coord(((render_roomspace.centreX - calc_distance_from_roomspace_centre(render_roomspace.width,0)) * STL_PER_SLB), 0));
         map_volume_box.beg_y = (!full_slab ? (subtile_coord(stl_y, 0)) : subtile_coord(((render_roomspace.centreY - calc_distance_from_roomspace_centre(render_roomspace.height,0)) * STL_PER_SLB), 0));
         map_volume_box.end_x = (!full_slab ? (subtile_coord(stl_x + 1, 0)) : subtile_coord((((render_roomspace.centreX + calc_distance_from_roomspace_centre(render_roomspace.width,(render_roomspace.width % 2 == 0))) + 1) * STL_PER_SLB), 0));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3102,6 +3102,7 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
 {
     SYNCDBG(7,"Starting for player %d at subtile (%d,%d)",(int)plyr_idx,(int)stl_x,(int)stl_y);
     //_DK_tag_cursor_blocks_dig(plyr_idx, stl_x, stl_y, full_slab);
+    struct DungeonAdd* dungeonadd = get_dungeonadd(plyr_idx);
     MapSlabCoord slb_x = subtile_slab_fast(stl_x);
     MapSlabCoord slb_y = subtile_slab_fast(stl_y);
     int floor_height_z = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
@@ -3111,6 +3112,10 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
         allowed = true;
     }
     else if (subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false)) // else if not using roomspace, is current slab diggable
+    {
+        allowed = true;
+    }
+    else if (dungeonadd->one_click_lock_cursor == 1)
     {
         allowed = true;
     }

--- a/src/packets.c
+++ b/src/packets.c
@@ -499,6 +499,7 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
 TbBool process_dungeon_power_hand_state(long plyr_idx)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct DungeonAdd* dungeonadd = get_dungeonadd(plyr_idx);
     struct Packet* pckt = get_packet_direct(player->packet_num);
     MapCoord x = ((unsigned short)pckt->pos_x);
     MapCoord y = ((unsigned short)pckt->pos_y);
@@ -528,8 +529,9 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
         create_power_hand(player->id_number);
       }
       long i = thing_is_creature_special_digger(thing);
-      if (can_drop_thing_here(stl_x, stl_y, player->id_number, i)
+      if ((can_drop_thing_here(stl_x, stl_y, player->id_number, i)
         || !can_dig_here(stl_x, stl_y, player->id_number, true))
+        && (dungeonadd->one_click_lock_cursor == 0))
       {
         render_roomspace = create_box_roomspace(render_roomspace, 1, 1, subtile_slab(stl_x), subtile_slab(stl_y));
         tag_cursor_blocks_thing_in_hand(player->id_number, stl_x, stl_y, i, player->full_slab_cursor);
@@ -689,6 +691,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
     long i;
     struct PlayerInfo* player = get_player(plyr_idx);
     struct Dungeon* dungeon = get_players_dungeon(player);
+    struct DungeonAdd* dungeonadd = get_dungeonadd(plyr_idx);
     struct Packet* pckt = get_packet_direct(player->packet_num);
     MapCoord x = ((unsigned short)pckt->pos_x);
     MapCoord y = ((unsigned short)pckt->pos_y);
@@ -859,6 +862,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
             player->cursor_button_down = 0;
         }
         unset_packet_control(pckt, PCtr_LBtnRelease);
+        dungeonadd->one_click_lock_cursor = 0;
         player->secondary_cursor_state = CSt_DefaultArrow;
         player->additional_flags &= ~PlaAF_NoThingUnderPowerHand;
       }

--- a/src/packets.c
+++ b/src/packets.c
@@ -531,10 +531,12 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
       if (can_drop_thing_here(stl_x, stl_y, player->id_number, i)
         || !can_dig_here(stl_x, stl_y, player->id_number, true))
       {
+        render_roomspace = create_box_roomspace(render_roomspace, 1, 1, subtile_slab(stl_x), subtile_slab(stl_y));
         tag_cursor_blocks_thing_in_hand(player->id_number, stl_x, stl_y, i, player->full_slab_cursor);
       } else
       {
         player->additional_flags |= PlaAF_ChosenSubTileIsHigh;
+        get_dungeon_highlight_user_roomspace(player->id_number, stl_x, stl_y);
         tag_cursor_blocks_dig(player->id_number, stl_x, stl_y, player->full_slab_cursor);
       }
     }
@@ -705,7 +707,10 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
       if (is_my_player(player) && !game_is_busy_doing_gui())
       {
         if (player->primary_cursor_state == CSt_PickAxe)
+        {
+          get_dungeon_highlight_user_roomspace(player->id_number, stl_x, stl_y);
           tag_cursor_blocks_dig(player->id_number, stl_x, stl_y, player->full_slab_cursor);
+        }
       }
       if ((pckt->control_flags & PCtr_LBtnClick) != 0)
       {
@@ -777,34 +782,11 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
           {
             if (player->secondary_cursor_state == CSt_PickAxe)
             {
-              if ((player->allocflags & PlaF_ChosenSlabHasActiveTask) != 0)
-              {
-                untag_blocks_for_digging_in_rectangle_around(cx, cy, plyr_idx);
-              } else
-              if (dungeon->task_count < MAPTASKS_COUNT)
-              {
-                tag_blocks_for_digging_in_rectangle_around(cx, cy, plyr_idx);
-              } else
-              if (is_my_player(player))
-              {
-                output_message(SMsg_WorkerJobsLimit, 500, true);
-              }
+              keeper_highlight_roomspace(plyr_idx, &render_roomspace, 3);
             } else
             if ((player->secondary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_NoThingUnderPowerHand) != 0))
             {
-              if ((player->allocflags & PlaF_ChosenSlabHasActiveTask) != 0)
-              {
-                untag_blocks_for_digging_in_rectangle_around(cx, cy, plyr_idx);
-              } else
-              if (dungeon->task_count < MAPTASKS_COUNT)
-              {
-                if (can_dig_here(stl_x, stl_y, player->id_number, true))
-                  tag_blocks_for_digging_in_rectangle_around(cx, cy, plyr_idx);
-              } else
-              if (is_my_player(player))
-              {
-                output_message(SMsg_WorkerJobsLimit, 500, true);
-              }
+              keeper_highlight_roomspace(plyr_idx, &render_roomspace, 2);
             }
           }
           unset_packet_control(pckt, PCtr_LBtnRelease);
@@ -862,18 +844,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         {
           if (player->primary_cursor_state == CSt_PickAxe)
           {
-            if ((player->allocflags & PlaF_ChosenSlabHasActiveTask) != 0)
-            {
-              untag_blocks_for_digging_in_rectangle_around(cx, cy, plyr_idx);
-            } else
-            if (dungeon->task_count <= (MAPTASKS_COUNT - 9))
-            {
-              tag_blocks_for_digging_in_rectangle_around(cx, cy, plyr_idx);
-            } else
-            if (is_my_player(player))
-            {
-              output_message(SMsg_WorkerJobsLimit, 500, true);
-            }
+            keeper_highlight_roomspace(plyr_idx, &render_roomspace, 1);
           } else
           if (player->primary_cursor_state == CSt_PowerHand)
           {

--- a/src/packets.c
+++ b/src/packets.c
@@ -790,11 +790,11 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
           {
             if (player->secondary_cursor_state == CSt_PickAxe)
             {
-              keeper_highlight_roomspace(plyr_idx, &render_roomspace, 3);
+              keeper_highlight_roomspace(plyr_idx, &render_roomspace, 0);
             } else
             if ((player->secondary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_NoThingUnderPowerHand) != 0))
             {
-              keeper_highlight_roomspace(plyr_idx, &render_roomspace, 2);
+              keeper_highlight_roomspace(plyr_idx, &render_roomspace, 0);
             }
           }
           unset_packet_control(pckt, PCtr_LBtnRelease);
@@ -852,7 +852,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         {
           if (player->primary_cursor_state == CSt_PickAxe)
           {
-            keeper_highlight_roomspace(plyr_idx, &render_roomspace, 1);
+            keeper_highlight_roomspace(plyr_idx, &render_roomspace, 9);
           } else
           if (player->primary_cursor_state == CSt_PowerHand)
           {

--- a/src/packets.c
+++ b/src/packets.c
@@ -684,6 +684,23 @@ TbBool process_dungeon_control_packet_dungeon_place_trap(long plyr_idx)
     return true;
 }
 
+void set_tag_untag_mode(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    struct PlayerInfo* player = get_player(plyr_idx);
+    // The commented out section is the old way, this check is now performed as part of keeper_highlight_roomspace() in roomspace.cabs
+    // which sets render_roomspace.untag_mode
+    /*i = get_subtile_number(stl_slab_center_subtile(stl_x),stl_slab_center_subtile(stl_y));
+    if (find_from_task_list(plyr_idx,i) != -1)
+        player->allocflags |= PlaF_ChosenSlabHasActiveTask;
+    else
+        player->allocflags &= ~PlaF_ChosenSlabHasActiveTask;*/
+
+    if (render_roomspace.untag_mode)
+        player->allocflags |= PlaF_ChosenSlabHasActiveTask;
+    else
+        player->allocflags &= ~PlaF_ChosenSlabHasActiveTask;
+}
+
 TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
 {
     struct Thing *thing;
@@ -724,11 +741,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         switch (player->primary_cursor_state)
         {
         case CSt_PickAxe:
-          i = get_subtile_number(stl_slab_center_subtile(player->cursor_stl_x),stl_slab_center_subtile(player->cursor_stl_y));
-          if (find_from_task_list(plyr_idx,i) != -1)
-              player->allocflags |= PlaF_ChosenSlabHasActiveTask;
-          else
-              player->allocflags &= ~PlaF_ChosenSlabHasActiveTask;
+          set_tag_untag_mode(plyr_idx, stl_x, stl_y);
           break;
         case CSt_DoorKey:
           thing = get_door_for_position(player->cursor_stl_x, player->cursor_stl_y);
@@ -745,11 +758,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         case CSt_PowerHand:
           if (player->thing_under_hand == 0)
           {
-            i = get_subtile_number(stl_slab_center_subtile(player->cursor_stl_x),stl_slab_center_subtile(player->cursor_stl_y));
-            if (find_from_task_list(plyr_idx,i) != -1)
-                player->allocflags |= PlaF_ChosenSlabHasActiveTask;
-            else
-                player->allocflags &= ~PlaF_ChosenSlabHasActiveTask;
+            set_tag_untag_mode(plyr_idx, stl_x, stl_y);
             player->additional_flags |= PlaAF_NoThingUnderPowerHand;
           }
           break;
@@ -772,11 +781,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
           player->secondary_cursor_state = player->primary_cursor_state;
           if (player->primary_cursor_state == CSt_PickAxe)
           {
-            i = get_subtile_number(stl_slab_center_subtile(stl_x),stl_slab_center_subtile(stl_y));
-            if (find_from_task_list(plyr_idx,i) != -1)
-                player->allocflags |= PlaF_ChosenSlabHasActiveTask;
-            else
-                player->allocflags &= ~PlaF_ChosenSlabHasActiveTask;
+            set_tag_untag_mode(plyr_idx, stl_x, stl_y);
           }
         }
         if (player->cursor_button_down != 0)

--- a/src/packets.c
+++ b/src/packets.c
@@ -854,7 +854,10 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
             }
           }
         }
-        player->cursor_button_down = 0;
+        if ((pckt->control_flags & PCtr_RBtnHeld) == 0)
+        {
+            player->cursor_button_down = 0;
+        }
         unset_packet_control(pckt, PCtr_LBtnRelease);
         player->secondary_cursor_state = CSt_DefaultArrow;
         player->additional_flags &= ~PlaAF_NoThingUnderPowerHand;
@@ -868,7 +871,10 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         if (!power_hand_is_empty(player))
         {
           if (dump_first_held_thing_on_map(player->id_number, stl_x, stl_y, 1)) {
-              player->cursor_button_down = 0;
+              if ((pckt->control_flags & PCtr_LBtnHeld) == 0)
+              {
+                  player->cursor_button_down = 0;
+              }
               unset_packet_control(pckt, PCtr_RBtnRelease);
           }
         } else
@@ -877,7 +883,10 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
               thing = get_nearest_thing_for_slap(plyr_idx, subtile_coord_center(stl_x), subtile_coord_center(stl_y));
               magic_use_available_power_on_thing(plyr_idx, PwrK_SLAP, 0, stl_x, stl_y, thing, PwMod_Default);
           }
-          player->cursor_button_down = 0;
+          if ((pckt->control_flags & PCtr_LBtnHeld) == 0)
+          {
+              player->cursor_button_down = 0;
+          }
           unset_packet_control(pckt, PCtr_RBtnRelease);
         }
       }

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -473,7 +473,7 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
 
     if (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true)) // Define square room (mouse scroll-wheel changes size - default is 5x5)
     {
-        if ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld) // Enable "paint mode" if Ctrl or Shift are held
+        if ((pckt->control_flags & PCtr_HeldAnyButton) != 0) // Enable "paint mode" if Ctrl or Shift are held
         {
             dungeonadd->painter_build_mode = 1; // Enable GuiLayer_OneClickBridgeBuild layer
         }

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -727,7 +727,7 @@ static void find_next_point(struct RoomSpace *roomspace)
     }
 }
 
-void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace, int mode)
+void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace, int task_allowance_reduction)
 {
     if (!roomspace->tag_for_dig)
     {
@@ -740,7 +740,7 @@ void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspa
     struct PlayerInfo* player = get_player(plyr_idx);
     struct Dungeon* dungeon = get_players_dungeon(player);
     TbBool tag_for_digging = ((player->allocflags & PlaF_ChosenSlabHasActiveTask) == 0);
-    int task_allowance = ((mode == 1) ? (MAPTASKS_COUNT - 9) : (MAPTASKS_COUNT));
+    int task_allowance = MAPTASKS_COUNT - task_allowance_reduction;
     for (int y = 0; y < roomspace->height; y++)
     {
         int current_y = roomspace->top + y;

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -455,8 +455,15 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
     MapSlabCoord slb_y = subtile_slab(stl_y);
     struct RoomSpace current_roomspace;
     TbBool highlight_mode = false;
+    struct DungeonAdd *dungeonadd = get_dungeonadd(player->id_number);
+    struct Packet* pckt = get_packet_direct(player->packet_num);
+    dungeonadd->painter_build_mode = 0;
     if (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true)) // Define square room (mouse scroll-wheel changes size - default is 5x5)
     {
+        if ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld) // Enable "paint mode" if Ctrl or Shift are held
+        {
+            dungeonadd->painter_build_mode = 1; // Enable GuiLayer_OneClickBridgeBuild layer
+        }
         if (is_game_key_pressed(Gkey_RoomSpaceIncSize, &keycode, true))
         {
             if (user_defined_roomspace_width != MAX_USER_ROOMSPACE_WIDTH)

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -199,8 +199,6 @@ struct RoomSpace check_roomspace_for_diggable_slabs(struct RoomSpace roomspace, 
         for (int x = 0; x < roomspace.width; x++)
         {
             int current_x = roomspace.left + x;
-            struct SlabMap* slb = get_slabmap_for_subtile(slab_subtile(current_x, 0), slab_subtile(current_y, 0));
-            struct SlabAttr* slbattr = get_slab_attrs(slb);
             if (subtile_is_diggable_for_player(plyr_idx, slab_subtile(current_x, 0), slab_subtile(current_y, 0), false))
             {
                 roomspace.slab_grid[x][y] = true;

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -509,6 +509,18 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
     current_roomspace.untag_mode = untag_mode;
     current_roomspace.one_click_mode_exclusive = one_click_mode_exclusive;
     current_roomspace = check_roomspace_for_diggable_slabs(current_roomspace, plyr_idx);
+    if (dungeonadd->one_click_lock_cursor == 0 && !untag_mode && current_roomspace.slab_count == 0 && ((current_roomspace.width > 1) || (current_roomspace.height > 1)))
+    {
+        // if highlight roomspace is empty (and we aren't in paint mode, and we were trying to tag slabs)
+        // then check for slabs to untag instead, and if some are found, give that option to the player
+        struct RoomSpace untag_roomspace = current_roomspace;
+        untag_roomspace.untag_mode = true;
+        untag_roomspace = check_roomspace_for_diggable_slabs(untag_roomspace, plyr_idx);
+        if (untag_roomspace.slab_count > 0)
+        {
+            current_roomspace = untag_roomspace;
+        }
+    }
     player->boxsize = current_roomspace.slab_count;
     if (current_roomspace.slab_count > 0)
     {

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -83,6 +83,7 @@ struct RoomSpace {
     TbBool tag_for_dig;
     TbBool highlight_mode;
     TbBool untag_mode;
+    TbBool one_click_mode_exclusive;
 };
 /******************************************************************************/
 extern int user_defined_roomspace_width;

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -82,6 +82,7 @@ struct RoomSpace {
     TbBool render_roomspace_as_box;
     TbBool tag_for_dig;
     TbBool highlight_mode;
+    TbBool untag_mode;
 };
 /******************************************************************************/
 extern int user_defined_roomspace_width;

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -123,7 +123,7 @@ void get_dungeon_sell_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord stl_x,
 void get_dungeon_build_user_roomspace(PlayerNumber plyr_idx, RoomKind rkind,
     MapSubtlCoord stl_x, MapSubtlCoord stl_y, int *mode, TbBool drag_check);
 
-void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace, int mode);
+void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace, int task_allowance_reduction);
 void keeper_sell_roomspace(struct RoomSpace *roomspace);
 void keeper_build_roomspace(struct RoomSpace *roomspace);
 

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -80,6 +80,8 @@ struct RoomSpace {
 	  MapSlabCoord buildx, buildy;
 	  TbBool is_active;
     TbBool render_roomspace_as_box;
+    TbBool tag_for_dig;
+    TbBool highlight_mode;
 };
 /******************************************************************************/
 extern int user_defined_roomspace_width;
@@ -112,13 +114,15 @@ struct RoomSpace get_current_room_as_roomspace(PlayerNumber current_plyr_idx,
                                                MapSlabCoord cursor_x, 
                                                MapSlabCoord cursor_y);
 
+void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+
 void get_dungeon_sell_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 void get_dungeon_build_user_roomspace(PlayerNumber plyr_idx, RoomKind rkind,
     MapSubtlCoord stl_x, MapSubtlCoord stl_y, int *mode, TbBool drag_check);
 
+void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace, int mode);
 void keeper_sell_roomspace(struct RoomSpace *roomspace);
-
 void keeper_build_roomspace(struct RoomSpace *roomspace);
 
 void update_roomspaces();

--- a/src/roomspace_detection.c
+++ b/src/roomspace_detection.c
@@ -416,7 +416,7 @@ struct RoomSpace get_biggest_roomspace(PlayerNumber plyr_idx, RoomKind rkind,
     int subRoomCheckCount = 6; // the number of sub-rooms to combine in to a final meta-room
     int bestRoomsCount = 0;
     // Set default "room" - i.e. 1x1 slabs, centred on the cursor
-    struct RoomSpace best_room = { {{false}}, 1, true, 1, 1, cursor_x, cursor_y, cursor_x, cursor_y, cursor_x, cursor_y, rkind_cost, 0, plyr_idx, rkind, false, 0, 0, false, true, false, false, false };
+    struct RoomSpace best_room = { {{false}}, 1, true, 1, 1, cursor_x, cursor_y, cursor_x, cursor_y, cursor_x, cursor_y, rkind_cost, 0, plyr_idx, rkind, false, 0, 0, false, true, false, false, false, false };
     //int leniency = (((mode & 16) == 16)) ? tolerance : 0; // mode=16 :- (setting to 1 would allow e.g. 1 dirt block in the room)
     int leniency = 0;
     struct RoomSpace best_corridor = best_room;

--- a/src/roomspace_detection.c
+++ b/src/roomspace_detection.c
@@ -416,7 +416,7 @@ struct RoomSpace get_biggest_roomspace(PlayerNumber plyr_idx, RoomKind rkind,
     int subRoomCheckCount = 6; // the number of sub-rooms to combine in to a final meta-room
     int bestRoomsCount = 0;
     // Set default "room" - i.e. 1x1 slabs, centred on the cursor
-    struct RoomSpace best_room = { {{false}}, 1, true, 1, 1, cursor_x, cursor_y, cursor_x, cursor_y, cursor_x, cursor_y, rkind_cost, 0, plyr_idx, rkind, false, 0, 0, false, true, false, false };
+    struct RoomSpace best_room = { {{false}}, 1, true, 1, 1, cursor_x, cursor_y, cursor_x, cursor_y, cursor_x, cursor_y, rkind_cost, 0, plyr_idx, rkind, false, 0, 0, false, true, false, false, false };
     //int leniency = (((mode & 16) == 16)) ? tolerance : 0; // mode=16 :- (setting to 1 would allow e.g. 1 dirt block in the room)
     int leniency = 0;
     struct RoomSpace best_corridor = best_room;

--- a/src/roomspace_detection.c
+++ b/src/roomspace_detection.c
@@ -416,7 +416,7 @@ struct RoomSpace get_biggest_roomspace(PlayerNumber plyr_idx, RoomKind rkind,
     int subRoomCheckCount = 6; // the number of sub-rooms to combine in to a final meta-room
     int bestRoomsCount = 0;
     // Set default "room" - i.e. 1x1 slabs, centred on the cursor
-    struct RoomSpace best_room = { {{false}}, 1, true, 1, 1, cursor_x, cursor_y, cursor_x, cursor_y, cursor_x, cursor_y, rkind_cost, 0, plyr_idx, rkind, false, 0, 0, false, true };
+    struct RoomSpace best_room = { {{false}}, 1, true, 1, 1, cursor_x, cursor_y, cursor_x, cursor_y, cursor_x, cursor_y, rkind_cost, 0, plyr_idx, rkind, false, 0, 0, false, true, false, false };
     //int leniency = (((mode & 16) == 16)) ? tolerance : 0; // mode=16 :- (setting to 1 would allow e.g. 1 dirt block in the room)
     int leniency = 0;
     struct RoomSpace best_corridor = best_room;


### PR DESCRIPTION
**basic one-click highlight**

Any time you could tag/untag for digging, you can now hold CTRL to use the one-click square brush.

Interface conflicts with scroll wheel are handled the same as for one-click build/sell.

tag_cursor_blocks_dig() now works with roomspaces

process_dungeon_power_hand_state() and process_dungeon_control_packet_dungeon_control() now use get_dungeon_highlight_user_roomspace() before tag_cursor_blocks_dig() to set up a roomspace.

keeper_highlight_roomspace() is used instead of direct calls to untag_blocks_for_digging_in_rectangle_around() and tag_blocks_for_digging_in_rectangle_around() to allow slabs in a roomspace to be tagged/untagged.

multiple functions added to roomspace.c to allow one-click highlight to work