### PR TITLE
More differentiating unit weight computation

### DIFF
--- a/src/thing_stats.c
+++ b/src/thing_stats.c
@@ -851,6 +851,11 @@ long compute_creature_weight(const struct Thing* creatng, struct CreatureStats* 
         weight = weight / 2;
     }
 
+    if (crstat->can_go_locked_doors = true)
+    {
+        weight = weight / 10;
+    }
+
     return weight;
 }
 

--- a/src/thing_stats.c
+++ b/src/thing_stats.c
@@ -830,6 +830,30 @@ long calculate_gold_digged_out_of_slab_with_single_hit(long damage_did_to_slab, 
     return gold;
 }
 
+long compute_creature_weight(const struct Thing* creatng, struct CreatureStats* crstat, struct CreatureControl* cctrl)
+{
+    long eye_height = (crstat->eye_height + (crstat->eye_height * gameadd.crtr_conf.exp.size_increase_on_exp * cctrl->explevel) / 100);
+    long weight = eye_height >> 2;
+    weight += (crstat->hunger_fill + crstat->lair_size + 1) * cctrl->explevel;
+    
+    if (!crstat->affected_by_wind)
+    {
+        weight = weight * 3 / 2;
+    }
+    
+    if ((get_creature_model_flags(creatng) & CMF_TremblingFat) != 0)
+    {
+        weight = weight * 3 / 2;
+    }
+
+    if ((get_creature_model_flags(creatng) & CMF_IsDiptera) != 0)
+    {
+        weight = weight / 2;
+    }
+
+    return weight;
+}
+
 const char *creature_statistic_text(const struct Thing *creatng, CreatureLiveStatId clstat_id)
 {
     const char *text;
@@ -954,14 +978,7 @@ const char *creature_statistic_text(const struct Thing *creatng, CreatureLiveSta
         text = loc_text;
         break;
     case CrLStat_Weight:
-        i = ((crstat->thing_size_xy * crstat->thing_size_yz >> 8) * crstat->thing_size_xy >> 10);
-        i += (crstat->hunger_fill + crstat->lair_size + 1) * cctrl->explevel;
-        if (!crstat->affected_by_wind)
-            i = i*3/2;
-        if ((get_creature_model_flags(creatng) & CMF_TremblingFat) != 0)
-            i = i*3/2;
-        if ((get_creature_model_flags(creatng) & CMF_IsDiptera) != 0)
-            i = i/2;
+        i = compute_creature_weight(creatng, crstat, cctrl);
         snprintf(loc_text,sizeof(loc_text),"%ld", i);
         text = loc_text;
         break;


### PR DESCRIPTION
Creature weight was based on size and height, that are modified with some params for certain unit types (like how much they eat and if they are an insect). However, the size and height of every unit is exactly the same, so this leads to units being often the exact same weight. And Orc weighted as much as an Imp of the same XP level.

I now based the calculation on the Eye height of the unit, plus the same set of modifiers. As a result, smaller creatures weigh a bit less, larger creatures a bit more, low levels weigh a bit less, high levels weigh a bit more.