### PR TITLE
Additional custom traps work on restart

### DIFF
--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -29,9 +29,9 @@
 #include "config_campaigns.h"
 #include "config_creature.h"
 #include "config_compp.h"
-#include "custom_sprites.h"
 #include "front_simple.h"
 #include "frontend.h"
+#include "frontmenu_ingame_tabs.h"
 #include "front_landview.h"
 #include "front_highscore.h"
 #include "front_lvlstats.h"
@@ -207,6 +207,7 @@ int load_game_chunks(TbFileHandle fhandle,struct CatalogueEntry *centry)
                 check_and_auto_fix_stats();
                 init_creature_scores();
                 // Update interface items
+                update_trap_tab_to_config();
                 strncpy(high_score_entry,centry->player_name,PLAYER_NAME_LENGTH);
             }
             break;
@@ -402,7 +403,6 @@ TbBool load_game(long slot_num)
         init_lookups();
         return false;
     }
-    init_custom_sprites(get_selected_level_number());
     my_player_number = game.local_plyr_idx;
     LbFileClose(fh);
     LbStringCopy(game.campaign_fname,campaign.fname,sizeof(game.campaign_fname));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "bflib_filelst.h"
 #include "bflib_network.h"
 
+#include "custom_sprites.h"
 #include "version.h"
 #include "front_simple.h"
 #include "frontend.h"
@@ -1414,6 +1415,7 @@ void reinit_level_after_load(void)
     struct PlayerInfo *player;
     int i;
     SYNCDBG(6,"Starting");
+    init_custom_sprites(get_selected_level_number());
     // Reinit structures from within the game
     player = get_my_player();
     player->lens_palette = 0;


### PR DESCRIPTION
This is the reported bug:
1) Install this map on the custom map pack: [personal.zip](https://github.com/dkfans/keeperfx/files/7672210/personal.zip)
2) Start it and notice there are lots of custom traps on the tab panel
3) Save the game
4) Completely exit the game, before restarting and loading the save
-->> Notice there are no custom traps and the log is full of 'unknown trap' errors

This PR fixes that bug.