### PR TITLE
One click highlight lowslab adjustments

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1823,7 +1823,7 @@ TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *context
   unsigned int slb_y = subtile_slab_fast(y);
   struct SlabMap* slb = get_slabmap_block(slb_x, slb_y);
   struct SlabAttr* slbattr = get_slab_attrs(slb);
-  if (slab_kind_is_door(slb->kind) && (slabmap_owner(slb) == player->id_number) && (dungeonadd->one_click_lock_cursor == 0))
+  if (slab_kind_is_door(slb->kind) && (slabmap_owner(slb) == player->id_number) && (!dungeonadd->one_click_lock_cursor))
   {
     *context = CSt_DoorKey;
     pos->x.val = (x<<8) + top_pointed_at_frac_x;
@@ -1841,13 +1841,13 @@ TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *context
     pos->x.val = (x<<8) + top_pointed_at_frac_x;
     pos->y.val = (y<<8) + top_pointed_at_frac_y;
   } else
-  if (((slb_x >= map_tiles_x) || (slb_y >= map_tiles_y)) && (dungeonadd->one_click_lock_cursor == 0))
+  if (((slb_x >= map_tiles_x) || (slb_y >= map_tiles_y)) && (!dungeonadd->one_click_lock_cursor))
   {
     *context = CSt_DefaultArrow;
     pos->x.val = (block_pointed_at_x<<8) + pointed_at_frac_x;
     pos->y.val = (block_pointed_at_y<<8) + pointed_at_frac_y;
   } else
-  if (((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0) || (dungeonadd->one_click_lock_cursor == 1))
+  if (((slbattr->block_flags & (SlbAtFlg_Filled|SlbAtFlg_Digable|SlbAtFlg_Valuable)) != 0) || (dungeonadd->one_click_lock_cursor))
   {
     *context = CSt_PickAxe;
     pos->x.val = (x<<8) + top_pointed_at_frac_x;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3117,7 +3117,7 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     {
         allowed = true;
     }
-    else if (dungeonadd->one_click_lock_cursor)
+    else if ((dungeonadd->one_click_lock_cursor) && ((pckt->control_flags & PCtr_LBtnHeld) != 0))
     {
         allowed = true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3117,7 +3117,7 @@ void tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     {
         allowed = true;
     }
-    else if (dungeonadd->one_click_lock_cursor == 1)
+    else if (dungeonadd->one_click_lock_cursor)
     {
         allowed = true;
     }

--- a/src/packets.c
+++ b/src/packets.c
@@ -515,7 +515,7 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
       return false;
     }
     struct Thing* thing = get_nearest_thing_for_hand_or_slap(plyr_idx, x, y);
-    if (!thing_is_invalid(thing) && (dungeonadd->one_click_lock_cursor == 0))
+    if (!thing_is_invalid(thing) && (!dungeonadd->one_click_lock_cursor))
     {
       SYNCDBG(19,"Thing %d under hand at (%d,%d)",(int)thing->index,(int)thing->mappos.x.stl.num,(int)thing->mappos.y.stl.num);
       if (player->hand_thing_idx == 0)
@@ -531,7 +531,7 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
       long i = thing_is_creature_special_digger(thing);
       if ((can_drop_thing_here(stl_x, stl_y, player->id_number, i)
         || !can_dig_here(stl_x, stl_y, player->id_number, true))
-        && (dungeonadd->one_click_lock_cursor == 0))
+        && (!dungeonadd->one_click_lock_cursor))
       {
         render_roomspace = create_box_roomspace(render_roomspace, 1, 1, subtile_slab(stl_x), subtile_slab(stl_y));
         tag_cursor_blocks_thing_in_hand(player->id_number, stl_x, stl_y, i, player->full_slab_cursor);
@@ -874,7 +874,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         if ((pckt->control_flags & PCtr_RBtnHeld) == 0)
         {
             player->cursor_button_down = 0;
-            dungeonadd->one_click_lock_cursor = 0;
+            dungeonadd->one_click_lock_cursor = false;
         }
         unset_packet_control(pckt, PCtr_LBtnRelease);
         if (render_roomspace.drag_mode)
@@ -896,7 +896,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
 
     if ((pckt->control_flags & PCtr_RBtnRelease) != 0)
     {
-      if (dungeonadd->ignore_next_PCtr_RBtnRelease && (dungeonadd->one_click_lock_cursor == 0))
+      if (dungeonadd->ignore_next_PCtr_RBtnRelease && (!dungeonadd->one_click_lock_cursor))
       {
           dungeonadd->ignore_next_PCtr_RBtnRelease = false;
           if ((pckt->control_flags & PCtr_LBtnHeld) == 0)
@@ -907,7 +907,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
       } else
       if (player->cursor_button_down != 0)
       {
-        if (!power_hand_is_empty(player) && (dungeonadd->one_click_lock_cursor == 0))
+        if (!power_hand_is_empty(player) && (!dungeonadd->one_click_lock_cursor))
         {
           if (dump_first_held_thing_on_map(player->id_number, stl_x, stl_y, 1)) {
               if ((pckt->control_flags & PCtr_LBtnHeld) == 0)
@@ -918,20 +918,20 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
           }
         } else
         {
-          if (player->primary_cursor_state == CSt_PowerHand && (dungeonadd->one_click_lock_cursor == 0)) {
+          if (player->primary_cursor_state == CSt_PowerHand && (!dungeonadd->one_click_lock_cursor)) {
               thing = get_nearest_thing_for_slap(plyr_idx, subtile_coord_center(stl_x), subtile_coord_center(stl_y));
               magic_use_available_power_on_thing(plyr_idx, PwrK_SLAP, 0, stl_x, stl_y, thing, PwMod_Default);
           }
           if ((pckt->control_flags & PCtr_LBtnHeld) == 0)
           {
               player->cursor_button_down = 0;
-              dungeonadd->one_click_lock_cursor = 0;
+              dungeonadd->one_click_lock_cursor = false;
           }
           unset_packet_control(pckt, PCtr_RBtnRelease);
         }
       }
     }
-    if (player->cursor_button_down == 0 || dungeonadd->one_click_lock_cursor == 0)
+    if ((player->cursor_button_down == 0) || (!dungeonadd->one_click_lock_cursor))
     {
       //if (untag_or_tag_completed_or_cancelled)
       dungeonadd->swap_to_untag_mode = 0; // no
@@ -1861,7 +1861,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     }
     if (((pckt->control_flags & PCtr_HeldAnyButton) != 0) && (influence_own_creatures))
     {
-      if (((player->secondary_cursor_state == CSt_DefaultArrow) || (player->secondary_cursor_state == CSt_PowerHand)) && (dungeonadd->one_click_lock_cursor == 0))
+      if (((player->secondary_cursor_state == CSt_DefaultArrow) || (player->secondary_cursor_state == CSt_PowerHand)) && (!dungeonadd->one_click_lock_cursor))
         stop_creatures_around_hand(plyr_idx, stl_x, stl_y);
     }
     return ret;

--- a/src/packets.c
+++ b/src/packets.c
@@ -716,6 +716,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
     if ((pckt->control_flags & PCtr_LBtnAnyAction) == 0)
       player->secondary_cursor_state = CSt_DefaultArrow;
     player->primary_cursor_state = (unsigned short)(pckt->additional_packet_values & PCAdV_ContextMask) >> 1; // get current cursor state from pckt->additional_packet_values
+    render_roomspace.highlight_mode = false; // reset one-click highlight mode
 
     process_dungeon_power_hand_state(plyr_idx);
 

--- a/src/packets.c
+++ b/src/packets.c
@@ -935,6 +935,10 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
     {
       //if (untag_or_tag_completed_or_cancelled)
       dungeonadd->swap_to_untag_mode = 0; // no
+      if ((player->cursor_button_down == 0) && ((pckt->control_flags & PCtr_LBtnHeld) == 0))
+      {
+        dungeonadd->one_click_lock_cursor = false;
+      }
     }
     return true;
 }

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -506,7 +506,7 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
         // exit out of click and drag mode
         if (render_roomspace.drag_mode)
         {
-            dungeonadd->one_click_lock_cursor = 0;
+            dungeonadd->one_click_lock_cursor = false;
             if ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld)
             {
                 dungeonadd->ignore_next_PCtr_LBtnRelease = true;
@@ -518,7 +518,7 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
     {
         // because player cancelled a tag/untag with RMB, we need to default back to vanilla 1x1 box
         render_roomspace.drag_mode = false;
-        dungeonadd->one_click_lock_cursor = 0;
+        dungeonadd->one_click_lock_cursor = false;
         reset_dungeon_build_room_ui_variables();
         current_roomspace = create_box_roomspace(render_roomspace, width, height, slb_x, slb_y);
         current_roomspace.highlight_mode = false;
@@ -536,7 +536,7 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
     }
     if ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld) // highlight "paint mode" enabled
     {
-        dungeonadd->one_click_lock_cursor = 1;
+        dungeonadd->one_click_lock_cursor = true;
         untag_mode = render_roomspace.untag_mode; // get tag/untag mode from the slab that was clicked (before the user started holding mouse button)
     }
     else // user is hovering the mouse cursor
@@ -558,7 +558,7 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
     {
         if (((pckt->control_flags & PCtr_HeldAnyButton) != 0) || ((pckt->control_flags & PCtr_LBtnRelease) != 0))
         {
-            dungeonadd->one_click_lock_cursor = 1; // Allow click and drag over low slabs (if clicked on high slab)
+            dungeonadd->one_click_lock_cursor = true; // Allow click and drag over low slabs (if clicked on high slab)
             untag_mode = render_roomspace.untag_mode; // get tag/untag mode from the slab that was clicked (before the user started holding mouse button)
             one_click_mode_exclusive = true; // Block camera zoom/rotate if Ctrl is held with LMB/RMB
             drag_start_x = render_roomspace.drag_start_x; // if we are dragging, get the starting coords from the slab the player clicked on
@@ -640,7 +640,7 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
     {
         current_roomspace.tag_for_dig = true;
     }
-    if (dungeonadd->one_click_lock_cursor == 1  && ((pckt->control_flags & PCtr_LBtnHeld) != 0) && !current_roomspace.drag_mode)
+    if ((dungeonadd->one_click_lock_cursor) && ((pckt->control_flags & PCtr_LBtnHeld) != 0) && (!current_roomspace.drag_mode))
     {
         current_roomspace.is_roomspace_a_box = true; // force full box cursor in "paint mode" - this stops the accurate boundbox appearing for a frame, before the slabs are tagged/untagged (which appears as flickering to the user)
     }

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -546,10 +546,16 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
             untag_mode = true;
         }
     }
+    if ((dungeonadd->swap_to_untag_mode == -1) && ((pckt->control_flags & PCtr_RBtnHeld) == PCtr_RBtnHeld) && (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true)) && (!subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false)) && ((pckt->control_flags & PCtr_LBtnAnyAction) == 0))
+    {
+        // Allow RMB + CTRL to work as expected over lowslabs (for tagging and untagging)
+        // we reset swap_to_untag_mode whenever LMB is not pressed (i.e. we are still in preview mode)
+        dungeonadd->swap_to_untag_mode = 0;
+    }
     if (dungeonadd->swap_to_untag_mode == 0) // if swap_to_untag_mode ==  no / enabled
     {
-        //if (untag_or_tag_started_on_undiggable_highslab)
-        if ((subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, true)) && (!subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false)))
+        //if (untag_or_tag_started_on_undiggable_highslab OR lowslab)
+        if (!subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false))
         {
             dungeonadd->swap_to_untag_mode = 1; // maybe
         }
@@ -582,6 +588,7 @@ void get_dungeon_highlight_user_roomspace(PlayerNumber plyr_idx, MapSubtlCoord s
     {
         if ((pckt->control_flags & PCtr_HeldAnyButton) != 0) // Block camera zoom/rotate if Ctrl is held with LMB/RMB
         {
+            dungeonadd->one_click_lock_cursor = true;
             one_click_mode_exclusive = true;
         }
         if (is_game_key_pressed(Gkey_RoomSpaceIncSize, &keycode, true))


### PR DESCRIPTION
Bugfix:
Holding left mouse button over a dungeon message stuck the cursor in PickAxe/Highlight mode when hovering over "low slabs", and it could only be reset to normal by clicking left or right mouse button.
This is now fixed.

Feature:
Holding Ctrl+RMB now works over low slabs, as long as you start holding Ctrl+RMB over a high slab (wip)
![image](https://user-images.githubusercontent.com/1984342/115479809-25760e80-a241-11eb-8edd-2a3627f32be5.png)
