### PR TITLE
Rework SET_TRAP_CONFIGURATION

### DIFF
--- a/src/config_trapdoor.h
+++ b/src/config_trapdoor.h
@@ -118,6 +118,8 @@ TbBool is_trap_built(PlayerNumber plyr_idx, long tngmodel);
 TbBool is_door_placeable(PlayerNumber plyr_idx, long door_idx);
 TbBool is_door_buildable(PlayerNumber plyr_idx, long door_idx);
 TbBool is_door_built(PlayerNumber plyr_idx, long door_idx);
+TbBool create_manufacture_array_from_trapdoor_data(void);
+
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/dungeon_data.c
+++ b/src/dungeon_data.c
@@ -307,11 +307,15 @@ TbBool set_trap_buildable_and_add_to_amount(PlayerNumber plyr_idx, ThingModel tn
         return false;
     }
     if (buildable)
+    {
         dungeonadd->mnfct_info.trap_build_flags[tngmodel] |= MnfBldF_Manufacturable;
+    }
     dungeonadd->mnfct_info.trap_amount_offmap[tngmodel] += amount;
     dungeonadd->mnfct_info.trap_amount_placeable[tngmodel] += amount;
     if (amount > 0)
-      dungeonadd->mnfct_info.trap_build_flags[tngmodel] |= MnfBldF_Built;
+    {
+        dungeonadd->mnfct_info.trap_build_flags[tngmodel] |= MnfBldF_Built;
+    }
     return true;
 }
 

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -5996,6 +5996,7 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
   struct SlabMap *slb;
   struct TrapConfigStats* trapst;
   struct ManfctrConfig* mconf;
+  struct ManufactureData* manufctr;
   int plr_start;
   int plr_end;
   long i;
@@ -6875,6 +6876,7 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
   case Cmd_SET_TRAP_CONFIGURATION:  
       trapst = &trapdoor_conf.trap_cfgstats[val2];
       mconf = &gameadd.traps_config[val2];
+      manufctr = get_manufacture_data(val2);
       switch (val3)
       {
       case 1: // NameTextID
@@ -6886,7 +6888,6 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       case 3: // SymbolSprites
           trapst->bigsym_sprite_idx = val4 << 16 >> 16;
           trapst->medsym_sprite_idx = val4 >> 16;
-          struct ManufactureData* manufctr = get_manufacture_data(val2);
           manufctr->bigsym_sprite_idx = trapst->bigsym_sprite_idx;
           manufctr->medsym_sprite_idx = trapst->medsym_sprite_idx;
           update_trap_tab_to_config();
@@ -6896,6 +6897,9 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
           break;
       case 5: // PanelTabIndex
           trapst->panel_tab_idx = val4;
+          manufctr->panel_tab_idx = val4;
+          //create_manufacture_array_from_trapdoor_data();
+          update_trap_tab_to_config();
           break;
       case 6: // Crate
           object_conf.object_to_door_or_trap[val4] = val2;

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -312,6 +312,31 @@ const struct NamedCommand game_rule_desc[] = {
   {NULL,                      0},
 };
 
+const struct NamedCommand trap_config_desc[] = {
+  {"NameTextID",           1},
+  {"TooltipTextID",        2},
+  {"SymbolSprites",        3},
+  {"PointerSprites",       4},
+  {"PanelTabIndex",        5},
+  {"Crate",                6},
+  {"ManufactureLevel",     7},
+  {"ManufactureRequired",  8},
+  {"Shots",                9},
+  {"TimeBetweenShots",    10},
+  {"SellingValue",        11},
+  {"Model",               12},
+  {"ModelSize",           13},
+  {"AnimationSpeed",      14},
+  {"TriggerType",         15},
+  {"ActivationType",      16},
+  {"EffectType",          17},
+  {"Hidden",              18},
+  {"TriggerAlarm",        19},
+  {"Slappable",           20},
+  {"Unanimated",          21},
+  {NULL,                   0},
+};
+
 /**
  * Text names of groups of GUI Buttons.
  */
@@ -2549,102 +2574,24 @@ void refresh_trap_anim(long trap_id)
 }
 
 
-                                                 // Name, Shots, TimeBetweenShots, Model, TriggerType, ActivationType, EffectType, Hidden
-void command_set_trap_configuration(const char* trapname, long val1, long val2, long val3, long val4, long val5, long val6, long val7)
+void command_set_trap_configuration(const char* trapname, const char* variable, long value)
 {
-    if (script_current_condition != -1)
-    {
-        SCRPTWRNLOG("Trap configured inside conditional block; condition ignored");
-    }
     long trap_id = get_rid(trap_desc, trapname);
     if (trap_id == -1)
     {
         SCRPTERRLOG("Unknown trap, '%s'", trapname);
     }
-    int validval1 = 1;
-    if (val1 <= 0)
-    {
-        validval1 = 0;
-        SCRPTERRLOG("Shots '%d' out of range", val1);
-    }
-    int validval2 = 1;
-    if (val2 < 0)
-    {
-        validval2 = 0;
-        SCRPTERRLOG("Model '%d' out of range", val2);
-    }
-    int validval3 = 1;
-    if (val3 <= 0)
-    {
-        validval3 = 0;
-        SCRPTERRLOG("Model '%d' out of range", val3);
-    }
-    int validval4 = 0;
-    switch (val4) {
-    case TrpTrg_LineOfSight90:
-    case TrpTrg_Pressure:
-    case TrpTrg_LineOfSight:
-    case TrpTrg_None:
-        validval4 = 1;
-        break;
-    default:
-        SCRPTERRLOG("No TriggerType '%d' found", val4);
-    }
-    int validval5 = 0;
-    switch (val5) {
-    case TrpAcT_HeadforTarget90:
-    case TrpAcT_EffectonTrap:
-    case TrpAcT_ShotonTrap:
-    case TrpAcT_SlabChange:
-    case TrpAcT_CreatureShot:
-    case TrpAcT_CreatureSpawn:
-    case TrpAcT_Power:
-        validval5 = 1;
-        break;
-    default:
-        SCRPTERRLOG("No ActivationType '%d' found", val5);
-    }
-    int validval6 = 1;
-    if ((val6 <= 0) ||
-        ((val6 > magic_conf.shot_types_count) && (val5 == (TrpAcT_HeadforTarget90 || TrpAcT_ShotonTrap || TrpAcT_CreatureShot))) ||
-        ((val6 > slab_conf.slab_types_count ) && (val5 == TrpAcT_SlabChange)) ||
-        ((val6 > effects_conf.effect_types_count) && (val5 == TrpAcT_EffectonTrap)) ||
-        ((val6 >= CREATURE_TYPES_COUNT) && (val5 == TrpAcT_CreatureSpawn)) ||
-        ((val6 >= magic_conf.power_types_count) && (val5 == TrpAcT_Power))
-        )
-    {
-        validval6 = 0;
-        SCRPTERRLOG("EffectType '%d' out of range", val6);
-    }
-    int validval7 = 1;
-    if ((val7 < 0) || (val7 > 1))
-    {
-        validval7 = 0;
-        SCRPTERRLOG("TriggerAlarm '%d' out of range", val7);
-    }
 
-    if (validval1 && validval2 && validval3 && validval4 && validval5 && validval6 && validval7)
+
+    long trapvar = get_id(trap_config_desc, variable);
+    if (trapvar == -1)
     {
-        struct TrapConfigStats* trapst;
-        struct ManfctrConfig* mconf;
-        trapst = &trapdoor_conf.trap_cfgstats[trap_id];
-        mconf = &gameadd.traps_config[trap_id];
-        SCRIPTDBG(7, "Changing trap %d configuration from (%d,%d,%d,%d,%d,%d,%d)", trap_id, mconf->shots, mconf->shots_delay, gameadd.trap_stats[trap_id].sprite_anim_idx, gameadd.trap_stats[trap_id].trigger_type, gameadd.trap_stats[trap_id].activation_type, gameadd.trap_stats[trap_id].created_itm_model,trapst->hidden);
-        SCRIPTDBG(7, "Changing trap %d configuration to (%d,%d,%d,%d,%d,%d,%d)", trap_id, val1, val2, val3, val4, val5, val6, val7);
-        mconf->shots = val1;
-        mconf->shots_delay = val2;
-        gameadd.trap_stats[trap_id].sprite_anim_idx = val3;
-        gameadd.trap_stats[trap_id].trigger_type = val4;
-        gameadd.trap_stats[trap_id].activation_type = val5;
-        gameadd.trap_stats[trap_id].created_itm_model = val6;
-        trapst->hidden = val7;
-        //trapst->notify = val8; cannot fit 9 variables
-        refresh_trap_anim(trap_id);
-    } else
-    {
+        SCRPTERRLOG("Unknown trap variable");
         return;
     }
-}
+    command_add_value(Cmd_SET_TRAP_CONFIGURATION, 0, trap_id, trapvar, value );
+ }
+
                                               //Name,  ManufactureLevel, ManufactureRequired,SellingValue,Health
 void command_set_door_configuration(const char* doorname, long val1, long val2, long val3, long val4)
 {
@@ -3912,7 +3859,7 @@ void script_add_command(const struct CommandDesc *cmd_desc, const struct ScriptL
         command_set_game_rule(scline->tp[0], scline->np[1]);
         break;
     case Cmd_SET_TRAP_CONFIGURATION:
-        command_set_trap_configuration(scline->tp[0], scline->np[1], scline->np[2], scline->np[3], scline->np[4], scline->np[5], scline->np[6], scline->np[7]);
+        command_set_trap_configuration(scline->tp[0], scline->tp[1], scline->np[2]);
         break;
     case Cmd_SET_DOOR_CONFIGURATION:
         command_set_door_configuration(scline->tp[0], scline->np[1], scline->np[2], scline->np[3], scline->np[4]);
@@ -6920,6 +6867,90 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
           break;
       }
       break;
+  case Cmd_SET_TRAP_CONFIGURATION:
+      
+      JUSTMSG("TESTLOG val4 %d, val2 %d, val3 %d", val4, val2, val3); 
+      struct TrapConfigStats* trapst;
+      struct ManfctrConfig* mconf;
+      trapst = &trapdoor_conf.trap_cfgstats[val2];
+      mconf = &gameadd.traps_config[val2];
+      switch (val3)
+      {
+      case 1: // NameTextID
+          trapst->name_stridx = val4;
+          break;
+      case 2: // TooltipTextID
+          trapst->tooltip_stridx = val4;
+          break;
+      case 3: // SymbolSprites
+          trapst->bigsym_sprite_idx = val4;
+          trapst->medsym_sprite_idx = val4; //todo I hate my life
+          break;
+      case 4: // PointerSprites
+          trapst->pointer_sprite_idx = val4;
+          break;
+      case 5: // PanelTabIndex
+          trapst->panel_tab_idx = val4;
+          break;
+      case 6: // Crate
+          object_conf.object_to_door_or_trap[val4] = val2;
+          object_conf.workshop_object_class[val4] = TCls_Trap;
+          trapdoor_conf.trap_to_object[val2] = val4;
+          break;
+      case 7: // ManufactureLevel
+          mconf->manufct_level = val4;
+          break;
+      case 8: // ManufactureRequired
+          mconf->manufct_required = val4;
+          break;
+      case 9: // Shots
+          mconf->shots = val4;
+          break;
+      case 10: // TimeBetweenShots
+          mconf->shots_delay = val4;
+          break;
+      case 11: // SellingValue
+          mconf->selling_value = val4;
+          break;
+      case 12: // Model
+          gameadd.trap_stats[val2].sprite_anim_idx = val4;
+          refresh_trap_anim(val2);
+          break;
+      case 13: // ModelSize
+          gameadd.trap_stats[val2].sprite_size_max = val4;
+          refresh_trap_anim(val2);
+          break;
+      case 14: // AnimationSpeed
+          gameadd.trap_stats[val2].anim_speed = val4;
+          refresh_trap_anim(val2);
+          break;
+      case 15: // TriggerType
+          gameadd.trap_stats[val2].trigger_type = val4;
+          break;
+      case 16: // ActivationType
+          gameadd.trap_stats[val2].activation_type = val4;
+          break;
+      case 17: // EffectType
+          gameadd.trap_stats[val2].created_itm_model = val4;
+          break;
+      case 18: // Hidden
+          trapst->hidden = val4;
+          break;
+      case 19: // TriggerAlarm
+          trapst->notify = val4;
+          break;
+      case 20: // Slappable
+          trapst->slappable = val4;
+          break;
+      case 21: // Unanimated
+          gameadd.trap_stats[val2].unanimated = val4;
+          refresh_trap_anim(val2);
+          break;
+      default:
+          WARNMSG("Unsupported Trap configuration, variable %d.", val3);
+          break;
+      }
+      break;     
   default:
       WARNMSG("Unsupported Game VALUE, command %d.",var_index);
       break;
@@ -7184,7 +7215,7 @@ const struct CommandDesc command_desc[] = {
   {"LEVEL_UP_CREATURE",                 "PC!AN   ", Cmd_LEVEL_UP_CREATURE, NULL, NULL},
   {"CHANGE_CREATURE_OWNER",             "PC!AP   ", Cmd_CHANGE_CREATURE_OWNER, NULL, NULL},
   {"SET_GAME_RULE",                     "AN      ", Cmd_SET_GAME_RULE, NULL, NULL},
-  {"SET_TRAP_CONFIGURATION",            "ANNNNNNN", Cmd_SET_TRAP_CONFIGURATION, NULL, NULL},
+  {"SET_TRAP_CONFIGURATION",            "AAN     ", Cmd_SET_TRAP_CONFIGURATION, NULL, NULL},
   {"SET_DOOR_CONFIGURATION",            "ANNNN   ", Cmd_SET_DOOR_CONFIGURATION, NULL, NULL},
   {"SET_SACRIFICE_RECIPE",              "AAA+    ", Cmd_SET_SACRIFICE_RECIPE, &set_sacrifice_recipe_check, &set_sacrifice_recipe_process},
   {"REMOVE_SACRIFICE_RECIPE",           "A+      ", Cmd_REMOVE_SACRIFICE_RECIPE, &remove_sacrifice_recipe_check, &set_sacrifice_recipe_process},

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2601,7 +2601,7 @@ void command_set_trap_configuration(const char* trapname, const char* property, 
         return;
     }
     long mergedval = value + (optvalue << 16);
-
+    SCRIPTDBG(7, "Setting trap %s property %s to %d", trapname, property, mergedval);
     command_add_value(Cmd_SET_TRAP_CONFIGURATION, 0, trap_id, trapvar, mergedval);
  }
 

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2574,7 +2574,7 @@ void refresh_trap_anim(long trap_id)
 }
 
 
-void command_set_trap_configuration(const char* trapname, const char* variable, long val1, long val2)
+void command_set_trap_configuration(const char* trapname, const char* property, long value, long optvalue)
 {
     long trap_id = get_rid(trap_desc, trapname);
     if (trap_id == -1)
@@ -2582,7 +2582,7 @@ void command_set_trap_configuration(const char* trapname, const char* variable, 
         SCRPTERRLOG("Unknown trap, '%s'", trapname);
     }
 
-    long trapvar = get_id(trap_config_desc, variable);
+    long trapvar = get_id(trap_config_desc, property);
     if (trapvar == -1)
     {
         SCRPTERRLOG("Unknown trap variable");
@@ -2590,17 +2590,17 @@ void command_set_trap_configuration(const char* trapname, const char* variable, 
     }
 
     //val2 is an optional variable, used when there's 2 numbers on one command. Pass them along as one merged val.
-    if ((val1 > 0xFFFF) || (val1 < 0))
+    if ((value > 0xFFFF) || (value < 0))
     {
-        SCRPTERRLOG("Value out of range: %d", val1);
+        SCRPTERRLOG("Value out of range: %d", value);
         return;
     }
-    if ((val2 > 0xFFFF) || (val2 < 0))
+    if ((optvalue > 0xFFFF) || (optvalue < 0))
     {
-        SCRPTERRLOG("Value out of range: %d", val2);
+        SCRPTERRLOG("Value out of range: %d", optvalue);
         return;
     }
-    long mergedval = val1 + (val2 << 16);
+    long mergedval = value + (optvalue << 16);
 
     command_add_value(Cmd_SET_TRAP_CONFIGURATION, 0, trap_id, trapvar, mergedval);
  }

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -2589,7 +2589,17 @@ void command_set_trap_configuration(const char* trapname, const char* variable, 
         return;
     }
 
-    //val2 is an optional variable, used when there's 2 numbers on one command.
+    //val2 is an optional variable, used when there's 2 numbers on one command. Pass them along as one merged val.
+    if ((val1 > 0xFFFF) || (val1 < 0))
+    {
+        SCRPTERRLOG("Value out of range: %d", val1);
+        return;
+    }
+    if ((val2 > 0xFFFF) || (val2 < 0))
+    {
+        SCRPTERRLOG("Value out of range: %d", val2);
+        return;
+    }
     long mergedval = val1 + (val2 << 16);
 
     command_add_value(Cmd_SET_TRAP_CONFIGURATION, 0, trap_id, trapvar, mergedval);
@@ -6898,7 +6908,6 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       case 5: // PanelTabIndex
           trapst->panel_tab_idx = val4;
           manufctr->panel_tab_idx = val4;
-          //create_manufacture_array_from_trapdoor_data();
           update_trap_tab_to_config();
           break;
       case 6: // Crate

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -6886,7 +6886,9 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       case 3: // SymbolSprites
           trapst->bigsym_sprite_idx = val4 << 16 >> 16;
           trapst->medsym_sprite_idx = val4 >> 16;
-          create_manufacture_array_from_trapdoor_data();
+          struct ManufactureData* manufctr = get_manufacture_data(val2);
+          manufctr->bigsym_sprite_idx = trapst->bigsym_sprite_idx;
+          manufctr->medsym_sprite_idx = trapst->medsym_sprite_idx;
           update_trap_tab_to_config();
           break;
       case 4: // PointerSprites


### PR DESCRIPTION
Changing the script command from:

`SET_TRAP_CONFIGURATION([trapname],[val1],[val2],[val3],[val4],[val5],[val6],[val7])`

to

`SET_TRAP_CONFIGURATION([trapname],[command],[value])`

This to allow you to set any of the 21 trap values, and hopefully in an easier way.

Example:

``` 
 SET_TRAP_CONFIGURATION(BOULDER,Shots,4)
 SET_TRAP_CONFIGURATION(BOULDER,SellingValue,5000)
```