### PR TITLE
replace downloading zip with cloning git gfx sfx

### DIFF
--- a/pkg_gfx.mk
+++ b/pkg_gfx.mk
@@ -304,8 +304,6 @@ pkg/creatrs/%.jty pkg/data/%.jty:
 	-$(ECHO) 'Finished building: $@'
 	-$(ECHO) ' '
 
-ifeq ($(ENABLE_EXTRACT), 1)
-
 # The package is extracted only if targets does not exits; the "|" causes file dates to be ignored
 # Note that ignoring timestamp means it is possible to have outadated files after a new
 # package release, if no targets were modified with the update.
@@ -322,22 +320,7 @@ gfx/sprites-32/%.txt gfx/sprites-64/%.txt gfx/sprites-128/%.txt \
 gfx/swipes-32/%.txt gfx/swipes-64/%.txt gfx/swipes-128/%.txt \
 gfx/textures-32/%.png gfx/textures-64/%.png gfx/textures-128/%.png \
 gfx/textures-32/%.txt gfx/textures-64/%.txt gfx/textures-128/%.txt \
-gfx/torturescr/%.png gfx/torturescr/%.txt gfx/guimap/%.txt gfx/parchmentbug/%.txt gfx/creatrportrait/%.txt: | gfx/$(GFXSRC_PACKAGE)
-	-$(ECHO) 'Extracting package: $<'
-	7z x -aoa -y -ogfx "$|"
-	-$(ECHO) 'Finished extracting: $<'
-	-$(ECHO) ' '
-
-endif
-
-# Downloading the gfx sources pack
-gfx/$(GFXSRC_PACKAGE):
-	-$(ECHO) 'Downloading package: $@'
-	$(MKDIR) "$(@D)"
-	curl -L -o "$@.dl" "$(GFXSRC_DOWNLOAD)"
-	7z t "$@.dl"
-	$(MV) "$@.dl" "$@"
-	-$(ECHO) 'Finished downloading: $@'
-	-$(ECHO) ' '
+gfx/torturescr/%.png gfx/torturescr/%.txt gfx/guimap/%.txt gfx/parchmentbug/%.txt gfx/creatrportrait/%.txt:
+	git clone --depth=1 https://github.com/dkfans/FXGraphics.git gfx
 
 #******************************************************************************

--- a/pkg_sfx.mk
+++ b/pkg_sfx.mk
@@ -118,24 +118,9 @@ convert-campaign-sfx-%: sfx/campgns/%/filelist.txt
 	-$(ECHO) 'Finished converting list: $<'
 	-$(ECHO) ' '
 
-ifeq ($(ENABLE_EXTRACT), 1)
 
-sfx/%/filelist.txt sfx/campgns/%/filelist.txt: | sfx/$(SFXSRC_PACKAGE)
-	-$(ECHO) 'Extracting package: $<'
-	7z x -aoa -y -osfx "$|"
-	-$(ECHO) 'Finished extracting: $<'
-	-$(ECHO) ' '
+sfx/%/filelist.txt sfx/campgns/%/filelist.txt:
+	git clone --depth=1 https://github.com/dkfans/FXsounds.git sfx
 
-endif
-
-# Downloading the sfx sources pack
-sfx/$(SFXSRC_PACKAGE):
-	-$(ECHO) 'Downloading package: $@'
-	$(MKDIR) "$(@D)"
-	curl -L -o "$@.dl" "$(SFXSRC_DOWNLOAD)"
-	7z t "$@.dl"
-	$(MV) "$@.dl" "$@"
-	-$(ECHO) 'Finished downloading: $@'
-	-$(ECHO) ' '
 
 #******************************************************************************

--- a/prebuilds.mk
+++ b/prebuilds.mk
@@ -49,9 +49,3 @@ SDL_MIXER_DOWNLOAD=https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-
 SDL_PACKAGE=$(notdir $(SDL_DOWNLOAD))
 SDL_NET_PACKAGE=$(notdir $(SDL_NET_DOWNLOAD))
 SDL_MIXER_PACKAGE=$(notdir $(SDL_MIXER_DOWNLOAD))
-
-# Assets which are sources of data files are platform-independent
-GFXSRC_DOWNLOAD=https://github.com/dkfans/keeperfx/releases/download/v2154/gfx_sources_v11.zip
-GFXSRC_PACKAGE=$(notdir $(GFXSRC_DOWNLOAD))
-SFXSRC_DOWNLOAD=https://github.com/dkfans/keeperfx/releases/download/v2154/sfx_sources_v5.7z
-SFXSRC_PACKAGE=$(notdir $(SFXSRC_DOWNLOAD))


### PR DESCRIPTION
when doing a make pgg-gxf or sfx it currently downloads an outdated zip and unpacks it
this replaces it with cloning the correct repo instead

note this doesn't include updating existing repo or anything
only clones when the zip would've otherwise been downloaded
but better then the outdated zip it is now