### PR TITLE
Rooms also rebuild when destroyed

### DIFF
--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -492,7 +492,7 @@ long computer_event_check_rooms_full(struct Computer2 *comp, struct ComputerEven
 long computer_event_rebuild_room(struct Computer2* comp, struct ComputerEvent* cevent, struct Event* event)
 {
     SYNCDBG(18, "Starting");
-    if (get_room_slabs_count(comp->dungeon->owner, event->target) == 0)
+    if (count_slabs_of_room_type(comp->dungeon->owner, event->target) == 0)
     {
         for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
         {

--- a/src/room_util.c
+++ b/src/room_util.c
@@ -268,7 +268,7 @@ TbBool delete_room_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, unsigned char is
     if (room->slabs_count <= 1)
     {
         delete_room_flag(room);
-        if (count_slabs_of_room_type(room->owner, room->kind) == 0)
+        if (count_slabs_of_room_type(room->owner, room->kind) <= 1)
         {
             event_create_event_or_update_nearby_existing_event(slb_x, slb_y, EvKind_RoomLost, room->owner, room->kind);
         }
@@ -330,7 +330,7 @@ TbBool replace_slab_from_script(MapSlabCoord slb_x, MapSlabCoord slb_y, unsigned
         delete_room_flag(room);
         // Create a new one-slab room
         place_room(plyr_idx, rkind, slab_subtile(slb_x, 0), slab_subtile(slb_y, 0));
-        if (count_slabs_of_room_type(room->owner, room->kind) == 0)
+        if (count_slabs_of_room_type(room->owner, room->kind) <= 1)
         {
             event_create_event_or_update_nearby_existing_event(slb_x, slb_y, EvKind_RoomLost, room->owner, room->kind);
         }


### PR DESCRIPTION
When destroying a room by attacking it with units and the call to arm spell, the 'room lost' event should also be called.