### PR TITLE
Changed default room detection looseness for one-click build

### DIFF
--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -6319,4 +6319,4 @@ msgstr "神秘物品：没有说明它是干什么用的。"
 #: guitext:1006
 msgctxt "Network game message"
 msgid "Joined player has different map version from host."
-msgstr ""
+msgstr "已加入的玩家的主机中的地图版本不相同。"

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -30,7 +30,7 @@ extern "C" {
 #define MAX_USER_ROOMSPACE_WIDTH                    9
 #define MIN_USER_ROOMSPACE_WIDTH                    1
 #define DEFAULT_USER_ROOMSPACE_WIDTH                5
-#define DEFAULT_USER_ROOMSPACE_DETECTION_LOOSENESS  0
+#define DEFAULT_USER_ROOMSPACE_DETECTION_LOOSENESS  2
 #define MAX_USER_ROOMSPACE_DETECTION_LOOSENESS      9
 
 enum roomspace_placement_modes {
@@ -43,8 +43,8 @@ enum roomspace_placement_modes {
 enum roomspace_tolerance_layers {
     disable_tolerance_layers = 0,
     tolerate_only_self_claimed_path = 1,
-    tolerate_other_room_types = 2,
-    tolerate_same_room_type = 3,
+    tolerate_same_room_type = 2,
+    tolerate_other_room_types = 3,
     tolerate_gems = 4,
     tolerate_gold = 5,
     tolerate_liquid = 6,

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -366,11 +366,11 @@ int check_room_at_slab_loose(PlayerNumber plyr_idx, RoomKind rkind, MapSlabCoord
                 
                 if (slab_type_from_room_kind == slb->kind)
                 {
-                    result = 3; // same room type
+                    result = 2; // same room type
                 }
                 else if (slab_type_from_room_kind > 0)
                 {
-                    result = 2; // different room type
+                    result = 3; // different room type
                 }
                 
             }


### PR DESCRIPTION
When building rooms, using shift-build will now automatically suggest expanding the current room type without mouse scrolling.
Scrolling back will still allow to use the slab type as a wall.

Fixes https://github.com/dkfans/keeperfx/issues/1125