### PR TITLE
Computer players recognize dropping on entrance is dangerous

### DIFF
--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -1371,9 +1371,11 @@ TbBool is_dangerous_drop_subtile(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
     if (subtile_has_sacrificial_on_top(stl_x, stl_y)) {
         return true;
     }
-    //long cube_id;
-    //cube_id = get_top_cube_at(stl_x, stl_y, NULL);
-    //TODO do the same with entrance cube
+    struct Room* droproom = (subtile_room_get(stl_x, stl_y));
+    if (room_role_matches(droproom->kind, RoRoF_CrPoolLeave))
+    {
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
Fixes an exploit where you can get enemy keepers to drop his entire army away.

To reproduce:
1) Get near an enemy dungeon undetected
2) Get towards the enemy Portal
3) Get detected by an enemy unit while you are standing on or near the entrance
-> the computer will drop in his army to fight your unit
4) Pick up your unit
-> Notice the enemy units see nothing to fight and believe they are being fired and will leave through the portal

New behavior is that the enemy keeper should avoid dropping units on the entrance.