### PR TITLE
Special diggers are considered first for party leadership

### DIFF
--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -319,6 +319,7 @@ TbBool remove_creature_from_group_without_leader_consideration(struct Thing *cre
 // 0 = no digger, 1 = only defensive diggers, 2 = digger for leader
 short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
 {
+    struct Thing* ctng = INVALID_THING;
     short defender = 0;
     struct CreatureControl* cctrl;
     cctrl = creature_control_get_from_thing(grptng);
@@ -341,7 +342,8 @@ short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
     }
     while (i > 0)
     {
-        struct Thing* ctng = thing_get(i);
+        ctng = thing_get(i);
+        cctrl = creature_control_get_from_thing(ctng);
         TRACE_THING(ctng);
         if (thing_is_creature_special_digger(ctng))
         {

--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -320,7 +320,7 @@ TbBool remove_creature_from_group_without_leader_consideration(struct Thing *cre
  * Determines if the creature is a Tunneler or Imp to consider for leadership.
   * @return 0 if it's no digger, 1 if it's a digger who does not want to be a leader, and 2 if the digger is a preferred leader
  */
-short creature_could_be_lead_digger(struct Thing* crtng, struct CreatureControl* cctrl)
+static short creature_could_be_lead_digger(struct Thing* crtng, struct CreatureControl* cctrl)
 {
     short potential_leader = 0;
     if (thing_is_creature_special_digger(crtng))
@@ -342,7 +342,7 @@ short creature_could_be_lead_digger(struct Thing* crtng, struct CreatureControl*
  * @param grptng is the creature whos party is considerd
  * @return 0 if there's no digger, 1 if there's a digger who does not want to be a leader, and 2 if the digger is a preferred leader
  */
-short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
+static short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
 {
     struct Thing* ctng = INVALID_THING;
     short potential_leader = 0;

--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -259,7 +259,7 @@ void internal_add_member_to_group_chain_head(struct Thing *creatng, struct Thing
 /**
  * Removes a creature from group. If the group had size of 2, it is disbanded; otherwise, next
  *   creature becomes a leader without checking whether it's best for it.
- * @param creatng The creatuire to be removed.
+ * @param creatng The creature to be removed.
  * @return True if the group still exists after removal, false otherwise.
  */
 TbBool remove_creature_from_group_without_leader_consideration(struct Thing *creatng)
@@ -316,22 +316,27 @@ TbBool remove_creature_from_group_without_leader_consideration(struct Thing *cre
     return true;
 }
 
-// 0 = no digger, 1 = only defensive diggers, 2 = digger for leader
+/**
+ * Determines if a party has a Tunneler or Imp to consider for leadership.
+ * @param grptng is the creature whos party is considerd
+ * @return 0 if there's no digger, 1 if there's a digger who does not want to be a leader, and 2 if the digger is a preferred leader
+ */
 short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
 {
     struct Thing* ctng = INVALID_THING;
-    short defender = 0;
+    short potential_leader = 0;
     struct CreatureControl* cctrl;
     cctrl = creature_control_get_from_thing(grptng);
     if (thing_is_creature_special_digger(grptng))
     {
         if (cctrl->party_objective != CHeroTsk_DefendParty)
         {
-            return 2;
+            potential_leader = 2;
+            return potential_leader;
         }
         else
         {
-            defender = 1;
+            potential_leader = 1;
         }
     }
     long i = cctrl->group_info & TngGroup_LeaderIndex;
@@ -349,11 +354,12 @@ short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
         {
             if (cctrl->party_objective != CHeroTsk_DefendParty)
             {
-                return 2;
+                potential_leader = 2;
+                return potential_leader;
             }
             else
             {
-                defender = 1;
+                potential_leader = 1;
             }
         }
         i = cctrl->next_in_group;
@@ -364,9 +370,14 @@ short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
             break;
         }
     }
-    return defender;
+    return potential_leader;
 }
 
+/**
+ * Finds a creature to become group leader. Considers objectives, diggers and score.
+ * @param grptng is the party member which needs a leader
+ * @return The Creature that should lead the group.
+ */
 struct Thing* get_best_creature_to_lead_group(struct Thing* grptng)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(grptng);

--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -349,7 +349,7 @@ static short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
     struct CreatureControl* cctrl;
     cctrl = creature_control_get_from_thing(grptng);
     potential_leader = creature_could_be_lead_digger(grptng, cctrl);
-    if (potential_leader = 2)
+    if (potential_leader == 2)
     {
         return potential_leader;
     }
@@ -364,7 +364,7 @@ static short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
         ctng = thing_get(i);
         cctrl = creature_control_get_from_thing(ctng);
         potential_leader = creature_could_be_lead_digger(ctng, cctrl);
-        if (potential_leader = 2)
+        if (potential_leader == 2)
         {
             return potential_leader;
         }

--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -317,6 +317,27 @@ TbBool remove_creature_from_group_without_leader_consideration(struct Thing *cre
 }
 
 /**
+ * Determines if the creature is a Tunneler or Imp to consider for leadership.
+  * @return 0 if it's no digger, 1 if it's a digger who does not want to be a leader, and 2 if the digger is a preferred leader
+ */
+short creature_could_be_lead_digger(struct Thing* crtng, struct CreatureControl* cctrl)
+{
+    short potential_leader = 0;
+    if (thing_is_creature_special_digger(crtng))
+    {
+        if (cctrl->party_objective != CHeroTsk_DefendParty)
+        {
+            potential_leader = 2;
+        }
+        else
+        {
+            potential_leader = 1;
+        }
+    }
+    return potential_leader;
+}
+
+/**
  * Determines if a party has a Tunneler or Imp to consider for leadership.
  * @param grptng is the creature whos party is considerd
  * @return 0 if there's no digger, 1 if there's a digger who does not want to be a leader, and 2 if the digger is a preferred leader
@@ -327,17 +348,10 @@ short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
     short potential_leader = 0;
     struct CreatureControl* cctrl;
     cctrl = creature_control_get_from_thing(grptng);
-    if (thing_is_creature_special_digger(grptng))
+    potential_leader = creature_could_be_lead_digger(grptng, cctrl);
+    if (potential_leader = 2)
     {
-        if (cctrl->party_objective != CHeroTsk_DefendParty)
-        {
-            potential_leader = 2;
-            return potential_leader;
-        }
-        else
-        {
-            potential_leader = 1;
-        }
+        return potential_leader;
     }
     long i = cctrl->group_info & TngGroup_LeaderIndex;
     unsigned long k = 0;
@@ -349,18 +363,10 @@ short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
     {
         ctng = thing_get(i);
         cctrl = creature_control_get_from_thing(ctng);
-        TRACE_THING(ctng);
-        if (thing_is_creature_special_digger(ctng))
+        potential_leader = creature_could_be_lead_digger(ctng, cctrl);
+        if (potential_leader = 2)
         {
-            if (cctrl->party_objective != CHeroTsk_DefendParty)
-            {
-                potential_leader = 2;
-                return potential_leader;
-            }
-            else
-            {
-                potential_leader = 1;
-            }
+            return potential_leader;
         }
         i = cctrl->next_in_group;
         k++;


### PR DESCRIPTION
However, DEFEND_PARTY still overwrites it.
Testmap: [1419.zip](https://github.com/dkfans/keeperfx/files/8410032/1419.zip)

1) Reveal the map to see the tunneler coming from Hero Gate 1
2) Use cheats to kill the tunneler and notice the thief becomes the new leader (the tunneler does not want to, by script)
3) Kill the thief and see the tunneler does become leader (the other units do not want to either), and continues digging

Change the tunneler party objective to have it become leader as soon as the thief is killed.