### PR TITLE
remove libwinpthread-1.dll dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,8 @@ ifneq (,$(findstring Windows,$(OS)))
   # linker flags
   # useful for development only: -Wl,-Map,"$(@:%.exe=%.map)"
   LINKFLAGS = -static-libgcc -static-libstdc++ -Wl,--enable-auto-import -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive
-  # "-Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive" added to LINKFLAGS to statically link lwinpthread
-  # "--whole-archive" and "--no-whole-archive" are used to ensure lwinpthread is linked statically, but does not attempt to make all libraries static (like "-static" would)
-  # This removes a dependency on  libwinpthread-1.dll when keeperfx is built with MSYS2
-  # See: https://github.com/dkfans/keeperfx/pull/1018
+  # The following flags are only here to prevent a dependency on libwinpthread-1.dll when keeperfx is built with MSYS2:
+  # "-Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive
 else
   CROSS_EXEEXT =
   CROSS_COMPILE = i686-w64-mingw32-

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ ifneq (,$(findstring Windows,$(OS)))
   # linker flags
   # useful for development only: -Wl,-Map,"$(@:%.exe=%.map)"
   LINKFLAGS = -static-libgcc -static-libstdc++ -Wl,--enable-auto-import -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive
+  # "-Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive" added to LINKFLAGS to statically link lwinpthread
+  # "--whole-archive" and "--no-whole-archive" are used to ensure lwinpthread is linked statically, but does not attempt to make all libraries static (like "-static" would)
+  # This removes a dependency on  libwinpthread-1.dll when keeperfx is built with MSYS2
+  # See: https://github.com/dkfans/keeperfx/pull/1018
 else
   CROSS_EXEEXT =
   CROSS_COMPILE = i686-w64-mingw32-

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifneq (,$(findstring Windows,$(OS)))
   CROSS_EXEEXT = .exe
   # linker flags
   # useful for development only: -Wl,-Map,"$(@:%.exe=%.map)"
-  LINKFLAGS = -static-libgcc -static-libstdc++ -Wl,--enable-auto-import
+  LINKFLAGS = -static-libgcc -static-libstdc++ -Wl,--enable-auto-import -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive
 else
   CROSS_EXEEXT =
   CROSS_COMPILE = i686-w64-mingw32-


### PR DESCRIPTION
keeperfx.exe has a dependancy on libwinpthread-1.dll when building with MSYS2 & mingw32.

This PR removes the dependency.

Side effect - this PR adds an error message like:
![image](https://user-images.githubusercontent.com/1984342/115732401-daaee080-a37f-11eb-8ccc-e45f54cfe9db.png)

C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/10.2.0/../../../../i686-w64-mingw32/bin/ld.exe: .rsrc merge failure: duplicate leaf: type: 10 (VERSION) name: 1 lang: 409

to end of KFX build process, but it is harmless.

Sources:
* https://stackoverflow.com/questions/13768515/how-to-do-static-linking-of-libwinpthread-1-dll-in-mingw (why I added the new commands)
* https://stackoverflow.com/a/63375091 (why the new error message is harmless)

So, to explicitly state the details here: 
* A static link to lwinpthread is added at the end of the linker flags, this means libwinpthread-1.dll is no longer needed by KFX (when built with MSYS2)
* `--whole-archive` and `--no-whole-archive` are used to ensure only lwinpthread is statically linked, and it is fully linked
* "In the libpthread.a, there is a version.o containing a compiled VERSIONINFO resource", this conflicts with the .rc file for keeperfx creating duplicate VERSIONINFO resources - which is what produces the error message above
* because lwinpthread's VERSIONINFO resource is the second listed, it is ignored; keeperfx's .rc file is still processed correctly, as it is the first listed