### PR TITLE
ma_triangle_route goes out of bounds

### DIFF
--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -1939,7 +1939,7 @@ long ma_triangle_route(long ttriA, long ttriB, long *routecost)
     NAVIDBG(19,"Selecting route");
     if (par_fwd < par_bak)
     {
-        for (i=0; i <= sizeof(tree_route)/sizeof(tree_route[0]); i++)
+        for (i=0; i < sizeof(tree_route)/sizeof(tree_route[0]); i++)
         {
              tree_route[i] = route_fwd[i];
         }


### PR DESCRIPTION
Fixes #1585

src/ariadne.c: In function ‘ma_triangle_route’:
src/ariadne.c:1944:28: warning: iteration 3517 invokes undefined behavior [-Waggressive-loop-optimizations]
 1944 |              tree_route[i] = route_fwd[i];
src/ariadne.c:1942:9: note: within this loop
 1942 |         for (i=0; i <= sizeof(tree_route)/sizeof(tree_route[0]); i++)