### PR TITLE
Changed arrow button tooltips in message windows to something more ap…

### DIFF
--- a/src/frontmenu_ingame_evnt_data.cpp
+++ b/src/frontmenu_ingame_evnt_data.cpp
@@ -50,8 +50,8 @@ struct GuiButtonInit text_info_buttons[] = {
   { 0,  0, 0, 0, NULL,               NULL,        NULL,               0, 999,   4, 999,   4,400, 78, gui_area_scroll_window,            0, GUIStr_Empty,        0,{(long)&game.evntbox_scroll_window},0,NULL },
   { 1, 63, 0, 0, gui_go_to_event,    NULL,        NULL,               0,   4,   4,   4,   4, 30, 24, gui_area_new_normal_button,      276, GUIStr_ZoomToArea,   0,       {0},            0, maintain_zoom_to_event },
   { 0, 64, 0, 1, gui_close_objective,gui_close_objective,NULL,        0,   4,  56,   4,  56, 30, 24, gui_area_new_normal_button,      274, GUIStr_CloseWindow,  0,       {0},            0, NULL },
-  { 1, 66, 0, 0, gui_scroll_text_up, NULL,        NULL,               0, 446,   4, 446,   4, 30, 24, gui_area_new_normal_button,      486, GUIStr_KeyUp,        0,{(long)&game.evntbox_scroll_window},0,maintain_scroll_up },
-  { 1, 65, 0, 0, gui_scroll_text_down,NULL,       NULL,               0, 446,  56, 446,  56, 30, 24, gui_area_new_normal_button,      272, GUIStr_KeyDown,      0,{(long)&game.evntbox_scroll_window},0,maintain_scroll_down },
+  { 1, 66, 0, 0, gui_scroll_text_up, NULL,        NULL,               0, 446,   4, 446,   4, 30, 24, gui_area_new_normal_button,      486, GUIStr_CtrlUp,       0,{(long)&game.evntbox_scroll_window},0,maintain_scroll_up },
+  { 1, 65, 0, 0, gui_scroll_text_down,NULL,       NULL,               0, 446,  56, 446,  56, 30, 24, gui_area_new_normal_button,      272, GUIStr_CtrlDown,     0,{(long)&game.evntbox_scroll_window},0,maintain_scroll_down },
   {-1,  0, 0, 0, NULL,               NULL,        NULL,               0,   0,   0,   0,   0,  0,  0, NULL,                              0,   0,                 0,       {0},            0, NULL },
 };
 


### PR DESCRIPTION
…propriate

In some languages, there no difference, but others make it plain the current strings pertain to keyboard keys (which makes no sense here) rather than the directions themselves, which these ones do.