### PR TITLE
Navigate Missile spell now rebounds like it used to

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -540,7 +540,7 @@ void draw_flame_breath(struct Coord3d *pos1, struct Coord3d *pos2, long delta_st
                 if ((tngpos.x.val < subtile_coord(map_subtiles_x,0)) && (tngpos.y.val < subtile_coord(map_subtiles_y,0)))
                 {
                     struct Thing *eelemtng;
-                    eelemtng = create_thing(&tngpos, TCls_EffectElem, 9, game.neutral_player_num, -1);
+                    eelemtng = create_thing(&tngpos, TCls_EffectElem, TngEffElm_BallOfLight, game.neutral_player_num, -1);
                     if (!thing_is_invalid(eelemtng)) {
                         eelemtng->sprite_size = sprsize >> 8;
                     }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -4637,7 +4637,7 @@ void place_bloody_footprint(struct Thing *thing)
     case 5:
         if (nfoot)
         {
-            footng = create_thing(&thing->mappos, TCls_EffectElem, 23, thing->owner, -1);
+            footng = create_thing(&thing->mappos, TCls_EffectElem, TngEffElm_Blood4, thing->owner, -1);
             if (!thing_is_invalid(footng)) {
                 cctrl->bloody_footsteps_turns--;
             }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -876,6 +876,10 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
         }
         if (!thing_is_invalid(killertng))
         {
+            if (shot_model_is_navigable(shotng->model))
+            {
+                shotst->model_flags ^= ShMF_Navigable;
+            }
             struct CreatureStats* crstat = creature_stats_get_from_thing(killertng);
             struct Coord3d pos2;
             pos2.x.val = killertng->mappos.x.val;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -878,7 +878,7 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
         {
             if (shot_model_is_navigable(shotng->model))
             {
-                shotst->model_flags ^= ShMF_Navigable;
+                shotng->shot.target_idx = 0;
             }
             struct CreatureStats* crstat = creature_stats_get_from_thing(killertng);
             struct Coord3d pos2;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -1297,7 +1297,7 @@ TngUpdateRet update_shot(struct Thing *thing)
               pos1.x.val = thing->mappos.x.val - ACTION_RANDOM(127) + 63;
               pos1.y.val = thing->mappos.y.val - ACTION_RANDOM(127) + 63;
               pos1.z.val = thing->mappos.z.val - ACTION_RANDOM(127) + 63;
-              create_thing(&pos1, TCls_EffectElem, 1, thing->owner, -1);
+              create_thing(&pos1, TCls_EffectElem, TngEffElm_Blast1, thing->owner, -1);
             }
             break;
         case ShM_Lightning:


### PR DESCRIPTION
Fixes #1109

In DK navigate missile would rebound, in FX it would circle around the target.