### PR TITLE
Creature lenses in possession now always show

### DIFF
--- a/src/creature_control.c
+++ b/src/creature_control.c
@@ -361,10 +361,7 @@ void play_creature_sound_and_create_sound_thing(struct Thing *thing, long snd_id
 
 void reset_creature_eye_lens(struct Thing *thing)
 {
-    if (is_my_player_number(thing->owner))
-    {
-        setup_eye_lens(0);
-    }
+    setup_eye_lens(0);
 }
 
 TbBool creature_can_gain_experience(const struct Thing *thing)

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -306,13 +306,10 @@ TbBool control_creature_as_controller(struct PlayerInfo *player, struct Thing *t
     {
         create_light_for_possession(thing);
     }
-    if (is_my_player_number(thing->owner))
+    if (thing->class_id == TCls_Creature)
     {
-      if (thing->class_id == TCls_Creature)
-      {
         crstat = creature_stats_get_from_thing(thing);
         setup_eye_lens(crstat->eye_effect);
-      }
     }
     return true;
 }


### PR DESCRIPTION
Previously, they only showed when possessing your own creatures.