### PR TITLE
Add PAUSE_GAME_ON_LOSE_FOCUS as cfg setting

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -118,6 +118,7 @@ const struct NamedCommand conf_commands[] = {
   {"RESIZE_MOVIES",       14},
   {"MUSIC_TRACKS",        15},
   {"WIBBLE",              16},
+  {"PAUSE_GAME_ON_LOSE_FOCUS", 17},
   {NULL,                   0},
   };
 
@@ -215,6 +216,14 @@ TbBool resize_movies_enabled(void)
 TbBool wibble_enabled(void)
 {
   return ((features_enabled & Ft_Wibble) != 0);
+}
+
+/**
+ * Returns if we should pause the game, if the game window loses focus.
+ */
+TbBool pause_on_lose_focus_enabled(void)
+{
+  return ((features_enabled & Ft_PauseOnLoseFocus) != 0);
 }
 
 TbBool is_feature_on(unsigned long feature)
@@ -808,6 +817,19 @@ short load_configuration(void)
               features_enabled |= Ft_Wibble;
           else
               features_enabled &= ~Ft_Wibble;
+          break;
+      case 17: // PAUSE_GAME_ON_LOSE_FOCUS
+          i = recognize_conf_parameter(buf,&pos,len,logicval_type);
+          if (i <= 0)
+          {
+              CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
+                COMMAND_TEXT(cmd_num),config_textname);
+            break;
+          }
+          if (i == 1)
+              features_enabled |= Ft_PauseOnLoseFocus;
+          else
+              features_enabled &= ~Ft_PauseOnLoseFocus;
           break;
       case 0: // comment
           break;

--- a/src/config.h
+++ b/src/config.h
@@ -74,6 +74,7 @@ enum TbFeature {
     Ft_Atmossounds  =  0x0040,
     Ft_Resizemovies =  0x0080,
     Ft_Wibble       =  0x0100,
+    Ft_PauseOnLoseFocus = 0x0200,
 };
 
 enum TbExtraLevels {
@@ -207,6 +208,7 @@ TbBool censorship_enabled(void);
 TbBool atmos_sounds_enabled(void);
 TbBool resize_movies_enabled(void);
 TbBool wibble_enabled(void);
+TbBool pause_on_lose_focus_enabled(void);
 short load_configuration(void);
 short calculate_moon_phase(short do_calculate,short add_to_log);
 void load_or_create_high_score_table(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1044,6 +1044,7 @@ short setup_game(void)
   update_features(mem_size);
 
   features_enabled |= Ft_Wibble; // enable wibble by default
+  features_enabled |= Ft_PauseOnLoseFocus; // pause the game, if the game window loses focus by default
 
   // Configuration file
   if ( !load_configuration() )
@@ -3668,6 +3669,8 @@ TbBool keeper_wait_for_screen_focus(void)
         if (LbIsActive())
           return true;
         if ((game.system_flags & GSF_NetworkActive) != 0)
+          return true;
+        if (!pause_on_lose_focus_enabled())
           return true;
         LbSleepFor(50);
     } while ((!exit_keeper) && (!quit_game));


### PR DESCRIPTION
Implements #609 as a keeperfx.cfg setting

IF PAUSE_GAME_ON_LOSE_FOCUS=DISABLED then the game will not pause when you alt-tab away from the game

IF PAUSE_GAME_ON_LOSE_FOCUS=ENABLED, or the line is missing from keeperfx.cfg then, as with current master, the game will pause when you alt-tab away from the game