### PR TITLE
Arrows no longer slide against walls when fired from trap or rebound spell

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -437,35 +437,35 @@ void process_creature_instance(struct Thing *thing)
 long instf_creature_fire_shot(struct Thing *creatng, long *param)
 {
     struct Thing *target;
-    int i;
+    int hittype;
     TRACE_THING(creatng);
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     if (cctrl->targtng_idx <= 0)
     {
         if ((creatng->alloc_flags & TAlF_IsControlled) == 0)
-            i = 4;
+            hittype = THit_CrtrsOnlyNotOwn;
         else
-            i = 1;
+            hittype = THit_CrtrsNObjcts;
     }
     else if ((creatng->alloc_flags & TAlF_IsControlled) != 0)
     {
         target = thing_get(cctrl->targtng_idx);
         TRACE_THING(target);
         if (target->class_id == TCls_Object)
-            i = 1;
+            hittype = THit_CrtrsNObjcts;
         else
-            i = 2;
+            hittype = THit_CrtrsOnly;
     }
     else
     {
         target = thing_get(cctrl->targtng_idx);
         TRACE_THING(target);
         if (target->class_id == TCls_Object)
-            i = 1;
+            hittype = THit_CrtrsNObjcts;
         else if (target->owner == creatng->owner)
-            i = 2;
+            hittype = THit_CrtrsOnly;
         else
-            i = 4;
+            hittype = THit_CrtrsOnlyNotOwn;
     }
     if (cctrl->targtng_idx > 0)
     {
@@ -477,7 +477,7 @@ long instf_creature_fire_shot(struct Thing *creatng, long *param)
         target = NULL;
         SYNCDBG(8,"The %s index %d fires %s",thing_model_name(creatng),(int)creatng->index,shot_code_name(*param));
     }
-    creature_fire_shot(creatng, target, *param, 1, i);
+    creature_fire_shot(creatng, target, *param, 1, hittype);
     // Start cooldown after shot is fired
     cctrl->instance_use_turn[cctrl->instance_id] = game.play_gameturn;
     return 0;

--- a/src/thing_corpses.c
+++ b/src/thing_corpses.c
@@ -438,7 +438,7 @@ struct Thing *create_dead_creature(const struct Coord3d *pos, ThingModel model, 
     thing->fall_acceleration = 16;
     thing->field_23 = 204;
     thing->field_24 = 51;
-    thing->field_22 = 0;
+    thing->bounce_angle = 0;
     thing->movement_flags |= TMvF_Unknown08;
     thing->creation_turn = game.play_gameturn;
     if (creatures[model].field_7) {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2824,7 +2824,7 @@ void creature_fire_shot(struct Thing *firing, struct Thing *target, ThingModel s
         pos2.y.val = target->mappos.y.val;
         pos2.z.val = target->mappos.z.val;
         pos2.z.val += (target->clipbox_size_yz >> 1);
-        if (((shotst->model_flags & ShMF_StrengthBased) != 0) && (target->class_id != TCls_Door))
+        if (((shotst->model_flags & ShMF_StrengthBased) != 0) && ((shotst->model_flags & ShMF_ReboundImmune) != 0) && (target->class_id != TCls_Door))
         {
           flag1 = true;
           pos1.z.val = pos2.z.val;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3505,7 +3505,7 @@ struct Thing *create_creature(struct Coord3d *pos, ThingModel model, PlayerNumbe
     crtng->solid_size_xy = crstat->thing_size_xy;
     crtng->solid_size_yz = crstat->thing_size_yz;
     crtng->fall_acceleration = 32;
-    crtng->field_22 = 0;
+    crtng->bounce_angle = 0;
     crtng->field_23 = 32;
     crtng->field_24 = 8;
     crtng->movement_flags |= TMvF_Unknown08;

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -112,7 +112,7 @@ void draw_swipe_graphic(void);
 long creature_available_for_combat_this_turn(struct Thing *thing);
 TbBool set_creature_object_combat(struct Thing *crthing, struct Thing *obthing);
 TbBool set_creature_door_combat(struct Thing *crthing, struct Thing *obthing);
-void creature_fire_shot(struct Thing *firing,struct  Thing *target, ThingModel shot_model, char a2, unsigned char hit_type);
+void creature_fire_shot(struct Thing *firing,struct  Thing *target, ThingModel shot_model, char shot_lvl, unsigned char hit_type);
 void creature_cast_spell_at_thing(struct Thing *caster, struct Thing *target, long a3, long a4);
 void creature_cast_spell(struct Thing *caster, long trg_x, long trg_y, long a4, long a5);
 unsigned int get_creature_blocked_flags_at(struct Thing *thing, struct Coord3d *newpos);

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -203,7 +203,7 @@ struct Thing {
     unsigned char class_id;
     unsigned char fall_acceleration;
 unsigned char field_21;
-unsigned char field_22;
+    unsigned char bounce_angle;
     unsigned char field_23;
     unsigned char field_24;
     unsigned char movement_flags;

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -83,7 +83,7 @@ enum ThingMovementFlags {
     TMvF_IsOnLava           = 0x02,
     TMvF_Unknown04          = 0x04, //Touching ground? Also don't cast shadows when this is set
     TMvF_Unknown08          = 0x08,
-    TMvF_Unknown10          = 0x10,
+    TMvF_Unknown10          = 0x10, //Stopped by walls?
     TMvF_Flying             = 0x20,
     TMvF_Unknown40          = 0x40,
     TMvF_Unknown80          = 0x80,

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -444,7 +444,7 @@ struct Thing *create_object(const struct Coord3d *pos, unsigned short model, uns
     thing->fall_acceleration = objconf->fall_acceleration;
     thing->field_23 = 204;
     thing->field_24 = 51;
-    thing->field_22 = 0;
+    thing->bounce_angle = 0;
     thing->movement_flags |= TMvF_Unknown08;
 
     set_flag_byte(&thing->movement_flags, TMvF_Unknown40, objconf->movement_flag);

--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -68,7 +68,6 @@ TbBool thing_above_flight_altitude(const struct Thing* thing)
 
 void slide_thing_against_wall_at(struct Thing *thing, struct Coord3d *pos, long blocked_flags)
 {
-   // _DK_slide_thing_against_wall_at(thing, pos, a3); return;
   unsigned short x_thing;
   unsigned short sizexy;
   unsigned short x_pos;
@@ -200,14 +199,14 @@ void bounce_thing_off_wall_at(struct Thing *thing, struct Coord3d *pos, long blo
   {
     case SlbBloF_WalledX:
       pos->x.val = thing->mappos.x.val;
-      thing->veloc_base.x.val = -(short)(x * thing->field_22 / 128);
+      thing->veloc_base.x.val = -(short)(x * thing->bounce_angle / 128);
       i = 256 - thing->field_23;
       thing->veloc_base.y.val = i * (short)thing->veloc_base.y.val / 256;
       thing->veloc_base.z.val = i * (short)thing->veloc_base.z.val / 256;
       break;
     case SlbBloF_WalledY:
       pos->y.val = thing->mappos.y.val;
-      thing->veloc_base.y.val = -(short)(y * thing->field_22 / 128);
+      thing->veloc_base.y.val = -(short)(y * thing->bounce_angle / 128);
       i = 256 - thing->field_23;
       thing->veloc_base.x.val = i * (short)thing->veloc_base.x.val / 256;
       thing->veloc_base.z.val = i * (short)thing->veloc_base.z.val / 256;
@@ -215,13 +214,13 @@ void bounce_thing_off_wall_at(struct Thing *thing, struct Coord3d *pos, long blo
     case SlbBloF_WalledX|SlbBloF_WalledY:
       pos->x.val = thing->mappos.x.val;
       pos->y.val = thing->mappos.y.val;
-      i = thing->field_22;
+      i = thing->bounce_angle;
       thing->veloc_base.x.val = -(short)(i * x / 128);
       thing->veloc_base.y.val = -(short)(i * y / 128);
       break;
     case SlbBloF_WalledZ:
       pos->z.val = thing->mappos.z.val;
-      thing->veloc_base.z.val = -(short)(z * thing->field_22 / 128);
+      thing->veloc_base.z.val = -(short)(z * thing->bounce_angle / 128);
       i = 256 - thing->field_23;
       thing->veloc_base.x.val = i * (short)thing->veloc_base.x.val / 256;
       thing->veloc_base.y.val = i * (short)thing->veloc_base.y.val / 256;
@@ -229,14 +228,14 @@ void bounce_thing_off_wall_at(struct Thing *thing, struct Coord3d *pos, long blo
     case SlbBloF_WalledZ|SlbBloF_WalledX:
       pos->z.val = thing->mappos.z.val;
       pos->x.val = thing->mappos.x.val;
-      i = thing->field_22;
+      i = thing->bounce_angle;
       thing->veloc_base.x.val = -(short)(i * x / 128);
       thing->veloc_base.z.val = -(short)(i * z / 128);
       break;
     case SlbBloF_WalledZ|SlbBloF_WalledY:
       pos->y.val = thing->mappos.y.val;
       pos->z.val = thing->mappos.z.val;
-      i = thing->field_22;
+      i = thing->bounce_angle;
       thing->veloc_base.y.val = -(short)(i * y / 128);
       int n = i * y;
       int j = thing->field_23;
@@ -248,7 +247,7 @@ void bounce_thing_off_wall_at(struct Thing *thing, struct Coord3d *pos, long blo
       pos->x.val = thing->mappos.x.val;
       pos->y.val = thing->mappos.y.val;
       pos->z.val = thing->mappos.z.val;
-      i = thing->field_22;
+      i = thing->bounce_angle;
       thing->veloc_base.x.val = -(short)(i * x / 128);
       thing->veloc_base.y.val = -(short)(i * y / 128);
       thing->veloc_base.z.val = -(short)(i * z / 128);

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -362,7 +362,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
     SYNCDBG(8,"Starting for %s index %d",thing_model_name(shotng),(int)shotng->index);
 
     struct Thing* efftng = INVALID_THING;
-    TbBool shot_explodes = 0;
+    TbBool destroy_shot = 0;
     struct ShotConfigStats* shotst = get_shot_model_stats(shotng->model);
     long blocked_flags = get_thing_blocked_flags_at(shotng, pos);
     if (shotst->model_flags & ShMF_Digging)
@@ -379,7 +379,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
         {
             efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_door.effect_model, shotst->old->hit_door.sndsample_idx, shotst->old->hit_door.sndsample_range);
             if (shotst->old->hit_door.destroyed)
-              shot_explodes = 1;
+              destroy_shot = 1;
             i = calculate_shot_real_damage_to_door(doortng, shotng);
             apply_damage_to_thing(doortng, i, shotst->damage_type, -1);
         } else
@@ -387,25 +387,25 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
         {
             efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_water_effect_model, shotst->old->hit_water_sndsample_idx, 1);
             if (shotst->old->hit_water_destroyed) {
-                shot_explodes = 1;
+                destroy_shot = 1;
             }
         } else
         if (cube_is_lava(cube_id))
         {
             efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_lava_effect_model, shotst->old->hit_lava_sndsample_idx, 1);
             if (shotst->old->hit_lava_destroyed) {
-                shot_explodes = 1;
+                destroy_shot = 1;
             }
         } else
         {
             efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_generic.effect_model, shotst->old->hit_generic.sndsample_idx, shotst->old->hit_generic.sndsample_range);
             if (shotst->old->hit_generic.destroyed) {
-                shot_explodes = 1;
+                destroy_shot = 1;
             }
         }
     }
 
-    if ( !shot_explodes )
+    if ( !destroy_shot )
     {
         if ((blocked_flags & (SlbBloF_WalledX|SlbBloF_WalledY)) != 0)
         {
@@ -426,7 +426,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
             {
                 efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_door.effect_model, shotst->old->hit_door.sndsample_idx, shotst->old->hit_door.sndsample_range);
                 if (shotst->old->hit_door.destroyed)
-                    shot_explodes = 1;
+                    destroy_shot = 1;
                 i = calculate_shot_real_damage_to_door(doortng, shotng);
                 apply_damage_to_thing(doortng, i, shotst->damage_type, -1);
             } else
@@ -434,7 +434,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
                 efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_generic.effect_model, shotst->old->hit_generic.sndsample_idx, shotst->old->hit_generic.sndsample_range);
                 if (shotst->old->hit_generic.destroyed)
                 {
-                    shot_explodes = 1;
+                    destroy_shot = 1;
                 }
             }
         }
@@ -442,7 +442,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
     if (!thing_is_invalid(efftng)) {
         efftng->hit_type = shotst->area_hit_type;
     }
-    if ( shot_explodes )
+    if ( destroy_shot )
     {
         return detonate_shot(shotng);
     }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -444,10 +444,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
     {
         return detonate_shot(shotng);
     }
-    if (shotst->old->field_D <= 0)
-    {
-        slide_thing_against_wall_at(shotng, pos, blocked_flags);
-    } else
+    if (shotng->bounce_angle > 0)
     {
         bounce_thing_off_wall_at(shotng, pos, blocked_flags);
     }
@@ -510,10 +507,7 @@ long shot_hit_door_at(struct Thing *shotng, struct Coord3d *pos)
     {
         return detonate_shot(shotng);
     }
-    if (shotst->old->field_D <= 0)
-    {
-        slide_thing_against_wall_at(shotng, pos, blocked_flags);
-    } else
+    if (shotng->bounce_angle > 0)
     {
         bounce_thing_off_wall_at(shotng, pos, blocked_flags);
     }
@@ -1430,7 +1424,7 @@ struct Thing *create_shot(struct Coord3d *pos, unsigned short model, unsigned sh
     memcpy(&thing->mappos,pos,sizeof(struct Coord3d));
     thing->parent_idx = thing->index;
     thing->owner = owner;
-    thing->field_22 = shotst->old->field_D;
+    thing->bounce_angle = shotst->old->field_D;
     thing->fall_acceleration = shotst->old->field_F;
     thing->field_21 = shotst->old->field_10;
     thing->field_23 = shotst->old->field_11;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -433,7 +433,9 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
             {
                 efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->old->hit_generic.effect_model, shotst->old->hit_generic.sndsample_idx, shotst->old->hit_generic.sndsample_range);
                 if (shotst->old->hit_generic.destroyed)
-                  shot_explodes = 1;
+                {
+                    shot_explodes = 1;
+                }
             }
         }
     }
@@ -444,7 +446,11 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
     {
         return detonate_shot(shotng);
     }
-    if (shotng->bounce_angle > 0)
+    if (shotng->bounce_angle <= 0)
+    {
+        slide_thing_against_wall_at(shotng, pos, blocked_flags);
+    }
+    else
     {
         bounce_thing_off_wall_at(shotng, pos, blocked_flags);
     }
@@ -507,7 +513,11 @@ long shot_hit_door_at(struct Thing *shotng, struct Coord3d *pos)
     {
         return detonate_shot(shotng);
     }
-    if (shotng->bounce_angle > 0)
+    if (shotng->bounce_angle <= 0)
+    {
+        slide_thing_against_wall_at(shotng, pos, blocked_flags);
+    }
+    else
     {
         bounce_thing_off_wall_at(shotng, pos, blocked_flags);
     }

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -532,7 +532,7 @@ void activate_trap(struct Thing *traptng, struct Thing *creatng)
         activate_trap_slab_change(traptng, creatng);
         break;
     case TrpAcT_CreatureShot:
-        creature_fire_shot(traptng, creatng, trapstat->created_itm_model, 1, 1);
+        creature_fire_shot(traptng, creatng, trapstat->created_itm_model, THit_CrtrsNObjcts, 1);
         break;
     case TrpAcT_CreatureSpawn:
         activate_trap_spawn_creature(traptng, trapstat);


### PR DESCRIPTION
- Bug was introduced because arrows are now strength based, and code assumed those were melee.
- Changed that part to look at both strength-based and reboundable properties to exclude 'strength based projectiles
- (Re)named a bunch of variables in my quest to understand the code

To reproduce the original bug, make an arrow trap and have it shoot an arrow against the wall (by missing an enemy)
Testmap attached: [test106.zip](https://github.com/dkfans/keeperfx/files/7726809/test106.zip)
