### PR TITLE
Fixed 'MOVE CREATURE TO TRAINING' check

### DIFF
--- a/config/fxdata/keepcompp.cfg
+++ b/config/fxdata/keepcompp.cfg
@@ -1,5 +1,5 @@
 ; Computer Player (so-called AI) configuration file
-; file version 0.55
+; file version 0.60
 ; Modify only if you know what you're doing!
 
 ; Don't change the [common] block!
@@ -300,6 +300,7 @@ Name = CHECK AVAILIABLE TRAP
 Mnemonic = TrapAvl1
 Values = 0 430
 Functions = check_for_place_trap
+;Params = <Allow placement of final trap>,<trap number to place first>
 Params = 0 0 0 0
 
 [check9]
@@ -478,7 +479,7 @@ Mnemonic = ImpEngh1
 Values = 0 203
 ; Function which uses create imp spell if player has not enough imps
 Functions = check_no_imps
-; Preferred amount of imps, minimal amount of imps, increase per gems face;
+;Params = <Preferred amount of imps>, <minimal amount of imps>, <increase per gems face>
 ; when player has less than minimum, or less than maximum and spare money, then he will use
 ; digger creation spell; both the minimum and maximum are increased by the third amount times
 ; number of gem faces marked for digging
@@ -534,27 +535,38 @@ Functions = check_no_imps
 Params = 99 9 0 0
 
 [check41]
-Name = MOVE CREATURE TO TRAINING
+Name = MOVE CREATURE TO ROOM
 Mnemonic = MvTrain1
+; Flags and game turns interval between checks
 Values = 0 400
+; Function which moves units to the specified room type
 Functions = check_move_to_room
+;Params = <Percentage of active units>, <room type>,<unused>,<fist possible turn>
 Params = 95 6 0 7000
 
 [check42]
+Name = MOVE CREATURE TO ROOM
+Mnemonic = MvGuard1
+Values = 0 400
+Functions = check_move_to_room
+Params = 10 16 0 7000
+
+[check43]
 Name = MOVE CREATURE TO BEST ROOM
 Mnemonic = MvBest1
 Values = 0 270
 Functions = check_move_to_best_room
+;Params = <percentage of active units>
 Params = 75 0 0 0
 
-[check43]
+[check44]
 Name = MOVE CREATURE TO BEST ROOM
 Mnemonic = MvBest2
 Values = 0 270
 Functions = check_move_to_best_room
 Params = 70 0 0 0
 
-[check44]
+[check45]
 Name = COMPUTER CHECK HATES
 Mnemonic = Hates1
 Values = 0 400
@@ -562,28 +574,28 @@ Functions = checks_hates
 ;Params = <Hate for no reason after x turns>,<unused>,<unused>,<fist possible turn>
 Params = 8000 0 0 1600
 
-[check45]
+[check46]
 Name = COMPUTER CHECK HATES
 Mnemonic = Hates2
 Values = 0 500
 Functions = checks_hates
 Params = 4000 0 0 0
 
-[check46]
+[check47]
 Name = COMPUTER CHECK HATES
 Mnemonic = Hates3
 Values = 0 500
 Functions = checks_hates
 Params = 40000 0 0 2000
 
-[check47]
+[check48]
 Name = COMPUTER CHECK HATES
 Mnemonic = Hates4
 Values = 0 400
 Functions = checks_hates
 Params = 4000 0 0 2000
 
-[check48]
+[check49]
 Name = COMPUTER CHECK IMPRISONMENT
 Mnemonic = Prison1
 Values = 0 400
@@ -592,9 +604,6 @@ Functions = check_prison_tendency
 ; param 2 is minimum required total prison capacity before prison is enabled
 ; param 3 at max units in dungeon. If allowed, switches of at this creature count.
 Params = 1 2 50 200
-
-[check49]
-Name = UNUSED
 
 [check50]
 Name = UNUSED
@@ -688,7 +697,11 @@ Params = 5 0 0 0
 Name = EVENT MAGIC FOE
 Mnemonic = MagcFoe
 Values = 2 2 100
+; Function to attack enemy units in battle with predefined attack spells
 Functions = none event_attack_magic_foe
+; Params = <default spell level>,<default repeat number>
+; The spell level is hardcoded for each spell, the repeat is used once. The AI will cast:
+; [disease],[lightning],[chicken], 5x[lightning]
 Params = 1 5 0 0
 
 [event12]

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2472,13 +2472,16 @@ long task_move_creature_to_room(struct Computer2 *comp, struct ComputerTask *cta
     long i;
     struct Dungeon *dungeon;
     dungeon = comp->dungeon;
-    room = INVALID_ROOM;
+    room = room_get(ctask->move_to_room.room_idx1);
     thing = thing_get(comp->held_thing_idx);
-    if (!thing_is_invalid(thing))
+    if (!thing_is_invalid(thing)) // We have no unit in hand
     {
         // 2nd phase - we have specific creature and specific room index, and creature is picked up already
         SYNCDBG(9,"Starting player %d drop",(int)dungeon->owner);
-        room = room_get(ctask->move_to_room.room_idx2);
+        if (room_is_invalid(room))
+        {
+            room = room_get(ctask->move_to_room.room_idx2);
+        }
         if (thing_is_creature(thing) && room_exists(room))
         {
             struct CreatureStats *crstat;


### PR DESCRIPTION
The  <room type> param is now respected. Before, it was forgotten when a unit was picked up.
Also commented the keepcompp.cfg file some more, and included a new - but still unused - check configuration.