### PR TITLE
minimap (and money total) now correct size at all resolutions

### DIFF
--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -971,7 +971,7 @@ TbPixel LbPaletteFindColour(const unsigned char *pal, unsigned char r, unsigned 
 
 /**
  * Takes a fixed value designed for 640x400 resolution and scales it to the game's current resolution
- * Returns a new fixed integer value, calculated from base_value relative to ("current units_per_pixel" / "reference units_per_pixel")
+ * Returns a new integer value, calculated from base_value relative to ("current units_per_pixel" / "reference units_per_pixel")
  *
  * "reference units_per_pixel" is = 16, as this is the value of units_per_pixel at 640x400 or 640x480 mode
  *
@@ -987,6 +987,44 @@ long scale_value_for_resolution(long base_value)
 {
     // return value is equivalent to: round(base_value * units_per_pixel /16)
     return ((((units_per_pixel * base_value) >> 3) + (((units_per_pixel * base_value) >> 3) & 1)) >> 1);
+}
+
+/**
+ * Duplicates scale_value_for_resolution() except that this function:
+ * is passed a units_per_px parameter, rather than using the global units_per_pixel
+ *
+ * @param base_value The fixed value from original DK 640x400 mode that needs to be scaled with the game's current resolution
+ * @param units_per_px The current units_per_px value for the current resolution
+ */
+long scale_value_for_resolution_with_upp(long base_value, long units_per_px)
+{
+    long value = ((((units_per_px * base_value) >> 3) + (((units_per_px * base_value) >> 3) & 1)) >> 1);
+    // return value is equivalent to: round(base_value * units_per_px /16)
+    return max(1,value);
+}
+
+/**
+ * Duplicates scale_value_for_resolution() except that this function:
+ * uses units_per_pixel_width rather than using units_per_pixel
+ *
+ * @param base_value The fixed value from original DK 640x400 mode that needs to be scaled with the game's current horizontal resolution
+ */
+long scale_value_by_horizontal_resolution(long base_value)
+{
+    // return value is equivalent to: round(base_value * units_per_pixel_width /16)
+    return ((((units_per_pixel_width * base_value) >> 3) + (((units_per_pixel_width * base_value) >> 3) & 1)) >> 1);
+}
+
+/**
+ * Duplicates scale_value_for_resolution() except that this function:
+ * uses units_per_pixel_height rather than using units_per_pixel
+ *
+ * @param base_value The fixed value from original DK 640x400 mode that needs to be scaled with the game's current vertical resolution
+ */
+long scale_value_by_vertical_resolution(long base_value)
+{
+    // return value is equivalent to: round(base_value * units_per_pixel_height /16)
+    return ((((units_per_pixel_height * base_value) >> 3) + (((units_per_pixel_height * base_value) >> 3) & 1)) >> 1);
 }
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -224,6 +224,8 @@ typedef struct DisplayStructEx TbDisplayStructEx;
 struct SSurface;
 typedef struct SSurface TSurface;
 
+extern unsigned short units_per_pixel_width;
+extern unsigned short units_per_pixel_height;
 /******************************************************************************/
 
 DLLIMPORT extern TbDisplayStruct _DK_lbDisplay;
@@ -319,6 +321,9 @@ TbResult LbSetTitle(const char *title);
 TbResult LbSetIcon(unsigned short nicon);
 
 long scale_value_for_resolution(long base_value);
+long scale_value_for_resolution_with_upp(long base_value, long units_per_px);
+long scale_value_by_horizontal_resolution(long base_value);
+long scale_value_by_vertical_resolution(long base_value);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/frontmenu_ingame_map.c
+++ b/src/frontmenu_ingame_map.c
@@ -1142,8 +1142,8 @@ void auto_gen_tables(long units_per_px)
 
 void pannel_map_draw_slabs(long x, long y, long units_per_px, long zoom)
 {
-    PannelMapX = x * units_per_px / 16;
-    PannelMapY = y * units_per_px / 16;
+    PannelMapX = scale_value_for_resolution_with_upp(x,units_per_px);
+    PannelMapY = scale_value_for_resolution_with_upp(y,units_per_px);
     auto_gen_tables(units_per_px);
     update_pannel_colours();
     struct PlayerInfo *player;

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -2084,14 +2084,14 @@ void draw_gold_total(PlayerNumber plyr_idx, long scr_x, long scr_y, long units_p
         ndigits++;
     }
     struct TbSprite* spr = &button_sprite[71];
-    val_width = (spr->SWidth * units_per_px / 16) * ndigits;
+    val_width = scale_value_for_resolution_with_upp(spr->SWidth, units_per_px) * ndigits;
     if (ndigits > 0)
     {
         long pos_x = scr_x + val_width / 2;
         for (i = value; i > 0; i /= 10)
         {
             // Make space for the character first, as we're drawing right char towards left
-            pos_x -= spr->SWidth * units_per_px / 16;
+            pos_x -= scale_value_for_resolution_with_upp(spr->SWidth, units_per_px);
             spr = &button_sprite[i % 10 + 71];
             LbSpriteDrawResized(pos_x, scr_y, units_per_px, spr);
         }

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -2129,7 +2129,7 @@ void draw_whole_status_panel(void)
     // Draws gold amount; note that button_sprite[] is used instead of full font
     draw_gold_total(player->id_number, gmnu->pos_x + gmnu->width/2, gmnu->pos_y + gmnu->height*67/200, bs_units_per_px, dungeon->total_money_owned);
     if (16/mm_units_per_px < 3)
-        mmzoom = (player->minimap_zoom) / (3-16/mm_units_per_px);
+        mmzoom = (player->minimap_zoom) / scale_value_for_resolution_with_upp(2,mm_units_per_px);
     else
         mmzoom = player->minimap_zoom;
     pannel_map_draw_slabs(player->minimap_pos_x, player->minimap_pos_y, mm_units_per_px, mmzoom);

--- a/src/vidmode.c
+++ b/src/vidmode.c
@@ -64,6 +64,8 @@ TbScreenMode frontend_vidmode = Lb_SCREEN_MODE_640_480_8;
 
 //struct IPOINT_2D units_per_pixel;
 unsigned short units_per_pixel_min;
+unsigned short units_per_pixel_width;
+unsigned short units_per_pixel_height;
 long base_mouse_sensitivity = 256;
 
 short force_video_mode_reset = true;
@@ -727,6 +729,9 @@ TbBool update_screen_mode_data(long width, long height)
   pixels_per_block = 16 * psize;
   units_per_pixel = (width>height?width:height)/40;// originally was 16 for hires, 8 for lores
   units_per_pixel_min = (width>height?height:width)/40;// originally 10 for hires
+  units_per_pixel_width = width/40; // 8 for low res, 16 is "kfx default"
+  units_per_pixel_height = height/25; // 8 for low res, 16 is "kfx default"
+  
   if (MinimalResolutionSetup)
     LbSpriteSetupAll(setup_sprites_minimal);
   else


### PR DESCRIPTION
Fixes #824.
there may be slight rounding errors, but minimap now does not get more zoomed out the higher the video resolution.

e.g. 1920x1200 is a 3:1 match of 640x400 and looks the same in fullscreen, 1920x1080 _might_ be slightly off.

3840x2160 fully zoomed in:
![image](https://user-images.githubusercontent.com/1984342/115974678-38952100-a556-11eb-94fe-f1b423b6716a.png)
