### PR TITLE
Handle 2 dungeon hearts

### DIFF
--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -321,12 +321,13 @@ struct DungeonAdd
     long                  creatures_total_backpay;
     long                  cheaper_diggers;
     struct ComputerInfo   computer_info;
-    long event_last_run_turn[EVENT_KIND_COUNT];
-    long script_flags[SCRIPT_FLAGS_COUNT];
-    unsigned short room_kind[TERRAIN_ITEMS_MAX];
-    unsigned char room_buildable[TERRAIN_ITEMS_MAX];
-    unsigned char room_resrchable[TERRAIN_ITEMS_MAX];
-    unsigned char room_slabs_count[TERRAIN_ITEMS_MAX+1];
+    long                  event_last_run_turn[EVENT_KIND_COUNT];
+    long                  script_flags[SCRIPT_FLAGS_COUNT];
+    unsigned short        room_kind[TERRAIN_ITEMS_MAX];
+    unsigned char         room_buildable[TERRAIN_ITEMS_MAX];
+    unsigned char         room_resrchable[TERRAIN_ITEMS_MAX];
+    unsigned char         room_slabs_count[TERRAIN_ITEMS_MAX+1];
+    unsigned short        backup_heart_idx;
 
 };
 /******************************************************************************/

--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -76,11 +76,10 @@ void initialise_devastate_dungeon_from_heart(PlayerNumber plyr_idx)
 
 void process_dungeon_destroy(struct Thing* heartng)
 {
-    struct Dungeon* dungeon;
-    long plyr_idx;
-    plyr_idx = heartng->owner;
-    //_DK_process_dungeon_destroy(heartng); return;
-    dungeon = get_dungeon(plyr_idx);
+    long plyr_idx = heartng->owner;
+    struct Dungeon* dungeon = get_dungeon(plyr_idx);
+    struct DungeonAdd* dungeonadd = get_dungeonadd(plyr_idx);
+
     if (dungeon->heart_destroy_state == 0)
     {
         return;
@@ -89,12 +88,16 @@ void process_dungeon_destroy(struct Thing* heartng)
     {
         return;
     }
+
+    TbBool no_backup = !(dungeonadd->backup_heart_idx > 0);
+
     powerful_magic_breaking_sparks(heartng);
     const struct Coord3d* central_pos;
     central_pos = &heartng->mappos;
     switch (dungeon->heart_destroy_state)
     {
     case 1:
+        if (no_backup)
         initialise_devastate_dungeon_from_heart(plyr_idx);
         dungeon->heart_destroy_turn++;
         if (dungeon->heart_destroy_turn < 32)
@@ -125,12 +128,14 @@ void process_dungeon_destroy(struct Thing* heartng)
         // Drop all held things, by keeper
         if ((dungeon->num_things_in_hand > 0) && ((gameadd.classic_bugs_flags & ClscBug_NoHandPurgeOnDefeat) == 0))
         {
-            dump_all_held_things_on_map(plyr_idx, central_pos->x.stl.num, central_pos->y.stl.num);
+            if (no_backup)
+                dump_all_held_things_on_map(plyr_idx, central_pos->x.stl.num, central_pos->y.stl.num);
         }
         // Drop all held things, by computer player
         struct Computer2* comp;
         comp = get_computer_player(plyr_idx);
-        computer_force_dump_held_things_on_map(comp, central_pos);
+        if (no_backup)
+            computer_force_dump_held_things_on_map(comp, central_pos);
         // Now if players things are still in hand - they must be kept by enemies
         // Got to next phase
         dungeon->heart_destroy_state = 4;

--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -81,7 +81,12 @@ void process_dungeon_destroy(struct Thing* heartng)
     plyr_idx = heartng->owner;
     //_DK_process_dungeon_destroy(heartng); return;
     dungeon = get_dungeon(plyr_idx);
-    if (dungeon->heart_destroy_state == 0) {
+    if (dungeon->heart_destroy_state == 0)
+    {
+        return;
+    }
+    if (heartng->index != dungeon->dnheart_idx)
+    {
         return;
     }
     powerful_magic_breaking_sparks(heartng);
@@ -141,14 +146,6 @@ void process_dungeon_destroy(struct Thing* heartng)
         efftng = create_effect(central_pos, TngEff_WoPExplosion, plyr_idx);
         if (!thing_is_invalid(efftng))
             efftng->shot_effect.hit_type = THit_HeartOnlyNotOwn;
-        if (gameadd.heart_lost_display_message)
-        {
-            if (is_my_player_number(heartng->owner))
-            {
-                const char *objective = (gameadd.heart_lost_quick_message) ? gameadd.quick_messages[gameadd.heart_lost_message_id] : get_string(gameadd.heart_lost_message_id);
-                process_objective(objective, gameadd.heart_lost_message_target, 0, 0);
-            }
-        }
         destroy_dungeon_heart_room(plyr_idx, heartng);
         delete_thing_structure(heartng, 0);
     }
@@ -163,6 +160,14 @@ void process_dungeon_destroy(struct Thing* heartng)
         }
         else
         {
+            if (gameadd.heart_lost_display_message)
+            {
+                if (is_my_player_number(heartng->owner))
+                {
+                    const char* objective = (gameadd.heart_lost_quick_message) ? gameadd.quick_messages[gameadd.heart_lost_message_id] : get_string(gameadd.heart_lost_message_id);
+                    process_objective(objective, gameadd.heart_lost_message_target, 0, 0);
+                }
+            }
             // If this is the last heart the player had, finish him
             setup_all_player_creatures_and_diggers_leave_or_die(plyr_idx);
             player->allied_players = (1 << player->id_number);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2231,16 +2231,17 @@ void check_players_lost(void)
 {
   long i;
   SYNCDBG(8,"Starting");
-  //_DK_check_players_lost(); return;
+  struct PlayerInfo* player;
+  struct DungeonAdd* dungeonadd;
   for (i=0; i < PLAYERS_COUNT; i++)
   {
-      struct PlayerInfo *player;
       player = get_player(i);
+      dungeonadd = get_players_dungeonadd(player);
       if (player_exists(player) && (player->is_active == 1))
       {
           struct Thing *heartng;
           heartng = get_player_soul_container(i);
-          if ((!thing_exists(heartng) || (heartng->active_state == ObSt_BeingDestroyed)) && (player->victory_state == VicS_Undecided))
+          if ((!thing_exists(heartng) || ((heartng->active_state == ObSt_BeingDestroyed) && !(dungeonadd->backup_heart_idx > 0))) && (player->victory_state == VicS_Undecided))
           {
             event_kill_all_players_events(i);
             set_player_as_lost_level(player);

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -1078,6 +1078,37 @@ struct Thing *find_players_dungeon_heart(PlayerNumber plyridx)
     return INVALID_THING;
 }
 
+struct Thing* find_players_backup_dungeon_heart(PlayerNumber plyridx)
+{
+    struct Dungeon* dungeon = get_dungeon(plyridx);
+    int k = 0;
+    int i = game.thing_lists[TngList_Objects].index;
+    while (i != 0)
+    {
+        struct Thing* thing = thing_get(i);
+        if (thing_is_invalid(thing))
+        {
+            ERRORLOG("Jump to invalid thing detected");
+            break;
+        }
+        i = thing->next_of_class;
+        // Per-thing code
+        if (thing_is_dungeon_heart(thing) && (thing->owner == plyridx) && (thing->index != dungeon->dnheart_idx))
+        {
+            return thing;
+        }
+        // Per-thing code ends
+        k++;
+        if (k > THINGS_COUNT)
+        {
+            ERRORLOG("Infinite loop detected when sweeping things list");
+            break;
+        }
+    }
+    SYNCDBG(6, "No secondary heart for player %d", (int)plyridx);
+    return INVALID_THING;
+}
+
 /**
  * Initializes start position of the player.
  * Finds players dungeon heart and initializes players start position.
@@ -1088,6 +1119,7 @@ void init_player_start(struct PlayerInfo *player, TbBool keep_prev)
 {
     struct Thing* thing = find_players_dungeon_heart(player->id_number);
     struct Dungeon* dungeon = get_players_dungeon(player);
+    struct DungeonAdd* dungeonadd = get_players_dungeonadd(player);
     if (dungeon_invalid(dungeon)) {
         WARNLOG("Tried to init player %d which has no dungeon",(int)player->id_number);
         return;
@@ -1108,6 +1140,15 @@ void init_player_start(struct PlayerInfo *player, TbBool keep_prev)
             dungeon->mappos.x.val = subtile_coord_center(map_subtiles_x/2);
             dungeon->mappos.y.val = subtile_coord_center(map_subtiles_y/2);
             dungeon->mappos.z.val = subtile_coord_center(map_subtiles_z/2);
+        }
+    }
+
+    dungeonadd->backup_heart_idx = 0;
+    struct Thing* scndthing = find_players_backup_dungeon_heart(player->id_number);
+    {
+        if (!thing_is_invalid(thing))
+        {
+            dungeonadd->backup_heart_idx = scndthing->index;
         }
     }
 }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -593,7 +593,7 @@ long shot_kill_object(struct Thing *shotng, struct Thing *target)
 {
     if (thing_is_dungeon_heart(target))
     {
-        target->active_state = 3;
+        target->active_state = ObSt_BeingDestroyed;
         target->health = -1;
         if (is_my_player_number(shotng->owner))
         {


### PR DESCRIPTION
Enemies will only attack the main one. After it is destroyed, the second one takes over.

Solves a bug where all soul containers would be destroyed if one lost health.