### PR TITLE
Introduced do_room_recalculation function

### DIFF
--- a/src/room_data.h
+++ b/src/room_data.h
@@ -189,6 +189,7 @@ long get_room_look_through(RoomKind rkind);
 unsigned long compute_room_max_health(unsigned short slabs_count,unsigned short efficiency);
 void set_room_efficiency(struct Room *room);
 void set_room_stats(struct Room *room, TbBool skip_integration);
+void do_room_recalculation(struct Room* room);
 long get_room_slabs_count(PlayerNumber plyr_idx, RoomKind rkind);
 long get_room_kind_used_capacity_fraction(PlayerNumber plyr_idx, RoomKind room_kind);
 void get_room_kind_total_and_used_capacity(struct Dungeon *dungeon, RoomKind room_kind, long *total_cap, long *used_cap);

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -577,7 +577,7 @@ void do_slab_efficiency_alteration(MapSlabCoord slb_x, MapSlabCoord slb_y)
         if (slbattr->category == SlbAtCtg_RoomInterior)
         {
             struct Room* room = slab_room_get(sslb_x, sslb_y);
-            set_room_stats(room, false);
+            do_room_recalculation(room);
         }
     }
 }


### PR DESCRIPTION
Should stop books getting lost by them getting repositioned into oblivion when neighbouring tiles are claimed.

Also now keeps health% the same.