### PR TITLE
Messages from dead players now show the dead icon on chat messages

### DIFF
--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -110,7 +110,7 @@ void message_draw(void)
             if (gameadd.messages[i].plyr_idx == game.hero_player_num)
             {
                 // use discoloured icon for the hero player
-                spr_idx = 498;
+                spr_idx = 533;
             }
             else if (gameadd.messages[i].plyr_idx == game.neutral_player_num)
             {
@@ -118,7 +118,7 @@ void message_draw(void)
             }
             else
             {
-                spr_idx = 488+gameadd.messages[i].plyr_idx;
+                spr_idx = ((player_has_heart(gameadd.messages[i].plyr_idx)) ? 488 : 535) + gameadd.messages[i].plyr_idx;
             }
         }
         if (gameadd.messages[i].plyr_idx != 127)

--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -109,7 +109,6 @@ void message_draw(void)
         {
             if (gameadd.messages[i].plyr_idx == game.hero_player_num)
             {
-                // use discoloured icon for the hero player
                 spr_idx = 533;
             }
             else if (gameadd.messages[i].plyr_idx == game.neutral_player_num)


### PR DESCRIPTION
Resolves #1351

Also changed the hero player's icon to the white one.