### PR TITLE
No matching function call to max()

### DIFF
--- a/src/vidmode_data.cpp
+++ b/src/vidmode_data.cpp
@@ -236,7 +236,7 @@ struct TbLoadFiles legal_load_files[] = {
 
 struct TbLoadFiles game_load_files[] = {
     {"*SCRATCH",         &scratch,                               NULL,                                    0x10000, 0, 0},
-    {"*TEXTURE_PAGE",    (unsigned char **)&block_mem,                             NULL,                     max(sizeof(block_mem),960*720u), 0, 0},// Store whole texture image or land view image
+    {"*TEXTURE_PAGE",    (unsigned char **)&block_mem, NULL, max(sizeof(block_mem), size_t(960*720)), 0, 0},// Store whole texture image or land view image
 #ifdef SPRITE_FORMAT_V2
     {"data/thingspr-32.tab",(unsigned char**)&creature_table,    NULL,                                          0, 0, 0},
 #else


### PR DESCRIPTION
`max(sizeof(block_mem), 960*720u)` does not compile on 64-bits as they are different data types:
```
g++ -DHAVE_CONFIG_H -I.    -g -O2 -D_REENTRANT -I/usr/include/SDL2 -g -O2 -MT src/keeperfx-stubs.o -MD -MP -MF src/.deps/keeperfx-stubs.Tpo -c -o src/keeperfx-stubs.o `test -f 'src/stubs.cpp' || echo './'`src/stubs.cpp
mv -f src/.deps/keeperfx-vidmode.Tpo src/.deps/keeperfx-vidmode.Po
src/vidmode_data.cpp:239:93: error: no matching function for call to ‘max(long unsigned int, unsigned int)’
  239 |     {"*TEXTURE_PAGE",    (unsigned char **)&block_mem, NULL, max(sizeof(block_mem), 960*720u), 0, 0},// Store whole texture image or land view image
```
