### PR TITLE
Moved loading custom icons to be before loading the stats files

### DIFF
--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -29,6 +29,7 @@
 #include "config_campaigns.h"
 #include "config_creature.h"
 #include "config_compp.h"
+#include "custom_sprites.h"
 #include "front_simple.h"
 #include "frontend.h"
 #include "frontmenu_ingame_tabs.h"
@@ -202,6 +203,7 @@ int load_game_chunks(TbFileHandle fhandle,struct CatalogueEntry *centry)
                     return GLoad_Failed;
                 }
                 // Load configs which may have per-campaign part, and even be modified within a level
+                init_custom_sprites(SPRITE_LAST_LEVEL);
                 load_computer_player_config(CnfLd_Standard);
                 load_stats_files();
                 check_and_auto_fix_stats();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1566,7 +1566,6 @@ void reinit_level_after_load(void)
     struct PlayerInfo *player;
     int i;
     SYNCDBG(6,"Starting");
-    init_custom_sprites(SPRITE_LAST_LEVEL);
     // Reinit structures from within the game
     player = get_my_player();
     player->lens_palette = 0;


### PR DESCRIPTION
Because the stats files could have custom icons configured, they should be known at that point.

Fixes a bug where on reload, the creature icons are unknown.