### PR TITLE
position tool tips correctly

### DIFF
--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -72,7 +72,8 @@ void set_gui_tooltip_box_fmt(int bxtype,const char *format, ...)
   va_end(val);
   if (bxtype != 0) {
       tool_tip_box.pos_x = GetMouseX();
-      tool_tip_box.pos_y = GetMouseY()+86;
+      long y_offset = ((43 * (units_per_pixel << 4)) >> 7); // equivalent to (86 * (units_per_pixel/16)) but accounts for rounding, 86 was the previous value of y_offset
+      tool_tip_box.pos_y = GetMouseY() + y_offset;
   }
   tool_tip_box.field_809 = bxtype;
 }
@@ -102,7 +103,8 @@ static inline TbBool update_gui_tooltip_button(struct GuiButton *gbtn)
     {
         tool_tip_box.gbutton = gbtn;
         tool_tip_box.pos_x = GetMouseX();
-        tool_tip_box.pos_y = GetMouseY()+86;
+        long y_offset = ((43 * (units_per_pixel << 4)) >> 7); // equivalent to (86 * (units_per_pixel/16)) but accounts for rounding, 86 was the previous value of y_offset
+        tool_tip_box.pos_y = GetMouseY() + y_offset;
         tool_tip_box.field_809 = 0;
         return true;
     }

--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -72,7 +72,8 @@ void set_gui_tooltip_box_fmt(int bxtype,const char *format, ...)
   va_end(val);
   if (bxtype != 0) {
       tool_tip_box.pos_x = GetMouseX();
-      long y_offset = ((43 * (units_per_pixel << 4)) >> 7); // equivalent to (86 * (units_per_pixel/16)) but accounts for rounding, 86 was the previous value of y_offset
+      long y_offset_times_two = (43 * units_per_pixel) >> 2;
+      long y_offset = (y_offset_times_two + (y_offset_times_two & 1)) >> 1; // equivalent to (86 * (units_per_pixel/16)) but accounts for rounding, 86 was the previous hard value of y_offset (meant for 640x400)
       tool_tip_box.pos_y = GetMouseY() + y_offset;
   }
   tool_tip_box.field_809 = bxtype;
@@ -103,7 +104,8 @@ static inline TbBool update_gui_tooltip_button(struct GuiButton *gbtn)
     {
         tool_tip_box.gbutton = gbtn;
         tool_tip_box.pos_x = GetMouseX();
-        long y_offset = ((43 * (units_per_pixel << 4)) >> 7); // equivalent to (86 * (units_per_pixel/16)) but accounts for rounding, 86 was the previous value of y_offset
+        long y_offset_times_two = (43 * units_per_pixel) >> 2;
+        long y_offset = (y_offset_times_two + (y_offset_times_two & 1)) >> 1; // equivalent to (86 * (units_per_pixel/16)) but accounts for rounding, 86 was the previous hard value of y_offset (meant for 640x400)
         tool_tip_box.pos_y = GetMouseY() + y_offset;
         tool_tip_box.field_809 = 0;
         return true;


### PR DESCRIPTION
Fixes #1003

Tool Tips are positioned according to the mouse X and Y coordinate. A y-offset of 86 was added, which was correct for 640x400.

This fixed 86 has now been replaced with a value based on the units_per_pixel value. This means that the tool tip is now in the correct position at all resolutions.

Instead of this:
![image](https://user-images.githubusercontent.com/1984342/115759163-dabada80-a397-11eb-9896-93628abc0d71.png)


we now have this:
![image](https://user-images.githubusercontent.com/1984342/115758857-81eb4200-a397-11eb-9626-2621fcbf92d5.png)
