### PR TITLE
Scaled minimap control input zoom the same as the minimal itself

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -884,7 +884,7 @@ long get_dungeon_control_action_inputs(void)
     long mmzoom;
     if (16/mm_units_per_px < 3)
     {
-        mmzoom = (player->minimap_zoom) / (3-16/mm_units_per_px);
+        mmzoom = (player->minimap_zoom) / scale_value_for_resolution_with_upp(2, mm_units_per_px);
     }
     else
         mmzoom = (player->minimap_zoom);


### PR DESCRIPTION
only the drawing was scaled, the inputs were forgotten.

Zooms are now the same in draw_whole_status_panel and get_dungeon_control_action_inputs

Fixes #1161 