### PR TITLE
Corrected a overzealous automated rename

### DIFF
--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -1160,7 +1160,7 @@ TngUpdateRet process_effect_generator(struct Thing *thing)
         struct Coord3d pos;
         set_coords_to_cylindric_shift(&pos, &thing->mappos, deviation_mag, deviation_angle, 0);
         SYNCDBG(18,"The %s creates effect %d/%d at (%d,%d,%d)",thing_model_name(thing),(int)pos.x.val,(int)pos.y.val,(int)pos.z.val);
-        struct Thing* elemtng = create_effect_element(&pos, egenstat->effect_sound, thing->owner);
+        struct Thing* elemtng = create_effect_element(&pos, egenstat->effect_element_model , thing->owner);
         TRACE_THING(elemtng);
         if (thing_is_invalid(elemtng))
             break;

--- a/src/thing_effects.h
+++ b/src/thing_effects.h
@@ -235,7 +235,7 @@ struct EffectGeneratorStats { // sizeof = 57
     long genation_delay_min;
     long genation_delay_max;
     long genation_amount;
-    long effect_sound;
+    long effect_element_model;
     unsigned char field_10;
     long field_11;
     long acc_x_min;


### PR DESCRIPTION
See commit: 9537df940fed5cb9999592ffe030730084491bb8

The auto rename had renamed two separate 'field_c' commands to the same thing. Now the naming is correct again.