### PR TITLE
roomroles jobs

### DIFF
--- a/src/config_creature.c
+++ b/src/config_creature.c
@@ -2114,7 +2114,7 @@ CreatureJob get_jobs_enemies_may_do_in_room(RoomKind rkind)
  * @param job_flags
  * @return
  */
-RoomKind get_room_for_job(CreatureJob job_flags)
+RoomKind get_first_room_kind_for_job(CreatureJob job_flags)
 {
     struct CreatureJobConfig* jobcfg = get_config_for_job(job_flags);
     for (RoomKind rkind = 0; rkind < slab_conf.room_types_count; rkind++)

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -312,7 +312,7 @@ struct CreatureInstanceConfig *get_config_for_instance(CrInstance inst_id);
 const char *creature_instance_code_name(CrInstance inst_id);
 /******************************************************************************/
 struct CreatureJobConfig *get_config_for_job(CreatureJob job_flags);
-RoomKind get_room_for_job(CreatureJob job_flags);
+RoomKind get_first_room_kind_for_job(CreatureJob job_flags);
 RoomRole get_room_role_for_job(CreatureJob job_flags);
 EventKind get_event_for_job(CreatureJob job_flags);
 CrtrStateId get_initial_state_for_job(CreatureJob jobpref);

--- a/src/creature_jobs.c
+++ b/src/creature_jobs.c
@@ -517,13 +517,13 @@ TbBool is_correct_position_to_perform_job(const struct Thing *creatng, MapSubtlC
 {
     const struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
     const struct Room* room = subtile_room_get(stl_x, stl_y);
-    RoomKind job_rkind = get_room_for_job(new_job);
-    if (job_rkind != RoK_NONE)
+    RoomRole job_rrole = get_room_role_for_job(new_job);
+    if (job_rrole != RoRoF_None)
     {
         if (room_is_invalid(room)) {
             return false;
         }
-        if (room->kind != job_rkind) {
+        if (!room_role_matches(room->kind,job_rrole)) {
             return false;
         }
     }
@@ -561,7 +561,7 @@ TbBool creature_can_do_scavenging_for_player(const struct Thing *creatng, Player
 TbBool creature_can_freeze_prisoners_for_player(const struct Thing *creatng, PlayerNumber plyr_idx, CreatureJob new_job)
 {
     // To freeze prisoners, our prison can't be empty
-    struct Room* room = find_room_for_thing_with_used_capacity(creatng, creatng->owner, get_room_for_job(Job_FREEZE_PRISONERS), NavRtF_Default, 1);
+    struct Room* room = find_room_of_role_for_thing_with_used_capacity(creatng, creatng->owner, get_room_role_for_job(Job_FREEZE_PRISONERS), NavRtF_Default, 1);
     return creature_instance_is_available(creatng, CrInst_FREEZE) && !room_is_invalid(room);
 }
 
@@ -1046,10 +1046,10 @@ TbBool attempt_job_sleep_in_lair_near_pos(struct Thing *creatng, MapSubtlCoord s
 
 TbBool attempt_job_in_state_on_room_content_for_player(struct Thing *creatng, PlayerNumber plyr_idx, CreatureJob new_job)
 {
-    RoomKind rkind = get_room_for_job(new_job);
-    struct Room* room = find_room_for_thing_with_used_capacity(creatng, creatng->owner, rkind, NavRtF_Default, 1);
+    RoomRole rrole = get_room_role_for_job(new_job);
+    struct Room* room = find_room_of_role_for_thing_with_used_capacity(creatng, creatng->owner, rrole, NavRtF_Default, 1);
     if (room_is_invalid(room)) {
-        WARNLOG("Could not find room %s to perform job %s by %s index %d owner %d",room_code_name(rkind),creature_job_code_name(new_job),thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);
+        WARNLOG("Could not find room %s to perform job %s by %s index %d owner %d",room_role_code_name(rrole),creature_job_code_name(new_job),thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);
         return false;
     }
     internal_set_thing_state(creatng, get_initial_state_for_job(new_job));

--- a/src/creature_jobs.c
+++ b/src/creature_jobs.c
@@ -708,7 +708,7 @@ TbBool creature_can_do_job_for_player(const struct Thing *creatng, PlayerNumber 
         {
             SYNCDBG(3,"Cannot assign %s in player %d room for %s index %d owner %d; no required room built",creature_job_code_name(new_job),(int)plyr_idx,thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);
             if ((flags & JobChk_PlayMsgOnFail) != 0) {
-                output_message_room_related_from_computer_or_player_action(plyr_idx, get_room_for_job(new_job), OMsg_RoomNeeded);
+                output_message_room_related_from_computer_or_player_action(plyr_idx, get_first_room_kind_for_job(new_job), OMsg_RoomNeeded);
             }
             return false;
         }
@@ -719,7 +719,7 @@ TbBool creature_can_do_job_for_player(const struct Thing *creatng, PlayerNumber 
             {
                 SYNCDBG(3,"Cannot assign %s in player %d room for %s index %d owner %d; not enough room capacity",creature_job_code_name(new_job),(int)plyr_idx,thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);
                 if ((flags & JobChk_PlayMsgOnFail) != 0) {
-                    output_message_room_related_from_computer_or_player_action(plyr_idx, get_room_for_job(new_job), OMsg_RoomTooSmall);
+                    output_message_room_related_from_computer_or_player_action(plyr_idx, get_first_room_kind_for_job(new_job), OMsg_RoomTooSmall);
                 }
                 return false;
             }

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -3562,7 +3562,7 @@ short person_sulk_at_lair(struct Thing *creatng)
     struct Room* room = get_room_thing_is_on(creatng);
     // Usually we use creature_job_in_room_no_longer_possible() for checking rooms
     // but sulking in lair is a special case, we can't compare room id as it's not working in room
-    if (!room_still_valid_as_type_for_thing(room, RoK_LAIR, creatng))
+    if (!room_still_valid_as_type_for_thing(room, RoRoF_LairStorage, creatng))
     {
         WARNLOG("Room %s index %d is not valid %s for %s owned by player %d to work in",
             room_code_name(room->kind),(int)room->index,room_code_name(RoK_LAIR),
@@ -3670,16 +3670,16 @@ TbBool room_initially_valid_as_type_for_thing(const struct Room *room, RoomRole 
  * Returns if the room is a valid place for a thing for thing which is already working in that room.
  * Used to check if creatures are working in correct rooms.
  * @param room The work room to be checked.
- * @param rkind Room kind required for work.
+ * @param rrole Room role required for work.
  * @param thing The thing which is working in the room.
  * @return True if the room can still be used, false otherwise.
  */
-TbBool room_still_valid_as_type_for_thing(const struct Room *room, RoomKind rkind, const struct Thing *thing)
+TbBool room_still_valid_as_type_for_thing(const struct Room *room, RoomRole rrole, const struct Thing *thing)
 {
     if (!room_exists(room)) {
         return false;
     }
-    if (room->kind != rkind) {
+    if (!room_role_matches(room->kind,rrole)) {
         return false;
     }
     return ((room->owner == thing->owner) || enemies_may_work_in_room(room->kind));
@@ -3695,18 +3695,18 @@ TbBool room_still_valid_as_type_for_thing(const struct Room *room, RoomKind rkin
  */
 TbBool creature_job_in_room_no_longer_possible_f(const struct Room *room, CreatureJob jobpref, const struct Thing *thing, const char *func_name)
 {
-    RoomKind rkind = get_room_for_job(jobpref);
+    RoomRole rrole = get_room_role_for_job(jobpref);
     if (!room_exists(room))
     {
         SYNCLOG("%s: The %s owned by player %d can no longer work in %s because former work room doesn't exist",
-            func_name,thing_model_name(thing),(int)thing->owner,room_code_name(rkind));
+            func_name,thing_model_name(thing),(int)thing->owner,room_role_code_name(rrole));
         // Note that if given room doesn't exist, it do not mean this
         return true;
     }
-    if (!room_still_valid_as_type_for_thing(room, rkind, thing))
+    if (!room_still_valid_as_type_for_thing(room, rrole, thing))
     {
         WARNLOG("%s: Room %s index %d is not valid %s for %s owned by player %d to work in",
-            func_name,room_code_name(room->kind),(int)room->index,room_code_name(rkind),
+            func_name,room_code_name(room->kind),(int)room->index,room_role_code_name(rrole),
             thing_model_name(thing),(int)thing->owner);
         return true;
     }
@@ -3714,7 +3714,7 @@ TbBool creature_job_in_room_no_longer_possible_f(const struct Room *room, Creatu
     {
         // This is not an error, because room index is often changed, ie. when room is expanded or its slab sold
         SYNCDBG(2,"%s: Room %s index %d is not the %s which %s owned by player %d selected to work in",
-            func_name,room_code_name(room->kind),(int)room->index,room_code_name(rkind),
+            func_name,room_code_name(room->kind),(int)room->index,room_role_code_name(rrole),
             thing_model_name(thing),(int)thing->owner);
         return true;
     }

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -1624,7 +1624,7 @@ TbBool creature_try_going_to_lazy_sleep(struct Thing *creatng)
     if (room_is_invalid(room)) {
         return false;
     }
-    if ((room->kind != get_room_for_job(Job_TAKE_SLEEP)) || (room->owner != creatng->owner)) {
+    if ((!room_role_matches(room->kind,get_room_role_for_job(Job_TAKE_SLEEP))) || (room->owner != creatng->owner)) {
         ERRORLOG("The %s index %d has lair in invalid room",thing_model_name(creatng),(int)creatng->index);
         return false;
     }

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -3152,7 +3152,7 @@ short creature_wants_salary(struct Thing *creatng)
             struct CreatureStats* crstat = creature_stats_get_from_thing(creatng);
             anger_apply_anger_to_creature(creatng, crstat->annoy_no_salary, AngR_NotPaid, 1);
         }
-        SYNCDBG(5, "No player %d %s with used capacity found to pay %s", (int)creatng->owner, room_code_name(get_room_for_job(Job_TAKE_SALARY)), thing_model_name(creatng));
+        SYNCDBG(5, "No player %d %s with used capacity found to pay %s", (int)creatng->owner, room_role_code_name(get_room_role_for_job(Job_TAKE_SALARY)), thing_model_name(creatng));
         set_start_state(creatng);
         return 1;
     }
@@ -3655,12 +3655,12 @@ short person_sulking(struct Thing *creatng)
  * @param thing The thing which seeks for work room.
  * @return True if the room can be used, false otherwise.
  */
-TbBool room_initially_valid_as_type_for_thing(const struct Room *room, RoomKind rkind, const struct Thing *thing)
+TbBool room_initially_valid_as_type_for_thing(const struct Room *room, RoomRole rrole, const struct Thing *thing)
 {
     if (!room_exists(room)) {
         return false;
     }
-    if (room->kind != rkind) {
+    if (!room_role_matches(room->kind,rrole)) {
         return false;
     }
     return ((room->owner == thing->owner) || enemies_may_work_in_room(room->kind));

--- a/src/creature_states.h
+++ b/src/creature_states.h
@@ -349,7 +349,7 @@ void process_person_moods_and_needs(struct Thing *thing);
 TbBool restore_creature_flight_flag(struct Thing *creatng);
 TbBool attempt_to_destroy_enemy_room(struct Thing *thing, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
-TbBool room_initially_valid_as_type_for_thing(const struct Room *room, RoomKind rkind, const struct Thing *thing);
+TbBool room_initially_valid_as_type_for_thing(const struct Room *room, RoomRole rrole, const struct Thing *thing);
 TbBool room_still_valid_as_type_for_thing(const struct Room *room, RoomKind rkind, const struct Thing *thing);
 TbBool creature_job_in_room_no_longer_possible_f(const struct Room *room, CreatureJob jobpref, const struct Thing *thing, const char *func_name);
 #define creature_job_in_room_no_longer_possible(room, jobpref, thing) creature_job_in_room_no_longer_possible_f(room, jobpref, thing, __func__)

--- a/src/creature_states.h
+++ b/src/creature_states.h
@@ -350,7 +350,7 @@ TbBool restore_creature_flight_flag(struct Thing *creatng);
 TbBool attempt_to_destroy_enemy_room(struct Thing *thing, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 TbBool room_initially_valid_as_type_for_thing(const struct Room *room, RoomRole rrole, const struct Thing *thing);
-TbBool room_still_valid_as_type_for_thing(const struct Room *room, RoomKind rkind, const struct Thing *thing);
+TbBool room_still_valid_as_type_for_thing(const struct Room *room, RoomRole rrole, const struct Thing *thing);
 TbBool creature_job_in_room_no_longer_possible_f(const struct Room *room, CreatureJob jobpref, const struct Thing *thing, const char *func_name);
 #define creature_job_in_room_no_longer_possible(room, jobpref, thing) creature_job_in_room_no_longer_possible_f(room, jobpref, thing, __func__)
 TbBool creature_free_for_sleep(const struct Thing *thing,  CrtrStateId state);

--- a/src/creature_states_barck.c
+++ b/src/creature_states_barck.c
@@ -42,7 +42,7 @@ short at_barrack_room(struct Thing *creatng)
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(creatng);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_BARRACK), creatng))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_BARRACK), creatng))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",room_code_name(room->kind),(int)room->owner,thing_model_name(creatng),(int)creatng->index);
         set_start_state(creatng);

--- a/src/creature_states_barck.c
+++ b/src/creature_states_barck.c
@@ -60,7 +60,7 @@ short at_barrack_room(struct Thing *creatng)
 short barracking(struct Thing *creatng)
 {
     struct Room* room = get_room_thing_is_on(creatng);
-    if (!room_still_valid_as_type_for_thing(room, get_room_for_job(Job_BARRACK), creatng))
+    if (!room_still_valid_as_type_for_thing(room, get_room_role_for_job(Job_BARRACK), creatng))
     {
         WARNLOG("Room %s owned by player %d is bad work place for %s index %d owner %d",room_code_name(room->kind),(int)room->owner,thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);
         remove_creature_from_work_room(creatng);

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1638,12 +1638,12 @@ long guard_post_combat_move(struct Thing *thing, long cntn_crstate)
     //return _DK_guard_post_combat_move(thing, a2);
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_is_invalid(room) && (room->kind == get_room_for_job(Job_GUARD)) && (cctrl->last_work_room_id == room->index)) {
+    if (!room_is_invalid(room) && (room_role_matches(room->kind,get_room_role_for_job(Job_GUARD))) && (cctrl->last_work_room_id == room->index)) {
         return 0;
     }
     if (cctrl->last_work_room_id <= 0)
     {
-        ERRORLOG("Cannot get to %s",room_code_name(get_room_for_job(Job_GUARD)));
+        ERRORLOG("Cannot get to %s",room_role_code_name(get_room_role_for_job(Job_GUARD)));
         cctrl->job_assigned = 0;
         return 0;
     }

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1648,7 +1648,7 @@ long guard_post_combat_move(struct Thing *thing, long cntn_crstate)
         return 0;
     }
     room = room_get(cctrl->last_work_room_id);
-    if (!room_still_valid_as_type_for_thing(room, get_room_for_job(Job_GUARD), thing))
+    if (!room_still_valid_as_type_for_thing(room, get_room_role_for_job(Job_GUARD), thing))
     {
         cctrl->job_assigned = 0;
         return 0;

--- a/src/creature_states_gardn.c
+++ b/src/creature_states_gardn.c
@@ -229,14 +229,14 @@ short creature_eating_at_garden(struct Thing *creatng)
     }
     struct Room* room = INVALID_ROOM;
     room = get_room_thing_is_on(foodtng);
-    if (room_is_invalid(room) || (room->kind != get_room_for_job(Job_TAKE_FEED))) {
+    if (room_is_invalid(room) || (!room_role_matches(room->kind,get_room_role_for_job(Job_TAKE_FEED)))) {
         set_start_state(creatng);
         return 0;
     }
     if (!thing_can_be_eaten(foodtng))
     {
         WARNLOG("Tried to eat %s index %d which cannot be eaten now but is in %s",
-            thing_model_name(foodtng),(int)foodtng->index,room_code_name(get_room_for_job(Job_TAKE_FEED)));
+            thing_model_name(foodtng),(int)foodtng->index,room_role_code_name(get_room_role_for_job(Job_TAKE_FEED)));
         set_start_state(creatng);
         return 0;
     }

--- a/src/creature_states_gardn.c
+++ b/src/creature_states_gardn.c
@@ -199,7 +199,7 @@ short creature_arrived_at_garden(struct Thing *thing)
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_TAKE_FEED), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_TAKE_FEED), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",
             room_code_name(room->kind),(int)room->owner,thing_model_name(thing),(int)thing->index);

--- a/src/creature_states_guard.c
+++ b/src/creature_states_guard.c
@@ -43,7 +43,7 @@ short at_guard_post_room(struct Thing *thing)
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_GUARD), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_GUARD), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",room_code_name(room->kind),(int)room->owner,thing_model_name(thing),(int)thing->index);
         set_start_state(thing);

--- a/src/creature_states_lair.c
+++ b/src/creature_states_lair.c
@@ -243,7 +243,7 @@ CrStateRet creature_at_new_lair(struct Thing *creatng)
 {
     TRACE_THING(creatng);
     struct Room* room = get_room_thing_is_on(creatng);
-    if ( !room_still_valid_as_type_for_thing(room, get_room_for_job(Job_TAKE_SLEEP), creatng) )
+    if ( !room_still_valid_as_type_for_thing(room, get_room_role_for_job(Job_TAKE_SLEEP), creatng) )
     {
         WARNLOG("Room %s owned by player %d is bad work place for %s index %d owner %d",room_code_name(room->kind),(int)room->owner,thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);
         set_start_state(creatng);

--- a/src/creature_states_lair.c
+++ b/src/creature_states_lair.c
@@ -450,7 +450,7 @@ short creature_sleep(struct Thing *thing)
         return 0;
     }
     struct Room* room = get_room_thing_is_on(thing);
-    if (room_is_invalid(room) || (room->kind != get_room_for_job(Job_TAKE_SLEEP))
+    if (room_is_invalid(room) || (!room_role_matches(room->kind,get_room_role_for_job(Job_TAKE_SLEEP)))
         || (cctrl->lair_room_id != room->index) || (room->owner != thing->owner)) {
         set_start_state(thing);
         return 0;

--- a/src/creature_states_lair.c
+++ b/src/creature_states_lair.c
@@ -224,7 +224,7 @@ CrStateRet creature_at_changed_lair(struct Thing *creatng)
         return CrStRet_ResetFail;
     }
     struct Room* room = get_room_thing_is_on(creatng);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_TAKE_SLEEP), creatng))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_TAKE_SLEEP), creatng))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",room_code_name(room->kind),(int)room->owner,thing_model_name(creatng),(int)creatng->index);
         set_start_state(creatng);
@@ -312,7 +312,7 @@ short creature_change_lair(struct Thing *thing)
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_TAKE_SLEEP), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_TAKE_SLEEP), thing))
     {
         set_start_state(thing);
         return 0;
@@ -373,7 +373,7 @@ short at_lair_to_sleep(struct Thing *thing)
         return 0;
     }
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_TAKE_SLEEP), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_TAKE_SLEEP), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d owner %d",room_code_name(room->kind),(int)room->owner,thing_model_name(thing),(int)thing->index,(int)thing->owner);
         set_start_state(thing);

--- a/src/creature_states_pray.c
+++ b/src/creature_states_pray.c
@@ -89,7 +89,7 @@ short at_temple(struct Thing *thing)
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_TEMPLE_PRAY), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_TEMPLE_PRAY), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",room_code_name(room->kind),(int)room->owner,thing_model_name(thing),(int)thing->index);
         set_start_state(thing);

--- a/src/creature_states_pray.c
+++ b/src/creature_states_pray.c
@@ -148,7 +148,7 @@ long process_temple_cure(struct Thing *creatng)
 CrCheckRet process_temple_function(struct Thing *thing)
 {
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_still_valid_as_type_for_thing(room, get_room_for_job(Job_TEMPLE_PRAY), thing))
+    if (!room_still_valid_as_type_for_thing(room, get_room_role_for_job(Job_TEMPLE_PRAY), thing))
     {
         remove_creature_from_work_room(thing);
         set_start_state(thing);

--- a/src/creature_states_prisn.c
+++ b/src/creature_states_prisn.c
@@ -428,7 +428,7 @@ TbBool process_prison_food(struct Thing *creatng, struct Room *room)
 CrCheckRet process_prison_function(struct Thing *creatng)
 {
     struct Room* room = get_room_creature_works_in(creatng);
-    if (!room_still_valid_as_type_for_thing(room, RoK_PRISON, creatng))
+    if (!room_still_valid_as_type_for_thing(room, RoRoF_Prison, creatng))
     {
         WARNLOG("Room %s owned by player %d is bad work place for %s index %d owner %d", room_code_name(room->kind), (int)room->owner, thing_model_name(creatng), (int)creatng->index, (int)creatng->owner);
         set_start_state(creatng);

--- a/src/creature_states_prisn.c
+++ b/src/creature_states_prisn.c
@@ -98,7 +98,7 @@ short creature_arrived_at_prison(struct Thing *creatng)
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(creatng);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_CAPTIVITY), creatng))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_CAPTIVITY), creatng))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",room_code_name(room->kind),(int)room->owner,thing_model_name(creatng),(int)creatng->index);
         set_start_state(creatng);

--- a/src/creature_states_rsrch.c
+++ b/src/creature_states_rsrch.c
@@ -213,7 +213,7 @@ CrCheckRet process_research_function(struct Thing *creatng)
         return CrCkRet_Continue;
     }
     struct Room* room = get_room_creature_works_in(creatng);
-    if ( !room_still_valid_as_type_for_thing(room, get_room_for_job(Job_RESEARCH), creatng) ) {
+    if ( !room_still_valid_as_type_for_thing(room, get_room_role_for_job(Job_RESEARCH), creatng) ) {
         WARNLOG("Room %s owned by player %d is bad work place for %s index %d owner %d",
             room_code_name(room->kind), (int)room->owner, thing_model_name(creatng),(int)creatng->index,(int)creatng->owner);
         set_start_state(creatng);

--- a/src/creature_states_rsrch.c
+++ b/src/creature_states_rsrch.c
@@ -66,7 +66,7 @@ short at_research_room(struct Thing *thing)
         return 0;
     }
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_RESEARCH), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_RESEARCH), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",room_code_name(room->kind),(int)room->owner,thing_model_name(thing),(int)thing->index);
         set_start_state(thing);

--- a/src/creature_states_scavn.c
+++ b/src/creature_states_scavn.c
@@ -504,7 +504,7 @@ CrCheckRet process_scavenge_function(struct Thing *calltng)
     struct CreatureControl* callctrl = creature_control_get_from_thing(calltng);
     struct Dungeon* calldngn = get_dungeon(calltng->owner);
     struct Room* room = get_room_creature_works_in(calltng);
-    if ( !room_still_valid_as_type_for_thing(room, RoK_SCAVENGER, calltng) )
+    if ( !room_still_valid_as_type_for_thing(room, RoRoF_CrScavenge, calltng) )
     {
         WARNLOG("Room %s owned by player %d is bad work place for %s owned by played %d",room_code_name(room->kind),(int)room->owner,thing_model_name(calltng),(int)calltng->owner);
         set_start_state(calltng);

--- a/src/creature_states_scavn.c
+++ b/src/creature_states_scavn.c
@@ -63,7 +63,7 @@ TbBool creature_can_do_scavenging(const struct Thing *creatng)
 short at_scavenger_room(struct Thing *thing)
 {
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_SCAVENGE), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_SCAVENGE), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",room_code_name(room->kind),(int)room->owner,thing_model_name(thing),(int)thing->index);
         set_start_state(thing);
@@ -454,7 +454,7 @@ TbBool creature_scavenge_from_creature_pool(struct Thing *calltng)
 {
     struct Coord3d pos;
     struct Room* room = get_room_thing_is_on(calltng);
-    if (!room_initially_valid_as_type_for_thing(room, RoK_SCAVENGER, calltng)) {
+    if (!room_initially_valid_as_type_for_thing(room, RoRoF_CrScavenge, calltng)) {
         WARNLOG("Room %s owned by player %d is bad work place for %s index %d owner %d",room_code_name(room->kind),(int)room->owner,thing_model_name(calltng),(int)calltng->index,(int)calltng->owner);
         return false;
     }

--- a/src/creature_states_tortr.c
+++ b/src/creature_states_tortr.c
@@ -52,7 +52,7 @@ short at_kinky_torture_room(struct Thing *thing)
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_KINKY_TORTURE), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_KINKY_TORTURE), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s",room_code_name(room->kind),(int)room->owner,thing_model_name(thing));
         set_start_state(thing);
@@ -84,7 +84,7 @@ short at_torture_room(struct Thing *thing)
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_PAINFUL_TORTURE), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_PAINFUL_TORTURE), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s",room_code_name(room->kind),(int)room->owner,thing_model_name(thing));
         set_start_state(thing);

--- a/src/creature_states_tortr.c
+++ b/src/creature_states_tortr.c
@@ -482,7 +482,7 @@ CrCheckRet process_torture_function(struct Thing *creatng)
 {
     long i;
     struct Room* room = get_room_creature_works_in(creatng);
-    if ( !room_still_valid_as_type_for_thing(room,RoK_TORTURE,creatng) )
+    if ( !room_still_valid_as_type_for_thing(room,RoRoF_Torture,creatng) )
     {
         WARNLOG("Room %s owned by player %d is bad work place for %s owned by played %d",room_code_name(room->kind),(int)room->owner,thing_model_name(creatng),(int)creatng->owner);
         set_start_state(creatng);

--- a/src/creature_states_train.c
+++ b/src/creature_states_train.c
@@ -520,7 +520,7 @@ short at_training_room(struct Thing *thing)
         return 0;
     }
     struct Room* room = get_room_thing_is_on(thing);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_TRAIN), thing))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_TRAIN), thing))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s",room_code_name(room->kind),(int)room->owner,thing_model_name(thing));
         set_start_state(thing);

--- a/src/creature_states_wrshp.c
+++ b/src/creature_states_wrshp.c
@@ -203,7 +203,7 @@ short at_workshop_room(struct Thing *creatng)
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     cctrl->target_room_id = 0;
     struct Room* room = get_room_thing_is_on(creatng);
-    if (!room_initially_valid_as_type_for_thing(room, get_room_for_job(Job_MANUFACTURE), creatng))
+    if (!room_initially_valid_as_type_for_thing(room, get_room_role_for_job(Job_MANUFACTURE), creatng))
     {
         WARNLOG("Room %s owned by player %d is invalid for %s",room_code_name(room->kind),(int)room->owner,thing_model_name(creatng));
         set_start_state(creatng);

--- a/src/player_compchecks.c
+++ b/src/player_compchecks.c
@@ -1202,7 +1202,7 @@ long computer_check_prison_tendency(struct Computer2* comp, struct ComputerCheck
     SYNCDBG(8, "Starting");
     struct Dungeon* dungeon = comp->dungeon;
     struct PlayerInfo* player = get_player(comp->dungeon->owner);
-    RoomKind room = get_room_for_job(Job_CAPTIVITY);
+    RoomRole rrole = get_room_role_for_job(Job_CAPTIVITY);
 
     int status = check->param1;
     int min_capacity = check->param2;
@@ -1213,7 +1213,7 @@ long computer_check_prison_tendency(struct Computer2* comp, struct ComputerCheck
         SYNCDBG(8, "Prison tendency handled manually by script, aborting.");
         return CTaskRet_Unk1;
     }
-    int total_capacity = computer_get_room_kind_total_capacity(comp, room);
+    int total_capacity = computer_get_room_role_total_capacity(comp, rrole);
     // Enough prison capacity to enable imprisonment
     if ((total_capacity >= min_capacity) && (dungeon->num_active_creatrs < max_units))
     {

--- a/src/player_compprocs.c
+++ b/src/player_compprocs.c
@@ -449,12 +449,24 @@ long computer_check_build_all_rooms(struct Computer2 *comp, struct ComputerProce
     return CProcRet_Wait;
 }
 
-long computer_get_room_kind_total_capacity(struct Computer2 *comp, RoomKind room_kind)
+long computer_get_room_role_total_capacity(struct Computer2 *comp, RoomRole rrole)
 {
     struct Dungeon* dungeon = comp->dungeon;
-    long used_capacity;
-    long total_capacity;
-    get_room_kind_total_and_used_capacity(dungeon, room_kind, &total_capacity, &used_capacity);
+    long used_capacity_kind;
+    long total_capacity_kind;
+    long total_capacity = 0;
+    
+  
+    for (RoomKind rkind = 0; rkind < slab_conf.room_types_count; rkind++)
+    {
+        if(room_role_matches(rkind,rrole))
+        {
+
+            get_room_kind_total_and_used_capacity(dungeon, rkind, &total_capacity_kind, &used_capacity_kind);
+            total_capacity += total_capacity_kind;
+        }
+    }
+    
     return total_capacity;
 }
 

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -745,7 +745,6 @@ CreatureJob get_job_to_place_creature_in_room(const struct Computer2 *comp, cons
     CreatureJob chosen_job;
     struct Room *room;
     long total_spare_cap;
-    long i;
     long k;
 
     const struct Dungeon *dungeon = comp->dungeon;
@@ -768,11 +767,8 @@ CreatureJob get_job_to_place_creature_in_room(const struct Computer2 *comp, cons
             SYNCDBG(9,"Cannot assign %s for %s index %d; no worker needed",creature_job_code_name(mvto->job_kind),thing_model_name(thing),(int)thing->index);
             continue;
         }
-        RoomKind rkind;
-        rkind = get_room_for_job(mvto->job_kind);
         // Find specific room which meets capacity demands
-        i = dungeonadd->room_kind[rkind];
-        room = find_room_with_most_spare_capacity_starting_with(i,&total_spare_cap);
+        room = find_room_of_role_with_most_spare_capacity(dungeonadd,rrole,&total_spare_cap);
         if (room_is_invalid(room)) {
             SYNCDBG(9,"Cannot assign %s for %s index %d; no room with spares",creature_job_code_name(mvto->job_kind),thing_model_name(thing),(int)thing->index);
             continue;

--- a/src/player_computer.h
+++ b/src/player_computer.h
@@ -663,7 +663,7 @@ TbBool create_task_magic_speed_up(struct Computer2 *comp, const struct Thing *cr
 TbBool create_task_attack_magic(struct Computer2 *comp, const struct Thing *creatng, PowerKind pwkind, int repeat_num, int splevel, int gaction);
 
 TbBool computer_able_to_use_power(struct Computer2 *comp, PowerKind pwkind, long pwlevel, long amount);
-long computer_get_room_kind_total_capacity(struct Computer2 *comp, RoomKind room_kind);
+long computer_get_room_role_total_capacity(struct Computer2 *comp, RoomRole rrole);
 long computer_get_room_kind_free_capacity(struct Computer2 *comp, RoomKind room_kind);
 TbBool computer_finds_nearest_room_to_pos(struct Computer2 *comp, struct Room **retroom, struct Coord3d *nearpos);
 long process_tasks(struct Computer2 *comp);

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -2621,7 +2621,7 @@ TbBool clear_dig_on_room_slabs(struct Room *room, PlayerNumber plyr_idx)
 
 TbBool room_has_enough_free_capacity_for_creature_job(const struct Room *room, const struct Thing *creatng, CreatureJob jobpref)
 {
-    if (room->kind != get_room_for_job(jobpref)) {
+    if (!room_role_matches(room->kind,get_room_role_for_job(jobpref))) {
         return false;
     }
     int required_cap = get_required_room_capacity_for_job(jobpref, creatng->model);

--- a/src/room_data.h
+++ b/src/room_data.h
@@ -71,6 +71,7 @@ struct Thing;
 struct Coord3d;
 struct Room;
 struct Dungeon;
+struct DungeonAdd;
 
 typedef void (*Room_Update_Func)(struct Room *);
 
@@ -191,7 +192,7 @@ struct Room *find_room_of_role_with_spare_room_item_capacity(PlayerNumber plyr_i
 struct Room *find_nth_room_of_owner_with_spare_item_capacity_starting_with(long room_idx, long n, long spare);
 struct Room *find_room_of_role_with_spare_capacity(PlayerNumber owner, RoomRole rrole, long spare);
 struct Room *find_nth_room_of_owner_with_spare_capacity_starting_with(long room_idx, long n, long spare);
-struct Room *find_room_with_most_spare_capacity_starting_with(long room_idx, long *total_spare_cap);
+struct Room *find_room_of_role_with_most_spare_capacity(const struct DungeonAdd *dungeonadd,RoomRole rrole, long *total_spare_cap);
 struct Room *find_room_nearest_to_position(PlayerNumber plyr_idx, RoomKind rkind, const struct Coord3d *pos, long *room_distance);
 // Finding a navigable room for a thing
 struct Room *find_room_of_role_for_thing_with_used_capacity(const struct Thing *creatng, PlayerNumber plyr_idx, RoomRole rrole, unsigned char nav_flags, long min_used_cap);

--- a/src/room_data.h
+++ b/src/room_data.h
@@ -194,7 +194,7 @@ struct Room *find_nth_room_of_owner_with_spare_capacity_starting_with(long room_
 struct Room *find_room_with_most_spare_capacity_starting_with(long room_idx, long *total_spare_cap);
 struct Room *find_room_nearest_to_position(PlayerNumber plyr_idx, RoomKind rkind, const struct Coord3d *pos, long *room_distance);
 // Finding a navigable room for a thing
-struct Room *find_room_for_thing_with_used_capacity(const struct Thing *creatng, PlayerNumber plyr_idx, RoomKind rkind, unsigned char nav_flags, long min_used_cap);
+struct Room *find_room_of_role_for_thing_with_used_capacity(const struct Thing *creatng, PlayerNumber plyr_idx, RoomRole rrole, unsigned char nav_flags, long min_used_cap);
 struct Room *find_random_room_of_role_with_used_capacity_creature_can_navigate_to(struct Thing *thing, PlayerNumber owner, RoomRole rrole, unsigned char nav_flags);
 struct Room *find_nearest_room_of_role_for_thing_with_spare_capacity(struct Thing *thing, signed char owner, RoomRole rrole, unsigned char nav_flags, long spare);
 

--- a/src/room_jobs.c
+++ b/src/room_jobs.c
@@ -384,7 +384,7 @@ TbBool creature_setup_random_move_for_job_in_room_f(struct Thing *creatng, struc
 
 TbBool room_is_correct_to_perform_job(const struct Thing *creatng, const struct Room *room, CreatureJob jobpref)
 {
-    if ((get_room_for_job(jobpref) != RoK_NONE) && (room->kind != get_room_for_job(jobpref))) {
+    if ((get_room_role_for_job(jobpref) != RoRoF_None) && (!room_role_matches(room->kind,get_room_role_for_job(jobpref)))) {
         return false;
     }
     if (creatng->owner == room->owner)

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -219,7 +219,7 @@ long check_for_first_person_barrack_party(struct Thing *grthing)
         return 0;
     }
     struct Room* room = get_room_thing_is_on(grthing);
-    if (!room_still_valid_as_type_for_thing(room, RoK_BARRACKS, grthing))
+    if (!room_still_valid_as_type_for_thing(room, RoRoF_CrMakeGroup, grthing))
     {
         SYNCDBG(2,"Room %s owned by player %d does not allow the %s index %d owner %d to lead a party",room_code_name(room->kind),(int)room->owner,thing_model_name(grthing),(int)grthing->index,(int)grthing->owner);
         return 0;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3450,7 +3450,7 @@ struct Room *get_creature_lair_room(const struct Thing *creatng)
 TbBool creature_has_lair_room(const struct Thing *creatng)
 {
     struct Room* room = get_creature_lair_room(creatng);
-    if (!room_is_invalid(room) && (room->kind == get_room_for_job(Job_TAKE_SLEEP))) {
+    if (!room_is_invalid(room) && room_role_matches(room->kind,get_room_role_for_job(Job_TAKE_SLEEP))) {
         return true;
     }
     return false;


### PR DESCRIPTION
make creatures able to work properly in multiple rooms that have the correct role, used to only accept the first roomkind that had the role