### PR TITLE
Creatures now remember backpay, instead of just their emotions

### DIFF
--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -165,7 +165,7 @@ unsigned char field_37[2];
     long field_43;
     unsigned char field_47;
     unsigned char paydays_owed;
-    unsigned char prepayments_received;
+    char paydays_advanced;
     long annoy_untrained_turn;
     unsigned long last_roar_turn;
    /** The game enumerates the elements of annoyance array periodically and looks for the highest value.

--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -317,6 +317,7 @@ struct DungeonAdd
     unsigned long         traps_sold;
     unsigned long         doors_sold;
     unsigned long         manufacture_gold;
+    long                  creatures_total_backpay;
     long                  cheaper_diggers;
     struct ComputerInfo   computer_info;
     long event_last_run_turn[EVENT_KIND_COUNT];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2340,9 +2340,9 @@ void count_players_creatures_being_paid(int *creatures_count)
             {
                 struct CreatureControl *cctrl;
                 cctrl = creature_control_get_from_thing(thing);
-                if (cctrl->prepayments_received > 0)
+                if (cctrl->paydays_advanced > 0)
                 {
-                    cctrl->prepayments_received--;
+                    cctrl->paydays_advanced--;
                 } else
                 {
                     cctrl->paydays_owed++;
@@ -2375,6 +2375,7 @@ void process_payday(void)
         if (player_exists(player) && (player->is_active == 1))
         {
             compute_and_update_player_payday_total(plyr_idx);
+            compute_and_update_player_backpay_total(plyr_idx);
         }
     }
     if (game.pay_day_gap <= game.pay_day_progress)

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -974,5 +974,12 @@ void compute_and_update_player_payday_total(PlayerNumber plyr_idx)
     struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
     dungeon->creatures_total_pay = compute_player_payday_total(dungeon);
 }
+void compute_and_update_player_backpay_total(PlayerNumber plyr_idx)
+{
+    SYNCDBG(15, "Starting for player %d", (int)plyr_idx);
+    struct DungeonAdd* dungeonadd = get_dungeonadd(plyr_idx);
+    struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
+    dungeonadd->creatures_total_backpay = compute_player_payday_total(dungeon);
+}
 
 /******************************************************************************/

--- a/src/player_utils.h
+++ b/src/player_utils.h
@@ -50,6 +50,7 @@ long compute_player_final_score(struct PlayerInfo *player, long gameplay_score);
 long take_money_from_dungeon_f(PlayerNumber plyr_idx, GoldAmount amount_take, TbBool only_whole_sum, const char *func_name);
 long update_dungeon_generation_speeds(void);
 void compute_and_update_player_payday_total(PlayerNumber plyr_idx);
+void compute_and_update_player_backpay_total(PlayerNumber plyr_idx);
 void calculate_dungeon_area_scores(void);
 
 TbBool player_sell_trap_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -859,8 +859,8 @@ long gold_being_dropped_on_creature(long plyr_idx, struct Thing *goldtng, struct
     if ( !taking_salary )
     {
         cctrl = creature_control_get_from_thing(creatng);
-        if (cctrl->prepayments_received < 255) {
-            cctrl->prepayments_received++;
+        if (cctrl->paydays_advanced < SCHAR_MAX) {
+            cctrl->paydays_advanced++;
         }
     }
     struct CreatureStats *crstat;


### PR DESCRIPTION
This commit introduced issues: 395da4e933b17d54cdacf9a15aadcfb7cb0498aa
It sought to fix keepers never having to pay missed paydays, and units being angry forever by converting anger to money and back. However
- Mad Psycho reapers cannot get happy so they took infinite money
- Units get angry more from missed pay then they gain in happiness on payday, so it ended up costing the player too much money for other units too.

So instead I'm allowing for the 'prepayments_received' function to go negative - renamed to paydays_advanced - to keep track on how much money is still owed. If during payday there's enough cash to pay backpay for that single unit, it is done.
Also, if there's enough money to pay the backpay in between paydays to pay ALL backpay, units will go get payment instead of complaining about being unpaid.

Fixes #1478 