### PR TITLE
power hand, cursor and tooltips now correct size in all aspect ratios/resolutions

### DIFF
--- a/src/bflib_mspointer.cpp
+++ b/src/bflib_mspointer.cpp
@@ -85,8 +85,8 @@ long PointerDraw(long x, long y, struct TbSprite *spr, TbPixel *outbuf, unsigned
     unsigned int dwidth;
     unsigned int dheight;
     // Prepare bounds
-    dwidth = (spr->SWidth*units_per_pixel)/16;
-    dheight = (spr->SHeight*units_per_pixel)/16;
+    dwidth = scale_ui_value_lofi(spr->SWidth);
+    dheight = scale_ui_value_lofi(spr->SHeight);
     if ( (dwidth <= 0) || (dheight <= 0) )
         return 1;
     if ( (lbDisplay.MouseWindowWidth <= 0) || (lbDisplay.MouseWindowHeight <= 0) )
@@ -196,8 +196,8 @@ void LbI_PointerHandler::Initialise(struct TbSprite *spr, struct TbPoint *npos, 
     LbSemaLock semlock(&sema_rel,0);
     semlock.Lock(true);
     sprite = spr;
-    dstwidth = (sprite->SWidth*units_per_pixel + 16)/16;
-    dstheight = (sprite->SHeight*units_per_pixel + 16)/16;
+    dstwidth = scale_ui_value_lofi(sprite->SWidth);
+    dstheight = scale_ui_value_lofi(sprite->SHeight);
     LbScreenSurfaceCreate(&surf1, dstwidth, dstheight);
     LbScreenSurfaceCreate(&surf2, dstwidth, dstheight);
     surfbuf = LbScreenSurfaceLock(&surf1);
@@ -273,12 +273,12 @@ void LbI_PointerHandler::Release(void)
 
 void LbI_PointerHandler::NewMousePos(void)
 {
-    this->draw_pos_x = position->x - spr_offset->x*units_per_pixel/16;
-    this->draw_pos_y = position->y - spr_offset->y*units_per_pixel/16;
+    this->draw_pos_x = position->x - scale_ui_value_lofi(spr_offset->x);
+    this->draw_pos_y = position->y - scale_ui_value_lofi(spr_offset->y);
     int dstwidth;
     int dstheight;
-    dstwidth = (sprite->SWidth*units_per_pixel)/16;
-    dstheight = (sprite->SHeight*units_per_pixel)/16;
+    dstwidth = scale_ui_value_lofi(sprite->SWidth);
+    dstheight = scale_ui_value_lofi(sprite->SHeight);
     LbSetRect(&rect_1038, 0, 0, dstwidth, dstheight);
     if (this->draw_pos_x < 0)
     {
@@ -347,7 +347,7 @@ void LbI_PointerHandler::OnBeginSwap(void)
     } else
     if (LbScreenLock() == Lb_SUCCESS)
     {
-      PointerDraw(position->x - spr_offset->x*units_per_pixel/16, position->y - spr_offset->y*units_per_pixel/16,
+      PointerDraw(position->x - scale_ui_value_lofi(spr_offset->x), position->y - scale_ui_value_lofi(spr_offset->y),
           sprite, lbDisplay.WScreen, lbDisplay.GraphicsScreenWidth);
       LbScreenUnlock();
     }

--- a/src/bflib_mspointer.cpp
+++ b/src/bflib_mspointer.cpp
@@ -196,8 +196,8 @@ void LbI_PointerHandler::Initialise(struct TbSprite *spr, struct TbPoint *npos, 
     LbSemaLock semlock(&sema_rel,0);
     semlock.Lock(true);
     sprite = spr;
-    dstwidth = scale_ui_value_lofi(sprite->SWidth);
-    dstheight = scale_ui_value_lofi(sprite->SHeight);
+    dstwidth = scale_ui_value_lofi(sprite->SWidth) + 1;
+    dstheight = scale_ui_value_lofi(sprite->SHeight) + 1;
     LbScreenSurfaceCreate(&surf1, dstwidth, dstheight);
     LbScreenSurfaceCreate(&surf2, dstwidth, dstheight);
     surfbuf = LbScreenSurfaceLock(&surf1);

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -1040,6 +1040,18 @@ long scale_ui_value(long base_value)
 }
 
 /**
+ * Takes a fixed value tuned for original DK at 640x400 and scales it for the game's current resolution.
+ * Uses units_per_pixel_best (which is 16 at 640x400)
+ *
+ * @param base_value The fixed value tuned for original DK 640x400 mode
+ */
+long scale_fixed_DK_value(long base_value)
+{
+    // return value is equivalent to: round(base_value * units_per_pixel_best /16)
+    return ((((units_per_pixel_best * base_value) >> 3) + (((units_per_pixel_best * base_value) >> 3) & 1)) >> 1);
+}
+
+/**
  * Determine whether the current window aspect ratio is wider than the original (16/10)
  *
  * @param width current window width
@@ -1050,6 +1062,59 @@ TbBool is_ar_wider_than_original(long width, long height)
     long original_aspect_ratio = (320 << 8) / 200;
     long current_aspect_ratio = (width << 8) / height;
     return (current_aspect_ratio > original_aspect_ratio);
+}
+
+long get_upp_from_type(long upp_type)
+{
+    long return_upp;
+    switch(upp_type)
+    {
+        case upp_WIDTH:
+            return_upp = units_per_pixel_width;
+            break;
+        case upp_HEIGHT:
+            return_upp = units_per_pixel_height;
+            break;
+        case upp_BEST:
+            return_upp = units_per_pixel_best;
+            break;
+        case upp_UI:
+            return_upp = units_per_pixel_ui;
+            break;
+        /*case upp_MIN:
+            return_upp = units_per_pixel_min;
+            break;*/
+        case upp_MAX:
+        default:
+            return_upp = units_per_pixel;
+            break;
+    }
+    return return_upp;
+}
+
+/**
+ * Calculate a units_per_px value relative to a given 640x400 base length,
+*  a current reference length, and a current reference units_per_pixel
+ *
+ * @param base_length a given length/size for DK 640x400 mode
+ * @param upp_type a reference units_per_pixel type, that is relative to the current window resolution
+ * @param reference_length a reference length/size to put in a ratio relative to the give base_length
+ */
+long calculate_relative_upp(long base_length, long upp_type, long reference_length)
+{
+    long reference_upp = get_upp_from_type(upp_type);
+    return ((((base_length * reference_upp) << 2) / reference_length) >> 2); // bitshifts to round up
+}
+
+/**
+ * Scale UI relative to the base DEFAULT_UI_SCALE
+ *
+ * @param units_per_px the current units_per_pixel value
+ * @param ui_scale the relative scale to multiply units_per_px by
+ */
+long resize_ui(long units_per_px, long ui_scale)
+{
+    return (units_per_px * ui_scale / DEFAULT_UI_SCALE);
 }
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -1026,6 +1026,31 @@ long scale_value_by_vertical_resolution(long base_value)
     // return value is equivalent to: round(base_value * units_per_pixel_height /16)
     return ((((units_per_pixel_height * base_value) >> 3) + (((units_per_pixel_height * base_value) >> 3) & 1)) >> 1);
 }
+
+/**
+ * Takes a fixed value tuned for original DK at 640x400 and scales it for the game's current resolution and UI scale.
+ * Uses units_per_pixel_ui (which is 16 at 640x400)
+ *
+ * @param base_value The fixed value tuned for original DK 640x400 mode
+ */
+long scale_ui_value(long base_value)
+{
+    // return value is equivalent to: round(base_value * units_per_pixel_ui /16)
+    return ((((units_per_pixel_ui * base_value) >> 3) + (((units_per_pixel_ui * base_value) >> 3) & 1)) >> 1);
+}
+
+/**
+ * Determine whether the current window aspect ratio is wider than the original (16/10)
+ *
+ * @param width current window width
+ * @param height current window height
+ */
+TbBool is_ar_wider_than_original(long width, long height)
+{
+    long original_aspect_ratio = (320 << 8) / 200;
+    long current_aspect_ratio = (width << 8) / height;
+    return (current_aspect_ratio > original_aspect_ratio);
+}
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -1044,6 +1044,26 @@ long scale_ui_value(long base_value)
 }
 
 /**
+ * Sames as scale_ui_value, but if "lofi" detected, then scale is doubled
+ *
+ * @param base_value The fixed value tuned for original DK 640x400 mode
+ */
+long scale_ui_value_lofi(long base_value)
+{
+    TbBool lofi_mode = ((LbGraphicsScreenHeight() < 400) ? true : false);
+    long value;
+    if (lofi_mode)
+    {
+        value = scale_ui_value(base_value * 2);
+    }
+    else
+    {
+        value = scale_ui_value(base_value);
+    }
+    return value; // can return zero
+}
+
+/**
  * Takes a fixed value tuned for original DK at 640x400 and scales it for the game's current resolution.
  * Uses units_per_pixel_best (which is 16 at 640x400)
  *

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -1040,7 +1040,7 @@ long scale_ui_value(long base_value)
 {
     // return value is equivalent to: round(base_value * units_per_pixel_ui /16)
     long value = ((((units_per_pixel_ui * base_value) >> 3) + (((units_per_pixel_ui * base_value) >> 3) & 1)) >> 1);
-    return max(1,value);
+    return value; // can return zero
 }
 
 /**

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -986,7 +986,8 @@ TbPixel LbPaletteFindColour(const unsigned char *pal, unsigned char r, unsigned 
 long scale_value_for_resolution(long base_value)
 {
     // return value is equivalent to: round(base_value * units_per_pixel /16)
-    return ((((units_per_pixel * base_value) >> 3) + (((units_per_pixel * base_value) >> 3) & 1)) >> 1);
+    long value = ((((units_per_pixel * base_value) >> 3) + (((units_per_pixel * base_value) >> 3) & 1)) >> 1);
+    return max(1,value);
 }
 
 /**
@@ -1012,7 +1013,8 @@ long scale_value_for_resolution_with_upp(long base_value, long units_per_px)
 long scale_value_by_horizontal_resolution(long base_value)
 {
     // return value is equivalent to: round(base_value * units_per_pixel_width /16)
-    return ((((units_per_pixel_width * base_value) >> 3) + (((units_per_pixel_width * base_value) >> 3) & 1)) >> 1);
+    long value = ((((units_per_pixel_width * base_value) >> 3) + (((units_per_pixel_width * base_value) >> 3) & 1)) >> 1);
+    return max(1,value);
 }
 
 /**
@@ -1024,7 +1026,8 @@ long scale_value_by_horizontal_resolution(long base_value)
 long scale_value_by_vertical_resolution(long base_value)
 {
     // return value is equivalent to: round(base_value * units_per_pixel_height /16)
-    return ((((units_per_pixel_height * base_value) >> 3) + (((units_per_pixel_height * base_value) >> 3) & 1)) >> 1);
+    long value = ((((units_per_pixel_height * base_value) >> 3) + (((units_per_pixel_height * base_value) >> 3) & 1)) >> 1);
+    return max(1,value);
 }
 
 /**
@@ -1036,7 +1039,8 @@ long scale_value_by_vertical_resolution(long base_value)
 long scale_ui_value(long base_value)
 {
     // return value is equivalent to: round(base_value * units_per_pixel_ui /16)
-    return ((((units_per_pixel_ui * base_value) >> 3) + (((units_per_pixel_ui * base_value) >> 3) & 1)) >> 1);
+    long value = ((((units_per_pixel_ui * base_value) >> 3) + (((units_per_pixel_ui * base_value) >> 3) & 1)) >> 1);
+    return max(1,value);
 }
 
 /**
@@ -1048,7 +1052,8 @@ long scale_ui_value(long base_value)
 long scale_fixed_DK_value(long base_value)
 {
     // return value is equivalent to: round(base_value * units_per_pixel_best /16)
-    return ((((units_per_pixel_best * base_value) >> 3) + (((units_per_pixel_best * base_value) >> 3) & 1)) >> 1);
+    long value = ((((units_per_pixel_best * base_value) >> 3) + (((units_per_pixel_best * base_value) >> 3) & 1)) >> 1);
+    return max(1,value);
 }
 
 /**
@@ -1103,7 +1108,8 @@ long get_upp_from_type(long upp_type)
 long calculate_relative_upp(long base_length, long upp_type, long reference_length)
 {
     long reference_upp = get_upp_from_type(upp_type);
-    return ((((base_length * reference_upp) << 2) / reference_length) >> 2); // bitshifts to round up
+    long value = ((((base_length * reference_upp) << 2) / reference_length) >> 2); // bitshifts to round up
+    return max(1,value);
 }
 
 /**
@@ -1114,7 +1120,8 @@ long calculate_relative_upp(long base_length, long upp_type, long reference_leng
  */
 long resize_ui(long units_per_px, long ui_scale)
 {
-    return (units_per_px * ui_scale / DEFAULT_UI_SCALE);
+    long value = (units_per_px * ui_scale / DEFAULT_UI_SCALE);
+    return max(1,value);
 }
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -1069,45 +1069,16 @@ TbBool is_ar_wider_than_original(long width, long height)
     return (current_aspect_ratio > original_aspect_ratio);
 }
 
-long get_upp_from_type(long upp_type)
-{
-    long return_upp;
-    switch(upp_type)
-    {
-        case upp_WIDTH:
-            return_upp = units_per_pixel_width;
-            break;
-        case upp_HEIGHT:
-            return_upp = units_per_pixel_height;
-            break;
-        case upp_BEST:
-            return_upp = units_per_pixel_best;
-            break;
-        case upp_UI:
-            return_upp = units_per_pixel_ui;
-            break;
-        /*case upp_MIN:
-            return_upp = units_per_pixel_min;
-            break;*/
-        case upp_MAX:
-        default:
-            return_upp = units_per_pixel;
-            break;
-    }
-    return return_upp;
-}
-
 /**
  * Calculate a units_per_px value relative to a given 640x400 base length,
 *  a current reference length, and a current reference units_per_pixel
  *
  * @param base_length a given length/size for DK 640x400 mode
- * @param upp_type a reference units_per_pixel type, that is relative to the current window resolution
+ * @param reference_upp a reference units_per_pixel value, that is relative to the current window resolution
  * @param reference_length a reference length/size to put in a ratio relative to the give base_length
  */
-long calculate_relative_upp(long base_length, long upp_type, long reference_length)
+long calculate_relative_upp(long base_length, long reference_upp, long reference_length)
 {
-    long reference_upp = get_upp_from_type(upp_type);
     long value = ((((base_length * reference_upp) << 2) / reference_length) >> 2); // bitshifts to round up
     return max(1,value);
 }

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -272,15 +272,6 @@ extern volatile TbBool lbInteruptMouse;
 extern volatile TbDisplayStructEx lbDisplayEx;
 extern unsigned char lbPalette[PALETTE_SIZE];
 
-enum UnitsPerPixelTypes{
-    upp_MAX,
-    upp_MIN,
-    upp_WIDTH,
-    upp_HEIGHT,
-    upp_BEST,
-    upp_UI,
-};
-
 #define DEFAULT_UI_SCALE                128
 
 enum UIScaleSettings {
@@ -347,7 +338,7 @@ long scale_value_by_vertical_resolution(long base_value);
 long scale_ui_value(long base_value);
 long scale_fixed_DK_value(long base_value);
 TbBool is_ar_wider_than_original(long width, long height);
-long calculate_relative_upp(long base_length, long upp_type, long reference_length);
+long calculate_relative_upp(long base_length, long reference_upp, long reference_length);
 long resize_ui(long units_per_px, long ui_scale);
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -226,6 +226,7 @@ typedef struct SSurface TSurface;
 
 extern unsigned short units_per_pixel_width;
 extern unsigned short units_per_pixel_height;
+extern unsigned short units_per_pixel_ui;
 /******************************************************************************/
 
 DLLIMPORT extern TbDisplayStruct _DK_lbDisplay;
@@ -324,6 +325,8 @@ long scale_value_for_resolution(long base_value);
 long scale_value_for_resolution_with_upp(long base_value, long units_per_px);
 long scale_value_by_horizontal_resolution(long base_value);
 long scale_value_by_vertical_resolution(long base_value);
+long scale_ui_value(long base_value);
+TbBool is_ar_wider_than_original(long width, long height);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -224,9 +224,6 @@ typedef struct DisplayStructEx TbDisplayStructEx;
 struct SSurface;
 typedef struct SSurface TSurface;
 
-extern unsigned short units_per_pixel_width;
-extern unsigned short units_per_pixel_height;
-extern unsigned short units_per_pixel_ui;
 /******************************************************************************/
 
 DLLIMPORT extern TbDisplayStruct _DK_lbDisplay;
@@ -274,6 +271,28 @@ extern volatile TbBool lbUseSdk;
 extern volatile TbBool lbInteruptMouse;
 extern volatile TbDisplayStructEx lbDisplayEx;
 extern unsigned char lbPalette[PALETTE_SIZE];
+
+enum UnitsPerPixelTypes{
+    upp_MAX,
+    upp_MIN,
+    upp_WIDTH,
+    upp_HEIGHT,
+    upp_BEST,
+    upp_UI,
+};
+
+#define DEFAULT_UI_SCALE                128
+
+enum UIScaleSettings {
+    UI_NORMAL_SIZE = DEFAULT_UI_SCALE,
+    UI_HALF_SIZE   = DEFAULT_UI_SCALE / 2,
+    UI_DOUBLE_SIZE = DEFAULT_UI_SCALE * 2,
+};
+
+extern unsigned short units_per_pixel_width;
+extern unsigned short units_per_pixel_height;
+extern unsigned short units_per_pixel_best;
+extern unsigned short units_per_pixel_ui;
 /******************************************************************************/
 TbResult LbScreenInitialize(void);
 TbResult LbScreenSetDoubleBuffering(TbBool state);
@@ -326,7 +345,10 @@ long scale_value_for_resolution_with_upp(long base_value, long units_per_px);
 long scale_value_by_horizontal_resolution(long base_value);
 long scale_value_by_vertical_resolution(long base_value);
 long scale_ui_value(long base_value);
+long scale_fixed_DK_value(long base_value);
 TbBool is_ar_wider_than_original(long width, long height);
+long calculate_relative_upp(long base_length, long upp_type, long reference_length);
+long resize_ui(long units_per_px, long ui_scale);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -272,7 +272,7 @@ extern volatile TbBool lbInteruptMouse;
 extern volatile TbDisplayStructEx lbDisplayEx;
 extern unsigned char lbPalette[PALETTE_SIZE];
 
-#define DEFAULT_UI_SCALE                128
+#define DEFAULT_UI_SCALE                128 // is equivilent to size 1 or 100%
 
 enum UIScaleSettings {
     UI_NORMAL_SIZE = DEFAULT_UI_SCALE,
@@ -335,6 +335,7 @@ long scale_value_for_resolution(long base_value);
 long scale_value_for_resolution_with_upp(long base_value, long units_per_px);
 long scale_value_by_horizontal_resolution(long base_value);
 long scale_value_by_vertical_resolution(long base_value);
+long scale_ui_value_lofi(long base_value);
 long scale_ui_value(long base_value);
 long scale_fixed_DK_value(long base_value);
 TbBool is_ar_wider_than_original(long width, long height);

--- a/src/gui_draw.c
+++ b/src/gui_draw.c
@@ -173,19 +173,20 @@ void draw_slab64k_background(long pos_x, long pos_y, long width, long height)
 void draw_slab64k(long pos_x, long pos_y, int units_per_px, long width, long height)
 {
     // Draw one pixel more, to make sure we won't get empty area after scaling
-    draw_slab64k_background(pos_x, pos_y, width+1, height+1);
+    draw_slab64k_background(pos_x, pos_y, width+scale_value_for_resolution_with_upp(1,units_per_px), height+scale_value_for_resolution_with_upp(1,units_per_px));
     struct TbSprite* spr = &button_sprite[206];
-    int bs_units_per_spr = 16*units_per_px/spr->SWidth;
-    int border_shift = 6*units_per_px/16;
+    int bs_units_per_spr = calculate_relative_upp(16, units_per_px, spr->SWidth);
+    int border_shift = scale_value_for_resolution_with_upp(6,units_per_px);
     int i;
-    for (i=16*units_per_px/16 - border_shift; i < width-2*border_shift; i += 16*units_per_px/16)
+    int i_increment = units_per_px;
+    for (i = i_increment - border_shift; i < width-2*border_shift; i += i_increment)
     {
         spr = &button_sprite[210];
         LbSpriteDrawResized(pos_x + i, pos_y - border_shift, bs_units_per_spr, spr);
         spr = &button_sprite[211];
         LbSpriteDrawResized(pos_x + i, pos_y + height, bs_units_per_spr, spr);
     }
-    for (i=16*units_per_px/16 - border_shift; i < height-2*border_shift; i += 16*units_per_px/16)
+    for (i = i_increment - border_shift; i < height-2*border_shift; i += i_increment)
     {
         spr = &button_sprite[212];
         LbSpriteDrawResized(pos_x - border_shift, pos_y + i, bs_units_per_spr, spr);

--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -72,8 +72,7 @@ void set_gui_tooltip_box_fmt(int bxtype,const char *format, ...)
   va_end(val);
   if (bxtype != 0) {
       tool_tip_box.pos_x = GetMouseX();
-      long y_offset_times_two = (43 * units_per_pixel) >> 2;
-      long y_offset = (y_offset_times_two + (y_offset_times_two & 1)) >> 1; // equivalent to (86 * (units_per_pixel/16)) but accounts for rounding, 86 was the previous hard value of y_offset (meant for 640x400)
+      long y_offset = scale_ui_value(86);
       tool_tip_box.pos_y = GetMouseY() + y_offset;
   }
   tool_tip_box.field_809 = bxtype;
@@ -104,8 +103,7 @@ static inline TbBool update_gui_tooltip_button(struct GuiButton *gbtn)
     {
         tool_tip_box.gbutton = gbtn;
         tool_tip_box.pos_x = GetMouseX();
-        long y_offset_times_two = (43 * units_per_pixel) >> 2;
-        long y_offset = (y_offset_times_two + (y_offset_times_two & 1)) >> 1; // equivalent to (86 * (units_per_pixel/16)) but accounts for rounding, 86 was the previous hard value of y_offset (meant for 640x400)
+        long y_offset = scale_ui_value(86);
         tool_tip_box.pos_y = GetMouseY() + y_offset;
         tool_tip_box.field_809 = 0;
         return true;
@@ -441,28 +439,28 @@ void draw_tooltip_slab64k(char *tttext, long pos_x, long pos_y, long ttwidth, lo
     }
     if (tttext != NULL)
     {
-        long x = pos_x + 26 * units_per_pixel / 16;
+        long x = pos_x + scale_ui_value(26);
         lbDisplay.DrawFlags &= ~Lb_TEXT_ONE_COLOR;
-        long y = pos_y - (ttheight + 28) * units_per_pixel / 16;
+        long y = pos_y - scale_ui_value(ttheight + 28);
         if (x > MyScreenWidth)
           x = MyScreenWidth;
-        if (x < 6*units_per_pixel/16)
-          x = 6*units_per_pixel/16;
+        if (x < scale_ui_value(6))
+          x = scale_ui_value(6);
         if (y > MyScreenHeight)
           y = MyScreenHeight;
-        if (y < 4*units_per_pixel/16)
-          y = 4*units_per_pixel/16;
-        if (x + viswidth*units_per_pixel/16 >= MyScreenWidth)
-          x = MyScreenWidth - viswidth*units_per_pixel/16;
-        if (y + ttheight*units_per_pixel/16 >= MyScreenHeight)
-          y = MyScreenHeight - ttheight*units_per_pixel/16;
+        if (y < scale_ui_value(4))
+          y = scale_ui_value(4);
+        if (x + scale_ui_value(viswidth) >= MyScreenWidth)
+          x = MyScreenWidth - scale_ui_value(viswidth);
+        if (y + scale_ui_value(ttheight) >= MyScreenHeight)
+          y = MyScreenHeight - scale_ui_value(ttheight);
         if (tttext[0] != '\0')
         {
-            LbTextSetWindow(x, y, viswidth*units_per_pixel/16, ttheight*units_per_pixel/16);
-            draw_slab64k(x, y, units_per_pixel, viswidth*units_per_pixel/16, ttheight*units_per_pixel/16);
+            LbTextSetWindow(x, y, scale_ui_value(viswidth), scale_ui_value(ttheight));
+            draw_slab64k(x, y, units_per_pixel_ui, scale_ui_value(viswidth), scale_ui_value(ttheight));
             lbDisplay.DrawFlags = 0;
-            int tx_units_per_px = (22 * units_per_pixel) / LbTextLineHeight();
-            LbTextDrawResized(tooltip_scroll_offset*units_per_pixel/16, -2*units_per_pixel/16, tx_units_per_px, tttext);
+            int tx_units_per_px = calculate_relative_upp(22, units_per_pixel_ui, LbTextLineHeight());
+            LbTextDrawResized(scale_ui_value(tooltip_scroll_offset), -scale_ui_value(2), tx_units_per_px, tttext);
         }
     }
     LbTextSetWindow(0/pixel_size, 0/pixel_size, MyScreenHeight/pixel_size, MyScreenWidth/pixel_size);
@@ -537,9 +535,9 @@ void draw_tooltip_at(long ttpos_x,long ttpos_y,char *tttext)
   long pos_y = ttpos_y;
   if (player->view_type == PVT_MapScreen)
   {
-      pos_y = GetMouseY() + 24*units_per_pixel/16;
-      if (pos_y > MyScreenHeight - 104*units_per_pixel/16)
-          pos_y = MyScreenHeight - 104*units_per_pixel/16;
+      pos_y = GetMouseY() + scale_ui_value(24);
+      if (pos_y > MyScreenHeight - scale_ui_value(104))
+          pos_y = MyScreenHeight - scale_ui_value(104);
       if (pos_y < 0)
           pos_y = 0;
   }

--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -456,11 +456,11 @@ void draw_tooltip_slab64k(char *tttext, long pos_x, long pos_y, long ttwidth, lo
           y = MyScreenHeight - scale_ui_value(ttheight);
         if (tttext[0] != '\0')
         {
-            LbTextSetWindow(x, y, scale_ui_value(viswidth), scale_ui_value(ttheight));
-            draw_slab64k(x, y, units_per_pixel_ui, scale_ui_value(viswidth), scale_ui_value(ttheight));
+            LbTextSetWindow(x, y, scale_ui_value_lofi(viswidth), scale_ui_value_lofi(ttheight));
+            draw_slab64k(x, y, units_per_pixel_ui, scale_ui_value_lofi(viswidth), scale_ui_value_lofi(ttheight));
             lbDisplay.DrawFlags = 0;
             int tx_units_per_px = calculate_relative_upp(22, units_per_pixel_ui, LbTextLineHeight());
-            LbTextDrawResized(scale_ui_value(tooltip_scroll_offset), -scale_ui_value(2), tx_units_per_px, tttext);
+            LbTextDrawResized(scale_ui_value_lofi(tooltip_scroll_offset), -scale_ui_value_lofi(2), tx_units_per_px, tttext);
         }
     }
     LbTextSetWindow(0/pixel_size, 0/pixel_size, MyScreenHeight/pixel_size, MyScreenWidth/pixel_size);

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -515,7 +515,7 @@ void draw_power_hand(void)
     {
         struct TbSprite *spr;
         spr = &gui_panel_sprites[164]; // Use dungeon special box as reference
-        ps_units_per_px = (46 * units_per_pixel_ui) / spr->SHeight;
+        ps_units_per_px = calculate_relative_upp(46, upp_UI, spr->SHeight);
     }
     // Now draw
     if (((game.operation_flags & GOF_ShowGui) != 0) && (game.small_map_state != 2)
@@ -1079,13 +1079,13 @@ void draw_mini_things_in_hand(long x, long y)
     {
         struct TbSprite *spr;
         spr = &gui_panel_sprites[164]; // Use dungeon special box as reference
-        ps_units_per_px = (46 * units_per_pixel_ui) / spr->SHeight;
+        ps_units_per_px = calculate_relative_upp(46, upp_UI, spr->SHeight);
     }
     int bs_units_per_px;
     {
         struct TbSprite *spr;
         spr = &button_sprite[184]; // Use creature flower level number as reference
-        bs_units_per_px = (17 * units_per_pixel_ui) / spr->SHeight;
+        bs_units_per_px = calculate_relative_upp(17, upp_UI, spr->SHeight);
     }
     unsigned long spr_idx;
     spr_idx = get_creature_model_graphics(get_players_special_digger_model(dungeon->owner), CGI_HandSymbol);

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -515,7 +515,7 @@ void draw_power_hand(void)
     {
         struct TbSprite *spr;
         spr = &gui_panel_sprites[164]; // Use dungeon special box as reference
-        ps_units_per_px = (46 * units_per_pixel) / spr->SHeight;
+        ps_units_per_px = (46 * units_per_pixel_ui) / spr->SHeight;
     }
     // Now draw
     if (((game.operation_flags & GOF_ShowGui) != 0) && (game.small_map_state != 2)
@@ -530,18 +530,18 @@ void draw_power_hand(void)
         if ((!room_is_invalid(room)) && (subtile_revealed(stl_x, stl_y, player->id_number)))
         {
             rdata = room_data_get_for_room(room);
-            draw_gui_panel_sprite_centered(GetMouseX()+24*units_per_pixel/16, GetMouseY()+32*units_per_pixel/16, ps_units_per_px, rdata->medsym_sprite_idx);
+            draw_gui_panel_sprite_centered(GetMouseX()+scale_ui_value(24), GetMouseY()+scale_ui_value(32), ps_units_per_px, rdata->medsym_sprite_idx);
         }
         if ((!power_hand_is_empty(player)) && (game.small_map_state == 1))
         {
-            draw_mini_things_in_hand(GetMouseX()+10*units_per_pixel/16, GetMouseY()+10*units_per_pixel/16);
+            draw_mini_things_in_hand(GetMouseX()+scale_ui_value(10), GetMouseY()+scale_ui_value(10));
         }
         return;
     }
     if (game_is_busy_doing_gui())
     {
         SYNCDBG(7,"Drawing while GUI busy");
-        draw_mini_things_in_hand(GetMouseX()+10*units_per_pixel/16, GetMouseY()+10*units_per_pixel/16);
+        draw_mini_things_in_hand(GetMouseX()+scale_ui_value(10), GetMouseY()+scale_ui_value(10));
         return;
     }
     thing = thing_get(player->hand_thing_idx);
@@ -550,15 +550,15 @@ void draw_power_hand(void)
     if (player->hand_busy_until_turn > game.play_gameturn)
     {
         SYNCDBG(7,"Drawing hand %s index %d, busy state", thing_model_name(thing), (int)thing->index);
-        process_keeper_sprite(GetMouseX()+60*units_per_pixel/16, GetMouseY()+40*units_per_pixel/16,
-          thing->anim_sprite, 0, thing->field_48, 64*units_per_pixel/16);
-        draw_mini_things_in_hand(GetMouseX()+60*units_per_pixel/16, GetMouseY());
+        process_keeper_sprite(GetMouseX()+scale_ui_value(60), GetMouseY()+scale_ui_value(40),
+          thing->anim_sprite, 0, thing->field_48, scale_ui_value(64));
+        draw_mini_things_in_hand(GetMouseX()+scale_ui_value(60), GetMouseY());
         return;
     }
     SYNCDBG(7,"Drawing hand %s index %d", thing_model_name(thing), (int)thing->index);
     if ((player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0)
     {
-        draw_mini_things_in_hand(GetMouseX()+18*units_per_pixel/16, GetMouseY());
+        draw_mini_things_in_hand(GetMouseX()+scale_ui_value(18), GetMouseY());
         return;
     }
     if (player->work_state != PSt_HoldInHand)
@@ -570,14 +570,14 @@ void draw_power_hand(void)
         {
           if (player->work_state == PSt_Slap)
           {
-            process_keeper_sprite(GetMouseX() + 70*units_per_pixel/16, GetMouseY() + 46*units_per_pixel/16,
-                thing->anim_sprite, 0, thing->field_48, 64*units_per_pixel/16);
+            process_keeper_sprite(GetMouseX() + scale_ui_value(70), GetMouseY() + scale_ui_value(46),
+                thing->anim_sprite, 0, thing->field_48, scale_ui_value(64));
           } else
           if (player->work_state == PSt_CtrlDungeon)
           {
             if ((player->secondary_cursor_state == CSt_DoorKey) || (player->primary_cursor_state == CSt_DoorKey))
             {
-              draw_mini_things_in_hand(GetMouseX()+18*units_per_pixel/16, GetMouseY());
+              draw_mini_things_in_hand(GetMouseX()+scale_ui_value(18), GetMouseY());
             }
           }
           return;
@@ -596,28 +596,28 @@ void draw_power_hand(void)
             if (!creature_affected_by_spell(picktng, SplK_Chicken))
             {
                 pickoffs = get_creature_picked_up_offset(picktng);
-                inputpos_x = GetMouseX() + pickoffs->delta_x*units_per_pixel/16;
-                inputpos_y = GetMouseY() + pickoffs->delta_y*units_per_pixel/16;
+                inputpos_x = GetMouseX() + scale_ui_value(pickoffs->delta_x);
+                inputpos_y = GetMouseY() + scale_ui_value(pickoffs->delta_y);
                 if (creatures[picktng->model].field_7)
                   EngineSpriteDrawUsingAlpha = 1;
                 process_keeper_sprite(inputpos_x / pixel_size, inputpos_y / pixel_size,
-                    picktng->anim_sprite, 0, picktng->field_48, 64*units_per_pixel/16);
+                    picktng->anim_sprite, 0, picktng->field_48, scale_ui_value(64));
                 EngineSpriteDrawUsingAlpha = 0;
             } else
             {
-                inputpos_x = GetMouseX() + 11*units_per_pixel/16;
-                inputpos_y = GetMouseY() + 56*units_per_pixel/16;
+                inputpos_x = GetMouseX() + scale_ui_value(11);
+                inputpos_y = GetMouseY() + scale_ui_value(56);
                 process_keeper_sprite(inputpos_x / pixel_size, inputpos_y / pixel_size,
-                    picktng->anim_sprite, 0, picktng->field_48, 64*units_per_pixel/16);
+                    picktng->anim_sprite, 0, picktng->field_48, scale_ui_value(64));
             }
             break;
         case TCls_Object:
             if (object_is_mature_food(picktng))
             {
-              inputpos_x = GetMouseX() + 11*units_per_pixel/16;
-              inputpos_y = GetMouseY() + 56*units_per_pixel/16;
+              inputpos_x = GetMouseX() + scale_ui_value(11);
+              inputpos_y = GetMouseY() + scale_ui_value(56);
               process_keeper_sprite(inputpos_x / pixel_size, inputpos_y / pixel_size,
-                  picktng->anim_sprite, 0, picktng->field_48, 64*units_per_pixel/16);
+                  picktng->anim_sprite, 0, picktng->field_48, scale_ui_value(64));
               break;
             } else
             if ((picktng->class_id == TCls_Object) && object_is_gold_pile(picktng))
@@ -629,24 +629,24 @@ void draw_power_hand(void)
             inputpos_x = GetMouseX();
             inputpos_y = GetMouseY();
             process_keeper_sprite(inputpos_x / pixel_size, inputpos_y / pixel_size,
-                  picktng->anim_sprite, 0, picktng->field_48, 64*units_per_pixel/16);
+                  picktng->anim_sprite, 0, picktng->field_48, scale_ui_value(64));
             break;
         }
     }
     if (player->field_C == 784)
     {
-        inputpos_x = GetMouseX() + 58*units_per_pixel/16;
-        inputpos_y = GetMouseY() +  6*units_per_pixel/16;
+        inputpos_x = GetMouseX() + scale_ui_value(58);
+        inputpos_y = GetMouseY() +  scale_ui_value(6);
         process_keeper_sprite(inputpos_x / pixel_size, inputpos_y / pixel_size,
-            thing->anim_sprite, 0, thing->field_48, 64*units_per_pixel/16);
-        draw_mini_things_in_hand(GetMouseX()+60*units_per_pixel/16, GetMouseY());
+            thing->anim_sprite, 0, thing->field_48, scale_ui_value(64));
+        draw_mini_things_in_hand(GetMouseX()+scale_ui_value(60), GetMouseY());
     } else
     {
-        inputpos_x = GetMouseX() + 60*units_per_pixel/16;
-        inputpos_y = GetMouseY() + 40*units_per_pixel/16;
+        inputpos_x = GetMouseX() + scale_ui_value(60);
+        inputpos_y = GetMouseY() + scale_ui_value(40);
         process_keeper_sprite(inputpos_x / pixel_size, inputpos_y / pixel_size,
-            thing->anim_sprite, 0, thing->field_48, 64*units_per_pixel/16);
-        draw_mini_things_in_hand(GetMouseX()+60*units_per_pixel/16, GetMouseY());
+            thing->anim_sprite, 0, thing->field_48, scale_ui_value(64));
+        draw_mini_things_in_hand(GetMouseX()+scale_ui_value(60), GetMouseY());
     }
 }
 
@@ -1079,13 +1079,13 @@ void draw_mini_things_in_hand(long x, long y)
     {
         struct TbSprite *spr;
         spr = &gui_panel_sprites[164]; // Use dungeon special box as reference
-        ps_units_per_px = (46 * units_per_pixel) / spr->SHeight;
+        ps_units_per_px = (46 * units_per_pixel_ui) / spr->SHeight;
     }
     int bs_units_per_px;
     {
         struct TbSprite *spr;
         spr = &button_sprite[184]; // Use creature flower level number as reference
-        bs_units_per_px = (17 * units_per_pixel) / spr->SHeight;
+        bs_units_per_px = (17 * units_per_pixel_ui) / spr->SHeight;
     }
     unsigned long spr_idx;
     spr_idx = get_creature_model_graphics(get_players_special_digger_model(dungeon->owner), CGI_HandSymbol);
@@ -1096,8 +1096,8 @@ void draw_mini_things_in_hand(long x, long y)
     long scrbase_x;
     long scrbase_y;
     scrbase_x = x;
-    scrbase_y = y - 58*units_per_pixel/16;
-    expshift_x = (abs(i)*units_per_pixel/16) / 2;
+    scrbase_y = y - scale_ui_value(58);
+    expshift_x = scale_ui_value(abs(i)) / 2;
     for (i = dungeon->num_things_in_hand-1; i >= 0; i--)
     {
         int icol;
@@ -1125,10 +1125,10 @@ void draw_mini_things_in_hand(long x, long y)
                     shift_y = 40;
                 else
                     shift_y = 6;
-                scrpos_x = scrbase_x + (16*units_per_pixel/16) * icol;
-                scrpos_y = scrbase_y + (18*units_per_pixel/16) * irow;
+                scrpos_x = scrbase_x + scale_ui_value(16) * icol;
+                scrpos_y = scrbase_y + scale_ui_value(18) * irow;
                 // Draw exp level
-                draw_button_sprite_left(scrpos_x + expshift_x, scrpos_y + shift_y*units_per_pixel/16, bs_units_per_px, expspr_idx);
+                draw_button_sprite_left(scrpos_x + expshift_x, scrpos_y + scale_ui_value(shift_y), bs_units_per_px, expspr_idx);
                 // Draw creature symbol
                 draw_gui_panel_sprite_left(scrpos_x, scrpos_y, ps_units_per_px, spr_idx);
             }
@@ -1140,9 +1140,9 @@ void draw_mini_things_in_hand(long x, long y)
                 shift_y = 20;
             else
                 shift_y = 0;
-            scrpos_x = scrbase_x + (16*units_per_pixel/16) * icol;
-            scrpos_y = scrbase_y + (14*units_per_pixel/16) * irow;
-            draw_gui_panel_sprite_left(scrpos_x - 2, scrpos_y + shift_y*units_per_pixel/16, ps_units_per_px, spr_idx);
+            scrpos_x = scrbase_x + scale_ui_value(16) * icol;
+            scrpos_y = scrbase_y + scale_ui_value(14) * irow;
+            draw_gui_panel_sprite_left(scrpos_x - 2, scrpos_y + scale_ui_value(shift_y), ps_units_per_px, spr_idx);
         } else
         {
             spr_idx = 59;
@@ -1150,9 +1150,9 @@ void draw_mini_things_in_hand(long x, long y)
                 shift_y = 20;
             else
                 shift_y = 0;
-            scrpos_x = scrbase_x + (16*units_per_pixel/16) * icol;
-            scrpos_y = scrbase_y + (14*units_per_pixel/16) * irow;
-            draw_gui_panel_sprite_left(scrpos_x - 2, scrpos_y + shift_y*units_per_pixel/16, ps_units_per_px, spr_idx);
+            scrpos_x = scrbase_x + scale_ui_value(16) * icol;
+            scrpos_y = scrbase_y + scale_ui_value(14) * irow;
+            draw_gui_panel_sprite_left(scrpos_x - 2, scrpos_y + scale_ui_value(shift_y), ps_units_per_px, spr_idx);
         }
     }
 }

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -515,7 +515,7 @@ void draw_power_hand(void)
     {
         struct TbSprite *spr;
         spr = &gui_panel_sprites[164]; // Use dungeon special box as reference
-        ps_units_per_px = calculate_relative_upp(46, upp_UI, spr->SHeight);
+        ps_units_per_px = calculate_relative_upp(46, units_per_pixel_ui, spr->SHeight);
     }
     // Now draw
     if (((game.operation_flags & GOF_ShowGui) != 0) && (game.small_map_state != 2)
@@ -1079,13 +1079,13 @@ void draw_mini_things_in_hand(long x, long y)
     {
         struct TbSprite *spr;
         spr = &gui_panel_sprites[164]; // Use dungeon special box as reference
-        ps_units_per_px = calculate_relative_upp(46, upp_UI, spr->SHeight);
+        ps_units_per_px = calculate_relative_upp(46, units_per_pixel_ui, spr->SHeight);
     }
     int bs_units_per_px;
     {
         struct TbSprite *spr;
         spr = &button_sprite[184]; // Use creature flower level number as reference
-        bs_units_per_px = calculate_relative_upp(17, upp_UI, spr->SHeight);
+        bs_units_per_px = calculate_relative_upp(17, units_per_pixel_ui, spr->SHeight);
     }
     unsigned long spr_idx;
     spr_idx = get_creature_model_graphics(get_players_special_digger_model(dungeon->owner), CGI_HandSymbol);

--- a/src/vidmode.c
+++ b/src/vidmode.c
@@ -66,6 +66,7 @@ TbScreenMode frontend_vidmode = Lb_SCREEN_MODE_640_480_8;
 unsigned short units_per_pixel_min;
 unsigned short units_per_pixel_width;
 unsigned short units_per_pixel_height;
+unsigned short units_per_pixel_best;
 unsigned short units_per_pixel_ui;
 long base_mouse_sensitivity = 256;
 
@@ -732,7 +733,9 @@ TbBool update_screen_mode_data(long width, long height)
   units_per_pixel_min = (width>height?height:width)/40;// originally 10 for hires
   units_per_pixel_width = width/40; // 8 for low res, 16 is "kfx default"
   units_per_pixel_height = height/25; // 8 for low res, 16 is "kfx default"
-  units_per_pixel_ui = ((is_ar_wider_than_original(width, height)) ? units_per_pixel_height : units_per_pixel_width);
+  units_per_pixel_best = ((is_ar_wider_than_original(width, height)) ? units_per_pixel_height : units_per_pixel_width); // 8 for low res, 16 is "kfx default"
+  long ui_scale = UI_NORMAL_SIZE; // UI_NORMAL_SIZE, UI_HALF_SIZE, or UI_DOUBLE_SIZE (not fully implemented yet)
+  units_per_pixel_ui = resize_ui(units_per_pixel_best, ui_scale);
   
   if (MinimalResolutionSetup)
     LbSpriteSetupAll(setup_sprites_minimal);

--- a/src/vidmode.c
+++ b/src/vidmode.c
@@ -66,6 +66,7 @@ TbScreenMode frontend_vidmode = Lb_SCREEN_MODE_640_480_8;
 unsigned short units_per_pixel_min;
 unsigned short units_per_pixel_width;
 unsigned short units_per_pixel_height;
+unsigned short units_per_pixel_ui;
 long base_mouse_sensitivity = 256;
 
 short force_video_mode_reset = true;
@@ -731,6 +732,7 @@ TbBool update_screen_mode_data(long width, long height)
   units_per_pixel_min = (width>height?height:width)/40;// originally 10 for hires
   units_per_pixel_width = width/40; // 8 for low res, 16 is "kfx default"
   units_per_pixel_height = height/25; // 8 for low res, 16 is "kfx default"
+  units_per_pixel_ui = ((is_ar_wider_than_original(width, height)) ? units_per_pixel_height : units_per_pixel_width);
   
   if (MinimalResolutionSetup)
     LbSpriteSetupAll(setup_sprites_minimal);


### PR DESCRIPTION
... uses HEIGHT to scale if window aspect ratio is over 16/10, uses WIDTH to scale if window aspect ratio is 16/10 or lower. 640x400 and 640x480 are the same, anything wider is now correct. All resolution now have the same size of cursor, power hand and tool tips relative to the window size.

3440x1440 mode (21:9):
![image](https://user-images.githubusercontent.com/1984342/116200364-266eda80-a730-11eb-93c9-3b5384a793f6.png)

uses the new `units_per_pixel_ui` and `scale_ui_value()`

_**Note:** 1080p power hand is now about 1 pixel smaller in both dimensions, but it now matches original DK 640x400 mode better._

_____

Other functions have been added to aid the scaling project: they are designed to help collect all of the scaling together in one place. At a future point in time, these functions and their use can be re-assessed to reduce redundancy.

**_Initial support for variable UI scaling (only works on power hand, cursor and tooltips for now)_** 
* **variable UI scaling** can be utilised by changing [`long ui_scale`](https://github.com/dkfans/keeperfx/pull/1028/files#diff-ed234cb3938b495d9e162739bb4266601c45d39c1f6d42a7385d32841bdcb656R737) in update_screen_mode_data() in vidmode.c 
* Once all UI code uses `scale_ui_value()` and `units_per_pixel_ui` **variable UI scaling** should function game wide
(although additional work may be required to get ideal results with positioning etc)