### PR TITLE
Things in hand no longer trigger action points

### DIFF
--- a/src/actionpt.c
+++ b/src/actionpt.c
@@ -22,6 +22,7 @@
 #include "bflib_basics.h"
 #include "bflib_memory.h"
 #include "bflib_planar.h"
+#include "power_hand.h"
 
 #include "game_legacy.h"
 
@@ -159,7 +160,7 @@ TbBool action_point_is_creature_from_list_within(const struct ActionPoint *apt, 
         struct Thing* thing = thing_get(i);
         TRACE_THING(thing);
         struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-        if (thing_is_invalid(thing) || creature_control_invalid(cctrl))
+        if (thing_is_invalid(thing) || creature_control_invalid(cctrl) || thing_is_picked_up(thing))
         {
             ERRORLOG("Jump to invalid creature detected");
             break;


### PR DESCRIPTION
If you pick up a unit from within action point range, he will keep triggering the AP. This could provide issues in cases where it is reset.

Here is a testmap: [testmap1282.zip](https://github.com/dkfans/keeperfx/files/7942675/testmap1282.zip)
A sound is played when the AP is triggered, and a sound is played when it is reset. Pick up the imp from the empty room to see the broken/fixed behavior.