### PR TITLE
Corners walls of unclaimed path should now be unfortified

### DIFF
--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -664,8 +664,8 @@ void unfill_reinforced_corners(PlayerNumber keep_plyr_idx, MapSlabCoord base_slb
         MapSlabCoord y = base_slb_y + small_around[n].delta_y;
         struct SlabMap *slb = get_slabmap_block(x, y);
         struct SlabAttr* slbattr = get_slab_attrs(slb);
-        if ( (((slbattr->category == SlbAtCtg_FortifiedGround) || (slbattr->block_flags & SlbAtFlg_IsRoom) || ((slbattr->block_flags & SlbAtFlg_IsDoor)) )) 
-        && (slabmap_owner(slb) == keep_plyr_idx ) )
+        if ( ( (((slbattr->category == SlbAtCtg_FortifiedGround) || (slbattr->block_flags & SlbAtFlg_IsRoom) || ((slbattr->block_flags & SlbAtFlg_IsDoor)) )) 
+      && (slabmap_owner(slb) == keep_plyr_idx) ) || (slbattr->category == SlbAtCtg_Unclaimed) )
         {
             for (int k = -1; k < 2; k+=2)
             {


### PR DESCRIPTION
Fixes walls remaining when a Dungeon Heart is destroyed.