### PR TITLE
Add campaign name and level number info into log

### DIFF
--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -393,7 +393,7 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
   int k = find_conf_block(buf, &pos, len, block_buf);
   if (k < 0)
   {
-      WARNMSG("Block [%s] not found in %s file.",block_buf,config_textname);
+      WARNMSG("Block [%s] not found in %s %s file.",block_buf, campgn->name, config_textname);
       return 0;
   }
 #define COMMAND_TEXT(cmd_num) get_conf_parameter_text(cmpgn_common_commands,cmd_num)
@@ -410,8 +410,8 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
       case 1: // NAME
           i = get_conf_parameter_whole(buf,&pos,len,campgn->name,LINEMSG_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num), campgn->name, config_textname);
           break;
       case 2: // SINGLE_LEVELS
           while (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
@@ -420,17 +420,17 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
             if (k > 0)
             {
               if (add_single_level_to_campaign(campgn,k) < 0)
-                  CONFWRNLOG("No free slot to add level %d from \"%s\" command of %s file.",
-                      k,COMMAND_TEXT(cmd_num),config_textname);
+                  CONFWRNLOG("No free slot to add level %d from \"%s\" command of %s %s file.",
+                      k,COMMAND_TEXT(cmd_num),campgn->name,config_textname);
             } else
             {
-                CONFWRNLOG("Couldn't recognize level in \"%s\" command of %s file.",
-                  COMMAND_TEXT(cmd_num),config_textname);
+                CONFWRNLOG("Couldn't recognize level in \"%s\" command of %s %s file.",
+                  COMMAND_TEXT(cmd_num),campgn->name,config_textname);
             }
           }
           if (campgn->single_levels_count <= 0)
-              CONFWRNLOG("Levels list empty in \"%s\" command of %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Levels list empty in \"%s\" command of %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 3: // MULTI_LEVELS
           while (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
@@ -439,18 +439,18 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
             if (k > 0)
             {
               if (add_multi_level_to_campaign(campgn,k) < 0)
-                  CONFWRNLOG("No free slot to add level %d from \"%s\" command of %s file.",
-                      k,COMMAND_TEXT(cmd_num),config_textname);
+                  CONFWRNLOG("No free slot to add level %d from \"%s\" command of %s %s file.",
+                      k,COMMAND_TEXT(cmd_num),campgn->name,config_textname);
             } else
             {
-                CONFWRNLOG("Couldn't recognize level in \"%s\" command of %s file.",
-                  COMMAND_TEXT(cmd_num),config_textname);
+                CONFWRNLOG("Couldn't recognize level in \"%s\" command of %s %s file.",
+                  COMMAND_TEXT(cmd_num),campgn->name,config_textname);
             }
           }
           if (campgn->multi_levels_count <= 0)
           {
-              CONFWRNLOG("Levels list empty in \"%s\" command of %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Levels list empty in \"%s\" command of %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           }
           break;
       case 4: // BONUS_LEVELS
@@ -460,12 +460,12 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
             if (k >= 0) // Some bonus levels may not exist
             {
               if (add_bonus_level_to_campaign(campgn,k) < 0)
-                  CONFWRNLOG("No free slot to add level %d from \"%s\" command of %s file.",
-                      k,COMMAND_TEXT(cmd_num),config_textname);
+                  CONFWRNLOG("No free slot to add level %d from \"%s\" command of %s %s file.",
+                      k,COMMAND_TEXT(cmd_num),campgn->name,config_textname);
             } else
             {
-                CONFWRNLOG("Couldn't recognize level in \"%s\" command of %s file.",
-                  COMMAND_TEXT(cmd_num),config_textname);
+                CONFWRNLOG("Couldn't recognize level in \"%s\" command of %s %s file.",
+                  COMMAND_TEXT(cmd_num),campgn->name,config_textname);
             }
           }
           //if (campgn->bonus_levels_count <= 0)
@@ -478,17 +478,17 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
             if (k > 0)
             {
               if (add_extra_level_to_campaign(campgn,k) < 0)
-                  CONFWRNLOG("No free slot to add level %d from \"%s\" command of %s file.",
-                      k,COMMAND_TEXT(cmd_num),config_textname);
+                  CONFWRNLOG("No free slot to add level %d from \"%s\" command of %s %s file.",
+                      k,COMMAND_TEXT(cmd_num),campgn->name,config_textname);
             } else
             {
-                CONFWRNLOG("Couldn't recognize level in \"%s\" command of %s file.",
-                  COMMAND_TEXT(cmd_num),config_textname);
+                CONFWRNLOG("Couldn't recognize level in \"%s\" command of %s %s file.",
+                  COMMAND_TEXT(cmd_num),campgn->name,config_textname);
             }
           }
           if (campgn->extra_levels_count <= 0)
-              CONFLOG("Levels list empty in \"%s\" command of %s file.",
-                    COMMAND_TEXT(cmd_num),config_textname);
+              CONFLOG("Levels list empty in \"%s\" command of %s %s file.",
+                    COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 6: // HIGH_SCORES
           if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
@@ -568,50 +568,50 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
       case 10: // LEVELS_LOCATION
           i = get_conf_parameter_whole(buf,&pos,len,campgn->levels_location,DISKPATH_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 11: // LAND_LOCATION
           i = get_conf_parameter_whole(buf,&pos,len,campgn->land_location,DISKPATH_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 12: // CREATURES_LOCATION
           i = get_conf_parameter_whole(buf,&pos,len,campgn->creatures_location,DISKPATH_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 13: // CONFIGS_LOCATION
           i = get_conf_parameter_whole(buf,&pos,len,campgn->configs_location,DISKPATH_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 14: // CREDITS
           i = get_conf_parameter_whole(buf,&pos,len,campgn->credits_fname,DISKPATH_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 15: // MEDIA_LOCATION
           i = get_conf_parameter_whole(buf,&pos,len,campgn->media_location,DISKPATH_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 16: // INTRO_MOVIE
           i = get_conf_parameter_whole(buf,&pos,len,campgn->movie_intro_fname,DISKPATH_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 17: // OUTRO_MOVIE
           i = get_conf_parameter_whole(buf,&pos,len,campgn->movie_outro_fname,DISKPATH_SIZE);
           if (i <= 0)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 18: // LAND_MARKERS
           i = recognize_conf_parameter(buf,&pos,len,cmpgn_level_markers_options);
@@ -620,8 +620,8 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
               n++;
           }
           if (n < 1)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 19: // HUMAN_PLAYER
           i = recognize_conf_parameter(buf,&pos,len,cmpgn_human_player_options);
@@ -630,14 +630,14 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
               n++;
           }
           if (n < 1)
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           break;
       case 20: // NAME_TEXT_ID
           i = get_conf_parameter_whole(buf,&pos,len,word_buf,sizeof(word_buf));
           if (i <= 0) {
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           }
           else {
               k = atoi(word_buf);
@@ -647,21 +647,21 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
                         LbStringCopy(campgn->name,newname,LINEMSG_SIZE); // use the index provided in the config file to get a specific UI string
                     }
                     else {
-                    CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file. NAME_TEXT_ID is too high, NAME used instead.",
-                      COMMAND_TEXT(cmd_num),config_textname);
+                    CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file. NAME_TEXT_ID is too high, NAME used instead.",
+                      COMMAND_TEXT(cmd_num),campgn->name,config_textname);
                     }
                 }
                 else {
-                    CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file. Not a valid number.",
-                      COMMAND_TEXT(cmd_num),config_textname);
+                    CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file. Not a valid number.",
+                      COMMAND_TEXT(cmd_num),campgn->name,config_textname);
                 }
           }
           break;
       case 21: // ASSIGN_CPU_KEEPERS
           i = recognize_conf_parameter(buf,&pos,len,logicval_type);
           if (i <= 0) {
-              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
+              CONFWRNLOG("Couldn't read \"%s\" command parameter in %s %s file.",
+                COMMAND_TEXT(cmd_num),campgn->name,config_textname);
           }
           else if (i < 2) { // ASSIGN_CPU_KEEPERS = ON
               campgn->assignCpuKeepers = 1;
@@ -672,8 +672,8 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
       case -1: // end of buffer
           break;
       default:
-          CONFWRNLOG("Unrecognized command (%d) in [%s] block of %s file.",
-              cmd_num,block_buf,config_textname);
+          CONFWRNLOG("Unrecognized command (%d) in [%s] block of %s %s file.",
+              cmd_num,block_buf,campgn->name,config_textname);
           break;
       }
       skip_conf_to_next_line(buf,&pos,len);
@@ -681,8 +681,8 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
 #undef COMMAND_TEXT
   if (campgn->single_levels_count != campgn->bonus_levels_index)
   {
-    WARNMSG("Amount of SP levels (%d) and bonuses (%d) do not match in [%s] block of %s file.",
-      campgn->single_levels_count, campgn->bonus_levels_count, block_buf, config_textname);
+    WARNMSG("Amount of SP levels (%d) and bonuses (%d) do not match in [%s] block of %s %s file.",
+      campgn->single_levels_count, campgn->bonus_levels_count, block_buf, campgn->name, config_textname);
   }
   return 1;
 }

--- a/src/config_objects.c
+++ b/src/config_objects.c
@@ -245,7 +245,7 @@ TbBool parse_objects_object_blocks(char *buf, long len, const char *config_textn
                 if (gameadd.object_conf.object_types_count == OBJECT_TYPES_MAX - 1)
                 {
                     gameadd.object_conf.object_types_count = tmodel;
-                    JUSTMSG("Loaded %d object types", gameadd.object_conf.object_types_count);
+                    JUSTMSG("Loaded %d object types from %s", gameadd.object_conf.object_types_count, config_textname);
                     break;
                 }
                 WARNMSG("Block [%s] not found in %s file.", block_buf, config_textname);
@@ -256,7 +256,7 @@ TbBool parse_objects_object_blocks(char *buf, long len, const char *config_textn
                 if (tmodel > gameadd.object_conf.object_types_count)
                 {
                     gameadd.object_conf.object_types_count = tmodel;
-                    JUSTMSG("Extended to %d object types", gameadd.object_conf.object_types_count);
+                    JUSTMSG("Extended to %d object types from %s", gameadd.object_conf.object_types_count, config_textname);
                     break;
                 }
             }

--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -435,6 +435,7 @@ TbBool load_game(long slot_num)
       dungeon->lvstats.allow_save_score = 1;
     }
     game.loaded_swipe_idx = -1;
+    JUSTMSG("Loaded level %d from %s", game.continue_level_number, campaign.name);
     return true;
 }
 
@@ -657,6 +658,7 @@ short load_continue_game(void)
         sizeof(struct IntralevelData));
     LbStringCopy(game.campaign_fname,campaign.fname,sizeof(game.campaign_fname));
     update_extra_levels_visibility();
+    JUSTMSG("Continued level %d from %s", lvnum, campaign.name);
     return true;
 }
 

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -195,6 +195,7 @@ static void init_level(void)
     game.manufactr_element = 0;
     game.manufactr_spridx = 0;
     game.manufactr_tooltip = 0;
+    JUSTMSG("Started level %d from %s", get_selected_level_number(), campaign.name);
 }
 
 static void post_init_level(void)


### PR DESCRIPTION
This stores information in the log that I now need to ask often.
Fixes https://github.com/dkfans/keeperfx/issues/1505

Also updated the object loading information to specify the campaign it's for.