### PR TITLE
Party members won't mutiny on slow tunneler escape

### DIFF
--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -441,7 +441,7 @@ unsigned short shot_shift_z;
     unsigned long field_2FE;
     unsigned char field_302;
     long field_303;
-    unsigned char field_307;
+    unsigned char follow_leader_fails;
 };
 
 struct CreatureStatsOLD { // sizeof = 230

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2003,7 +2003,7 @@ short creature_follow_leader(struct Thing *creatng)
         return 1;
     }
     int fails_amount = cctrl->field_307;
-    if (fails_amount > 8)
+    if (fails_amount > 12) //When set too low, group might disband before a white wall is breached
     {
         SYNCDBG(3,"Removing %s index %d owned by player %d from group due to fails to follow",
             thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2002,7 +2002,7 @@ short creature_follow_leader(struct Thing *creatng)
         set_start_state(creatng);
         return 1;
     }
-    int fails_amount = cctrl->field_307;
+    int fails_amount = cctrl->follow_leader_fails;
     if (fails_amount > 12) //When set too low, group might disband before a white wall is breached
     {
         SYNCDBG(3,"Removing %s index %d owned by player %d from group due to fails to follow",
@@ -2025,7 +2025,7 @@ short creature_follow_leader(struct Thing *creatng)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-          cctrl->field_307++;
+          cctrl->follow_leader_fails++;
           return 0;
         }
     } else
@@ -2041,7 +2041,7 @@ short creature_follow_leader(struct Thing *creatng)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-          cctrl->field_307++;
+          cctrl->follow_leader_fails++;
           return 0;
         }
     } else
@@ -2054,7 +2054,7 @@ short creature_follow_leader(struct Thing *creatng)
         } else
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-            cctrl->field_307++;
+            cctrl->follow_leader_fails++;
             return 0;
         }
     } else
@@ -2069,11 +2069,11 @@ short creature_follow_leader(struct Thing *creatng)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-            cctrl->field_307++;
+            cctrl->follow_leader_fails++;
             return 0;
         }
     }
-    cctrl->field_307 = 0;
+    cctrl->follow_leader_fails = 0;
     return 0;
 }
 


### PR DESCRIPTION
When a tunneler party is placed in a very small room, units do not have space to follow.
When units do not have space to follow, they will elect a new leader after 8 failed attempts. And said new unit is big and strong but cannot tunnel and so they are forever trapped in the box.

Party members will have over 8 failed attempts before a tunneler can breach a white wall. So I changed the margin to 12.
At 10, they would escape after having the party disbanded.