### PR TITLE
Only get spider sacrifice with easter eggs enabled

### DIFF
--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1276,7 +1276,7 @@ long process_temple_special(struct Thing *thing, long sacowner)
     if (object_is_mature_food(thing))
     {
         dungeon->chickens_sacrificed++;
-        if (temple_check_for_arachnid_join_dungeon(dungeon))
+        if (temple_check_for_arachnid_join_dungeon(dungeon) && (game.flags_font & FFlg_AlexCheat))
             return true;
     } else
     {


### PR DESCRIPTION
You now need -alex command line to get the spider from gold+chicken sacrifice.