### PR TITLE
Redefined several variable-sized arrays as pointers to keep compiler happy

### DIFF
--- a/src/config_effects.c
+++ b/src/config_effects.c
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 /******************************************************************************/
-const char keeper_effects_file[]="effects.cfg";
+const char * keeper_effects_file = "effects.cfg";
 
 const struct NamedCommand effects_common_commands[] = {
   {"EFFECTSCOUNT",    1},

--- a/src/config_effects.h
+++ b/src/config_effects.h
@@ -42,9 +42,9 @@ struct EffectsConfig {
     struct EffectConfigStats effect_cfgstats[EFFECTS_TYPES_MAX];
 };
 /******************************************************************************/
-DLLIMPORT long _DK_imp_spangle_effects[];
+DLLIMPORT long * _DK_imp_spangle_effects;
 /******************************************************************************/
-extern const char keeper_effects_file[];
+extern const char * keeper_effects_file;
 extern struct NamedCommand effect_desc[EFFECTS_TYPES_MAX];
 extern long const imp_spangle_effects[];
 extern struct EffectsConfig effects_conf;

--- a/src/creature_graphics.h
+++ b/src/creature_graphics.h
@@ -100,9 +100,11 @@ struct KeeperSpriteExt // More info for custom sprites
     unsigned char rotation; // Used to implement rotated statues from rotatable
 };
 /******************************************************************************/
+#define KEEPERSPRITE_ADD_NUM 2048
+
 //extern unsigned short creature_graphics[][22];
 //extern struct KeeperSprite *creature_table;
-extern struct KeeperSprite creature_table_add[];
+extern struct KeeperSprite creature_table_add[KEEPERSPRITE_ADD_NUM];
 extern struct KeeperSpriteExt creatures_table_ext[];
 /******************************************************************************/
 DLLIMPORT struct KeeperSprite *_DK_creature_table;

--- a/src/creature_states.h
+++ b/src/creature_states.h
@@ -271,7 +271,7 @@ struct StateInfo { // sizeof = 41
 };
 
 /******************************************************************************/
-DLLIMPORT struct StateInfo _DK_states[];
+DLLIMPORT struct StateInfo * _DK_states;
 //#define states _DK_states
 extern struct StateInfo states[];
 DLLIMPORT long _DK_r_stackpos;

--- a/src/engine_render.h
+++ b/src/engine_render.h
@@ -25,6 +25,7 @@
 #include "bflib_render.h"
 #include "bflib_sprite.h"
 #include "engine_lenses.h"
+#include "creature_graphics.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +37,6 @@ extern "C" {
 #define KEEPSPRITE_LENGTH 9149
 
 #define KEEPERSPRITE_ADD_OFFSET 16384
-#define KEEPERSPRITE_ADD_NUM 2048
 
 enum QKinds {
     QK_PolygonStandard = 0,
@@ -498,9 +498,9 @@ DLLIMPORT struct Thing *_DK_thing_being_displayed;
 #define thing_being_displayed _DK_thing_being_displayed
 DLLIMPORT unsigned char _DK_thing_being_displayed_is_creature;
 #define thing_being_displayed_is_creature _DK_thing_being_displayed_is_creature
-DLLIMPORT extern struct EngineCol _DK_ecs1[];
+DLLIMPORT extern struct EngineCol * _DK_ecs1;
 #define ecs1 _DK_ecs1
-DLLIMPORT extern struct EngineCol _DK_ecs2[];
+DLLIMPORT extern struct EngineCol * _DK_ecs2;
 #define ecs2 _DK_ecs2
 DLLIMPORT extern struct EngineCol *_DK_front_ec;
 #define front_ec _DK_front_ec

--- a/src/front_highscore.h
+++ b/src/front_highscore.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /******************************************************************************/
-DLLIMPORT struct GuiButtonInit _DK_frontend_high_score_score_buttons[];
+DLLIMPORT struct GuiButtonInit * _DK_frontend_high_score_score_buttons;
 DLLIMPORT extern long _DK_high_score_entry_input_active;
 #define high_score_entry_input_active _DK_high_score_entry_input_active
 DLLIMPORT extern long _DK_high_score_entry_index;

--- a/src/front_landview.h
+++ b/src/front_landview.h
@@ -104,8 +104,8 @@ DLLIMPORT extern unsigned char *_DK_map_screen;
 #define map_screen _DK_map_screen
 DLLIMPORT extern long *_DK_window_y_offset;
 DLLIMPORT extern unsigned char *_DK_map_window;
-DLLIMPORT extern struct TbSetupSprite _DK_map_flag_setup_sprites[];
-DLLIMPORT extern struct TbSetupSprite _DK_netmap_flag_setup_sprites[];
+DLLIMPORT extern struct TbSetupSprite * _DK_map_flag_setup_sprites;
+DLLIMPORT extern struct TbSetupSprite * _DK_netmap_flag_setup_sprites;
 DLLIMPORT extern long _DK_fe_net_level_selected;
 #define fe_net_level_selected _DK_fe_net_level_selected
 DLLIMPORT extern long _DK_net_map_limp_time;

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -126,10 +126,6 @@ DLLIMPORT struct GuiButtonInit * _DK_frontend_net_session_buttons;
 DLLIMPORT struct GuiButtonInit * _DK_frontend_net_start_buttons;
 DLLIMPORT struct GuiButtonInit _DK_frontend_net_modem_buttons[37];
 DLLIMPORT struct GuiButtonInit _DK_frontend_net_serial_buttons[22];
-DLLIMPORT struct GuiButtonInit * _DK_frontend_statistics_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_autopilot_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_frontend_define_keys_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_frontend_option_buttons;
 
 DLLIMPORT char _DK_info_tag;
 #define info_tag _DK_info_tag

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -104,29 +104,6 @@ struct NetMessage { // sizeof = 0x41
 };
 
 /******************************************************************************/
-DLLIMPORT struct GuiButtonInit * _DK_event_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_options_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_instance_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_quit_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_load_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_save_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_video_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_sound_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_error_box_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_pause_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_hold_audience_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_armageddon_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_dungeon_special_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_resurrect_creature_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_transfer_creature_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_frontend_main_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_frontend_load_menu_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_frontend_net_service_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_frontend_net_session_buttons;
-DLLIMPORT struct GuiButtonInit * _DK_frontend_net_start_buttons;
-DLLIMPORT struct GuiButtonInit _DK_frontend_net_modem_buttons[37];
-DLLIMPORT struct GuiButtonInit _DK_frontend_net_serial_buttons[22];
-
 DLLIMPORT char _DK_info_tag;
 #define info_tag _DK_info_tag
 DLLIMPORT char _DK_room_tag;

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -104,32 +104,32 @@ struct NetMessage { // sizeof = 0x41
 };
 
 /******************************************************************************/
-DLLIMPORT struct GuiButtonInit _DK_event_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_options_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_instance_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_quit_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_load_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_save_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_video_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_sound_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_error_box_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_pause_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_hold_audience_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_armageddon_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_dungeon_special_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_resurrect_creature_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_transfer_creature_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_frontend_main_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_frontend_load_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_frontend_net_service_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_frontend_net_session_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_frontend_net_start_buttons[];
+DLLIMPORT struct GuiButtonInit * _DK_event_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_options_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_instance_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_quit_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_load_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_save_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_video_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_sound_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_error_box_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_pause_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_hold_audience_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_armageddon_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_dungeon_special_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_resurrect_creature_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_transfer_creature_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_frontend_main_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_frontend_load_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_frontend_net_service_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_frontend_net_session_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_frontend_net_start_buttons;
 DLLIMPORT struct GuiButtonInit _DK_frontend_net_modem_buttons[37];
 DLLIMPORT struct GuiButtonInit _DK_frontend_net_serial_buttons[22];
-DLLIMPORT struct GuiButtonInit _DK_frontend_statistics_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_autopilot_menu_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_frontend_define_keys_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_frontend_option_buttons[];
+DLLIMPORT struct GuiButtonInit * _DK_frontend_statistics_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_autopilot_menu_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_frontend_define_keys_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_frontend_option_buttons;
 
 DLLIMPORT char _DK_info_tag;
 #define info_tag _DK_info_tag

--- a/src/frontmenu_ingame_evnt.h
+++ b/src/frontmenu_ingame_evnt.h
@@ -33,8 +33,8 @@ struct GuiMenu;
 struct GuiButton;
 
 /******************************************************************************/
-DLLIMPORT struct GuiButtonInit _DK_text_info_buttons[];
-DLLIMPORT struct GuiButtonInit _DK_battle_buttons[];
+DLLIMPORT struct GuiButtonInit * _DK_text_info_buttons;
+DLLIMPORT struct GuiButtonInit * _DK_battle_buttons;
 DLLIMPORT extern unsigned short _DK_battle_creature_over;
 #define battle_creature_over _DK_battle_creature_over
 

--- a/src/gui_draw.h
+++ b/src/gui_draw.h
@@ -52,7 +52,7 @@ struct GuiButton;
 //#define gui_panel_sprites _DK_gui_panel_sprites
 //DLLIMPORT struct TbSprite *_DK_end_gui_panel_sprites;
 //#define end_gui_panel_sprites _DK_end_gui_panel_sprites
-extern struct TbSprite gui_panel_sprites[];
+extern struct TbSprite gui_panel_sprites[GUI_PANEL_SPRITES_COUNT + GUI_PANEL_SPRITES_NEW];
 extern struct TbSprite *end_gui_panel_sprites;
 extern int num_icons_total;
 

--- a/src/player_instances.h
+++ b/src/player_instances.h
@@ -78,7 +78,7 @@ struct PlayerInstanceInfo { // sizeof = 44
 };
 
 /******************************************************************************/
-DLLIMPORT struct PlayerInstanceInfo _DK_player_instance_info[];
+DLLIMPORT struct PlayerInstanceInfo * _DK_player_instance_info;
 //#define player_instance_info _DK_player_instance_info
 
 #pragma pack()


### PR DESCRIPTION
Maybe its because of slightly newer compiler (i686-w64-mingw32-gcc 9.3 -> gcc 9.4) but I'm getting various warnings about "storage size of ... is unknown" and "assumed to have one element" like below.

For arrays where the size is known I defined the size explicitly (eg. `creature_table_add[KEEPERSPRITE_ADD_NUM]`).

For arrays of unknown size I redefined the symbol as a pointer so that the compiler doesn't make any assumptions about the array size.

```
gcc -DHAVE_CONFIG_H -I.    -g -O2 -D_REENTRANT -I/usr/include/SDL2 -g -O2 -MT src/keeperfx-power_hand.o -MD -MP -MF src/.deps/keeperfx-power_hand.Tpo -c -o src/keeperfx-power_hand.o `test -f 'src/power_hand.c' || echo './'`src/power_hand.c
In file included from src/power_hand.c:49:
src/config_effects.h:45:16: warning: array ‘_DK_imp_spangle_effects’ assumed to have one element
   45 | DLLIMPORT long _DK_imp_spangle_effects[];
```