### PR TITLE
correct position of corner sprites in draw_zoom_box()

### DIFF
--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -970,15 +970,22 @@ TbPixel LbPaletteFindColour(const unsigned char *pal, unsigned char r, unsigned 
 }
 
 /**
- * Scale a given value according to the game resolution (units_per_pixel).
- * (returned value is rounded up to the next integer if ends in .5 or more)
- * default is based on 640x400 (units_per_pixel = 16)
- * so if units_per_pixel = 16 the this function returns (base_value * 1)
+ * Takes a fixed value designed for 640x400 resolution and scales it to the game's current resolution
+ * Returns a new fixed integer value, calculated from base_value relative to ("current units_per_pixel" / "reference units_per_pixel")
  *
- * @param base_value The value (or size) for the game running at 640x400. base_value should always be divisible by 2, for compatibility with 320x200.
+ * "reference units_per_pixel" is = 16, as this is the value of units_per_pixel at 640x400 or 640x480 mode
+ *
+ * If 640x400 mode   (units_per_pixel = 16) then this function returns (base_value * 1)
+ * If 320x200 mode   (units_per_pixel =  8) then this function returns (base_value * 0.5)
+ * If 1920x1080 mode (units_per_pixel = 48) then this function returns (base_value * 3)
+ *
+ * (!base_value should always be divisible by 2, for compatibility with 320x200 resolution!)
+ *
+ * @param base_value The fixed value from original DK 640x400 mode that needs to be scaled with the game's current resolution
  */
 long scale_value_for_resolution(long base_value)
 {
+    // return value is equivalent to: round(base_value * units_per_pixel /16)
     return ((((units_per_pixel * base_value) >> 3) + (((units_per_pixel * base_value) >> 3) & 1)) >> 1);
 }
 /******************************************************************************/

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -975,7 +975,7 @@ TbPixel LbPaletteFindColour(const unsigned char *pal, unsigned char r, unsigned 
  * default is based on 640x400 (units_per_pixel = 16)
  * so if units_per_pixel = 16 the this function returns (base_value * 1)
  *
- * @param base_value The value (or size) for the game running at 640x400.
+ * @param base_value The value (or size) for the game running at 640x400. base_value should always be divisible by 2, for compatibility with 320x200.
  */
 long scale_value_for_resolution(long base_value)
 {

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -968,6 +968,18 @@ TbPixel LbPaletteFindColour(const unsigned char *pal, unsigned char r, unsigned 
     }
     return *o;
 }
+
+/**
+ * Scale a given value according to the game resolution (units_per_pixel).
+ * default is based on 640x400 (units_per_pixel = 16)
+ * so if units_per_pixel = 16 the this function returns (base_value * 1)
+ *
+ * @param base_value The value (or size) for the game running at 640x400.
+ */
+long scale_value_for_resolution(long base_value)
+{
+    return ((((units_per_pixel * base_value) >> 3) + (((units_per_pixel * base_value) >> 3) & 1)) >> 1);
+}
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -971,6 +971,7 @@ TbPixel LbPaletteFindColour(const unsigned char *pal, unsigned char r, unsigned 
 
 /**
  * Scale a given value according to the game resolution (units_per_pixel).
+ * (returned value is rounded up to the next integer if ends in .5 or more)
  * default is based on 640x400 (units_per_pixel = 16)
  * so if units_per_pixel = 16 the this function returns (base_value * 1)
  *

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -317,6 +317,8 @@ TbResult LbScreenSetGraphicsWindow(TbScreenCoord x, TbScreenCoord y,
 
 TbResult LbSetTitle(const char *title);
 TbResult LbSetIcon(unsigned short nicon);
+
+long scale_value_for_resolution(long base_value);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/gui_parchment.c
+++ b/src/gui_parchment.c
@@ -790,11 +790,11 @@ void draw_zoom_box(void)
     long mouse_y = GetMouseY();
 
     // zoom box block size
-    const int subtile_size = (8*units_per_pixel+8)/16;
+    const int subtile_size = scale_value_for_resolution(8);
 
     // Drawing coordinates
-    long scrtop_x = mouse_x + 24 * units_per_pixel / 16;
-    long scrtop_y = mouse_y + 24 * units_per_pixel / 16;
+    long scrtop_x = mouse_x + scale_value_for_resolution(24);
+    long scrtop_y = mouse_y + scale_value_for_resolution(24);
     if (scrtop_x > MyScreenWidth-draw_tiles_x*subtile_size)
       scrtop_x = MyScreenWidth-draw_tiles_x*subtile_size;
     if (scrtop_x < 0)
@@ -821,10 +821,10 @@ void draw_zoom_box(void)
         bs_units_per_px = (74 * units_per_pixel) / spr->SWidth;
     }
     LbScreenSetGraphicsWindow(0/pixel_size, 0/pixel_size, MyScreenWidth/pixel_size, MyScreenHeight/pixel_size);
-    int beg_x = scrtop_x - (24 * units_per_pixel + 8) / 16;
-    int beg_y = scrtop_y - (20 * units_per_pixel + 8) / 16;
-    int end_x = scrtop_x - (50 * units_per_pixel + 8) / 16 + draw_tiles_x * subtile_size;
-    int end_y = scrtop_y - (54 * units_per_pixel + 8) / 16 + draw_tiles_y * subtile_size;
+    int beg_x = scrtop_x - scale_value_for_resolution(24);
+    int beg_y = scrtop_y - scale_value_for_resolution(20);
+    int end_x = scrtop_x - scale_value_for_resolution(50) + draw_tiles_x * subtile_size;
+    int end_y = scrtop_y - scale_value_for_resolution(54) + draw_tiles_y * subtile_size;
     LbSpriteDrawResized(beg_x, beg_y, bs_units_per_px, &button_sprite[194]);
     LbSpriteDrawResized(end_x, beg_y, bs_units_per_px, &button_sprite[195]);
     LbSpriteDrawResized(beg_x, end_y, bs_units_per_px, &button_sprite[196]);

--- a/src/gui_parchment.c
+++ b/src/gui_parchment.c
@@ -821,10 +821,10 @@ void draw_zoom_box(void)
         bs_units_per_px = (74 * units_per_pixel) / spr->SWidth;
     }
     LbScreenSetGraphicsWindow(0/pixel_size, 0/pixel_size, MyScreenWidth/pixel_size, MyScreenHeight/pixel_size);
-    int beg_x = scrtop_x - scale_value_for_resolution(24);
-    int beg_y = scrtop_y - scale_value_for_resolution(20);
-    int end_x = scrtop_x - scale_value_for_resolution(50) + draw_tiles_x * subtile_size;
-    int end_y = scrtop_y - scale_value_for_resolution(54) + draw_tiles_y * subtile_size;
+    int beg_x = scrtop_x - scale_value_for_resolution(20);
+    int beg_y = scrtop_y - scale_value_for_resolution(24);
+    int end_x = scrtop_x - scale_value_for_resolution(46) + draw_tiles_x * subtile_size;
+    int end_y = scrtop_y - scale_value_for_resolution(58) + draw_tiles_y * subtile_size;
     LbSpriteDrawResized(beg_x, beg_y, bs_units_per_px, &button_sprite[194]);
     LbSpriteDrawResized(end_x, beg_y, bs_units_per_px, &button_sprite[195]);
     LbSpriteDrawResized(beg_x, end_y, bs_units_per_px, &button_sprite[196]);


### PR DESCRIPTION
correcting the position of these corner sprites:
![image](https://user-images.githubusercontent.com/1984342/115801023-aebd4a80-a3d3-11eb-9352-543d58809882.png)
(top left shown)

For reference, DK GOG:
![image](https://user-images.githubusercontent.com/1984342/115800510-b03a4300-a3d2-11eb-93d6-0e0e3f731a8c.png)

KeeperFX 1080p master:
![image](https://user-images.githubusercontent.com/1984342/115800337-4e79d900-a3d2-11eb-8c1e-58644c69b51a.png)

KeeperFX 1080p with this PR:
![image](https://user-images.githubusercontent.com/1984342/115800291-386c1880-a3d2-11eb-893d-bef58174ba95.png)





