### PR TITLE
Door collide ID no longer reset for friendly doors

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -159,7 +159,7 @@ short creature_pick_up_spell_to_steal(struct Thing *creatng);
 /******************************************************************************/
 //process_state, cleanup_state, move_from_slab, move_check, 
 //override_feed, override_own_needs, override_sleep, override_fight_crtr, override_gets_salary, override_prev_fld1F, override_prev_fld20, override_escape, override_unconscious, override_anger_job, override_fight_object, override_fight_door, override_call2arms, override_follow,
-    //state_type, field_1F, field_20, unsigned short field_21, field_23, unsigned short sprite_idx, field_26, field_27, react_to_cta
+    //state_type, field_1F, field_20, field_21, field_23, sprite_idx, field_26, field_27, react_to_cta
 struct StateInfo states[] = {
   {NULL, NULL, NULL, NULL,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  CrStTyp_Idle, 0, 0, 0, 0,  0, 0, 0, 0},

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1819,12 +1819,14 @@ TngUpdateRet process_creature_state(struct Thing *thing)
                     {
                         if (set_creature_door_combat(thing, doortng))
                         {
+                            // If the door gets attacked, we're not running into it
                             cctrl->collided_door_subtile = 0;
                         }
                     }
                 }
                 else
                 {
+                    // If the door does not exist, clear this field too.
                     cctrl->collided_door_subtile = 0;
                 }
             }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1817,8 +1817,10 @@ TngUpdateRet process_creature_state(struct Thing *thing)
                 {
                     if (thing->owner != doortng->owner)
                     {
-                        set_creature_door_combat(thing, doortng);
-                        cctrl->collided_door_subtile = 0;
+                        if (set_creature_door_combat(thing, doortng))
+                        {
+                            cctrl->collided_door_subtile = 0;
+                        }
                     }
                 }
                 else

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1815,11 +1815,16 @@ TngUpdateRet process_creature_state(struct Thing *thing)
                 struct Thing* doortng = get_door_for_position(x, y);
                 if (!thing_is_invalid(doortng))
                 {
-                    if (thing->owner != doortng->owner) {
+                    if (thing->owner != doortng->owner)
+                    {
                         set_creature_door_combat(thing, doortng);
+                        cctrl->collided_door_subtile = 0;
                     }
                 }
-                cctrl->collided_door_subtile = 0;
+                else
+                {
+                    cctrl->collided_door_subtile = 0;
+                }
             }
         }
     }


### PR DESCRIPTION
This enables game to detect treasure room queue, making sure units line up nicely and will not die there.