### PR TITLE
Implemented workaround for too many chickens

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2805,7 +2805,7 @@ short creature_take_salary(struct Thing *creatng)
     struct Room* room = get_room_thing_is_on(creatng);
     struct Dungeon* dungeon = get_dungeon(creatng->owner);
     if (room_is_invalid(room) || !room_role_matches(room->kind, RoRoF_GoldStorage) ||
-      ((room->used_capacity <= 0) && (dungeon->offmap_money_owned <= 0)))
+      ((room->used_capacity == 0) && (dungeon->offmap_money_owned <= 0)))
     {
         internal_set_thing_state(creatng, CrSt_CreatureWantsSalary);
         return 1;

--- a/src/creature_states_gardn.c
+++ b/src/creature_states_gardn.c
@@ -94,6 +94,7 @@ void person_eat_food(struct Thing *creatng, struct Thing *foodtng, struct Room *
             room->used_capacity -= required_cap;
         } else {
             ERRORLOG("Trying to remove some food not in room");
+            room->used_capacity = 0;
         }
         delete_thing_structure(foodtng, 0);
     }

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -2247,12 +2247,19 @@ TbBool room_create_new_food_at(struct Room *room, MapSubtlCoord stl_x, MapSubtlC
 short room_grow_food(struct Room *room)
 {
     //return _DK_room_grow_food(room);
-    if (room->slabs_count < 1) {
+    if (room->slabs_count < 1)
+    {
         ERRORLOG("Room %s index %d has no slabs",room_code_name(room->kind),(int)room->index);
         return 0;
     }
+    if (room->used_capacity > room->total_capacity)
+    {
+        ERRORLOG("Room %s index %d has too much used capacity: %d/%d", room_code_name(room->kind), (int)room->index, room->used_capacity, room->total_capacity);
+        count_food_in_room(room);
+    }
     if ((room->used_capacity >= room->total_capacity)
-      || game.play_gameturn % ((game.food_generation_speed / room->total_capacity) + 1)) {
+      || game.play_gameturn % ((game.food_generation_speed / room->total_capacity) + 1))
+    {
         return 0;
     }
     unsigned long k;

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -284,8 +284,8 @@ long count_slabs_of_room_type(PlayerNumber plyr_idx, RoomKind rkind)
 
 void get_room_kind_total_and_used_capacity(struct Dungeon *dungeon, RoomKind rkind, long *total_cap, long *used_cap)
 {
-    int total_capacity = 0;
-    int used_capacity = 0;
+    unsigned int total_capacity = 0;
+    unsigned int used_capacity = 0;
     long i = dungeon->room_kind[rkind];
     unsigned long k = 0;
     while (i != 0)
@@ -314,8 +314,8 @@ void get_room_kind_total_and_used_capacity(struct Dungeon *dungeon, RoomKind rki
 
 void get_room_kind_total_used_and_storage_capacity(struct Dungeon *dungeon, RoomKind rkind, long *total_cap, long *used_cap, long *storaged_cap)
 {
-    int total_capacity = 0;
-    int used_capacity = 0;
+    unsigned int total_capacity = 0;
+    unsigned int used_capacity = 0;
     int storaged_capacity = 0;
     long i = dungeon->room_kind[rkind];
     unsigned long k = 0;

--- a/src/room_data.h
+++ b/src/room_data.h
@@ -89,7 +89,7 @@ struct Room {
     unsigned char central_stl_y;
     unsigned short kind;
     unsigned short health;
-    short total_capacity;
+    unsigned short total_capacity;
     unsigned short used_capacity;
     /* Informs whether players are interested in that room.
      * Usually used for neutral rooms, set if a player is starting to dig to that room. */


### PR DESCRIPTION
If used capacity is over total capacity, do a recound and throw an error message