### PR TITLE
Stop playing mentor speeches of things happening on screen

### DIFF
--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1091,14 +1091,14 @@ TbBool set_creature_combat_state(struct Thing *fighter, struct Thing *enemy, CrA
       if (is_my_player_number(fighter->owner))
       {
           if (is_my_player_number(enemy->owner)) {
-              output_message(SMsg_FingthingFriends, MESSAGE_DELAY_FIGHT, 1);
+              output_message_far_from_thing(fighter,SMsg_FingthingFriends, MESSAGE_DELAY_FIGHT, 1);
           } else {
-              output_message(SMsg_CreatureAttacking, MESSAGE_DELAY_FIGHT, 1);
+              output_message_far_from_thing(fighter,SMsg_CreatureAttacking, MESSAGE_DELAY_FIGHT, 1);
           }
       } else
       {
           if (is_my_player_number(enemy->owner)) {
-            output_message(SMsg_CreatureDefending, MESSAGE_DELAY_FIGHT, 1);
+              output_message_far_from_thing(enemy,SMsg_CreatureDefending, MESSAGE_DELAY_FIGHT, 1);
           }
       }
     }

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1086,7 +1086,7 @@ TbBool set_creature_combat_state(struct Thing *fighter, struct Thing *enemy, CrA
     }
     figctrl->combat.attack_type = attack_type;
     // If creatures weren't at combat before, then play a speech
-    if ((enmctrl->combat_flags & (CmbtF_Melee|CmbtF_Ranged)) == 0)
+    if ((enmctrl->combat_flags & (CmbtF_Melee|CmbtF_Ranged|CmbtF_Waiting)) == 0)
     {
       if (is_my_player_number(fighter->owner))
       {

--- a/src/gui_soundmsgs.c
+++ b/src/gui_soundmsgs.c
@@ -17,6 +17,7 @@
  */
 /******************************************************************************/
 #include "gui_soundmsgs.h"
+#include "bflib_sndlib.h"
 
 #include "globals.h"
 #include "bflib_basics.h"
@@ -358,6 +359,63 @@ TbBool output_message(long msg_idx, long delay, TbBool queue)
       }
     }
     WARNDBG(8,"Playing message %ld failed",msg_idx);
+    return false;
+}
+
+#define MinSoundDistance = 1800;
+TbBool output_message_far_from_thing(struct Thing* thing, long msg_idx, long delay, TbBool queue)
+{
+    if (SoundDisabled)
+        return 0;
+    if (GetCurrentSoundMasterVolume() <= 0)
+        return 0;
+    if (thing_is_invalid(thing))
+        return 0;
+    struct Coord3d rcpos;
+    rcpos.x.val = Receiver.pos.val_x;
+    rcpos.y.val = Receiver.pos.val_y;
+    rcpos.z.val = Receiver.pos.val_z;
+    if (get_3d_box_distance(&rcpos, &thing->mappos) > MaxSoundDistance)
+    {
+        SYNCDBG(5, "Message %ld, delay %ld, queue %s", msg_idx, delay, queue ? "on" : "off");
+        struct SMessage* smsg = &messages[msg_idx];
+        if (!message_can_be_played(msg_idx))
+        {
+            SYNCDBG(8, "Delay to turn %ld didn't passed, skipping", (long)smsg->end_time);
+            return false;
+        }
+        if (!speech_sample_playing())
+        {
+            long i = get_phrase_sample(get_phrase_for_message(msg_idx));
+            if (i == 0)
+            {
+                SYNCDBG(8, "No phrase %d sample, skipping", (int)msg_idx);
+                return false;
+            }
+            if (play_speech_sample(i))
+            {
+                message_playing = msg_idx;
+                smsg->end_time = (long)game.play_gameturn + delay;
+                SYNCDBG(8, "Playing prepared");
+                return true;
+            }
+        }
+        if ((msg_idx == message_playing) || (message_already_in_queue(msg_idx)))
+        {
+            SYNCDBG(8, "Message %ld is already in queue", msg_idx);
+            return false;
+        }
+        if (queue)
+        {
+            if (add_message_to_queue(msg_idx, delay))
+            {
+                SYNCDBG(8, "Playing queued");
+                return true;
+            }
+        }
+        WARNDBG(8, "Playing message %ld failed", msg_idx);
+        return false;
+    }
     return false;
 }
 

--- a/src/gui_soundmsgs.h
+++ b/src/gui_soundmsgs.h
@@ -197,9 +197,12 @@ struct MessageQueueEntry { // sizeof = 9
      long delay;
 };
 
+struct Thing;
+
 #pragma pack()
 /******************************************************************************/
 TbBool output_message(long msg_idx, long delay, TbBool queue);
+TbBool output_message_far_from_thing(struct Thing* thing, long msg_idx, long delay, TbBool queue);
 TbBool message_already_in_queue(long msg_idx);
 TbBool add_message_to_queue(long msg_idx, long delay);
 TbBool message_queue_empty(void);

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -91,7 +91,6 @@ DLLIMPORT unsigned long _DK_sound_seed;
 /******************************************************************************/
 TbBool init_sound_heap_two_banks(unsigned char *heap_mem, long heap_size, char *snd_fname, char *spc_fname, long a5);
 TbBool init_sound(void);
-void randomize_sound_font(void);
 void sound_reinit_after_load(void);
 
 void update_player_sounds(void);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2662,11 +2662,13 @@ TbBool kill_creature(struct Thing *creatng, struct Thing *killertng,
     if (!creature_control_invalid(cctrlgrp)) {
         cctrlgrp->kills_num++;
     }
-    if (is_my_player_number(creatng->owner)) {
-        output_message(SMsg_BattleDeath, MESSAGE_DELAY_BATTLE, true);
+    if (is_my_player_number(creatng->owner))
+    {
+        output_message_far_from_thing(creatng, SMsg_BattleDeath, MESSAGE_DELAY_BATTLE, true);
     } else
-    if (is_my_player_number(killertng->owner)) {
-        output_message(SMsg_BattleWon, MESSAGE_DELAY_BATTLE, true);
+    if (is_my_player_number(killertng->owner))
+    {
+        output_message_far_from_thing(creatng, SMsg_BattleWon, MESSAGE_DELAY_BATTLE, true);
     }
     if (is_hero_thing(killertng))
     {


### PR DESCRIPTION
Done it for 'creatures are winning/losing' battle and 'creatures are attacking enemy' 'being attacked by enemy' messages.
Also stopped notifying for units joining a battle when they were already in the battle queue.