### PR TITLE
add LIQUIDONLY option to WIBBLE setting

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -20,8 +20,8 @@ INGAME_RES=640x480x32 1366x768x32 1920x1080x32
 ; With value more than 0 sensitivity will also depend on resolution.
 POINTER_SENSITIVITY=100
 
-; Terrain is deformed to give it a natural look. Turn it OFF
-; for a clean look instead. Lava and water will be flat.
+; Terrain is deformed to give it a natural look. Turn it OFF for a 
+; clean look instead. LIQUIDONLY to have it for Lava and Water only.
 WIBBLE=ON
 
 ; Censorship - originally was ON only if language is german.

--- a/src/config.c
+++ b/src/config.c
@@ -133,6 +133,13 @@ const struct NamedCommand logicval_type[] = {
   {NULL,       0},
   };
 
+  const struct NamedCommand wibble_type[] = {
+  {"ON",             1},
+  {"OFF",            2},
+  {"LIQUIDONLY",     3},
+  {NULL,             0},
+  };
+
   const struct NamedCommand vidscale_type[] = {
   {"OFF",          256}, // = 0x100 = No scaling of Smacker Video
   {"FIT",           16}, // = 0x10 = SMK_FullscreenFit - fit to fullscreen, using letterbox and pillarbox as necessary
@@ -215,6 +222,14 @@ TbBool resize_movies_enabled(void)
 TbBool wibble_enabled(void)
 {
   return ((features_enabled & Ft_Wibble) != 0);
+}
+
+/**
+ * Returns if the liquid wibble effect is on.
+ */
+TbBool liquid_wibble_enabled(void)
+{
+  return ((features_enabled & Ft_LiquidWibble) != 0);
 }
 
 TbBool is_feature_on(unsigned long feature)
@@ -797,17 +812,28 @@ short load_configuration(void)
           }
           break;
       case 16: // WIBBLE
-          i = recognize_conf_parameter(buf,&pos,len,logicval_type);
+          i = recognize_conf_parameter(buf,&pos,len,wibble_type);
           if (i <= 0)
           {
               CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
                 COMMAND_TEXT(cmd_num),config_textname);
             break;
           }
-          if (i == 1)
+          if (i == 1) // WIBBLE ON
+          {
               features_enabled |= Ft_Wibble;
-          else
+              features_enabled |= Ft_LiquidWibble;
+          }
+          else if (i == 3) // LIQUID ONLY
+          {
               features_enabled &= ~Ft_Wibble;
+              features_enabled |= Ft_LiquidWibble;
+          }
+          else // WIBBLE OFF
+          {
+              features_enabled &= ~Ft_Wibble;
+              features_enabled &= ~Ft_LiquidWibble;
+          }
           break;
       case 0: // comment
           break;

--- a/src/config.h
+++ b/src/config.h
@@ -74,6 +74,7 @@ enum TbFeature {
     Ft_Atmossounds  =  0x0040,
     Ft_Resizemovies =  0x0080,
     Ft_Wibble       =  0x0100,
+    Ft_LiquidWibble =  0x0200,
 };
 
 enum TbExtraLevels {
@@ -207,6 +208,7 @@ TbBool censorship_enabled(void);
 TbBool atmos_sounds_enabled(void);
 TbBool resize_movies_enabled(void);
 TbBool wibble_enabled(void);
+TbBool liquid_wibble_enabled(void);
 short load_configuration(void);
 short calculate_moon_phase(short do_calculate,short add_to_log);
 void load_or_create_high_score_table(void);

--- a/src/engine_arrays.c
+++ b/src/engine_arrays.c
@@ -36,7 +36,7 @@ DLLIMPORT short _DK_td_iso[TD_ISO_POINTS];
 DLLIMPORT short _DK_iso_td[TD_ISO_POINTS];
 #define iso_td _DK_iso_td
 unsigned short floor_to_ceiling_map[FLOOR_TO_CEILING_MAP_LEN];
-
+struct WibbleTable blank_wibble_table[128];
 /******************************************************************************/
 #ifdef __cplusplus
 }
@@ -1049,21 +1049,25 @@ unsigned short wibble_random(unsigned short range, unsigned short *seed)
 void generate_wibble_table(void)
 {
     struct WibbleTable *wibl;
+    struct WibbleTable *empty_wibl;
     struct WibbleTable *qwibl;
     unsigned short seed;
     int i;
     int n;
-    // Clear the whole wibble table
+    // Clear the whole wibble table and create an empty wibble table
     for (n=0; n < 4; n++)
     {
         wibl = &wibble_table[32*n];
+        empty_wibl = &blank_wibble_table[32*n];
         for (i=0; i < 32; i++)
         {
             LbMemorySet(wibl, 0, sizeof(struct WibbleTable));
             wibl++;
+            LbMemorySet(empty_wibl, 0, sizeof(struct WibbleTable));
+            empty_wibl++;
         }
     }
-    if (wibble_enabled())
+    if (wibble_enabled() || liquid_wibble_enabled())
     {
         // Set wibble values using special random algorithm
         seed = 0;

--- a/src/engine_arrays.h
+++ b/src/engine_arrays.h
@@ -60,6 +60,7 @@ DLLIMPORT extern long _DK_lintel_bottom_height[256];
 #pragma pack()
 /******************************************************************************/
 extern unsigned short floor_to_ceiling_map[FLOOR_TO_CEILING_MAP_LEN];
+extern struct WibbleTable blank_wibble_table[128];
 /******************************************************************************/
 long convert_td_iso(unsigned long n);
 long straight_td_iso(unsigned long n);

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -476,10 +476,18 @@ void rotate_base_axis(struct M33 *matx, short angle, unsigned char axis)
 struct WibbleTable *get_wibble_from_table(long table_index, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
     struct WibbleTable *wibl;
-    struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
-    struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
-    struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
-    if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
+    TbBool use_wibble = wibble_enabled();
+    if (liquid_wibble_enabled() && !use_wibble)
+    {
+        struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
+        struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
+        struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
+        if (slab_kind_is_liquid(slb3->kind) && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind))
+        {
+            use_wibble = true;
+        }
+    }
+    if (use_wibble)
     {
         wibl = &wibble_table[table_index];
     }

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -604,7 +604,17 @@ void fill_in_points_perspective(long bstl_x, long bstl_y, struct MinMax *mm)
         wib_v = get_mapblk_wibble_value(mapblk);
         hpos = subtile_coord(get_mapblk_filled_subtiles(mapblk),0) - view_alt;
         if (wib_v == 2)
-          wibl = &wibble_table[wib_x + 2 * (hmax + 2 * wib_y - hmin) + 32];
+        {
+            if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
+            {
+                wibl = &wibble_table[wib_x + 2 * (hmax + 2 * wib_y - hmin) + 32];
+            }
+            else
+            {
+                wibl = &blank_wibble_table[wib_x + 2 * (hmax + 2 * wib_y - hmin) + 32];
+            }
+        }
+          
         ecord = &ecol->cors[8];
         {
             ecord->x = apos + wibl->field_0;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -473,6 +473,23 @@ void rotate_base_axis(struct M33 *matx, short angle, unsigned char axis)
     matx->r[2].v[3] = matx->r[2].v[0] * matx->r[2].v[1];
 }
 
+struct WibbleTable *get_wibble_from_table(long table_index, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    struct WibbleTable *wibl;
+    struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
+    struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
+    struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
+    if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
+    {
+        wibl = &wibble_table[table_index];
+    }
+    else
+    {
+        wibl = &blank_wibble_table[table_index];
+    }
+    return wibl;
+}
+
 void fill_in_points_perspective(long bstl_x, long bstl_y, struct MinMax *mm)
 {
     //_DK_fill_in_points_perspective(bstl_x, bstl_y, mm); return;
@@ -569,17 +586,7 @@ void fill_in_points_perspective(long bstl_x, long bstl_y, struct MinMax *mm)
         hpos = subtile_coord(hmin,0) - view_alt;
         wib_x = stl_x & 3;
         struct WibbleTable *wibl;
-        struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
-        struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
-        struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
-        if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
-        {
-            wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
-        }
-        else
-        {
-            wibl = &blank_wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
-        }
+        wibl = get_wibble_from_table(32 * wib_v + wib_x + (wib_y << 2), stl_x, stl_y);
         int idxh;
         for (idxh = hmax-hmin+1; idxh > 0; idxh--)
         {
@@ -605,16 +612,8 @@ void fill_in_points_perspective(long bstl_x, long bstl_y, struct MinMax *mm)
         hpos = subtile_coord(get_mapblk_filled_subtiles(mapblk),0) - view_alt;
         if (wib_v == 2)
         {
-            if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
-            {
-                wibl = &wibble_table[wib_x + 2 * (hmax + 2 * wib_y - hmin) + 32];
-            }
-            else
-            {
-                wibl = &blank_wibble_table[wib_x + 2 * (hmax + 2 * wib_y - hmin) + 32];
-            }
+            wibl = get_wibble_from_table(wib_x + 2 * (hmax + 2 * wib_y - hmin) + 32, stl_x, stl_y);
         }
-          
         ecord = &ecol->cors[8];
         {
             ecord->x = apos + wibl->field_0;
@@ -789,17 +788,7 @@ void fill_in_points_cluedo(long bstl_x, long bstl_y, struct MinMax *mm)
         ecord = &ecol->cors[hmin];
         wib_x = stl_x & 3;
         struct WibbleTable *wibl;
-        struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
-        struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
-        struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
-        if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
-        {
-            wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
-        }
-        else
-        {
-            wibl = &blank_wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
-        }
+        wibl = get_wibble_from_table(32 * wib_v + wib_x + (wib_y << 2), stl_x, stl_y);
         long *randmis;
         randmis = &randomisors[(stl_x + 17 * (stl_y + 1)) & 0xff];
         eview_h = dview_h * hmin + hview_y;
@@ -1030,17 +1019,7 @@ void fill_in_points_isometric(long bstl_x, long bstl_y, struct MinMax *mm)
         ecord = &ecol->cors[hmin];
         wib_x = stl_x & 3;
         struct WibbleTable *wibl;
-        struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
-        struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
-        struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
-        if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
-        {
-            wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
-        }
-        else
-        {
-            wibl = &blank_wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
-        }
+        wibl = get_wibble_from_table(32 * wib_v + wib_x + (wib_y << 2), stl_x, stl_y);
         eview_h = dview_h * hmin + hview_y;
         eview_z = dview_z * hmin + hview_z;
         randmis = &randomisors[(stl_x + 17 * (stl_y+1)) & 0xff] + hmin;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -569,7 +569,17 @@ void fill_in_points_perspective(long bstl_x, long bstl_y, struct MinMax *mm)
         hpos = subtile_coord(hmin,0) - view_alt;
         wib_x = stl_x & 3;
         struct WibbleTable *wibl;
-        wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
+        struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
+        struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
+        if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
+        {
+            wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        }
+        else
+        {
+            wibl = &blank_wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        }
         int idxh;
         for (idxh = hmax-hmin+1; idxh > 0; idxh--)
         {
@@ -769,7 +779,17 @@ void fill_in_points_cluedo(long bstl_x, long bstl_y, struct MinMax *mm)
         ecord = &ecol->cors[hmin];
         wib_x = stl_x & 3;
         struct WibbleTable *wibl;
-        wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
+        struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
+        struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
+        if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
+        {
+            wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        }
+        else
+        {
+            wibl = &blank_wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        }
         long *randmis;
         randmis = &randomisors[(stl_x + 17 * (stl_y + 1)) & 0xff];
         eview_h = dview_h * hmin + hview_y;
@@ -1000,7 +1020,17 @@ void fill_in_points_isometric(long bstl_x, long bstl_y, struct MinMax *mm)
         ecord = &ecol->cors[hmin];
         wib_x = stl_x & 3;
         struct WibbleTable *wibl;
-        wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        struct SlabMap *slb = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y));
+        struct SlabMap *slb2 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x), stl_slab_center_subtile(stl_y+1)); // additional checks needed to keep straight edges around liquid with liquid wibble mode
+        struct SlabMap *slb3 = get_slabmap_for_subtile(stl_slab_center_subtile(stl_x-1), stl_slab_center_subtile(stl_y));
+        if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slb3->kind)  && slab_kind_is_liquid(slb2->kind) && slab_kind_is_liquid(slb->kind)))
+        {
+            wibl = &wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        }
+        else
+        {
+            wibl = &blank_wibble_table[32 * wib_v + wib_x + (wib_y << 2)];
+        }
         eview_h = dview_h * hmin + hview_y;
         eview_z = dview_z * hmin + hview_z;
         randmis = &randomisors[(stl_x + 17 * (stl_y+1)) & 0xff] + hmin;
@@ -4929,7 +4959,7 @@ void draw_view(struct Camera *cam, unsigned char a2)
     x = cam->mappos.x.val;
     y = cam->mappos.y.val;
     z = cam->mappos.z.val;
-    if (wibble_enabled())
+    if (wibble_enabled() || liquid_wibble_enabled())
     {
         frame_wibble_generate();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1044,6 +1044,7 @@ short setup_game(void)
   update_features(mem_size);
 
   features_enabled |= Ft_Wibble; // enable wibble by default
+  features_enabled |= Ft_LiquidWibble; // enable liquid wibble by default
 
   // Configuration file
   if ( !load_configuration() )

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -722,7 +722,7 @@ void place_slab_columns(long slbkind, unsigned char stl_x, unsigned char stl_y, 
             if ( v10 < 0 )
               ERRORLOG("BBlocks instead of columns");
             update_map_collide(slbkind, stl_x+dx, stl_y+dy);
-            if (wibble_enabled())
+            if (wibble_enabled() || (liquid_wibble_enabled() && slab_kind_is_liquid(slbkind)))
             {
                 set_alt_bit_based_on_slab(slbkind, stl_x+dx, stl_y+dy);
             }


### PR DESCRIPTION
Implements #1048

When `WIBBLE=LIQUIDONLY` turn on some aspects of wibble, so that the water/lava is animated correctly with wibble, (but the walls remain straight like WIBBLE=OFF mode)

![image](https://user-images.githubusercontent.com/1984342/119432342-17b61c00-bd0c-11eb-8e18-ba92c0dabfd0.png)