### PR TITLE
saves the current mini map zoom level

### DIFF
--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -102,6 +102,8 @@ void setup_default_settings(void)
      0,                         // first_person_move_invert
      6,                         // first_person_move_sensitivity
      256,                       // minimap_zoom
+     8192,                      // isometric_view_zoom_level
+     65536,                     // frontview_zoom_level
     };
     LbMemoryCopy(&settings, &default_settings, sizeof(struct GameSettings));
     struct CPU_INFO cpu_info;

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -100,7 +100,8 @@ void setup_default_settings(void)
      },                         // kbkeys
      1,                         // tooltips_on
      0,                         // first_person_move_invert
-     6                          // first_person_move_sensitivity
+     6,                         // first_person_move_sensitivity
+     256,                       // minimap_zoom
     };
     LbMemoryCopy(&settings, &default_settings, sizeof(struct GameSettings));
     struct CPU_INFO cpu_info;

--- a/src/config_settings.h
+++ b/src/config_settings.h
@@ -70,6 +70,7 @@ struct GameSettings { // KFX settings
     unsigned char tooltips_on;
     unsigned char first_person_move_invert;
     unsigned char first_person_move_sensitivity;
+    unsigned int minimap_zoom;
     };
 #pragma pack()
 /******************************************************************************/

--- a/src/config_settings.h
+++ b/src/config_settings.h
@@ -71,6 +71,8 @@ struct GameSettings { // KFX settings
     unsigned char first_person_move_invert;
     unsigned char first_person_move_sensitivity;
     unsigned int minimap_zoom;
+    unsigned long isometric_view_zoom_level;
+    unsigned long frontview_zoom_level;
     };
 #pragma pack()
 /******************************************************************************/

--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -32,6 +32,7 @@
 #include "vidmode.h"
 #include "map_blocks.h"
 #include "dungeon_data.h"
+#include "config_settings.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -388,7 +389,7 @@ void init_player_cameras(struct PlayerInfo *player)
     cam->orient_b = -266;
     cam->orient_a = LbFPMath_PI/4;
     cam->view_mode = PVM_IsometricView;
-    cam->zoom = 10000;
+    cam->zoom = settings.isometric_view_zoom_level;
 
     cam = &player->cameras[CamIV_Parchment];
     cam->mappos.x.val = 0;
@@ -403,6 +404,6 @@ void init_player_cameras(struct PlayerInfo *player)
     cam->mappos.z.val = 32;
     cam->field_13 = 188;
     cam->view_mode = PVM_FrontView;
-    cam->zoom = 65536;
+    cam->zoom = settings.frontview_zoom_level;
 }
 /******************************************************************************/

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2484,6 +2484,11 @@ void set_gui_visible(TbBool visible)
   if (player->acamera && player->acamera->view_mode == PVM_IsometricView)
   {
       update_camera_zoom_bounds(player->acamera, CAMERA_ZOOM_MAX, adjust_min_camera_zoom(player->acamera, game.operation_flags & GOF_ShowGui));
+      if (is_my_player(player))
+      {
+        settings.isometric_view_zoom_level = player->acamera->zoom;
+        save_settings();
+      }
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1401,8 +1401,6 @@ void reset_gui_based_on_player_mode(void)
             turn_on_menu(GMnu_ROOM);
         }
     }
-    settings.video_cluedo_mode = player->video_cluedo_mode;
-    copy_settings_to_dk_settings();
     set_gui_visible(true);
 }
 

--- a/src/packets.c
+++ b/src/packets.c
@@ -2392,6 +2392,11 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       return 0;
   case PckA_SetMinimapConf:
       player->minimap_zoom = pckt->actn_par1;
+      if (is_my_player(player))
+      {
+        settings.minimap_zoom = player->minimap_zoom;
+        save_settings();
+      }
       return 0;
   case PckA_SetMapRotation:
       player->cameras[CamIV_Parchment].orient_a = pckt->actn_par1;

--- a/src/packets.c
+++ b/src/packets.c
@@ -2115,10 +2115,20 @@ void process_players_dungeon_control_packet_control(long plyr_idx)
         case PVM_IsometricView:
             view_zoom_camera_in(cam, zoom_max, zoom_min);
             update_camera_zoom_bounds(cam, zoom_max, zoom_min);
+            if (is_my_player(player))
+            {
+                settings.isometric_view_zoom_level = cam->zoom;
+                save_settings();
+            }
             break;
         default:
             view_zoom_camera_in(cam, zoom_max, zoom_min);
             break;
+        }
+        if (is_my_player(player))
+        {
+            settings.frontview_zoom_level = cam->zoom;
+            save_settings();
         }
     }
     if (pckt->control_flags & PCtr_ViewZoomOut)
@@ -2128,9 +2138,19 @@ void process_players_dungeon_control_packet_control(long plyr_idx)
         case PVM_IsometricView:
             view_zoom_camera_out(cam, zoom_max, zoom_min);
             update_camera_zoom_bounds(cam, zoom_max, zoom_min);
+            if (is_my_player(player))
+            {
+                settings.isometric_view_zoom_level = cam->zoom;
+                save_settings();
+            }
             break;
         default:
             view_zoom_camera_out(cam, zoom_max, zoom_min);
+            if (is_my_player(player))
+            {
+                settings.frontview_zoom_level = cam->zoom;
+                save_settings();
+            }
             break;
         }
     }

--- a/src/packets.c
+++ b/src/packets.c
@@ -2366,12 +2366,12 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       process_pause_packet((game.operation_flags & GOF_Paused) == 0, pckt->actn_par1);
       return 1;
   case PckA_SetCluedo:
+      player->video_cluedo_mode = pckt->actn_par1;
       if (is_my_player(player))
       {
-          settings.video_cluedo_mode = pckt->actn_par1;
-          save_settings();
+        settings.video_cluedo_mode = player->video_cluedo_mode;
+        save_settings();
       }
-      player->video_cluedo_mode = pckt->actn_par1;
       return 0;
   case PckA_Unknown025:
       if (is_my_player(player))

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -638,7 +638,7 @@ long pinstfs_zoom_out_of_heart(struct PlayerInfo *player, long *n)
   if (player->view_mode == PVM_FrontView)
   {
     cam->mappos.y.val = thing->mappos.y.val;
-    cam->zoom = 65536;
+    cam->zoom = settings.frontview_zoom_level;
   } else
   {
     cam->mappos.y.val = thing->mappos.y.val - (thing->clipbox_size_yz >> 1) -  thing->mappos.z.val;
@@ -664,7 +664,7 @@ long pinstfm_zoom_out_of_heart(struct PlayerInfo *player, long *n)
         unsigned long addval;
         if (cam != NULL)
         {
-          cam->zoom -= 988;
+          cam->zoom -= (24000 - settings.isometric_view_zoom_level) / 16;
           cam->orient_a += LbFPMath_PI/64;
           addval = (thing->clipbox_size_yz >> 1);
           deltax = distance_with_angle_to_coord_x((long)thing->mappos.z.val+addval, cam->orient_a);
@@ -693,7 +693,7 @@ long pinstfe_zoom_out_of_heart(struct PlayerInfo *player, long *n)
   struct Camera* cam = player->acamera;
   if ((player->view_mode != PVM_FrontView) && (cam != NULL))
   {
-    cam->zoom = 8192;
+    cam->zoom = settings.isometric_view_zoom_level;
     cam->orient_a = LbFPMath_PI/4;
   }
   light_turn_light_on(player->field_460);

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -535,7 +535,7 @@ void init_player(struct PlayerInfo *player, short no_explore)
     SYNCDBG(5,"Starting");
     player->minimap_pos_x = 11;
     player->minimap_pos_y = 11;
-    player->minimap_zoom = 256;
+    player->minimap_zoom = settings.minimap_zoom;
     player->field_4D1 = player->id_number;
     setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
     player->continue_work_state = PSt_CtrlDungeon;


### PR DESCRIPTION
... to settings.dat

Are there any others settings that should/could also be saved?

There is a discussion here: #296, that brings up the suggestion of camera zoom and rotation. I have fixed the mentioned bug about cluedo mode (low wall mode) not always saving.

Camera zoom level might be a good idea to add, especially after #1030.