### PR TITLE
Fixed work annoyance and going postal not working for workshop

### DIFF
--- a/config/creatrs/sorceror.cfg
+++ b/config/creatrs/sorceror.cfg
@@ -65,7 +65,7 @@ WinBattle = -450
 Untrained = 12000 25
 OthersLeaving = 10
 ; Annoyance caused by performing stressful jobs
-JobStress = 100
+JobStress = 0
 GoingPostal = 100
 Queue = 4
 LairEnemy = VAMPIRE
@@ -103,7 +103,7 @@ ExperienceForHitting = 12
 PrimaryJobs = RESEARCH
 SecondaryJobs =
 NotDoJobs = MANUFACTURE
-StressfulJobs = KINKY_TORTURE
+StressfulJobs =
 TrainingValue = 2
 TrainingCost = 30
 ScavengeValue = 5

--- a/config/creatrs/wizard.cfg
+++ b/config/creatrs/wizard.cfg
@@ -65,7 +65,7 @@ WinBattle = -330
 Untrained = 0 0
 OthersLeaving = 10
 ; Annoyance caused by performing stressful jobs
-JobStress = 100
+JobStress = 0
 GoingPostal = 100
 Queue = 4
 LairEnemy = NULL
@@ -103,7 +103,7 @@ ExperienceForHitting = 14
 PrimaryJobs = RESEARCH
 SecondaryJobs =
 NotDoJobs = MANUFACTURE
-StressfulJobs = KINKY_TORTURE
+StressfulJobs =
 TrainingValue = 2
 TrainingCost = 30
 ScavengeValue = 4

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -433,7 +433,7 @@ struct StateInfo states[] = {
     1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1,  CrStTyp_Idle, 1, 1, 0, 0,  0, 0, 0, 0},
   {creature_attack_rooms, NULL, NULL, move_check_attack_any_door,
     0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, CrStTyp_AngerJob, 0, 0, 0, 0, 51, 1, 0, 0},
-  {creature_freeze_prisonors, NULL, NULL, NULL,
+  {creature_freeze_prisoners, NULL, NULL, NULL,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  CrStTyp_Idle, 0, 0, 0, 0,  0, 0, 0, 1},
   {creature_explore_dungeon, NULL, NULL, NULL,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  CrStTyp_Idle, 0, 0, 0, 0,  0, 0, 0, 1},

--- a/src/creature_states_guard.c
+++ b/src/creature_states_guard.c
@@ -21,6 +21,7 @@
 
 #include "bflib_math.h"
 #include "creature_states.h"
+#include "creature_states_mood.h"
 #include "thing_list.h"
 #include "creature_control.h"
 #include "config_creature.h"
@@ -84,6 +85,7 @@ CrStateRet guarding(struct Thing *thing)
         cctrl->moveto_pos.y.val = thing->mappos.y.val;
         cctrl->moveto_pos.z.val = thing->mappos.z.val;
     }
+    process_job_stress_and_going_postal(thing);
     return CrStRet_Modified;
 }
 

--- a/src/creature_states_prisn.c
+++ b/src/creature_states_prisn.c
@@ -222,7 +222,7 @@ struct Thing *find_prisoner_for_thing(struct Thing *creatng)
     return out_creatng;
 }
 
-short creature_freeze_prisonors(struct Thing *creatng)
+short creature_freeze_prisoners(struct Thing *creatng)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     if (cctrl->instance_id != CrInst_NULL) {
@@ -252,7 +252,6 @@ short creature_freeze_prisonors(struct Thing *creatng)
         creature_move_to(creatng, &victng->mappos, cctrl->max_speed, 0, 0);
     }
     return 1;
-
 }
 
 CrStateRet process_prison_visuals(struct Thing *creatng, struct Room *room)

--- a/src/creature_states_prisn.h
+++ b/src/creature_states_prisn.h
@@ -37,7 +37,7 @@ struct Room;
 short cleanup_prison(struct Thing *thing);
 short creature_arrived_at_prison(struct Thing *thing);
 short creature_drop_body_in_prison(struct Thing *thing);
-short creature_freeze_prisonors(struct Thing *thing);
+short creature_freeze_prisoners(struct Thing *thing);
 CrStateRet creature_in_prison(struct Thing *thing);
 CrCheckRet process_prison_function(struct Thing *thing);
 /******************************************************************************/

--- a/src/creature_states_train.c
+++ b/src/creature_states_train.c
@@ -23,6 +23,7 @@
 
 #include "creature_states.h"
 #include "creature_states_combt.h"
+#include "creature_states_mood.h"
 #include "creature_instances.h"
 #include "thing_list.h"
 #include "creature_control.h"
@@ -497,6 +498,7 @@ void process_creature_in_training_room(struct Thing *thing, struct Room *room)
         cctrl->training.search_timeout = 0;
         break;
     }
+    process_job_stress_and_going_postal(thing);
     SYNCDBG(18,"End");
 }
 

--- a/src/creature_states_wrshp.c
+++ b/src/creature_states_wrshp.c
@@ -375,7 +375,7 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         }
         break;
     }
-    process_job_stress_and_going_postal(creatng);
+    process_job_stress_and_going_postal(creatng); //This is normally called at thing_navigate to handle all jobs, but since workshops have a special function, call it here too. 
     return 1;
 }
 

--- a/src/creature_states_wrshp.c
+++ b/src/creature_states_wrshp.c
@@ -21,6 +21,7 @@
 
 #include "bflib_math.h"
 #include "creature_states.h"
+#include "creature_states_mood.h"
 #include "thing_list.h"
 #include "creature_control.h"
 #include "creature_instances.h"
@@ -374,6 +375,7 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         }
         break;
     }
+    process_job_stress_and_going_postal(creatng);
     return 1;
 }
 

--- a/src/creature_states_wrshp.c
+++ b/src/creature_states_wrshp.c
@@ -375,7 +375,7 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
         }
         break;
     }
-    process_job_stress_and_going_postal(creatng); //This is normally called at thing_navigate to handle all jobs, but since workshops have a special function, call it here too. 
+    process_job_stress_and_going_postal(creatng);
     return 1;
 }
 

--- a/src/creature_states_wrshp.c
+++ b/src/creature_states_wrshp.c
@@ -308,7 +308,7 @@ long process_creature_in_workshop(struct Thing *creatng, struct Room *room)
             break;
         }
         SYNCDBG(19,"No %s post at current pos, the %s goes from %d to search position",room_code_name(room->kind),thing_model_name(creatng),(int)cctrl->job_stage);
-        //setup_move_to_new_workshop_position(creatng, room, 0);
+        setup_move_to_new_workshop_position(creatng, room, 0);
         break;
     case 2:
     {

--- a/src/thing_navigate.c
+++ b/src/thing_navigate.c
@@ -569,7 +569,7 @@ short move_to_position(struct Thing *creatng)
             SYNCDBG(8,"Couldn't move %s to place required for state %s; reset to state %s",thing_model_name(creatng),creature_state_code_name(cntstat),creatrtng_actstate_name(creatng));
             return CrStRet_ResetOk;
         }
-        // If continuing the job, check for job stress
+        // If continuing the job, check for job stress. Several - but not all - jobs use the move_to_position function.
         process_job_stress_and_going_postal(creatng);
     }
     switch (state_check)


### PR DESCRIPTION
and a revert to an accidental change made in 7c81dc636e836a2865a5f398ada0ceb80f171b00

- The 'work annoyance and going postal' function is called when creatures 'move' during there job. However, workshops have a special move function that avoids calling the regular function. Now the special workshop function checks for annoyance or going postal too.