### PR TITLE
Drag spellbooks backwards and moved all drag positions

### DIFF
--- a/src/creature_states_spdig.c
+++ b/src/creature_states_spdig.c
@@ -1504,7 +1504,7 @@ short creature_picks_up_spell_object(struct Thing *creatng)
     // Create event to inform player about the spell or special (need to be done before pickup due to ownership changes)
     update_library_object_pickup_event(creatng, picktng);
     creature_drag_object(creatng, picktng);
-    if (!setup_person_move_to_coord(creatng, &pos, NavRtF_Default))
+    if (!setup_person_move_backwards_to_coord(creatng, &pos, NavRtF_Default))
     {
         SYNCDBG(8,"Cannot move to (%d,%d)",(int)pos.x.stl.num, (int)pos.y.stl.num);
         set_start_state(creatng);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -5190,7 +5190,15 @@ TngUpdateRet update_creature(struct Thing *thing)
     {
         struct Thing* tngp = thing_get(cctrl->dragtng_idx);
         if ((tngp->state_flags & TF1_IsDragged1) != 0)
-          move_thing_in_map(tngp, &thing->mappos);
+        {
+            struct Coord3d* tngpos = &thing->mappos;
+            struct Coord3d pvpos;
+            pvpos.x.val = tngpos->x.val - (2 * thing->velocity.x.val);
+            pvpos.y.val = tngpos->y.val - (2 * thing->velocity.y.val);
+            pvpos.z.val = tngpos->z.val;
+
+            move_thing_in_map(tngp, &pvpos);
+        }
     }
     if (update_creature_levels(thing) == -1)
     {


### PR DESCRIPTION
- Stopped imps from moonwalking while dragging
- Stopped imps from teleporting books
- Made drag positions of all things to be behind the imp instead of inside the imp