### PR TITLE
Fixed non-fitting hoard to give too much gold

### DIFF
--- a/src/room_util.c
+++ b/src/room_util.c
@@ -434,7 +434,7 @@ short check_and_asimilate_thing_by_room(struct Thing *thing)
             value_left = gold_value - value_added;
             if (value_left > 0)
             {
-                create_gold_pile(&thing->mappos, thing->owner, gold_value);
+                create_gold_pile(&thing->mappos, thing->owner, value_left);
             }
             return true;
         }


### PR DESCRIPTION
Fix to a recently introduced issue. When placing a large gold hoard in a treasure room with limited efficiency, it should transfer the hoard to one that fits, and throw out the -remaining- gold into a pile. Instead it created the hoard and a pile of gold worth the full hoard amount too.