### PR TITLE
Toggle wibble feature

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -20,6 +20,10 @@ INGAME_RES=640x480x32 1366x768x32 1920x1080x32
 ; With value more than 0 sensitivity will also depend on resolution.
 POINTER_SENSITIVITY=100
 
+; Terrain is deformed to give it a natural look. Turn it OFF
+; for a clean look instead. Lava and water will be flat.
+WIBBLE=ON
+
 ; Censorship - originally was ON only if language is german.
 CENSORSHIP=OFF
 

--- a/src/config.c
+++ b/src/config.c
@@ -117,6 +117,7 @@ const struct NamedCommand conf_commands[] = {
   {"ATMOS_SAMPLES",       13},
   {"RESIZE_MOVIES",       14},
   {"MUSIC_TRACKS",        15},
+  {"WIBBLE",              16},
   {NULL,                   0},
   };
 
@@ -206,6 +207,14 @@ TbBool atmos_sounds_enabled(void)
 TbBool resize_movies_enabled(void)
 {
   return ((features_enabled & Ft_Resizemovies) != 0);
+}
+
+/**
+ * Returns if the wibble effect is on.
+ */
+TbBool wibble_enabled(void)
+{
+  return ((features_enabled & Ft_Wibble) != 0);
 }
 
 TbBool is_feature_on(unsigned long feature)
@@ -786,6 +795,19 @@ short load_configuration(void)
               CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
                 COMMAND_TEXT(cmd_num),config_textname);
           }
+          break;
+      case 16: // WIBBLE
+          i = recognize_conf_parameter(buf,&pos,len,logicval_type);
+          if (i <= 0)
+          {
+              CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
+                COMMAND_TEXT(cmd_num),config_textname);
+            break;
+          }
+          if (i == 1)
+              features_enabled |= Ft_Wibble;
+          else
+              features_enabled &= ~Ft_Wibble;
           break;
       case 0: // comment
           break;

--- a/src/config.h
+++ b/src/config.h
@@ -73,6 +73,7 @@ enum TbFeature {
     Ft_Censorship   =  0x0020,
     Ft_Atmossounds  =  0x0040,
     Ft_Resizemovies =  0x0080,
+    Ft_Wibble       =  0x0100,
 };
 
 enum TbExtraLevels {
@@ -205,6 +206,7 @@ TbBool is_feature_on(unsigned long feature);
 TbBool censorship_enabled(void);
 TbBool atmos_sounds_enabled(void);
 TbBool resize_movies_enabled(void);
+TbBool wibble_enabled(void);
 short load_configuration(void);
 short calculate_moon_phase(short do_calculate,short add_to_log);
 void load_or_create_high_score_table(void);

--- a/src/engine_arrays.c
+++ b/src/engine_arrays.c
@@ -1063,24 +1063,27 @@ void generate_wibble_table(void)
             wibl++;
         }
     }
-    // Set wibble values using special random algorithm
-    seed = 0;
-    for (i=0; i < 32; i++)
+    if (wibble_enabled())
     {
-        wibl = &wibble_table[i+32];
-        n = wibble_random(65447,&seed);
-        wibl->field_0 = (n % 127) - 63;
-        n = wibble_random(65447,&seed);
-        wibl->field_4 = ((n % 127) - 63) / 3;
-        n = wibble_random(65447,&seed);
-        wibl->field_8 = (n % 127) - 63;
-        qwibl = &wibble_table[i+64];
-        n = wibble_random(65447,&seed);
-        wibl->field_C = (n % 2047) - 1023;
-        n = wibble_random(65447,&seed);
-        qwibl->field_0 = (n % 127) - 63;
-        n = wibble_random(65447,&seed);
-        qwibl->field_8 = (n % 127) - 63;
+        // Set wibble values using special random algorithm
+        seed = 0;
+        for (i=0; i < 32; i++)
+        {
+            wibl = &wibble_table[i+32];
+            n = wibble_random(65447,&seed);
+            wibl->field_0 = (n % 127) - 63;
+            n = wibble_random(65447,&seed);
+            wibl->field_4 = ((n % 127) - 63) / 3;
+            n = wibble_random(65447,&seed);
+            wibl->field_8 = (n % 127) - 63;
+            qwibl = &wibble_table[i+64];
+            n = wibble_random(65447,&seed);
+            wibl->field_C = (n % 2047) - 1023;
+            n = wibble_random(65447,&seed);
+            qwibl->field_0 = (n % 127) - 63;
+            n = wibble_random(65447,&seed);
+            qwibl->field_8 = (n % 127) - 63;
+        }
     }
 }
 

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4929,7 +4929,10 @@ void draw_view(struct Camera *cam, unsigned char a2)
     x = cam->mappos.x.val;
     y = cam->mappos.y.val;
     z = cam->mappos.z.val;
-    frame_wibble_generate();
+    if (wibble_enabled())
+    {
+        frame_wibble_generate();
+    }
     view_alt = z;
     if (lens_mode != 0)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1043,6 +1043,8 @@ short setup_game(void)
   // Enable features that require more resources
   update_features(mem_size);
 
+  features_enabled |= Ft_Wibble; // enable wibble by default
+
   // Configuration file
   if ( !load_configuration() )
   {

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -722,7 +722,10 @@ void place_slab_columns(long slbkind, unsigned char stl_x, unsigned char stl_y, 
             if ( v10 < 0 )
               ERRORLOG("BBlocks instead of columns");
             update_map_collide(slbkind, stl_x+dx, stl_y+dy);
-            set_alt_bit_based_on_slab(slbkind, stl_x+dx, stl_y+dy);
+            if (wibble_enabled())
+            {
+                set_alt_bit_based_on_slab(slbkind, stl_x+dx, stl_y+dy);
+            }
             colid++;
         }
     }
@@ -1410,7 +1413,10 @@ void place_animating_slab_type_on_map(SlabKind slbkind, char ani_frame, MapSubtl
                 MapSubtlCoord sstl_y;
                 sstl_x = slab_subtile(sslb_x,ssub_x);
                 sstl_y = slab_subtile(sslb_y,ssub_y);
-                set_alt_bit_based_on_slab(slb->kind, sstl_x, sstl_y);
+                if (wibble_enabled())
+                {
+                    set_alt_bit_based_on_slab(slb->kind, sstl_x, sstl_y);
+                }
             }
         }
     }


### PR DESCRIPTION
initial commit is proof of concept, it needs testing to ensure there are no unintended consequences of turning wibble off.

wibble defaults to ON

you can also control it via the keeperfx.cfg file, use:
`WIBBLE=ON`
and
`WIBBLE=OFF`

preview with wibble turned off:
![image](https://user-images.githubusercontent.com/1984342/116158055-e97df600-a6e5-11eb-9c8a-8f8f5110e406.png)
