### PR TITLE
Search filters looking for any/all creatures broken

### DIFF
--- a/src/config_creature.c
+++ b/src/config_creature.c
@@ -423,6 +423,15 @@ struct CreatureData *creature_data_get_from_thing(const struct Thing *thing)
   return &creature_data[thing->model];
 }
 
+TbBool is_creature_model_wildcard(ThingModel crmodel)
+{
+    if((crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER) || (crmodel == CREATURE_DIGGER))
+    {
+        return true;
+    }
+    return false;
+}
+
 /**
  * Returns Code Name (name to use in script file) of given creature model.
  */

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -293,6 +293,7 @@ void check_and_auto_fix_stats(void);
 const char *creature_code_name(ThingModel crmodel);
 long creature_model_id(const char * name);
 const char *creature_own_name(const struct Thing *creatng);
+TbBool is_creature_model_wildcard(ThingModel crmodel);
 /******************************************************************************/
 TbBool load_creaturetypes_config(const char *conf_fname, unsigned short flags);
 /******************************************************************************/

--- a/src/creature_states_pray.c
+++ b/src/creature_states_pray.c
@@ -321,7 +321,7 @@ void kill_all_players_chickens(PlayerNumber plyr_idx)
         }
     }
     // Force leave or kill normal creatures and special diggers
-    do_to_players_all_creatures_of_model(plyr_idx, -1, kill_creature_if_under_chicken_spell);
+    do_to_players_all_creatures_of_model(plyr_idx, CREATURE_ANY, kill_creature_if_under_chicken_spell);
 }
 
 // This is state-process function of a creature

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -509,7 +509,7 @@ TbBool check_map_explored_at_current_pos(struct Thing *creatng)
 
 void init_keeper_map_exploration_by_creatures(struct PlayerInfo *player)
 {
-    do_to_players_all_creatures_of_model(player->id_number, -1, check_map_explored_at_current_pos);
+    do_to_players_all_creatures_of_model(player->id_number, CREATURE_ANY, check_map_explored_at_current_pos);
 }
 
 void init_player_as_single_keeper(struct PlayerInfo *player)

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -1894,13 +1894,15 @@ long do_on_player_list_all_creatures_of_model(long thing_idx, int crmodel,
 long do_to_players_all_creatures_of_model(PlayerNumber plyr_idx, int crmodel, Thing_Bool_Modifier do_cb)
 {
     struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
-    TbBool is_spec_digger = (((crmodel < CREATURE_DIGGER) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel)) || (crmodel == CREATURE_DIGGER));
+    TbBool is_spec_digger = ((!is_creature_model_wildcard(crmodel) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel)) || (crmodel == CREATURE_DIGGER));
     long count = 0;
-    if (((crmodel < CREATURE_DIGGER) && !is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER)) {
-        count += do_on_player_list_all_creatures_of_model(dungeon->creatr_list_start, (crmodel >= CREATURE_DIGGER) ? CREATURE_ANY : crmodel, do_cb);
+    if ((!is_creature_model_wildcard(crmodel) && !is_spec_digger) || (is_creature_model_wildcard(crmodel) && !(crmodel == CREATURE_DIGGER)))
+    {
+        count += do_on_player_list_all_creatures_of_model(dungeon->creatr_list_start, (is_creature_model_wildcard(crmodel)) ? CREATURE_ANY : crmodel, do_cb);
     }
-    if (((crmodel < CREATURE_DIGGER) && is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_DIGGER)) {
-        count += do_on_player_list_all_creatures_of_model(dungeon->digger_list_start, (crmodel >= CREATURE_DIGGER) ? CREATURE_ANY : crmodel, do_cb);
+    if ((!is_creature_model_wildcard(crmodel) && is_spec_digger) || (is_creature_model_wildcard(crmodel) && !(crmodel == CREATURE_NOT_A_DIGGER)))
+    {
+        count += do_on_player_list_all_creatures_of_model(dungeon->digger_list_start, (is_creature_model_wildcard(crmodel)) ? CREATURE_ANY : crmodel, do_cb);
     }
     return count;
 }

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -1894,13 +1894,13 @@ long do_on_player_list_all_creatures_of_model(long thing_idx, int crmodel,
 long do_to_players_all_creatures_of_model(PlayerNumber plyr_idx, int crmodel, Thing_Bool_Modifier do_cb)
 {
     struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
-    TbBool is_spec_digger = (crmodel > 0) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel);
+    TbBool is_spec_digger = (crmodel < CREATURE_DIGGER) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel);
     long count = 0;
-    if (((crmodel > 0) && !is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER)) {
-        count += do_on_player_list_all_creatures_of_model(dungeon->creatr_list_start, (crmodel<0)?CREATURE_ANY:crmodel, do_cb);
+    if (((crmodel < CREATURE_DIGGER) && !is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER)) {
+        count += do_on_player_list_all_creatures_of_model(dungeon->creatr_list_start, (crmodel < 0) ? CREATURE_ANY : crmodel, do_cb);
     }
-    if (((crmodel > 0) && is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_DIGGER)) {
-        count += do_on_player_list_all_creatures_of_model(dungeon->digger_list_start, (crmodel<0)?CREATURE_ANY:crmodel, do_cb);
+    if (((crmodel < CREATURE_DIGGER) && is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_DIGGER)) {
+        count += do_on_player_list_all_creatures_of_model(dungeon->digger_list_start, (crmodel < 0) ? CREATURE_ANY : crmodel, do_cb);
     }
     return count;
 }

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -1894,13 +1894,13 @@ long do_on_player_list_all_creatures_of_model(long thing_idx, int crmodel,
 long do_to_players_all_creatures_of_model(PlayerNumber plyr_idx, int crmodel, Thing_Bool_Modifier do_cb)
 {
     struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
-    TbBool is_spec_digger = (crmodel < CREATURE_DIGGER) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel);
+    TbBool is_spec_digger = (((crmodel < CREATURE_DIGGER) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel)) || (crmodel == CREATURE_DIGGER));
     long count = 0;
     if (((crmodel < CREATURE_DIGGER) && !is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER)) {
-        count += do_on_player_list_all_creatures_of_model(dungeon->creatr_list_start, (crmodel < 0) ? CREATURE_ANY : crmodel, do_cb);
+        count += do_on_player_list_all_creatures_of_model(dungeon->creatr_list_start, (crmodel >= CREATURE_DIGGER) ? CREATURE_ANY : crmodel, do_cb);
     }
     if (((crmodel < CREATURE_DIGGER) && is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_DIGGER)) {
-        count += do_on_player_list_all_creatures_of_model(dungeon->digger_list_start, (crmodel < 0) ? CREATURE_ANY : crmodel, do_cb);
+        count += do_on_player_list_all_creatures_of_model(dungeon->digger_list_start, (crmodel >= CREATURE_DIGGER) ? CREATURE_ANY : crmodel, do_cb);
     }
     return count;
 }
@@ -1918,7 +1918,7 @@ long count_player_creatures_of_model(PlayerNumber plyr_idx, int crmodel)
     Thing_Maximizer_Filter filter = anywhere_thing_filter_is_of_class_and_model_and_owned_by;
     struct CompoundTngFilterParam param;
     param.class_id = TCls_Creature;
-    param.model_id = (crmodel <= 0) ? CREATURE_ANY : crmodel;
+    param.model_id = (crmodel >= CREATURE_DIGGER) ? CREATURE_ANY : crmodel;
     param.plyr_idx = plyr_idx;
     param.num1 = -1;
     param.num2 = -1;
@@ -1929,10 +1929,10 @@ long count_player_creatures_of_model(PlayerNumber plyr_idx, int crmodel)
     }
     TbBool is_spec_digger = (crmodel > 0) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel);
     long count = 0;
-    if (((crmodel > 0) && !is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER)) {
+    if (((crmodel < CREATURE_DIGGER) && !is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER)) {
         count += count_player_list_creatures_with_filter(dungeon->creatr_list_start, filter, &param);
     }
-    if (((crmodel > 0) && is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_DIGGER)) {
+    if ((((crmodel > 0) && (crmodel < CREATURE_DIGGER)) && is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_DIGGER)) {
         count += count_player_list_creatures_with_filter(dungeon->digger_list_start, filter, &param);
     }
     return count;

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2006,7 +2006,7 @@ long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingMode
 TbBool reset_all_players_creatures_affected_by_cta(PlayerNumber plyr_idx)
 {
     SYNCDBG(3,"Processing all player %d creatures",plyr_idx);
-    int n = do_to_players_all_creatures_of_model(plyr_idx, -1, reset_creature_if_affected_by_cta);
+    int n = do_to_players_all_creatures_of_model(plyr_idx, CREATURE_ANY, reset_creature_if_affected_by_cta);
     return (n > 0);
 }
 
@@ -3125,7 +3125,7 @@ TbBool update_creature_speed(struct Thing *thing)
 TbBool update_speed_of_player_creatures_of_model(PlayerNumber plyr_idx, int crmodel)
 {
     SYNCDBG(3,"Processing player %d creatures of model %d",plyr_idx,(int)crmodel);
-    int n = do_to_players_all_creatures_of_model(plyr_idx, -1, update_creature_speed);
+    int n = do_to_players_all_creatures_of_model(plyr_idx, CREATURE_ANY, update_creature_speed);
     return (n > 0);
 }
 

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -1920,7 +1920,7 @@ long count_player_creatures_of_model(PlayerNumber plyr_idx, int crmodel)
     Thing_Maximizer_Filter filter = anywhere_thing_filter_is_of_class_and_model_and_owned_by;
     struct CompoundTngFilterParam param;
     param.class_id = TCls_Creature;
-    param.model_id = (crmodel >= CREATURE_DIGGER) ? CREATURE_ANY : crmodel;
+    param.model_id = (is_creature_model_wildcard(crmodel)) ? CREATURE_ANY : crmodel;
     param.plyr_idx = plyr_idx;
     param.num1 = -1;
     param.num2 = -1;
@@ -1931,10 +1931,14 @@ long count_player_creatures_of_model(PlayerNumber plyr_idx, int crmodel)
     }
     TbBool is_spec_digger = (crmodel > 0) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel);
     long count = 0;
-    if (((crmodel < CREATURE_DIGGER) && !is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER)) {
+    if (((crmodel > 0) && (!is_creature_model_wildcard(crmodel)) && !is_spec_digger) || 
+        (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER)) 
+    {
         count += count_player_list_creatures_with_filter(dungeon->creatr_list_start, filter, &param);
     }
-    if ((((crmodel > 0) && (crmodel < CREATURE_DIGGER)) && is_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_DIGGER)) {
+    if (((crmodel > 0) && (!is_creature_model_wildcard(crmodel)) && is_spec_digger) || 
+        (crmodel == CREATURE_ANY) || (crmodel == CREATURE_DIGGER)) 
+    {
         count += count_player_list_creatures_with_filter(dungeon->digger_list_start, filter, &param);
     }
     return count;


### PR DESCRIPTION
Fixes these bugs:

Bug 1: Units will always stay under Call to Arms
1) Cast call to arms
2) Disable it -> all units should stop being effected
-> notice they remain under the effect of Call to Arms

Bug 2: Imps will leave through the portal, units will never die without portal access.
1) Use the cheat menu to kill a blue keeper -> all his units should leave and imps should die
-> Notice imps will exit through the portal. If blue has no portal, his units continue working instead of dying.