### PR TITLE
Now correct numbers of workers can produce nothing in the workshop

### DIFF
--- a/src/creature_states_wrshp.c
+++ b/src/creature_states_wrshp.c
@@ -404,8 +404,7 @@ short manufacturing(struct Thing *creatng)
     } else
     {
         WARNDBG(9,"The %s index %d owner %d is manufacturing nothing",thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);
-        // This may be cause by a creature taking up place in workshop where crate should be created; the creature should take a break
-        if (room->used_capacity >= room->total_capacity) {
+        if (room->used_capacity > room->total_capacity) {
             external_set_thing_state(creatng, CrSt_CreatureGoingHomeToSleep);
             return CrStRet_Modified;
         }


### PR DESCRIPTION
Units would take one to few workers in cases where there were no workshop items available to produce. Now this is correct.

The code I fixed said the difference was to make sure crates could still be created in a full workshop, but I see no issues there.