### PR TITLE
Fixed a recent issue of stuff not dropping into water well

### DIFF
--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1792,16 +1792,13 @@ TngUpdateRet move_object(struct Thing *thing)
             long blocked_flags = get_thing_blocked_flags_at(thing, &pos);
             if (blocked_flags & SlbBloF_WalledZ)
             {
-                if (thing->owner != game.neutral_player_num)
+                struct Dungeon* dungeon = get_dungeon(thing->owner);
+                if (dungeon->sight_casted_thing_idx != thing->index)
                 {
-                    struct Dungeon* dungeon = get_dungeon(thing->owner);
-                    if (dungeon->sight_casted_thing_idx != thing->index)
+                    if (!find_free_position_on_slab(thing, &pos))
                     {
-                        if (!find_free_position_on_slab(thing, &pos))
-                        {
-                            SYNCDBG(7, "Found no free position next to (%ld,%ld) due to blocked flag %d. Move to valid position.", pos.x.val, pos.y.val, blocked_flags);
-                            move_creature_to_nearest_valid_position(thing);
-                        }
+                        SYNCDBG(7, "Found no free position next to (%ld,%ld) due to blocked flag %d. Move to valid position.", pos.x.val, pos.y.val, blocked_flags);
+                        move_creature_to_nearest_valid_position(thing);
                     }
                 }
             }


### PR DESCRIPTION
Introduced in #1279 (af1870454)
To reproduce the bug:
1) Start this map: [dropgoldbugmap.zip](https://github.com/dkfans/keeperfx/files/8011687/dropgoldbugmap.zip)
2) Reveal
3) Zoom to action point the objective points to
-> notice the gold pots do not drop completely

Crucially though, I reverted code introduced in the spellbook integration commit, which moves neutral books at level start. We might have regression there.