### PR TITLE
Spawned parties now attack best player

### DIFF
--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -64,7 +64,7 @@ extern "C" {
  * @param thing The hero searching for target.
  * @return Player index, or -1 if no dungeon to attack found.
  */
-long good_find_enemy_dungeon(struct Thing *thing)
+TbBool has_available_enemy_dungeon(struct Thing *thing, PlayerNumber plyr_idx)
 {
     SYNCDBG(18,"Starting");
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
@@ -72,34 +72,55 @@ long good_find_enemy_dungeon(struct Thing *thing)
     {
         cctrl->byte_8C = 0;
         cctrl->byte_8B = 0;
-        // Try accessing dungeon heart of undefeated enemy players
-        long i;
-        for (i = 0; i < PLAYERS_COUNT; i++)
+    }
+    // Try accessing dungeon heart of undefeated enemy players
+    if (!player_is_friendly_or_defeated(plyr_idx, thing->owner) && (creature_can_get_to_dungeon(thing, plyr_idx)))
+    {
+        return true;
+    }
+    if (players_are_enemies(thing->owner, plyr_idx) && creature_can_get_to_any_of_players_rooms(thing, plyr_idx)) 
+    {
+        return true;
+    }
+    return false;
+}
+
+long good_find_best_enemy_dungeon(struct Thing* creatng)
+{
+    //return _DK_get_best_dungeon_to_tunnel_to(creatng);
+    PlayerNumber best_plyr_idx = -1;
+    struct PlayerInfo* player;
+    struct Dungeon* dungeon;
+    long best_score = LONG_MIN;
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        player = get_player(plyr_idx);
+        if (gameadd.classic_bugs_flags & ClscBug_AlwaysTunnelToRed)
         {
-            if (player_is_friendly_or_defeated(i, thing->owner)) {
-                continue;
-            }
-            if (creature_can_get_to_dungeon(thing, i))
+            if (has_available_enemy_dungeon(creatng, plyr_idx))
             {
-                SYNCDBG(8,"The %s index %d can get to enemy player %d",thing_model_name(thing),(int)thing->index,(int)i);
-                return i;
+                JUSTMSG("Classic bug return %d",plyr_idx);
+                return plyr_idx;
             }
         }
-        // Try accessing any room of any non allied players
-        for (i = 0; i < PLAYERS_COUNT; i++)
+ 
+        dungeon = get_players_dungeon(player);
+        if (player_exists(player) && !dungeon_invalid(dungeon) && (creatng->owner != plyr_idx) && has_available_enemy_dungeon(creatng, plyr_idx))
         {
-            if (!players_are_enemies(thing->owner, i)) {
-                continue;
-            }
-            if (creature_can_get_to_any_of_players_rooms(thing, i))
+            long score = dungeon->total_score - 20 * dungeon->total_score * dungeon->field_F7D / 100;
+            JUSTMSG("Score for player %d = %d", plyr_idx, score);
+            if (score <= 0)
             {
-                SYNCDBG(8,"The %s index %d can get to room of player %d",thing_model_name(thing),(int)thing->index,(int)i);
-                return i;
+                score = 0;
+            }
+            if (best_score < score)
+            {
+                best_score = score;
+                best_plyr_idx = plyr_idx;
             }
         }
     }
-    SYNCDBG(8,"The %s index %d cannot find an enemy",thing_model_name(thing),(int)thing->index);
-    return -1;
+    return best_plyr_idx;
 }
 
 /**
@@ -854,7 +875,7 @@ short good_doing_nothing(struct Thing *creatng)
         if (nturns > 64)
         {
             cctrl->long_8D = game.play_gameturn;
-            cctrl->party.target_plyr_idx = good_find_enemy_dungeon(creatng);
+            cctrl->party.target_plyr_idx = good_find_best_enemy_dungeon(creatng);
         }
         target_plyr_idx = cctrl->party.target_plyr_idx;
         if (target_plyr_idx == -1)
@@ -1208,7 +1229,7 @@ short tunneller_doing_nothing(struct Thing *creatng)
             return 1;
         }
     }
-    cctrl->party.target_plyr_idx = good_find_enemy_dungeon(creatng);
+    cctrl->party.target_plyr_idx = good_find_best_enemy_dungeon(creatng);
     if ( (cctrl->party.target_plyr_idx != -1) && (cctrl->party.target_plyr_idx != CurrentTarget) )
     {
         internal_set_thing_state(creatng, CrSt_GoodDoingNothing);

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -106,7 +106,7 @@ long good_find_best_enemy_dungeon(struct Thing* creatng)
         dungeon = get_players_dungeon(player);
         if (player_exists(player) && !dungeon_invalid(dungeon) && (creatng->owner != plyr_idx) && has_available_enemy_dungeon(creatng, plyr_idx))
         {
-            long score = dungeon->total_score - 20 * dungeon->total_score * dungeon->field_F7D / 100;
+            long score = dungeon->total_score;
             if (score <= 0)
             {
                 score = 0;
@@ -1053,7 +1053,7 @@ long get_best_dungeon_to_tunnel_to(struct Thing *creatng)
         struct Dungeon* dungeon = get_players_dungeon(player);
         if (player_exists(player) && !dungeon_invalid(dungeon) && (creatng->owner != plyr_idx))
         {
-            long score = dungeon->total_score - 20 * dungeon->total_score * dungeon->field_F7D / 100;
+            long score = dungeon->total_score; //Original code: = dungeon->total_score -20 * dungeon->total_score * dungeon->field_F7D / 100;
             if ((score <= 0) || (gameadd.classic_bugs_flags & ClscBug_AlwaysTunnelToRed))
             {
                 score = 0;

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -99,7 +99,6 @@ long good_find_best_enemy_dungeon(struct Thing* creatng)
         {
             if (has_available_enemy_dungeon(creatng, plyr_idx))
             {
-                JUSTMSG("Classic bug return %d",plyr_idx);
                 return plyr_idx;
             }
         }
@@ -108,7 +107,6 @@ long good_find_best_enemy_dungeon(struct Thing* creatng)
         if (player_exists(player) && !dungeon_invalid(dungeon) && (creatng->owner != plyr_idx) && has_available_enemy_dungeon(creatng, plyr_idx))
         {
             long score = dungeon->total_score - 20 * dungeon->total_score * dungeon->field_F7D / 100;
-            JUSTMSG("Score for player %d = %d", plyr_idx, score);
             if (score <= 0)
             {
                 score = 0;

--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -196,7 +196,7 @@ struct Dungeon {
     struct ResearchVal research[DUNGEON_RESEARCH_COUNT];
     int current_research_idx;
     unsigned char research_num;
-unsigned char field_F7D;
+    unsigned char field_F7D_UNUSED;
     unsigned char room_buildable[ROOM_TYPES_COUNT];
     unsigned char room_resrchable[ROOM_TYPES_COUNT];
     /** How many creatures are force-enabled for each kind.


### PR DESCRIPTION
Before, they would attack the available player with the lowest player number. Now, they take 'best dungeon' from the APPROPRIATE_DUNGEON command.

With ALWAYS_TUNNEL_TO_RED bug it has classic behavior.