### PR TITLE
Fixed script modified traps/doors from being disfunctional

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1027,6 +1027,9 @@ static void set_door_configuration_check(const struct ScriptLine* scline)
 
     const char *doorname = scline->tp[0];
     short door_id = get_id(door_desc, doorname);
+    const char* valuestring = scline->tp[2];
+    long newvalue;
+
     if (door_id == -1)
     {
         SCRPTERRLOG("Unknown door, '%s'", doorname);
@@ -1097,15 +1100,25 @@ static void set_door_configuration_check(const struct ScriptLine* scline)
             return;
         }
     }
-    else if (doorvar != 9) // PointerSprites
+    else if (doorvar != 9) // Not PointerSprites
     {
-        if ((scline->np[2] > 0xFFFF) || (scline->np[2] < 0))
+        if (parameter_is_number(valuestring))
         {
-            SCRPTERRLOG("Value out of range: %d", scline->np[2]);
+            newvalue = atoi(valuestring);
+            if ((newvalue > USHRT_MAX) || (newvalue < 0))
+            {
+                SCRPTERRLOG("Value out of range: %d", newvalue);
+                DEALLOCATE_SCRIPT_VALUE
+                return;
+            }
+            value->shorts[2] = newvalue;
+        }
+        else
+        {
+            SCRPTERRLOG("Door property %s needs a number value, '%s' is invalid.", scline->tp[1], scline->tp[2]);
             DEALLOCATE_SCRIPT_VALUE
             return;
         }
-        value->shorts[2] = (short)scline->np[2];
     }
     else
     {
@@ -1117,7 +1130,7 @@ static void set_door_configuration_check(const struct ScriptLine* scline)
             return;
         }
     }
-    SCRIPTDBG(7, "Setting door %s property %s to %d", doorname, doorvar, value->shorts[2]);
+    SCRIPTDBG(7, "Setting door %s property %s to %d", doorname, scline->tp[1], value->shorts[2]);
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 


### PR DESCRIPTION
SET_DOOR_CONFIGURATION and SET_TRAP_CONFIGURATION no longer function on the master. [Here](https://github.com/dkfans/keeperfx/pull/1459/files#diff-123eb0866139d924a2a0d92ae7301a757f1ca6dc9a09f14177bcf6dcb619639dR2682) the functionality broke. Changed the script commands from 'AANn' to 'AAAn' but failed to convert the strings (A) to Numbers on the checks.

To see the problem in action, add this to any level script:
```
DOOR_AVAILABLE(ALL_PLAYERS,MAGIC,1,3)
SET_DOOR_CONFIGURATION(MAGIC,Health,33)
TRAP_AVAILABLE(PLAYER0,ALARM,1,3)
SET_TRAP_CONFIGURATION(ALARM,AnimationSpeed,128)
```
Then build a magic door and notice it dies from having 0 health, and place the alarm trap and notice it has animation speed 0.

With this PR they should be fully functional again, numbers should work and when applicable strings too.