### PR TITLE
Tunnel behavior improved - breaching and map colour

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -3450,6 +3450,8 @@ char new_slab_tunneller_check_for_breaches(struct Thing *creatng)
 {
     TRACE_THING(creatng);
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
+    struct Map* mapblk;
+    struct Column* col;
 
     // NB: the code assumes PLAYERS_COUNT = DUNGEONS_COUNT
     for (int i = 0; i < PLAYERS_COUNT; ++i)
@@ -3462,10 +3464,17 @@ char new_slab_tunneller_check_for_breaches(struct Thing *creatng)
         if (!dgn->dnheart_idx)
             continue;
 
+        // Player dungeon already broken into
         if (cctrl->byte_8A & (1 << i))
             continue;
 
         if (!subtile_revealed(creatng->mappos.x.stl.num, creatng->mappos.y.stl.num, i))
+            continue;
+
+        //If there is a ceiling, the tunneler is invisible too. For tunnels.
+        mapblk = get_map_block_at(creatng->mappos.x.stl.num, creatng->mappos.y.stl.num);
+        col = get_map_column(mapblk);
+        if ((col->bitfields & CLF_CEILING_MASK) != 0)
             continue;
 
         if (!creature_can_navigate_to(creatng, &game.things.lookup[dgn->dnheart_idx]->mappos, NavRtF_Default))

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -3465,12 +3465,10 @@ char new_slab_tunneller_check_for_breaches(struct Thing *creatng)
         if (cctrl->byte_8A & (1 << i))
             continue;
 
-        if (!creature_can_navigate_to(
-                creatng,
-                &game.things.lookup[dgn->dnheart_idx]->mappos,
-                0))
+        if (!subtile_revealed(creatng->mappos.x.stl.num, creatng->mappos.y.stl.num, i))
             continue;
-        if (!((game.map[creatng->mappos.x.stl.num + (creatng->mappos.y.stl.num << 8)].data >> 28) & (1 << i)))
+
+        if (!creature_can_navigate_to(creatng, &game.things.lookup[dgn->dnheart_idx]->mappos, NavRtF_Default))
             continue;
 
         cctrl->byte_8A |= 1 << i;

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -2266,6 +2266,7 @@ long ceiling_partially_recompute_heights(long sx, long sy, long ex, long ey)
 long element_top_face_texture(struct Map *mapblk)
 {
     struct Column *col;
+    struct CubeAttribs* cubed;
     unsigned int data = mapblk->data;
     TbBool map_block_revealed = map_block_revealed_bit(mapblk, player_bit);
     int result = data & 0x7FF;
@@ -2280,9 +2281,14 @@ long element_top_face_texture(struct Map *mapblk)
         {
             col = get_column(game.unrevealed_column_idx);
         }
-        if ( (col->bitfields & CLF_FLOOR_MASK) != 0 )
+        if ( (col->bitfields & CLF_CEILING_MASK) != 0 )
         {
-            struct CubeAttribs *cubed = &game.cubes_data[col->cubes[get_column_floor_filled_subtiles(col) - 1]];
+            cubed = &game.cubes_data[col->cubes[4]];
+            return cubed->texture_id[4];
+        }
+        else if ((col->bitfields & CLF_FLOOR_MASK) != 0)
+        {
+            cubed = &game.cubes_data[col->cubes[get_column_floor_filled_subtiles(col) - 1]];
             return cubed->texture_id[4];
         }
         else

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -2283,7 +2283,7 @@ long element_top_face_texture(struct Map *mapblk)
         }
         if ( (col->bitfields & CLF_CEILING_MASK) != 0 )
         {
-            cubed = &game.cubes_data[col->cubes[4]];
+            cubed = &game.cubes_data[col->cubes[COLUMN_STACK_HEIGHT-get_column_ceiling_filled_subtiles(col)-1]];
             return cubed->texture_id[4];
         }
         else if ((col->bitfields & CLF_FLOOR_MASK) != 0)


### PR DESCRIPTION
- Cleared up new_slab_tunneller_check_for_breaches function to make it obvious breaches only occur on explored slabs
- Stopped breaches from occurring by units inside a tunnel (with cubes above their head)
- The parchment map now shows the top slab instead of the floor slab in case of tunnels

Fixes a bug where tunnelers when they would cross a tunnel across the map into an enemy dungeon, would trigger a 'breach' notification for the player too.
Also closes #1468 