### PR TITLE
Keepers show dead faces on defeat info panel

### DIFF
--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1911,7 +1911,7 @@ void maintain_prison_bar(struct GuiButton *gbtn)
     }
 }
 
-void maintain_room_and_creature_button(struct GuiButton *gbtn)
+void maintain_room_button(struct GuiButton *gbtn)
 {
     PlayerNumber plyr_idx = (int)gbtn->content;
     struct PlayerInfo* player = get_player(plyr_idx);
@@ -1920,6 +1920,30 @@ void maintain_room_and_creature_button(struct GuiButton *gbtn)
         gbtn->btype_value &= LbBFeF_IntValueMask;
         gbtn->flags |= LbBtnF_Enabled;
     } else
+    {
+        gbtn->btype_value |= LbBFeF_NoMouseOver;
+        gbtn->flags &= ~LbBtnF_Enabled;
+        gbtn->tooltip_stridx = 201;
+    }
+}
+void maintain_creature_button(struct GuiButton* gbtn)
+{
+    PlayerNumber plyr_idx = (int)gbtn->content;
+    struct PlayerInfo* player = get_player(plyr_idx);
+    if (player_exists(player))
+    {
+        if (player_has_heart(plyr_idx))
+        {
+            gbtn->sprite_idx = 323 + (plyr_idx * 2);
+        }
+        else
+        {
+            gbtn->sprite_idx = 535 + (plyr_idx);
+        }
+        gbtn->btype_value &= LbBFeF_IntValueMask;
+        gbtn->flags |= LbBtnF_Enabled;
+    }
+    else
     {
         gbtn->btype_value |= LbBFeF_NoMouseOver;
         gbtn->flags &= ~LbBtnF_Enabled;

--- a/src/frontmenu_ingame_tabs_data.cpp
+++ b/src/frontmenu_ingame_tabs_data.cpp
@@ -107,7 +107,8 @@ void maintain_event_button(struct GuiButton *gbtn);
 void gui_toggle_ally(struct GuiButton *gbtn);
 void maintain_ally(struct GuiButton *gbtn);
 void maintain_prison_bar(struct GuiButton *gbtn);
-void maintain_room_and_creature_button(struct GuiButton *gbtn);
+void maintain_room_button(struct GuiButton *gbtn);
+void maintain_creature_button(struct GuiButton* gbtn);
 void pick_up_next_wanderer(struct GuiButton *gbtn);
 void gui_go_to_next_wanderer(struct GuiButton *gbtn);
 void pick_up_next_worker(struct GuiButton *gbtn);
@@ -275,14 +276,14 @@ struct GuiButtonInit query_menu_buttons[] = {
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 216,   4, 222,132, 24, gui_area_payday_button,          341, GUIStr_PayTimeDesc,          0,       {0},            0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   2, 246,   2, 246, 60, 24, gui_area_research_bar,            61, GUIStr_ResearchTimeDesc,     0,       {0},            0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 246,  74, 246, 60, 24, gui_area_workshop_bar,            75, GUIStr_WorkshopTimeDesc,     0,       {0},            0, NULL },
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 274,  74, 274, 60, 24, gui_area_player_creature_info,   323, GUIStr_NumberOfCreaturesDesc,0,       {0},            0, maintain_room_and_creature_button },
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 298,  74, 298, 60, 24, gui_area_player_creature_info,   325, GUIStr_NumberOfCreaturesDesc,0,       {1},            0, maintain_room_and_creature_button },
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 322,  74, 322, 60, 24, gui_area_player_creature_info,   327, GUIStr_NumberOfCreaturesDesc,0,       {2},            0, maintain_room_and_creature_button },
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 346,  74, 346, 60, 24, gui_area_player_creature_info,   329, GUIStr_NumberOfCreaturesDesc,0,       {3},            0, maintain_room_and_creature_button },
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 274,   4, 274, 60, 24, gui_area_player_room_info,       324, GUIStr_NumberOfRoomsDesc,    0,       {0},            0, maintain_room_and_creature_button },
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 298,   4, 298, 60, 24, gui_area_player_room_info,       326, GUIStr_NumberOfRoomsDesc,    0,       {1},            0, maintain_room_and_creature_button },
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 322,   4, 322, 60, 24, gui_area_player_room_info,       328, GUIStr_NumberOfRoomsDesc,    0,       {2},            0, maintain_room_and_creature_button },
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 346,   4, 346, 60, 24, gui_area_player_room_info,       330, GUIStr_NumberOfRoomsDesc,    0,       {3},            0, maintain_room_and_creature_button },
+  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 274,  74, 274, 60, 24, gui_area_player_creature_info,   323, GUIStr_NumberOfCreaturesDesc,0,       {0},            0, maintain_creature_button },
+  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 298,  74, 298, 60, 24, gui_area_player_creature_info,   325, GUIStr_NumberOfCreaturesDesc,0,       {1},            0, maintain_creature_button },
+  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 322,  74, 322, 60, 24, gui_area_player_creature_info,   327, GUIStr_NumberOfCreaturesDesc,0,       {2},            0, maintain_creature_button },
+  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  74, 346,  74, 346, 60, 24, gui_area_player_creature_info,   329, GUIStr_NumberOfCreaturesDesc,0,       {3},            0, maintain_creature_button },
+  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 274,   4, 274, 60, 24, gui_area_player_room_info,       324, GUIStr_NumberOfRoomsDesc,    0,       {0},            0, maintain_room_button },
+  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 298,   4, 298, 60, 24, gui_area_player_room_info,       326, GUIStr_NumberOfRoomsDesc,    0,       {1},            0, maintain_room_button },
+  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 322,   4, 322, 60, 24, gui_area_player_room_info,       328, GUIStr_NumberOfRoomsDesc,    0,       {2},            0, maintain_room_button },
+  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   4, 346,   4, 346, 60, 24, gui_area_player_room_info,       330, GUIStr_NumberOfRoomsDesc,    0,       {3},            0, maintain_room_button },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, gui_toggle_ally,    NULL,        NULL,               0,  62, 274,  62, 274, 14, 22, gui_area_ally,                     0, GUIStr_AllyWithPlayer,       0,       {0},            0, maintain_ally },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, gui_toggle_ally,    NULL,        NULL,               0,  62, 298,  62, 298, 14, 22, gui_area_ally,                     0, GUIStr_AllyWithPlayer,       0,       {1},            0, maintain_ally },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, gui_toggle_ally,    NULL,        NULL,               0,  62, 322,  62, 322, 14, 22, gui_area_ally,                     0, GUIStr_AllyWithPlayer,       0,       {2},            0, maintain_ally },
@@ -359,7 +360,7 @@ struct GuiMenu room_menu =
 struct GuiMenu spell_menu =
  {          GMnu_SPELL, 0, 1, spell_menu_buttons,                          0,   0, 140, 400, NULL,                        0, NULL,    NULL,                    0, 0, 1,};
 struct GuiMenu spell_lost_menu =
- {     GMnu_SPELL_LOST, 0, 1, spell_lost_menu_buttons,                    0,   0, 140, 400, NULL,                        0, NULL,    NULL,                    0, 0, 1,};
+ {     GMnu_SPELL_LOST, 0, 1, spell_lost_menu_buttons,                     0,   0, 140, 400, NULL,                        0, NULL,    NULL,                    0, 0, 1,};
 struct GuiMenu trap_menu =
  {           GMnu_TRAP, 0, 1, trap_menu_buttons,                           0,   0, 140, 400, NULL,                        0, NULL,    NULL,                    0, 0, 1,};
 struct GuiMenu creature_menu =

--- a/src/gui_draw.h
+++ b/src/gui_draw.h
@@ -29,7 +29,7 @@
 // Sprites
 // Maybe "Count + 1"? there is no sprite#517
 #define GUI_BUTTON_SPRITES_COUNT     215
-#define GUI_PANEL_SPRITES_COUNT      517
+#define GUI_PANEL_SPRITES_COUNT      600
 #define GUI_PANEL_SPRITES_NEW        256
 #define GUI_SLAB_DIMENSION 64
 // Positioning constants for menus


### PR DESCRIPTION
Kill an enemy keeper and the icon shows him defeated.
![image](https://user-images.githubusercontent.com/13840686/154824063-b3ea5393-1235-4d7f-9f1a-9416e8a0ed06.png)

Requires new data files, attached for easy testing: [data.zip](https://github.com/dkfans/keeperfx/files/8103252/data.zip)

