### PR TITLE
Objects that cannot be destroyed do not take damage

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -633,6 +633,7 @@ FallAcceleration = 8
 FiringSound = 0
 ShotSound = 35
 HitCreatureSound = 137
+HitWallSound = 1000
 HitWaterSound = 36
 HitWaterEffect = 68
 HitLavaEffect = 14

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -569,6 +569,17 @@ void destroy_object(struct Thing *thing)
     }
 }
 
+TbBool object_is_indestructable (const struct Thing* thing)
+{
+    if (thing_is_invalid(thing))
+        return false;
+    if (thing->class_id != TCls_Object)
+        return false;
+    if (thing_is_dungeon_heart(thing) || object_is_mature_food(thing) || object_is_growing_food(thing))
+        return true;
+    return false;
+}
+
 TbBool thing_is_object(const struct Thing *thing)
 {
     if (thing_is_invalid(thing))

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -569,16 +569,14 @@ void destroy_object(struct Thing *thing)
     }
 }
 
-TbBool object_is_indestructable (const struct Thing* thing)
+TbBool object_can_be_damaged (const struct Thing* thing)
 {
     //todo make this an object property. Then include the possibility to kill the other object types.
-    if (thing_is_invalid(thing))
-        return false;
     if (thing->class_id != TCls_Object)
         return false;
     if (thing_is_dungeon_heart(thing) || object_is_mature_food(thing) || object_is_growing_food(thing))
-        return false;
-    return true;
+        return true;
+    return false;
 }
 
 TbBool thing_is_object(const struct Thing *thing)

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -571,6 +571,7 @@ void destroy_object(struct Thing *thing)
 
 TbBool object_is_indestructable (const struct Thing* thing)
 {
+    //todo make this an object property. Then include the possibility to kill the other object types.
     if (thing_is_invalid(thing))
         return false;
     if (thing->class_id != TCls_Object)

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -576,8 +576,8 @@ TbBool object_is_indestructable (const struct Thing* thing)
     if (thing->class_id != TCls_Object)
         return false;
     if (thing_is_dungeon_heart(thing) || object_is_mature_food(thing) || object_is_growing_food(thing))
-        return true;
-    return false;
+        return false;
+    return true;
 }
 
 TbBool thing_is_object(const struct Thing *thing)

--- a/src/thing_objects.h
+++ b/src/thing_objects.h
@@ -142,7 +142,7 @@ TbBool thing_is_lair_totem(const struct Thing *thing);
 TbBool object_is_room_equipment(const struct Thing *thing, RoomKind rkind);
 TbBool object_is_room_inventory(const struct Thing *thing, RoomKind rkind);
 TbBool object_is_unaffected_by_terrain_changes(const struct Thing *thing);
-TbBool object_is_indestructable(const struct Thing* thing);
+TbBool object_is_destructable(const struct Thing* thing);
 
 TbBool creature_remove_lair_totem_from_room(struct Thing *creatng, struct Room *room);
 TbBool delete_lair_totem(struct Thing *lairtng);

--- a/src/thing_objects.h
+++ b/src/thing_objects.h
@@ -142,6 +142,7 @@ TbBool thing_is_lair_totem(const struct Thing *thing);
 TbBool object_is_room_equipment(const struct Thing *thing, RoomKind rkind);
 TbBool object_is_room_inventory(const struct Thing *thing, RoomKind rkind);
 TbBool object_is_unaffected_by_terrain_changes(const struct Thing *thing);
+TbBool object_is_indestructable(const struct Thing* thing);
 
 TbBool creature_remove_lair_totem_from_room(struct Thing *creatng, struct Room *room);
 TbBool delete_lair_totem(struct Thing *lairtng);

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -664,8 +664,11 @@ long shot_hit_object_at(struct Thing *shotng, struct Thing *target, struct Coord
         {
             apply_health_to_thing(creatng, shotng->damagepoints/2);
         }
-        apply_damage_to_thing(target, shotng->damagepoints, shotst->damage_type, -1);
-        target->byte_13 = 20;
+        if (!object_is_indestructible)
+        {
+            apply_damage_to_thing(target, shotng->damagepoints, shotst->damage_type, -1);
+            target->byte_13 = 20; //todo figure out what this is, and if it needs to be within this if statement or below
+        }
     }
     create_relevant_effect_for_shot_hitting_thing(shotng, target);
     if (target->health < 0) {

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -652,7 +652,7 @@ long shot_hit_object_at(struct Thing *shotng, struct Thing *target, struct Coord
         }
     } else
     {
-        int i = shotst->hit_creature.sndsample_idx;
+        int i = shotst->hit_generic.sndsample_idx;
         if (i > 0) {
             thing_play_sample(target, i, NORMAL_PITCH, 0, 3, 0, 3, FULL_LOUDNESS);
         }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -630,9 +630,9 @@ long shot_hit_object_at(struct Thing *shotng, struct Thing *target, struct Coord
     if (objconf->resistant_to_nonmagic && !(shotst->damage_type == DmgT_Magical)) {
         return 0;
     }
-    struct Thing* creatng = INVALID_THING;
+    struct Thing* shootertng = INVALID_THING;
     if (shotng->parent_idx != shotng->index) {
-        creatng = thing_get(shotng->parent_idx);
+        shootertng = thing_get(shotng->parent_idx);
     }
     if (thing_is_dungeon_heart(target))
     {
@@ -645,8 +645,8 @@ long shot_hit_object_at(struct Thing *shotng, struct Thing *target, struct Coord
             thing_play_sample(target, 144+UNSYNC_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 3, FULL_LOUDNESS);
         }
         event_create_event_or_update_nearby_existing_event(
-            creatng->mappos.x.val, creatng->mappos.y.val,
-          EvKind_HeartAttacked, target->owner, creatng->index);
+            shootertng->mappos.x.val, shootertng->mappos.y.val,
+          EvKind_HeartAttacked, target->owner, shootertng->index);
         if (is_my_player_number(target->owner)) {
             output_message(SMsg_HeartUnderAttack, 400, true);
         }
@@ -660,16 +660,13 @@ long shot_hit_object_at(struct Thing *shotng, struct Thing *target, struct Coord
     HitPoints damage = 0;
     if (shotng->damagepoints)
     {
-        if (!object_is_indestructable(target))
+        if (object_is_destructable(target)) // do not damage objects that cannot be destroyed
         {
             damage = apply_damage_to_thing(target, shotng->damagepoints, shotst->damage_type, -1);
-        }
-        else
-        {
-            // Drain allows caster to regain half of damage
-            if ((shotst->model_flags & ShMF_LifeDrain) && thing_is_creature(creatng))
+            // Drain allows caster to regain half of damage, even against objects
+            if ((shotst->model_flags & ShMF_LifeDrain) && thing_is_creature(shootertng))
             {
-                apply_health_to_thing(creatng, shotng->damagepoints / 2);
+                apply_health_to_thing(shootertng, shotng->damagepoints / 2);
             }
         }
         target->byte_13 = 20; //todo figure out what this is, and if it needs to be within this if statement above/below
@@ -1182,7 +1179,7 @@ struct Thing *get_thing_collided_with_at_satisfying_filter_for_subtile(struct Th
     return false;
 }
 
-struct Thing *get_thing_collided_with_at_satisfying_filter(struct Thing *shotng, struct Coord3d *pos, Thing_Collide_Func filter, long a4, long a5)
+struct Thing *get_thing_collided_with_at_satisfying_filter(struct Thing *shotng, struct Coord3d *pos, Thing_Collide_Func filter, long hit_targets, long a5)
 {
     MapSubtlCoord stl_x_min;
     MapSubtlCoord stl_y_min;
@@ -1207,7 +1204,7 @@ struct Thing *get_thing_collided_with_at_satisfying_filter(struct Thing *shotng,
     {
         for (MapSubtlCoord stl_x = stl_x_min; stl_x <= stl_x_max; stl_x++)
         {
-            struct Thing* coltng = get_thing_collided_with_at_satisfying_filter_for_subtile(shotng, pos, filter, a4, a5, stl_x, stl_y);
+            struct Thing* coltng = get_thing_collided_with_at_satisfying_filter_for_subtile(shotng, pos, filter, hit_targets, a5, stl_x, stl_y);
             if (!thing_is_invalid(coltng)) {
                 return coltng;
             }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -657,18 +657,22 @@ long shot_hit_object_at(struct Thing *shotng, struct Thing *target, struct Coord
             thing_play_sample(target, i, NORMAL_PITCH, 0, 3, 0, 3, FULL_LOUDNESS);
         }
     }
+    HitPoints damage = 0;
     if (shotng->damagepoints)
     {
-        // Drain allows caster to regain half of damage
-        if ((shotst->model_flags & ShMF_LifeDrain) && thing_is_creature(creatng)) 
+        if (!object_is_indestructable(target))
         {
-            apply_health_to_thing(creatng, shotng->damagepoints/2);
+            damage = apply_damage_to_thing(target, shotng->damagepoints, shotst->damage_type, -1);
         }
-        if (!object_is_indestructible)
+        else
         {
-            apply_damage_to_thing(target, shotng->damagepoints, shotst->damage_type, -1);
-            target->byte_13 = 20; //todo figure out what this is, and if it needs to be within this if statement or below
+            // Drain allows caster to regain half of damage
+            if ((shotst->model_flags & ShMF_LifeDrain) && thing_is_creature(creatng))
+            {
+                apply_health_to_thing(creatng, shotng->damagepoints / 2);
+            }
         }
+        target->byte_13 = 20; //todo figure out what this is, and if it needs to be within this if statement above/below
     }
     create_relevant_effect_for_shot_hitting_thing(shotng, target);
     if (target->health < 0) {
@@ -677,7 +681,7 @@ long shot_hit_object_at(struct Thing *shotng, struct Thing *target, struct Coord
     if (shotst->old->destroy_on_first_hit) {
         delete_thing_structure(shotng, 0);
     }
-    return 1;
+    return damage;
 }
 
 long get_damage_of_melee_shot(struct Thing *shotng, const struct Thing *target)


### PR DESCRIPTION
This stops boulders from getting slowed down by gold and the gold visibly showing damage.
Also made it so that objects getting hit do not use the 'creature' hit sound, but the 'generic' hit sound.