### PR TITLE
Fixed creatures casting out of range spells on the diagonals

### DIFF
--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -201,7 +201,7 @@ TbBool creature_will_do_combat(const struct Thing *thing)
 
 long get_combat_distance(const struct Thing *thing, const struct Thing *enmtng)
 {
-    long dist = get_2d_box_distance(&thing->mappos, &enmtng->mappos);
+    long dist = get_2d_distance(&thing->mappos, &enmtng->mappos);
     long avgc = ((long)enmtng->clipbox_size_xy + (long)thing->clipbox_size_xy) / 2;
     if (dist < avgc)
         return 0;


### PR DESCRIPTION
Fixes this issue:

![image](https://user-images.githubusercontent.com/13840686/178697810-9d03bbd6-2c33-4036-966d-db8771dd6966.png)
