### PR TITLE
No event on room sold

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -677,6 +677,10 @@ long instf_attack_room_slab(struct Thing *creatng, long *param)
         ERRORLOG("Cannot delete %s room tile destroyed by %s index %d",room_code_name(room->kind),thing_model_name(creatng),(int)creatng->index);
         return 0;
     }
+    if (count_slabs_of_room_type(room->owner, room->kind) <= 1)
+    {
+        event_create_event_or_update_nearby_existing_event(coord_slab(creatng->mappos.x.val), coord_slab(creatng->mappos.y.val), EvKind_RoomLost, room->owner, room->kind);
+    }
     create_effect(&creatng->mappos, TngEff_Explosion3, creatng->owner);
     thing_play_sample(creatng, 47, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
     return 1;

--- a/src/room_util.c
+++ b/src/room_util.c
@@ -268,10 +268,6 @@ TbBool delete_room_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, unsigned char is
     if (room->slabs_count <= 1)
     {
         delete_room_flag(room);
-        if (count_slabs_of_room_type(room->owner, room->kind) <= 1)
-        {
-            event_create_event_or_update_nearby_existing_event(slb_x, slb_y, EvKind_RoomLost, room->owner, room->kind);
-        }
         replace_room_slab(room, slb_x, slb_y, room->owner, is_destroyed);
         kill_all_room_slabs_and_contents(room);
         free_room_structure(room);


### PR DESCRIPTION
In the current master when you sell the last tile of a room type, (So that afterwards you have 0 tiles left in your entire dungeon) you would get a 'room lost' message.
This was a mistake.

With this PR, this event should no longer happen, but the AI should still rebuild rooms when you claim or destroy them.