### PR TITLE
Unshelved books do not take up space

### DIFF
--- a/src/room_data.c
+++ b/src/room_data.c
@@ -648,7 +648,7 @@ int check_books_on_subtile_for_reposition_in_room(struct Room *room, MapSubtlCoo
         if (thing->class_id == TCls_Object)
         {
             PowerKind spl_idx = book_thing_to_power_kind(thing);
-            if ((spl_idx > 0) && ((thing->alloc_flags & 0x80) == 0))
+            if ((spl_idx > 0) && ((thing->alloc_flags & 0x80) == 0) && (thing->owner == room->owner))
             {
                 // If exceeded capacity of the library
                 if (room->used_capacity >= room->total_capacity)


### PR DESCRIPTION
Now when you place a library under a spellbook, the capacity remains available, and an imp should be able to 'claim' the book still.
Same as with crates and workshops.