### PR TITLE
Prevent thing limit message on effect elements

### DIFF
--- a/src/thing_data.c
+++ b/src/thing_data.c
@@ -109,7 +109,7 @@ TbBool i_can_allocate_free_thing_structure(unsigned char allocflags)
         ERRORLOG("Cannot allocate thing structure.");
         things_stats_debug_dump();
     }
-    if (game.free_things_start_index > THINGS_COUNT - 2)
+    if ((game.free_things_start_index > THINGS_COUNT - 2) && ((allocflags & FTAF_FreeEffectIfNoSlots) != 0))
     {
         show_onscreen_msg(2 * game.num_fps, "Warning: Cannot create thing, %d/%d thing slots used.", game.free_things_start_index + 1, THINGS_COUNT);
     }


### PR DESCRIPTION
Reduces frequency of thing limit warning messages. To see the difference start a complex map then use sight of evil. Before, when it was closed it displayed a message, now it usually does not.