### PR TITLE
Fixed creatures escaping custody under cave-in spell.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2615,7 +2615,7 @@ TngUpdateRet damage_creatures_with_physical_force(struct Thing *thing, ModTngFil
         apply_damage_to_thing_and_display_health(thing, param->num2, DmgT_Physical, param->num1);
         if (thing->health >= 0)
         {
-            if ((thing->alloc_flags & TAlF_IsControlled) == 0)
+            if (((thing->alloc_flags & TAlF_IsControlled) == 0) && !creature_is_kept_in_custody(thing))
             {
                 if (get_creature_state_besides_interruptions(thing) != CrSt_CreatureEscapingDeath)
                 {


### PR DESCRIPTION
To reproduce the bug, cast cave-in on a torture victim to see it stop being tortured. Now that does not happen.