### PR TITLE
Chicken eye-height in possession

### DIFF
--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -416,7 +416,16 @@ void update_player_camera_fp(struct Camera *cam, struct Thing *thing)
     struct CreatureStatsOLD *creature_stats_OLD = &game.creature_stats_OLD[thing->model];
     struct CreatureStats* crstat = creature_stats_get_from_thing(thing);
     struct CreatureControl *cctrl = creature_control_get_from_thing(thing);
-    creature_stats_OLD->eye_height = crstat->eye_height + (crstat->eye_height * gameadd.crtr_conf.exp.size_increase_on_exp * cctrl->explevel) / 100;
+    int chicken_height = 100;
+    TbBool chicken = (creature_affected_by_spell(thing, SplK_Chicken));
+    if (!chicken)
+    {
+        creature_stats_OLD->eye_height = crstat->eye_height + (crstat->eye_height * gameadd.crtr_conf.exp.size_increase_on_exp * cctrl->explevel) / 100;
+    }
+    else
+    {
+        creature_stats_OLD->eye_height = chicken_height + (chicken_height * gameadd.crtr_conf.exp.size_increase_on_exp * cctrl->explevel) / 100;
+    }
     _DK_update_player_camera_fp(cam, thing);
 }
 


### PR DESCRIPTION
When possessing a chickened unit, you will move to a chicken eye level.

This is fun, but also helps the player with recognizing he is a chicken.