### PR TITLE
Stopped the no-turning bug forever

### DIFF
--- a/src/bflib_sprfnt.h
+++ b/src/bflib_sprfnt.h
@@ -33,6 +33,7 @@ enum TbFontDrawFlags {
   Fnt_LeftJustify   = 0x00,
   Fnt_RightJustify  = 0x01,
   Fnt_CenterPos     = 0x02,
+  Fnt_CenterLeftPos = 0x03,
   };
 
 /******************************************************************************/

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -145,7 +145,7 @@ int cmd_comp_list(PlayerNumber plyr_idx, int max_count,
     )
 {
     close_creature_cheat_menu();
-    //gui_cheat_box
+    //gui_cheat_box_2
     int i = 0;
     struct Computer2 *comp;
     comp = get_computer_player(plyr_idx);
@@ -197,7 +197,7 @@ static void cmd_comp_procs(PlayerNumber plyr_idx)
     cmd_comp_procs_data[i].label = "!";
     cmd_comp_procs_data[i].numfield_4 = 0;
 
-    gui_cheat_box = gui_create_box(my_mouse_x, 20, cmd_comp_procs_data);
+    gui_cheat_box_2 = gui_create_box(my_mouse_x, 20, cmd_comp_procs_data);
 }
 
 static const char *get_event_name(struct Computer2 *comp, int i)
@@ -215,7 +215,7 @@ static void cmd_comp_events(PlayerNumber plyr_idx)
         &get_event_name, &get_event_flags, NULL);
     cmd_comp_events_data[0].active_cb = NULL;
 
-    gui_cheat_box = gui_create_box(my_mouse_x, 20, cmd_comp_events_data);
+    gui_cheat_box_2 = gui_create_box(my_mouse_x, 20, cmd_comp_events_data);
 }
 
 
@@ -249,7 +249,7 @@ static void cmd_comp_checks(PlayerNumber plyr_idx)
         &get_check_name, &get_check_flags, &cmd_comp_checks_click);
     cmd_comp_checks_data[0].active_cb = NULL;
 
-    gui_cheat_box = gui_create_box(my_mouse_x, 20, cmd_comp_checks_data);
+    gui_cheat_box_2 = gui_create_box(my_mouse_x, 20, cmd_comp_checks_data);
 }
 
 static char *cmd_strtok(char *tail)

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -980,7 +980,7 @@ void process_pointer_graphic(void)
         break;
     case PVT_CreatureContrl:
     case PVT_CreaturePasngr:
-        if ( ((game.numfield_D & GNFldD_CreaturePasngr) != 0) || (gui_box != NULL) || (gui_cheat_box != NULL) )
+        if ( ((game.numfield_D & GNFldD_CreaturePasngr) != 0) || (cheat_menu_is_active()) )
           set_pointer_graphic(MousePG_Arrow);
         else
           set_pointer_graphic(MousePG_Invisible);

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -591,6 +591,19 @@ void redraw_creature_view(void)
     gui_draw_all_boxes();
     draw_tooltip();
     draw_creature_view_icons(thing);
+    if (!gui_box_is_not_valid(gui_cheat_box_3))
+    {
+        struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
+        if (!creature_control_invalid(cctrl))
+        {
+            struct GuiBoxOption* guop = gui_cheat_box_3->optn_list;
+            while (guop->label[0] != '!')
+            {
+              guop->active = (cctrl->active_instance_id == guop->cb_param1);
+              guop++;
+            }
+        }
+    }
 }
 
 void smooth_screen_area(unsigned char *scrbuf, long x, long y, long w, long h, long scanln)

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -145,6 +145,14 @@ static void draw_creature_view_icons(struct Thing* creatng)
         }
         draw_gui_panel_sprite_left(x, y, ps_units_per_px, spr_idx);
     }
+    else
+    {
+        if (!creature_instance_is_available(creatng, cctrl->active_instance_id))
+        {
+            x = MyScreenWidth - (scale_value_by_horizontal_resolution(148) / 4);
+            draw_gui_panel_sprite_left(x, y, ps_units_per_px, instance_button_init[cctrl->active_instance_id].symbol_spridx);
+        }
+    }
 }
 
 void setup_engine_window(long x, long y, long width, long height)

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -2144,10 +2144,14 @@ void get_creature_control_nonaction_inputs(void)
   pckt->pos_y = 127;
   if ((player->allocflags & PlaF_Unknown8) != 0)
     return;
+TbBool lock_z = point_is_over_gui_box(x, y);
 if (((MyScreenWidth >> 1) != GetMouseX()) || (GetMouseY() != y))
   {
-    LbMouseSetPositionInitial((MyScreenWidth/pixel_size) >> 1, y/pixel_size); // use LbMouseSetPositionInitial because we don't want to keep moving the host cursor
+      if (!lock_z)
+        LbMouseSetPositionInitial((MyScreenWidth/pixel_size) >> 1, y/pixel_size); // use LbMouseSetPositionInitial because we don't want to keep moving the host cursor
   }
+  if (!lock_z)
+  {
     if (settings.first_person_move_invert)
     pckt->pos_y = 255 * ((long)MyScreenHeight - y) / MyScreenHeight;
     else
@@ -2174,7 +2178,7 @@ if (((MyScreenWidth >> 1) != GetMouseX()) || (GetMouseY() != y))
     pckt->pos_x = map_subtiles_x;
     if (pckt->pos_y > map_subtiles_y)
     pckt->pos_y = map_subtiles_y;
-
+  }
     // Now do user actions
     if (thing_is_invalid(thing))
     return;

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -901,6 +901,11 @@ long get_dungeon_control_action_inputs(void)
     }
     if (is_key_pressed(KC_NUMPADENTER,KMod_NONE))
     {
+        if (close_instance_cheat_menu())
+        {
+            clear_key_pressed(KC_NUMPADENTER);
+        }
+        else
         if (toggle_main_cheat_menu())
         {
             clear_key_pressed(KC_NUMPADENTER);
@@ -909,6 +914,11 @@ long get_dungeon_control_action_inputs(void)
     // also use the main keyboard enter key (while holding shift) for cheat menu
     if (is_key_pressed(KC_RETURN,KMod_SHIFT))
         {
+            if (close_instance_cheat_menu())
+            {
+                clear_key_pressed(KC_RETURN);
+            }
+        else
             if (toggle_main_cheat_menu())
             {
                 clear_key_pressed(KC_RETURN);

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -905,7 +905,6 @@ long get_dungeon_control_action_inputs(void)
         {
             clear_key_pressed(KC_NUMPADENTER);
         }
-        set_players_packet_action(player, PckA_ToggleCheatMenuStatus, ( cheat_menu_is_active() ), 0, 0, 0);
     }
     // also use the main keyboard enter key (while holding shift) for cheat menu
     if (is_key_pressed(KC_RETURN,KMod_SHIFT))
@@ -914,7 +913,6 @@ long get_dungeon_control_action_inputs(void)
             {
                 clear_key_pressed(KC_RETURN);
             }
-            set_players_packet_action(player, PckA_ToggleCheatMenuStatus, ( cheat_menu_is_active() ), 0, 0, 0);
         }
     if (is_key_pressed(KC_F12,KMod_DONTCARE))
     {
@@ -923,7 +921,6 @@ long get_dungeon_control_action_inputs(void)
         {
             clear_key_pressed(KC_F12);
         }
-        set_players_packet_action(player, PckA_ToggleCheatMenuStatus, ( cheat_menu_is_active() ), 0, 0, 0);
     }
     if (player->view_mode == PVM_IsometricView)
     {
@@ -1167,20 +1164,17 @@ short get_creature_control_action_inputs(void)
         {
             clear_key_pressed(KC_NUMPADENTER);
         }
-        set_players_packet_action(player, PckA_ToggleCheatMenuStatus, ( cheat_menu_is_active() ), 0, 0, 0);
     }
     // also use the main keyboard enter key (while holding shift) for cheat menu
     if (is_key_pressed(KC_RETURN,KMod_SHIFT))
     {
         toggle_instance_cheat_menu();
         clear_key_pressed(KC_RETURN);
-        set_players_packet_action(player, PckA_ToggleCheatMenuStatus, ( cheat_menu_is_active() ), 0, 0, 0);
     }
     if (is_key_pressed(KC_F12,KMod_DONTCARE))
     {
         toggle_creature_cheat_menu();
         clear_key_pressed(KC_F12);
-        set_players_packet_action(player, PckA_ToggleCheatMenuStatus, ( cheat_menu_is_active() ), 0, 0, 0);
     }
 
     if (player->controlled_thing_idx != 0)
@@ -2150,68 +2144,61 @@ void get_creature_control_nonaction_inputs(void)
   pckt->pos_y = 127;
   if ((player->allocflags & PlaF_Unknown8) != 0)
     return;
-struct PlayerInfoAdd* playeradd = get_my_playeradd();
 if (((MyScreenWidth >> 1) != GetMouseX()) || (GetMouseY() != y))
   {
-      if (playeradd->cheat_menu_active == false)
-      {
-          LbMouseSetPositionInitial((MyScreenWidth/pixel_size) >> 1, y/pixel_size); // use LbMouseSetPositionInitial because we don't want to keep moving the host cursor
-      }
+    LbMouseSetPositionInitial((MyScreenWidth/pixel_size) >> 1, y/pixel_size); // use LbMouseSetPositionInitial because we don't want to keep moving the host cursor
   }
-  // Set pos_x and pos_y
-  if (playeradd->cheat_menu_active == false)
-  {
-      if (settings.first_person_move_invert)
-        pckt->pos_y = 255 * ((long)MyScreenHeight - y) / MyScreenHeight;
-      else
-        pckt->pos_y = 255 * y / MyScreenHeight;
-      pckt->pos_x = 255 * x / MyScreenWidth;
-      // Update the position based on current settings
-      long i = settings.first_person_move_sensitivity + 1;
-      x = pckt->pos_x - 127;
-      y = pckt->pos_y - 127;
-      if (i < 6)
-      {
-          k = 5 - settings.first_person_move_sensitivity;
-          pckt->pos_x = x/k + 127;
-          pckt->pos_y = y/k + 127;
-      } else
-      if (i > 6)
-      {
-          k = settings.first_person_move_sensitivity - 5;
-          pckt->pos_x = k*x + 127;
-          pckt->pos_y = k*y + 127;
-      }
-      // Bound posx and pos_y
-      if (pckt->pos_x > map_subtiles_x)
-        pckt->pos_x = map_subtiles_x;
-      if (pckt->pos_y > map_subtiles_y)
-        pckt->pos_y = map_subtiles_y;
-  }
-      // Now do user actions
-      if (thing_is_invalid(thing))
-        return;
-      if (thing->class_id == TCls_Creature)
-      {
-          if ( left_button_clicked )
-          {
-              left_button_clicked = 0;
-              left_button_released = 0;
-          }
-          if ( right_button_clicked )
-          {
-              right_button_clicked = 0;
-              right_button_released = 0;
-          }
-          if ( is_game_key_pressed(Gkey_MoveLeft, NULL, true) || is_key_pressed(KC_LEFT,KMod_DONTCARE) )
-              set_packet_control(pckt, PCtr_MoveLeft);
-          if ( is_game_key_pressed(Gkey_MoveRight, NULL, true) || is_key_pressed(KC_RIGHT,KMod_DONTCARE) )
-              set_packet_control(pckt, PCtr_MoveRight);
-          if ( is_game_key_pressed(Gkey_MoveUp, NULL, true) || is_key_pressed(KC_UP,KMod_DONTCARE) )
-              set_packet_control(pckt, PCtr_MoveUp);
-          if ( is_game_key_pressed(Gkey_MoveDown, NULL, true) || is_key_pressed(KC_DOWN,KMod_DONTCARE) )
-              set_packet_control(pckt, PCtr_MoveDown);
-      }
+    if (settings.first_person_move_invert)
+    pckt->pos_y = 255 * ((long)MyScreenHeight - y) / MyScreenHeight;
+    else
+    pckt->pos_y = 255 * y / MyScreenHeight;
+    pckt->pos_x = 255 * x / MyScreenWidth;
+    // Update the position based on current settings
+    long i = settings.first_person_move_sensitivity + 1;
+    x = pckt->pos_x - 127;
+    y = pckt->pos_y - 127;
+    if (i < 6)
+    {
+        k = 5 - settings.first_person_move_sensitivity;
+        pckt->pos_x = x/k + 127;
+        pckt->pos_y = y/k + 127;
+    } else
+    if (i > 6)
+    {
+        k = settings.first_person_move_sensitivity - 5;
+        pckt->pos_x = k*x + 127;
+        pckt->pos_y = k*y + 127;
+    }
+    // Bound posx and pos_y
+    if (pckt->pos_x > map_subtiles_x)
+    pckt->pos_x = map_subtiles_x;
+    if (pckt->pos_y > map_subtiles_y)
+    pckt->pos_y = map_subtiles_y;
+
+    // Now do user actions
+    if (thing_is_invalid(thing))
+    return;
+    if (thing->class_id == TCls_Creature)
+    {
+        if (left_button_clicked)
+        {
+            left_button_clicked = 0;
+            left_button_released = 0;
+        }
+        if (right_button_clicked)
+        {
+            right_button_clicked = 0;
+            right_button_released = 0;
+        }
+        if (is_game_key_pressed(Gkey_MoveLeft, NULL, true) || is_key_pressed(KC_LEFT, KMod_DONTCARE))
+            set_packet_control(pckt, PCtr_MoveLeft);
+        if (is_game_key_pressed(Gkey_MoveRight, NULL, true) || is_key_pressed(KC_RIGHT, KMod_DONTCARE))
+            set_packet_control(pckt, PCtr_MoveRight);
+        if (is_game_key_pressed(Gkey_MoveUp, NULL, true) || is_key_pressed(KC_UP, KMod_DONTCARE))
+            set_packet_control(pckt, PCtr_MoveUp);
+        if (is_game_key_pressed(Gkey_MoveDown, NULL, true) || is_key_pressed(KC_DOWN, KMod_DONTCARE))
+            set_packet_control(pckt, PCtr_MoveDown);
+    }
 }
 
 static void speech_pickup_of_gui_job(int job_idx)

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -2144,14 +2144,10 @@ void get_creature_control_nonaction_inputs(void)
   pckt->pos_y = 127;
   if ((player->allocflags & PlaF_Unknown8) != 0)
     return;
-TbBool lock_z = point_is_over_gui_box(x, y);
 if (((MyScreenWidth >> 1) != GetMouseX()) || (GetMouseY() != y))
   {
-      if (!lock_z)
-        LbMouseSetPositionInitial((MyScreenWidth/pixel_size) >> 1, y/pixel_size); // use LbMouseSetPositionInitial because we don't want to keep moving the host cursor
+    LbMouseSetPositionInitial((MyScreenWidth/pixel_size) >> 1, y/pixel_size); // use LbMouseSetPositionInitial because we don't want to keep moving the host cursor
   }
-  if (!lock_z)
-  {
     if (settings.first_person_move_invert)
     pckt->pos_y = 255 * ((long)MyScreenHeight - y) / MyScreenHeight;
     else
@@ -2178,7 +2174,7 @@ if (((MyScreenWidth >> 1) != GetMouseX()) || (GetMouseY() != y))
     pckt->pos_x = map_subtiles_x;
     if (pckt->pos_y > map_subtiles_y)
     pckt->pos_y = map_subtiles_y;
-  }
+
     // Now do user actions
     if (thing_is_invalid(thing))
     return;

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -2335,10 +2335,7 @@ short get_inputs(void)
         return false;
     }
     SYNCDBG(5,"Starting");
-    if (gui_process_inputs())
-    {
-        return true;
-    }
+    gui_process_inputs();
     if (player->victory_state == VicS_LostLevel)
     {
         if (player->is_active != 1)

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1160,6 +1160,11 @@ short get_creature_control_action_inputs(void)
         get_gui_inputs(1);
     if (is_key_pressed(KC_NUMPADENTER,KMod_DONTCARE))
     {
+        // Note that we're using "close", not "toggle". Menu can't be opened here.
+        if (close_main_cheat_menu())
+        {
+            clear_key_pressed(KC_NUMPADENTER);
+        } else
         if (toggle_instance_cheat_menu())
         {
             clear_key_pressed(KC_NUMPADENTER);

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1173,8 +1173,16 @@ short get_creature_control_action_inputs(void)
     // also use the main keyboard enter key (while holding shift) for cheat menu
     if (is_key_pressed(KC_RETURN,KMod_SHIFT))
     {
-        toggle_instance_cheat_menu();
-        clear_key_pressed(KC_RETURN);
+        // Note that we're using "close", not "toggle". Menu can't be opened here.
+        if (close_main_cheat_menu())
+        {
+            clear_key_pressed(KC_RETURN);
+        }
+        else
+        {
+            toggle_instance_cheat_menu();
+            clear_key_pressed(KC_RETURN);
+        }
     }
     if (is_key_pressed(KC_F12,KMod_DONTCARE))
     {

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -408,6 +408,7 @@ void set_level_objective(const char *msg_text);
 void display_objectives(PlayerNumber plyr_idx,long x,long y);
 
 short toggle_main_cheat_menu(void);
+TbBool close_main_cheat_menu(void);
 short toggle_instance_cheat_menu(void);
 TbBool open_creature_cheat_menu(void);
 TbBool close_creature_cheat_menu(void);

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -410,6 +410,7 @@ void display_objectives(PlayerNumber plyr_idx,long x,long y);
 short toggle_main_cheat_menu(void);
 TbBool close_main_cheat_menu(void);
 short toggle_instance_cheat_menu(void);
+TbBool close_instance_cheat_menu(void);
 TbBool open_creature_cheat_menu(void);
 TbBool close_creature_cheat_menu(void);
 TbBool toggle_creature_cheat_menu(void);

--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -435,8 +435,6 @@ TbBool load_game(long slot_num)
       dungeon->lvstats.allow_save_score = 1;
     }
     game.loaded_swipe_idx = -1;
-    struct PlayerInfoAdd* playeradd = get_my_playeradd();
-    playeradd->cheat_menu_active = cheat_menu_is_active();
     return true;
 }
 

--- a/src/gui_boxmenu.c
+++ b/src/gui_boxmenu.c
@@ -407,6 +407,11 @@ struct GuiBox *gui_create_box(long x, long y, struct GuiBoxOption *optn_list)
 
 short gui_move_box(struct GuiBox *gbox, long x, long y, unsigned short fdflags)
 {
+    if (gbox == NULL)
+    {
+        ERRORLOG("Trying to move cheat box that does not exist");
+        return false;
+    }
   short result;
   switch (fdflags)
   {
@@ -479,8 +484,8 @@ short toggle_instance_cheat_menu(void)
     {
         if ((game.flags_font & FFlg_AlexCheat) == 0)
             return false;
-        gui_cheat_box_3 = gui_create_box(200,20,gui_instance_option_list);
-        gui_move_box(gui_cheat_box_3, mouse_x, mouse_y, Fnt_CenterLeftPos);
+       gui_cheat_box_3 = gui_create_box(200,20,gui_instance_option_list);
+       gui_move_box(gui_cheat_box_3, mouse_x, mouse_y, Fnt_CenterLeftPos);
 /*
           player->unknownbyte  |= 0x08;
           game.unknownbyte |= 0x08;

--- a/src/gui_boxmenu.c
+++ b/src/gui_boxmenu.c
@@ -424,6 +424,11 @@ short gui_move_box(struct GuiBox *gbox, long x, long y, unsigned short fdflags)
       gbox->pos_y = y - (gbox->height >> 1);
       result = true;
       break;
+  case Fnt_CenterLeftPos:
+      gbox->pos_x = x - (gbox->width >> 2);
+      gbox->pos_y = y - (gbox->height >> 2);
+      result = true;
+      break;
   default:
       result = false;
       break;
@@ -452,7 +457,7 @@ short toggle_main_cheat_menu(void)
     if ((game.flags_font & FFlg_AlexCheat) == 0)
       return false;
     gui_box = gui_create_box(mouse_x,mouse_y,gui_main_cheat_list);
-    gui_move_box(gui_box, mouse_x, mouse_y, Fnt_CenterPos);
+    gui_move_box(gui_box, mouse_x, mouse_y, Fnt_CenterLeftPos);
   } else
   {
     gui_delete_box(gui_box);
@@ -467,12 +472,15 @@ short toggle_main_cheat_menu(void)
  */
 short toggle_instance_cheat_menu(void)
 {
+    long mouse_x = GetMouseX();
+    long mouse_y = GetMouseY();
     // Toggle cheat menu
     if ((gui_box==NULL) || (gui_box_is_not_valid(gui_box)))
     {
         if ((game.flags_font & FFlg_AlexCheat) == 0)
             return false;
         gui_box = gui_create_box(200,20,gui_instance_option_list);
+        gui_move_box(gui_box, mouse_x, mouse_y, Fnt_CenterLeftPos);
 /*
           player->unknownbyte  |= 0x08;
           game.unknownbyte |= 0x08;
@@ -495,11 +503,14 @@ short toggle_instance_cheat_menu(void)
  */
 TbBool open_creature_cheat_menu(void)
 {
+  long mouse_x = GetMouseX();
+  long mouse_y = GetMouseY();
   if ((game.flags_font & FFlg_AlexCheat) == 0)
     return false;
   if (!gui_box_is_not_valid(gui_cheat_box))
     return false;
   gui_cheat_box = gui_create_box(150,20,gui_creature_cheat_option_list);
+  gui_move_box(gui_cheat_box, mouse_x, mouse_y, Fnt_CenterLeftPos);
   return (!gui_box_is_not_valid(gui_cheat_box));
 }
 

--- a/src/gui_boxmenu.c
+++ b/src/gui_boxmenu.c
@@ -485,6 +485,19 @@ short toggle_main_cheat_menu(void)
   return true;
 }
 
+
+/**
+ * Closes cheat menu.
+ * Returns true if the menu was closed.
+ */
+TbBool close_instance_cheat_menu(void)
+{
+    if (gui_box_is_not_valid(gui_cheat_box_3))
+        return false;
+    gui_delete_box(gui_cheat_box_3);
+    gui_cheat_box_3 = NULL;
+    return true;
+}
 /**
  * Toggles cheat menu. It should not allow cheats in Network mode.
  * @return Gives true if the menu was toggled, false if cheat is not allowed.

--- a/src/gui_boxmenu.c
+++ b/src/gui_boxmenu.c
@@ -451,6 +451,19 @@ short gui_move_box(struct GuiBox *gbox, long x, long y, unsigned short fdflags)
 }
 
 /**
+ * Closes cheat menu.
+ * Returns true if the menu was closed.
+ */
+TbBool close_main_cheat_menu(void)
+{
+    if (gui_box_is_not_valid(gui_cheat_box_1))
+        return false;
+    gui_delete_box(gui_cheat_box_1);
+    gui_cheat_box_1 = NULL;
+    return true;
+}
+
+/**
  * Toggles cheat menu. It should not allow cheats in Network mode.
  * @return Gives true if the menu was toggled, false if cheat is not allowed.
  */
@@ -480,12 +493,19 @@ short toggle_instance_cheat_menu(void)
 {
     long mouse_x = GetMouseX();
     long mouse_y = GetMouseY();
-    if ((gui_cheat_box_3==NULL) || (gui_box_is_not_valid(gui_cheat_box_3)))
+    if (gui_box_is_not_valid(gui_cheat_box_3))
     {
         if ((game.flags_font & FFlg_AlexCheat) == 0)
             return false;
        gui_cheat_box_3 = gui_create_box(200,20,gui_instance_option_list);
-       gui_move_box(gui_cheat_box_3, mouse_x, mouse_y, Fnt_CenterLeftPos);
+       if (gui_cheat_box_3 == NULL)
+       {
+           return false;
+       }
+       else
+       {
+           gui_move_box(gui_cheat_box_3, mouse_x, mouse_y, Fnt_CenterLeftPos);
+       }
 /*
           player->unknownbyte  |= 0x08;
           game.unknownbyte |= 0x08;

--- a/src/gui_boxmenu.c
+++ b/src/gui_boxmenu.c
@@ -149,8 +149,9 @@ struct GuiBoxOption gui_instance_option_list[] = {
 };
 
 // Boxes used for service/cheat menu
-struct GuiBox *gui_box=NULL;
-struct GuiBox *gui_cheat_box=NULL;
+struct GuiBox *gui_cheat_box_1=NULL;
+struct GuiBox *gui_cheat_box_2=NULL;
+struct GuiBox *gui_cheat_box_3=NULL;
 
 struct GuiBox *first_box=NULL;
 struct GuiBox *last_box=NULL;
@@ -452,16 +453,16 @@ short toggle_main_cheat_menu(void)
 {
   long mouse_x = GetMouseX();
   long mouse_y = GetMouseY();
-  if ((gui_box==NULL) || (gui_box_is_not_valid(gui_box)))
+  if ((gui_cheat_box_1==NULL) || (gui_box_is_not_valid(gui_cheat_box_1)))
   {
     if ((game.flags_font & FFlg_AlexCheat) == 0)
       return false;
-    gui_box = gui_create_box(mouse_x,mouse_y,gui_main_cheat_list);
-    gui_move_box(gui_box, mouse_x, mouse_y, Fnt_CenterLeftPos);
+    gui_cheat_box_1 = gui_create_box(mouse_x,mouse_y,gui_main_cheat_list);
+    gui_move_box(gui_cheat_box_1, mouse_x, mouse_y, Fnt_CenterLeftPos);
   } else
   {
-    gui_delete_box(gui_box);
-    gui_box=NULL;
+    gui_delete_box(gui_cheat_box_1);
+    gui_cheat_box_1=NULL;
   }
   return true;
 }
@@ -474,21 +475,20 @@ short toggle_instance_cheat_menu(void)
 {
     long mouse_x = GetMouseX();
     long mouse_y = GetMouseY();
-    // Toggle cheat menu
-    if ((gui_box==NULL) || (gui_box_is_not_valid(gui_box)))
+    if ((gui_cheat_box_3==NULL) || (gui_box_is_not_valid(gui_cheat_box_3)))
     {
         if ((game.flags_font & FFlg_AlexCheat) == 0)
             return false;
-        gui_box = gui_create_box(200,20,gui_instance_option_list);
-        gui_move_box(gui_box, mouse_x, mouse_y, Fnt_CenterLeftPos);
+        gui_cheat_box_3 = gui_create_box(200,20,gui_instance_option_list);
+        gui_move_box(gui_cheat_box_3, mouse_x, mouse_y, Fnt_CenterLeftPos);
 /*
           player->unknownbyte  |= 0x08;
           game.unknownbyte |= 0x08;
 */
     } else
     {
-        gui_delete_box(gui_box);
-        gui_box=NULL;
+        gui_delete_box(gui_cheat_box_3);
+        gui_cheat_box_3=NULL;
 /*
           player->unknownbyte &= 0xF7;
           game.unknownbyte &= 0xF7;
@@ -507,11 +507,11 @@ TbBool open_creature_cheat_menu(void)
   long mouse_y = GetMouseY();
   if ((game.flags_font & FFlg_AlexCheat) == 0)
     return false;
-  if (!gui_box_is_not_valid(gui_cheat_box))
+  if (!gui_box_is_not_valid(gui_cheat_box_2))
     return false;
-  gui_cheat_box = gui_create_box(150,20,gui_creature_cheat_option_list);
-  gui_move_box(gui_cheat_box, mouse_x, mouse_y, Fnt_CenterLeftPos);
-  return (!gui_box_is_not_valid(gui_cheat_box));
+  gui_cheat_box_2 = gui_create_box(150,20,gui_creature_cheat_option_list);
+  gui_move_box(gui_cheat_box_2, mouse_x, mouse_y, Fnt_CenterLeftPos);
+  return (!gui_box_is_not_valid(gui_cheat_box_2));
 }
 
 /**
@@ -520,10 +520,10 @@ TbBool open_creature_cheat_menu(void)
  */
 TbBool close_creature_cheat_menu(void)
 {
-  if (gui_box_is_not_valid(gui_cheat_box))
+  if (gui_box_is_not_valid(gui_cheat_box_2))
     return false;
-  gui_delete_box(gui_cheat_box);
-  gui_cheat_box = NULL;
+  gui_delete_box(gui_cheat_box_2);
+  gui_cheat_box_2 = NULL;
   return true;
 }
 
@@ -534,7 +534,7 @@ TbBool close_creature_cheat_menu(void)
 TbBool toggle_creature_cheat_menu(void)
 {
   // Cheat sub-menus
-  if (gui_box_is_not_valid(gui_cheat_box))
+  if (gui_box_is_not_valid(gui_cheat_box_2))
   {
     return open_creature_cheat_menu();
   } else
@@ -878,16 +878,23 @@ long gfa_single_player_mode(struct GuiBox* gbox, struct GuiBoxOption* goptn, lon
 
 TbBool cheat_menu_is_active()
 {
-    if (!gui_box_is_not_valid(gui_box))
+    if (!gui_box_is_not_valid(gui_cheat_box_1))
     {
-        if ((gui_box->flags & GBoxF_InList) != 0)
+        if ((gui_cheat_box_1->flags & GBoxF_InList) != 0)
         {
             return true;
         }
     }
-    if (!gui_box_is_not_valid(gui_cheat_box))
+    if (!gui_box_is_not_valid(gui_cheat_box_2))
     {
-        if ((gui_cheat_box->flags & GBoxF_InList) != 0)
+        if ((gui_cheat_box_2->flags & GBoxF_InList) != 0)
+        {
+            return true;
+        }
+    }
+    if (!gui_box_is_not_valid(gui_cheat_box_3))
+    {
+        if ((gui_cheat_box_3->flags & GBoxF_InList) != 0)
         {
             return true;
         }

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -245,8 +245,9 @@ DLLIMPORT unsigned char *_DK_lightning_palette;
 // Variables inside the main module
 extern TbClockMSec last_loop_time;
 extern short default_loc_player;
-extern struct GuiBox *gui_box;
-extern struct GuiBox *gui_cheat_box;
+extern struct GuiBox *gui_cheat_box_1;
+extern struct GuiBox *gui_cheat_box_2;
+extern struct GuiBox *gui_cheat_box_3;
 extern int test_variable;
 extern struct StartupParameters start_params;
 

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -315,8 +315,6 @@ void startup_network_game(CoroutineLoop *context, TbBool local)
     setup_count_players(); // It is reset by init_level
     int args[COROUTINE_ARGS] = {ShouldAssignCpuKeepers, 0};
     coroutine_add_args(context, &startup_network_game_tail, args);
-    struct PlayerInfoAdd* playeradd = get_my_playeradd();
-    playeradd->cheat_menu_active = cheat_menu_is_active();
 }
 
 static CoroutineLoopState startup_network_game_tail(CoroutineLoop *context)

--- a/src/packets.c
+++ b/src/packets.c
@@ -963,11 +963,6 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         playeradd->roomspace_no_default = true;
         return false;
     }
-    case PckA_ToggleCheatMenuStatus:
-    {
-        playeradd->cheat_menu_active = (TbBool)pckt->actn_par1;
-        return false;
-    }
     default:
       return process_players_global_cheats_packet_action(plyr_idx, pckt);
   }
@@ -1187,41 +1182,37 @@ void process_players_creature_control_packet_control(long idx)
             }
         }
     }
-    struct PlayerInfoAdd* playeradd = get_playeradd(idx);
-    if (!playeradd->cheat_menu_active)
+    struct CreatureStats* crstat = creature_stats_get_from_thing(cctng);
+    i = pckt->pos_y;
+    if (i < 5)
+        i = 5;
+    else
+    if (i > 250)
+        i = 250;
+    long k = i - 127;
+    long angle = (pckt->pos_x - 127) / player->field_14;
+    if (angle != 0)
     {
-        struct CreatureStats* crstat = creature_stats_get_from_thing(cctng);
-        i = pckt->pos_y;
-        if (i < 5)
-          i = 5;
+        if (angle < -32)
+            angle = -32;
         else
-        if (i > 250)
-          i = 250;
-        long k = i - 127;
-        long angle = (pckt->pos_x - 127) / player->field_14;
-        if (angle != 0)
-        {
-          if (angle < -32)
-              angle = -32;
-          else
-          if (angle > 32)
-              angle = 32;
-          ccctrl->field_6C += 56 * angle / 32;
-        }
-        long angle_limit = crstat->max_angle_change;
-        if (angle_limit < 1)
-            angle_limit = 1;
-        angle = ccctrl->field_6C;
-        if (angle < -angle_limit)
-            angle = -angle_limit;
-        else
-        if (angle > angle_limit)
-            angle = angle_limit;
-        cctng->move_angle_xy = (cctng->move_angle_xy + angle) & LbFPMath_AngleMask;
-        cctng->move_angle_z = (227 * k / 127) & LbFPMath_AngleMask;
-        ccctrl->field_CC = 170 * angle / angle_limit;
-        ccctrl->field_6C = 4 * angle / 8;
+        if (angle > 32)
+            angle = 32;
+        ccctrl->field_6C += 56 * angle / 32;
     }
+    long angle_limit = crstat->max_angle_change;
+    if (angle_limit < 1)
+        angle_limit = 1;
+    angle = ccctrl->field_6C;
+    if (angle < -angle_limit)
+        angle = -angle_limit;
+    else
+    if (angle > angle_limit)
+        angle = angle_limit;
+    cctng->move_angle_xy = (cctng->move_angle_xy + angle) & LbFPMath_AngleMask;
+    cctng->move_angle_z = (227 * k / 127) & LbFPMath_AngleMask;
+    ccctrl->field_CC = 170 * angle / angle_limit;
+    ccctrl->field_6C = 4 * angle / 8;
 }
 
 void process_players_creature_control_packet_action(long plyr_idx)

--- a/src/packets.c
+++ b/src/packets.c
@@ -1160,6 +1160,12 @@ void process_players_creature_control_packet_control(long idx)
                     }
                 }
             }
+            else
+            {
+                inst_inf = creature_instance_info_get(i);
+                n = get_human_controlled_creature_target(cctng, inst_inf->field_1D);
+                set_creature_instance(cctng, i, 1, n, 0);
+            }
         }
     }
     if ((pckt->control_flags & PCtr_LBtnHeld) != 0)
@@ -1277,10 +1283,19 @@ void process_players_creature_control_packet_action(long plyr_idx)
         break;
       i = pckt->actn_par1;
       inst_inf = creature_instance_info_get(i);
-      k = (!inst_inf->instant) ? get_human_controlled_creature_target(thing, inst_inf->field_1D) : 0;
-      set_creature_instance(thing, i, 1, k, 0);
-      if ( (plyr_idx == my_player_number) && creature_instance_is_available(thing,i) ) {
-          instant_instance_selected(i);
+      if (!inst_inf->instant)
+      {
+        cctrl->active_instance_id = i;
+      } else
+      if (cctrl->instance_id == CrInst_NULL)
+      {
+          i = pckt->actn_par1;
+          inst_inf = creature_instance_info_get(i);
+          k = get_human_controlled_creature_target(thing, inst_inf->field_1D);
+          set_creature_instance(thing, i, 1, k, 0);
+          if (plyr_idx == my_player_number) {
+              instant_instance_selected(i);
+          }
       }
       break;
       case PckA_DirectCtrlDragDrop:

--- a/src/packets.h
+++ b/src/packets.h
@@ -178,7 +178,6 @@ enum TbPacketAction {
         PckA_SetRoomspaceSubtile,
         PckA_SetRoomspaceHighlight,
         PckA_SetNearestTeleport,
-        PckA_ToggleCheatMenuStatus
 };
 
 /** Packet flags for non-action player operation. */

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -257,7 +257,6 @@ struct PlayerInfoAdd {
     char swap_to_untag_mode; // 0 = no, 1 = maybe, 2= yes, -1 = disable
     unsigned char roomspace_highlight_mode;
     TbBool roomspace_no_default;
-    TbBool cheat_menu_active;
     };
 
 /******************************************************************************/


### PR DESCRIPTION
Removed all implementation related to playeradd->cheat_menu_active  and the PckA_ToggleCheatMenuStatus packet introduced to stop possessed creatures on spinning right, that caused several bugs related to not being able to turn in possession at all.

And introduced an alternate fix to the unwanted turning.