### PR TITLE
Units walk around single-slab workshop too

### DIFF
--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -259,7 +259,7 @@ unsigned char field_67;
         long long_A2x;
   } idle;
   struct {
-    unsigned char byte_9A;
+    unsigned char job_stage;
     unsigned char byte_9B;
     unsigned char byte_9C;
     unsigned char byte_9D;

--- a/src/creature_jobs.c
+++ b/src/creature_jobs.c
@@ -323,7 +323,7 @@ TbBool attempt_anger_job_mad_psycho(struct Thing *creatng)
     }
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     cctrl->spell_flags |= CSAfF_MadKilling;
-    cctrl->byte_9A = 0;
+    cctrl->job_stage = 0;
     return true;
 }
 
@@ -345,7 +345,7 @@ TbBool attempt_anger_job_persuade(struct Thing *creatng)
     if (!external_set_thing_state(creatng, CrSt_CreaturePersuade)) {
         return false;
     }
-    cctrl->byte_9A = persuade_count;
+    cctrl->job_stage = persuade_count;
     return true;
 }
 

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2310,7 +2310,7 @@ short creature_persuade(struct Thing *creatng)
     TRACE_THING(creatng);
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     struct Dungeon* dungeon = get_players_num_dungeon(creatng->owner);
-    if ((cctrl->byte_9A > 0) && (dungeon->num_active_creatrs > 1))
+    if ((cctrl->job_stage > 0) && (dungeon->num_active_creatrs > 1))
     {
         struct Thing* perstng = find_random_creature_for_persuade(creatng->owner, &creatng->mappos);
         if (setup_person_move_to_coord(creatng, &perstng->mappos, NavRtF_Default)) {

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -1307,6 +1307,8 @@ TbBool person_get_somewhere_adjacent_in_room_around_borders_f(struct Thing *thin
  */
 SubtlCodedCoords find_position_around_in_room(const struct Coord3d *pos, PlayerNumber owner, RoomKind rkind, struct Thing* thing)
 {
+    struct SlabMap* slb;// = get_slabmap_for_subtile(pos->x.stl.num, pos->y.stl.num);
+    struct Room* room;
     SubtlCodedCoords stl_num;
     long m = CREATURE_RANDOM(thing, AROUND_MAP_LENGTH);
     for (long n = 0; n < AROUND_MAP_LENGTH; n++)
@@ -1329,10 +1331,10 @@ SubtlCodedCoords find_position_around_in_room(const struct Coord3d *pos, PlayerN
                 break;
             MapSubtlCoord stl_x = stl_num_decode_x(stl_num);
             MapSubtlCoord stl_y = stl_num_decode_y(stl_num);
-            struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
+            slb = get_slabmap_for_subtile(stl_x, stl_y);
             if (slabmap_owner(slb) != owner)
                 break;
-            struct Room* room = room_get(slb->room_index);
+            room = room_get(slb->room_index);
             if (room->kind != rkind)
                 break;
             if (dist > 1)
@@ -1348,22 +1350,13 @@ SubtlCodedCoords find_position_around_in_room(const struct Coord3d *pos, PlayerN
         m = (m + 1) % AROUND_MAP_LENGTH;
     }
     // No position found - at least try to move within the same slab
-    do {
-        stl_num = get_subtile_number(pos->x.stl.num,pos->y.stl.num);
-        struct Map* mapblk = get_map_block_at_pos(stl_num);
-        if ( ((mapblk->flags & SlbAtFlg_IsRoom) != 0) && ((mapblk->flags & SlbAtFlg_Blocking) != 0) )
-            break;
-        MapSubtlCoord stl_x = stl_num_decode_x(stl_num);
-        MapSubtlCoord stl_y = stl_num_decode_y(stl_num);
-        struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
-        if (slabmap_owner(slb) != owner)
-            break;
-        struct Room* room = room_get(slb->room_index);
-        if (room->kind != rkind)
-            break;
-        return stl_num;
-    } while (0);
-    // Failed completely - cannot move
+    slb = get_slabmap_for_subtile(pos->x.stl.num, pos->y.stl.num);
+    room = room_get(slb->room_index);
+    struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
+    if (person_get_somewhere_adjacent_in_room(thing, room, &cctrl->moveto_pos))
+    {
+        return get_subtile_number(cctrl->moveto_pos.x.stl.num, cctrl->moveto_pos.y.stl.num);
+    }
     return 0;
 }
 

--- a/src/creature_states_rsrch.c
+++ b/src/creature_states_rsrch.c
@@ -86,7 +86,7 @@ short at_research_room(struct Thing *thing)
     }
     thing->continue_state = get_continue_state_for_job(Job_RESEARCH);
     cctrl->turns_at_job = 0;
-    cctrl->byte_9A = 3;
+    cctrl->job_stage = 3;
     return 1;
 }
 
@@ -277,21 +277,21 @@ short researching(struct Thing *thing)
     // Shall we do some "Standing and thinking"
     if (cctrl->turns_at_job <= 128)
     {
-      if (cctrl->byte_9A == 3)
+      if (cctrl->job_stage == 3)
       {
           // Do some random thinking
           if ((cctrl->turns_at_job % 16) == 0)
           {
               long i = CREATURE_RANDOM(thing, LbFPMath_PI) - LbFPMath_PI / 2;
               cctrl->long_9B = ((long)thing->move_angle_xy + i) & LbFPMath_AngleMask;
-              cctrl->byte_9A = 4;
+              cctrl->job_stage = 4;
           }
       } else
       {
           // Look at different direction while thinking
           if (creature_turn_to_face_angle(thing, cctrl->long_9B) < LbFPMath_PI/18)
           {
-              cctrl->byte_9A = 3;
+              cctrl->job_stage = 3;
           }
       }
       return 1;
@@ -305,7 +305,7 @@ short researching(struct Thing *thing)
     }
     thing->continue_state = get_continue_state_for_job(Job_RESEARCH);
     cctrl->turns_at_job = 0;
-    cctrl->byte_9A = 3;
+    cctrl->job_stage = 3;
     if (cctrl->explevel < 3)
     {
         create_effect(&thing->mappos, TngEff_RoomSparkeSmall, thing->owner);

--- a/src/creature_states_scavn.c
+++ b/src/creature_states_scavn.c
@@ -170,10 +170,10 @@ short creature_scavenged_disappear(struct Thing *thing)
 {
     struct Coord3d pos;
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-    cctrl->byte_9A--;
-    if (cctrl->byte_9A > 0)
+    cctrl->job_stage--;
+    if (cctrl->job_stage > 0)
     {
-      if ((cctrl->byte_9A == 7) && (cctrl->byte_9B < PLAYERS_COUNT))
+      if ((cctrl->job_stage == 7) && (cctrl->byte_9B < PLAYERS_COUNT))
       {
           //TODO EFFECTS Verify what is wrong here - we want either effect or effect element
           create_effect(&thing->mappos, get_scavenge_effect_element(cctrl->byte_9B), thing->owner);
@@ -373,7 +373,7 @@ long turn_creature_to_scavenger(struct Thing *scavtng, struct Thing *calltng)
     }
     {
         struct CreatureControl* cctrl = creature_control_get_from_thing(scavtng);
-        cctrl->byte_9A = 8;
+        cctrl->job_stage = 8;
         cctrl->byte_9B = calltng->owner;
         cctrl->byte_9D = pos.x.stl.num;
         cctrl->byte_9E = pos.y.stl.num;

--- a/src/creature_states_wrshp.c
+++ b/src/creature_states_wrshp.c
@@ -129,7 +129,7 @@ struct Thing *get_other_creature_manufacturing_on_subtile(PlayerNumber plyr_idx,
         if (thing_is_creature(thing) && (thing->active_state == CrSt_Manufacturing) && (thing->index != othertng->index))
         {
             struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-            if ((cctrl->byte_9A > 1) && (thing->owner == plyr_idx)) {
+            if ((cctrl->job_stage > 1) && (thing->owner == plyr_idx)) {
                 return thing;
             }
         }
@@ -187,7 +187,7 @@ TbBool setup_move_to_new_workshop_position(struct Thing *thing, struct Room *roo
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     if ( a3 )
         cctrl->byte_9E = 50;
-    cctrl->byte_9A = 1;
+    cctrl->job_stage = 1;
     SubtlCodedCoords stl_num = find_position_around_in_room(&thing->mappos, thing->owner, room->kind, thing);
     if (stl_num <= 0)
     {
@@ -276,8 +276,8 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
     long mvret;
     MapSlabCoord slb_x;
     MapSlabCoord slb_y;
-    SYNCDBG(19,"Work in %s, the %s in state %d",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->byte_9A);
-    switch (cctrl->byte_9A)
+    SYNCDBG(19,"Work in %s, the %s in state %d",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->job_stage);
+    switch (cctrl->job_stage)
     {
     case 1:
         cctrl->byte_9E--;
@@ -291,7 +291,7 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         if (mvret != 1)
         {
             if (mvret == -1) {
-                SYNCDBG(9,"Room %s move problem, the %s goes from %d to start state",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->byte_9A);
+                SYNCDBG(9,"Room %s move problem, the %s goes from %d to start state",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->job_stage);
                 set_start_state(creatng);
             }
             break;
@@ -302,13 +302,13 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         objtng = get_workshop_equipment_to_work_with_on_subtile(creatng->owner, slab_subtile_center(slb_x),slab_subtile_center(slb_y));
         if (!thing_is_invalid(objtng))
         {
-            SYNCDBG(19,"Got %s post, the %s goes from %d to 2",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->byte_9A);
-            cctrl->byte_9A = 2;
+            SYNCDBG(19,"Got %s post, the %s goes from %d to 2",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->job_stage);
+            cctrl->job_stage = 2;
             cctrl->byte_9E = 100;
             break;
         }
-        SYNCDBG(19,"No %s post at current pos, the %s goes from %d to search position",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->byte_9A);
-        setup_move_to_new_workshop_position(creatng, room, 0);
+        SYNCDBG(19,"No %s post at current pos, the %s goes from %d to search position",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->job_stage);
+        //setup_move_to_new_workshop_position(creatng, room, 0);
         break;
     case 2:
     {
@@ -320,11 +320,11 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
             cctrl->byte_9C = slab_subtile_center(slb_x);
             cctrl->byte_9D = slab_subtile_center(slb_y);
             setup_workshop_move(creatng, stl_num);
-            cctrl->byte_9A = 3;
+            cctrl->job_stage = 3;
             break;
         }
-        SYNCDBG(9,"No free adjacent %s post, the %s goes from %d to search position",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->byte_9A);
         setup_move_to_new_workshop_position(creatng, room, 1);
+        SYNCDBG(9,"No free adjacent %s post, the %s goes from %d to search position",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->job_stage);
         break;
     }
     case 3:
@@ -333,7 +333,7 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         if (mvret != 1)
         {
             if (mvret == -1) {
-                SYNCDBG(9,"Room %s move problem, the %s goes from %d to start state",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->byte_9A);
+                SYNCDBG(9,"Room %s move problem, the %s goes from %d to start state",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->job_stage);
                 set_start_state(creatng);
             }
             break;
@@ -341,11 +341,11 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         struct Thing *mnfc_creatng;
         mnfc_creatng = get_other_creature_manufacturing_on_subtile(creatng->owner, creatng->mappos.x.stl.num, creatng->mappos.y.stl.num, creatng);
         if (thing_is_invalid(mnfc_creatng)) {
-            cctrl->byte_9A = 4;
+            cctrl->job_stage = 4;
             break;
         }
         // Position used by another manufacturer
-        SYNCDBG(9,"The %s post already in use, the %s goes from %d to search position",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->byte_9A);
+        SYNCDBG(9,"The %s post already in use, the %s goes from %d to search position",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->job_stage);
         setup_move_to_new_workshop_position(creatng, room, 1);
         break;
     }
@@ -356,7 +356,7 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         pos.y.val = subtile_coord_center(cctrl->byte_9D);
         if (creature_turn_to_face(creatng, &pos) < LbFPMath_PI/18)
         {
-            cctrl->byte_9A = 5;
+            cctrl->job_stage = 5;
             cctrl->byte_9B = 75;
         }
         break;
@@ -366,7 +366,7 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         cctrl->byte_9B--;
         if (cctrl->byte_9B <= 0)
         {
-            SYNCDBG(9,"Room %s move counter %d, the %s keeps moving in state %d",room_code_name(room->kind),(int)cctrl->byte_9B,thing_model_name(creatng),(int)cctrl->byte_9A);
+            SYNCDBG(9,"Room %s move counter %d, the %s keeps moving in state %d",room_code_name(room->kind),(int)cctrl->byte_9B,thing_model_name(creatng),(int)cctrl->job_stage);
             setup_move_to_new_workshop_position(creatng, room, 1);
         } else
         if ((cctrl->byte_9B % 8) == 0) {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2680,7 +2680,7 @@ TbBool kill_creature(struct Thing *creatng, struct Thing *killertng,
         anger_apply_anger_to_creature(killertng, crstat->annoy_win_battle, AngR_Other, 1);
     }
     if (!creature_control_invalid(cctrlgrp) && ((flags & CrDed_DiedInBattle) != 0)) {
-        cctrlgrp->byte_9A++;
+        cctrlgrp->job_stage++;
     }
     if (!dungeon_invalid(dungeon)) {
         dungeon->hates_player[killertng->owner] += game.fight_hate_kill_value;

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -667,7 +667,7 @@ long anywhere_thing_filter_is_creature_of_model_training_and_owned_by(const stru
               if (((int)thing->index != param->num1) || (param->num1 == -1))
               {
                   struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-                  if ((thing->active_state == CrSt_Training) && (cctrl->byte_9A > 1))
+                  if ((thing->active_state == CrSt_Training) && (cctrl->job_stage > 1))
                   {
                       // Return the largest value to stop sweeping
                       return LONG_MAX;


### PR DESCRIPTION
Before this PR, a unit in a workshop that is just one slab, would freeze up. Now they walk around the tile, like they would before on a room with two slabs.