### PR TITLE
Flying units cannot be slapped to death into a wall anymore

### DIFF
--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2244,10 +2244,18 @@ void thing_death_normal(struct Thing *thing)
         ERRORLOG("Cannot create dead thing");
         return;
     }
-    deadtng->move_angle_xy = memp1;
-    deadtng->veloc_base.x.val = memaccl.x.val;
-    deadtng->veloc_base.y.val = memaccl.y.val;
-    deadtng->veloc_base.z.val = memaccl.z.val;
+    struct Coord3d pos;
+    TbBool move_allowed = get_thing_next_position(&pos, deadtng);
+    if (!positions_equivalent(&deadtng->mappos, &pos))
+    {
+        if ((move_allowed) && !thing_in_wall_at(deadtng, &pos))
+        {
+            deadtng->move_angle_xy = memp1;
+            deadtng->veloc_base.x.val = memaccl.x.val;
+            deadtng->veloc_base.y.val = memaccl.y.val;
+            deadtng->veloc_base.z.val = memaccl.z.val;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes #479

Testmap: [479.zip](https://github.com/dkfans/keeperfx/files/6971854/479.zip)
1) Use the reveal map below the heart in the testmap
2) Build graveyard
3) Capture fairies
4) It helps to use cheats to level them up in prison so they cast heal
5) Slap them against the wall until they die.
-> Notice they will all be dragged to graveyard, and none are stuck into the wall.