### PR TITLE
attacked heart stops beating for a second

### DIFF
--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1471,9 +1471,14 @@ TngUpdateRet object_update_dungeon_heart(struct Thing *heartng)
     SYNCDBG(18,"Beat update");
     if ((heartng->alloc_flags & TAlF_Exists) == 0)
       return 0;
-    if ( heartng->byte_13 )
-      heartng->byte_13--;
-    update_dungeon_heart_beat(heartng);
+    if (heartng->byte_13)
+    {
+        heartng->byte_13--;
+    }
+    else
+    {
+        update_dungeon_heart_beat(heartng);
+    }
     return TUFRet_Modified;
 }
 


### PR DESCRIPTION
A possible explanation for thing->byte_13 left in the code filled with 20 gameturns(?) each time a unit attacks the heart.