### PR TITLE
Now check each column for height to determine crumble

### DIFF
--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -1814,12 +1814,13 @@ void create_dirt_rubble_for_dug_slab(MapSlabCoord slb_x, MapSlabCoord slb_y)
     long z;
     stl_x = STL_PER_SLB * slb_x;
     stl_y = STL_PER_SLB * slb_y;
-    z = get_floor_filled_subtiles_at(stl_x, stl_y);
     for (y = stl_y; y < stl_y+STL_PER_SLB; y++)
     {
         for (x = stl_x; x < stl_x+STL_PER_SLB; x++)
         {
-            if (z > 0) {
+            if (z > 0) 
+            {
+                z = get_floor_filled_subtiles_at(x, y);
                 create_dirt_rubble_for_dug_block(x, y, z, game.neutral_player_num);
             }
         }

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -1818,9 +1818,9 @@ void create_dirt_rubble_for_dug_slab(MapSlabCoord slb_x, MapSlabCoord slb_y)
     {
         for (x = stl_x; x < stl_x+STL_PER_SLB; x++)
         {
+            z = get_floor_filled_subtiles_at(x, y);
             if (z > 0) 
             {
-                z = get_floor_filled_subtiles_at(x, y);
                 create_dirt_rubble_for_dug_block(x, y, z, game.neutral_player_num);
             }
         }


### PR DESCRIPTION
There's only rock crumble when the new slab is higher then the new slab, but it determined this based on just one column. Now each individual column determines if rock crumble is needed.