### PR TITLE
Followers do not abandon the party when they are close to the leader

### DIFF
--- a/src/ariadne_wallhug.c
+++ b/src/ariadne_wallhug.c
@@ -625,7 +625,7 @@ TbBool find_approach_position_to_subtile(const struct Coord3d *srcpos, MapSubtlC
         struct Map* mapblk = get_map_block_at(tmpos.x.stl.num, tmpos.y.stl.num);
         if ((!map_block_invalid(mapblk)) && ((mapblk->flags & SlbAtFlg_Blocking) == 0))
         {
-            long dist = get_2d_box_distance(srcpos, &tmpos);
+            MapCoordDelta dist = get_2d_box_distance(srcpos, &tmpos);
             if (min_dist > dist)
             {
                 min_dist = dist;

--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -440,7 +440,7 @@ unsigned short shot_shift_z;
     unsigned long field_2FA;
     unsigned long field_2FE;
     unsigned char field_302;
-    long field_303;
+    long following_leader_since;
     unsigned char follow_leader_fails;
 };
 

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2015,22 +2015,26 @@ short creature_follow_leader(struct Thing *creatng)
         return 0;
     }
     cctrl->field_303 = game.play_gameturn;
-    MapCoord dist = get_2d_box_distance(&creatng->mappos, &follwr_pos);
+    MapCoord distance_to_follower_pos = get_2d_box_distance(&creatng->mappos, &follwr_pos);
+    MapCoord distance_to_leader = get_2d_box_distance(&creatng->mappos, &leadtng->mappos);
     int speed = get_creature_speed(leadtng);
     // If we're too far from the designated position, do a speed run
-    if (dist > subtile_coord(12,0))
+    if (distance_to_follower_pos > subtile_coord(12,0))
     {
         speed = 2 * speed;
         if (speed >= MAX_VELOCITY)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-          cctrl->follow_leader_fails++;
+            if (distance_to_follower_pos < distance_to_leader) // only count fails when we're not able to get to the leader, instead of getting a position in the trail it cannot reach.
+            {
+                cctrl->follow_leader_fails++;
+            }
           return 0;
         }
     } else
     // If we're far from the designated position, move considerably faster
-    if (dist > subtile_coord(6,0))
+    if (distance_to_follower_pos > subtile_coord(6,0))
     {
         if (speed > 4) {
             speed = 5 * speed / 4;
@@ -2041,20 +2045,26 @@ short creature_follow_leader(struct Thing *creatng)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-          cctrl->follow_leader_fails++;
+            if (distance_to_follower_pos < distance_to_leader)
+            {
+                cctrl->follow_leader_fails++;
+            }
           return 0;
         }
     } else
     // If we're close, continue moving at normal speed
-    if (dist <= subtile_coord(2,0))
+    if (distance_to_follower_pos <= subtile_coord(2,0))
     {
-        if (dist <= 0)
+        if (distance_to_follower_pos <= 0)
         {
             creature_turn_to_face(creatng, &leadtng->mappos);
         } else
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-            cctrl->follow_leader_fails++;
+            if (distance_to_follower_pos < distance_to_leader)
+            {
+                cctrl->follow_leader_fails++;
+            }
             return 0;
         }
     } else
@@ -2069,7 +2079,10 @@ short creature_follow_leader(struct Thing *creatng)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-            cctrl->follow_leader_fails++;
+            if (distance_to_follower_pos < distance_to_leader)
+            {
+                cctrl->follow_leader_fails++;
+            }
             return 0;
         }
     }

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2016,7 +2016,7 @@ short creature_follow_leader(struct Thing *creatng)
     }
     cctrl->field_303 = game.play_gameturn;
     MapCoord distance_to_follower_pos = get_2d_box_distance(&creatng->mappos, &follwr_pos);
-    MapCoord distance_to_leader = get_2d_box_distance(&creatng->mappos, &leadtng->mappos);
+    MapCoord cannot_reach_leader = creature_cannot_move_directly_to(creatng, &leadtng->mappos);
     int speed = get_creature_speed(leadtng);
     // If we're too far from the designated position, do a speed run
     if (distance_to_follower_pos > subtile_coord(12,0))
@@ -2027,6 +2027,7 @@ short creature_follow_leader(struct Thing *creatng)
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
             if (distance_to_follower_pos < distance_to_leader) // only count fails when we're not able to get to the leader, instead of getting a position in the trail it cannot reach.
+            if (cannot_reach_leader) // only count fails when we're not able to get to the leader, instead of getting a position in the trail it cannot reach.
             {
                 cctrl->follow_leader_fails++;
             }
@@ -2080,6 +2081,7 @@ short creature_follow_leader(struct Thing *creatng)
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
             if (distance_to_follower_pos < distance_to_leader)
+            if (cannot_reach_leader)
             {
                 cctrl->follow_leader_fails++;
             }

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2026,7 +2026,6 @@ short creature_follow_leader(struct Thing *creatng)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-            if (distance_to_follower_pos < distance_to_leader) // only count fails when we're not able to get to the leader, instead of getting a position in the trail it cannot reach.
             if (cannot_reach_leader) // only count fails when we're not able to get to the leader, instead of getting a position in the trail it cannot reach.
             {
                 cctrl->follow_leader_fails++;
@@ -2046,7 +2045,7 @@ short creature_follow_leader(struct Thing *creatng)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-            if (distance_to_follower_pos < distance_to_leader)
+            if (cannot_reach_leader)
             {
                 cctrl->follow_leader_fails++;
             }
@@ -2062,7 +2061,7 @@ short creature_follow_leader(struct Thing *creatng)
         } else
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-            if (distance_to_follower_pos < distance_to_leader)
+            if (cannot_reach_leader)
             {
                 cctrl->follow_leader_fails++;
             }
@@ -2080,7 +2079,6 @@ short creature_follow_leader(struct Thing *creatng)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
         {
-            if (distance_to_follower_pos < distance_to_leader)
             if (cannot_reach_leader)
             {
                 cctrl->follow_leader_fails++;

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2015,8 +2015,8 @@ short creature_follow_leader(struct Thing *creatng)
         return 0;
     }
     cctrl->field_303 = game.play_gameturn;
-    MapCoord distance_to_follower_pos = get_2d_box_distance(&creatng->mappos, &follwr_pos);
-    MapCoord cannot_reach_leader = creature_cannot_move_directly_to(creatng, &leadtng->mappos);
+    MapCoordDelta distance_to_follower_pos = get_2d_box_distance(&creatng->mappos, &follwr_pos);
+    TbBool cannot_reach_leader = creature_cannot_move_directly_to(creatng, &leadtng->mappos);
     int speed = get_creature_speed(leadtng);
     // If we're too far from the designated position, do a speed run
     if (distance_to_follower_pos > subtile_coord(12,0))
@@ -4051,7 +4051,7 @@ short seek_the_enemy(struct Thing *creatng)
     struct Thing* enemytng = thing_update_enemy_to_fight_with(creatng);
     if (!thing_is_invalid(enemytng))
     {
-        long dist = get_2d_box_distance(&enemytng->mappos, &creatng->mappos);
+        MapCoordDelta dist = get_2d_box_distance(&enemytng->mappos, &creatng->mappos);
         if (creature_can_hear_within_distance(creatng, dist))
         {
             if (cctrl->instance_id == CrInst_NULL)

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2010,11 +2010,11 @@ short creature_follow_leader(struct Thing *creatng)
         remove_creature_from_group(creatng);
         return 0;
     }
-    if ((fails_amount > 0) && (cctrl->field_303 + 16 > game.play_gameturn))
+    if ((fails_amount > 0) && (cctrl->following_leader_since + 16 > game.play_gameturn))
     {
         return 0;
     }
-    cctrl->field_303 = game.play_gameturn;
+    cctrl->following_leader_since = game.play_gameturn;
     MapCoordDelta distance_to_follower_pos = get_2d_box_distance(&creatng->mappos, &follwr_pos);
     TbBool cannot_reach_leader = creature_cannot_move_directly_to(creatng, &leadtng->mappos);
     int speed = get_creature_speed(leadtng);

--- a/src/thing_doors.c
+++ b/src/thing_doors.c
@@ -260,7 +260,7 @@ long destroy_door(struct Thing *doortng)
         if (!player_exists(player))
             continue;
         struct Thing* thing = thing_get(player->controlled_thing_idx);
-        long dist = get_2d_box_distance(&pos, &thing->mappos);
+        MapCoordDelta dist = get_2d_box_distance(&pos, &thing->mappos);
         long sight_stl = slab_subtile(get_explore_sight_distance_in_slabs(thing), 0);
         if (dist <= subtile_coord(sight_stl,0)) {
             check_map_explored(thing, thing->mappos.x.stl.num, thing->mappos.y.stl.num);

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -1836,7 +1836,7 @@ TbBool electricity_affecting_thing(struct Thing *tngsrc, struct Thing *tngdst, c
         max_dist = max_dist * gameadd.friendly_fight_area_range_permil / 1000;
         max_damage = max_damage * gameadd.friendly_fight_area_damage_permil / 1000;
     }
-    MapCoord distance = get_2d_box_distance(pos, &tngdst->mappos);
+    MapCoordDelta distance = get_2d_box_distance(pos, &tngdst->mappos);
     if (distance < max_dist)
     {
         if (tngdst->class_id == TCls_Creature)

--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -382,7 +382,7 @@ TbBool position_over_floor_level(const struct Thing *thing, const struct Coord3d
     return false;
 }
 
-long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
+TbBool creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
 {
     struct Coord3d realpos;
     realpos.x.val = thing->mappos.x.val;
@@ -410,7 +410,7 @@ long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
             modpos.z.val = realpos.z.val;
             if (position_over_floor_level(thing, &modpos)) {
                 // No need to restore mappos - it was not modified yet
-                return 1;
+                return true;
             }
             thing->mappos.x.val = modpos.x.val;
             thing->mappos.y.val = modpos.y.val;
@@ -430,7 +430,7 @@ long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
             modpos.z.val = realpos.z.val;
             if (position_over_floor_level(thing, &modpos)) {
                 thing->mappos = origpos;
-                return 1;
+                return true;
             }
             thing->mappos.x.val = modpos.x.val;
             thing->mappos.y.val = modpos.y.val;
@@ -446,10 +446,10 @@ long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
             modpos.z.val = realpos.z.val;
             if (position_over_floor_level(thing, &modpos)) {
                 thing->mappos = origpos;
-                return 1;
+                return true;
             }
             thing->mappos = origpos;
-            return 0;
+            return false;
         }
 
         if (cross_y_boundary_first(&realpos, pos))
@@ -465,7 +465,7 @@ long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
             modpos.z.val = realpos.z.val;
             if (position_over_floor_level(thing, &modpos)) {
                 // No need to restore mappos - it was not modified yet
-                return 1;
+                return true;
             }
             thing->mappos.x.val = modpos.x.val;
             thing->mappos.y.val = modpos.y.val;
@@ -485,7 +485,7 @@ long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
             modpos.z.val = realpos.z.val;
             if (position_over_floor_level(thing, &modpos)) {
                 thing->mappos = origpos;
-                return 1;
+                return true;
             }
             thing->mappos.x.val = modpos.x.val;
             thing->mappos.y.val = modpos.y.val;
@@ -501,18 +501,18 @@ long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos)
             modpos.z.val = realpos.z.val;
             if (position_over_floor_level(thing, &modpos)) {
                 thing->mappos = origpos;
-                return 1;
+                return true;
             }
             thing->mappos = origpos;
-            return 0;
+            return false;
         }
 
         if (position_over_floor_level(thing, pos)) {
             thing->mappos = origpos;
-            return 1;
+            return true;
         }
         thing->mappos = origpos;
-        return 0;
+        return false;
     }
 
     if (position_over_floor_level(thing, pos)) {

--- a/src/thing_physics.h
+++ b/src/thing_physics.h
@@ -65,7 +65,7 @@ TbBool get_thing_next_position(struct Coord3d *pos, const struct Thing *thing);
 void remove_relevant_forces_from_thing_after_slide(struct Thing *thing, struct Coord3d *pos, long a3);
 void apply_transitive_velocity_to_thing(struct Thing *thing, struct ComponentVector *veloc);
 TbBool positions_equivalent(const struct Coord3d *pos_a, const struct Coord3d *pos_b);
-long creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos);
+TbBool creature_cannot_move_directly_to(struct Thing *thing, struct Coord3d *pos);
 void creature_set_speed(struct Thing *thing, long speed);
 
 long get_thing_height_at(const struct Thing *thing, const struct Coord3d *pos);


### PR DESCRIPTION
When a follower cannot get to his position, it is deemed he cannot reach the party and after x failed attempts, he will start his own party.

However, it is possible the follower position is on the other side of a wall while he is still very much a member of the party. As such, I do not count a fail if he is closer to the party leader than he is to the follower position he is trying to go.

On this image, the archers would try to reach all red circled positions, would deem 10 and 11 as free positions, but they cannot reach. 
![image](https://user-images.githubusercontent.com/13840686/161569971-1d26123f-bebf-4765-98c9-106d3f66b3c3.png)

This PR makes it so that they notice they are close enough to the tunneler to not need to start their own party.