### PR TITLE
Sprite matches click position on gfx option buttons again

### DIFF
--- a/src/frontmenu_ingame_opts_data.cpp
+++ b/src/frontmenu_ingame_opts_data.cpp
@@ -83,14 +83,14 @@ struct GuiButtonInit autopilot_menu_buttons[] = {
 };
 
 struct GuiButtonInit video_menu_buttons[] = {
-  {LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,                          NULL,                           NULL,  0, 999,  10, 999,  10,155, 32, gui_area_text,                     1, GUIStr_MnuGraphicsOptions,          0, {0},            0, NULL },
-  {LbBtnT_ToggleBtn,  BID_DEFAULT, 0, 0, gui_video_shadows,             NULL,                           NULL,  0,  28,  38,  10,  38, 46, 64, gui_area_no_anim_button,          27, GUIStr_OptionShadowsDesc,           0, {(long)&_DK_video_shadows}, 4, NULL },
-  {LbBtnT_ToggleBtn,  BID_DEFAULT, 0, 0, gui_video_view_distance_level, NULL,                           NULL,  0,  76,  38,  58,  38, 46, 64, gui_area_no_anim_button,          36, GUIStr_OptionViewDistanceDesc,      0, {(long)&video_view_distance_level}, 3, NULL },
-  {LbBtnT_ToggleBtn,  BID_DEFAULT, 0, 0, gui_video_rotate_mode,         NULL,                           NULL,  0, 124,  38, 106,  38, 46, 64, gui_area_no_anim_button,          32, GUIStr_OptionViewTypeDesc,          0, {(long)&settings.video_rotate_mode}, 1, NULL },
-  {LbBtnT_ToggleBtn,  BID_DEFAULT, 0, 0, gui_video_cluedo_mode,         NULL,                           NULL,  0,  28,  90,  10,  90, 46, 64, gui_area_no_anim_button,          42, GUIStr_OptionWallHeightDesc,        0, {(long)&_DK_video_cluedo_mode},1, gui_video_cluedo_maintain },
-  {LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, gui_video_gamma_correction,    NULL,                           NULL,  0,  76,  90,  58,  90, 46, 64, gui_area_no_anim_button,          44, GUIStr_OptionGammaCorrectionDesc,   0, {(long)&video_gamma_correction}, 0, NULL },
-  {LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, gui_switch_video_mode,         gui_display_current_resolution, NULL,  0, 124,  90, 106,  90, 46, 64, gui_area_no_anim_button,         122, GUIStr_DisplayResolution,           0, {0}, 0, NULL },
-  {              -1,  BID_DEFAULT, 0, 0, NULL,                          NULL,                           NULL,  0,   0,   0,   0,   0,  0,  0, NULL,                              0,                                     0, 0, {0},            0, NULL },
+  {LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,                          NULL,                           NULL,  0, 999,  10, 999,  10, 155, 32, gui_area_text,                     1, GUIStr_MnuGraphicsOptions,          0, {0},            0, NULL },
+  {LbBtnT_ToggleBtn,  BID_DEFAULT, 0, 0, gui_video_shadows,             NULL,                           NULL,  0,  28,  38,  30,  38,  46, 64, gui_area_no_anim_button,          27, GUIStr_OptionShadowsDesc,           0, {(long)&_DK_video_shadows}, 4, NULL },
+  {LbBtnT_ToggleBtn,  BID_DEFAULT, 0, 0, gui_video_view_distance_level, NULL,                           NULL,  0,  76,  38,  78,  38,  46, 64, gui_area_no_anim_button,          36, GUIStr_OptionViewDistanceDesc,      0, {(long)&video_view_distance_level}, 3, NULL },
+  {LbBtnT_ToggleBtn,  BID_DEFAULT, 0, 0, gui_video_rotate_mode,         NULL,                           NULL,  0, 124,  38, 126,  38,  46, 64, gui_area_no_anim_button,          32, GUIStr_OptionViewTypeDesc,          0, {(long)&settings.video_rotate_mode}, 1, NULL },
+  {LbBtnT_ToggleBtn,  BID_DEFAULT, 0, 0, gui_video_cluedo_mode,         NULL,                           NULL,  0,  28, 100,  30, 100,  46, 64, gui_area_no_anim_button,          42, GUIStr_OptionWallHeightDesc,        0, {(long)&_DK_video_cluedo_mode},1, gui_video_cluedo_maintain },
+  {LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, gui_video_gamma_correction,    NULL,                           NULL,  0,  76, 100,  78, 100,  46, 64, gui_area_no_anim_button,          44, GUIStr_OptionGammaCorrectionDesc,   0, {(long)&video_gamma_correction}, 0, NULL },
+  {LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, gui_switch_video_mode,         gui_display_current_resolution, NULL,  0, 124, 100, 126, 100,  46, 64, gui_area_no_anim_button,         122, GUIStr_DisplayResolution,           0, {0}, 0, NULL },
+  {              -1,  BID_DEFAULT, 0, 0, NULL,                          NULL,                           NULL,  0,   0,   0,   0,   0,   0,  0, NULL,                              0,                                     0, 0, {0},            0, NULL },
 };
 
 struct GuiButtonInit sound_menu_buttons[] = {
@@ -125,7 +125,7 @@ struct GuiMenu autopilot_menu =
  { GMnu_AUTOPILOT,    0, 4, autopilot_menu_buttons,     POS_GAMECTR,POS_GAMECTR,224, 120, gui_pretty_background,       0, NULL,    NULL,                    0, 1, 0,};
 
 struct GuiMenu video_menu =
- { GMnu_VIDEO, 0, 4, video_menu_buttons,         POS_GAMECTR,POS_GAMECTR,200, 170, gui_pretty_background,       0, NULL,    init_video_menu,         0, 1, 0,};
+ { GMnu_VIDEO, 0, 4, video_menu_buttons,         POS_GAMECTR,POS_GAMECTR,200, 180, gui_pretty_background,       0, NULL,    init_video_menu,         0, 1, 0,};
 struct GuiMenu sound_menu =
  { GMnu_SOUND, 0, 4, sound_menu_buttons,         POS_GAMECTR,POS_GAMECTR,280, 170, gui_pretty_background,       0, NULL,    init_audio_menu,         0, 1, 0,};
  


### PR DESCRIPTION
A mismatch was introduced in 0c6235e4a that made you click the button to the right by accident:

![image](https://user-images.githubusercontent.com/13840686/160261289-fe2fa79a-3be8-45c9-a6e7-97f3e87d98d7.png)
On the image, notice the tooltip below the cursor is for gamma.