### PR TITLE
Cube count extended

### DIFF
--- a/config/fxdata/cubes.cfg
+++ b/config/fxdata/cubes.cfg
@@ -5,7 +5,7 @@
 ; Such column is put on every subtile, and 3x3 area of subtiles is one slab.
 
 [common]
-CubesCount = 511
+CubesCount = 1023
 
 [cube0]
 Name = FREE_SPACE
@@ -2591,5 +2591,2565 @@ Flags =      0   0   0   0   0   0
 
 [cube510]
 Name = CUBE510
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube511]
+Name = CUBE511
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube512]
+Name = CUBE512
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube513]
+Name = CUBE513
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube514]
+Name = CUBE514
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube515]
+Name = CUBE515
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube516]
+Name = CUBE516
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube517]
+Name = CUBE517
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube518]
+Name = CUBE518
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube519]
+Name = CUBE519
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube520]
+Name = CUBE520
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube521]
+Name = CUBE521
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube522]
+Name = CUBE522
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube523]
+Name = CUBE523
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube524]
+Name = CUBE524
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube525]
+Name = CUBE525
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube526]
+Name = CUBE526
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube527]
+Name = CUBE527
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube528]
+Name = CUBE528
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube529]
+Name = CUBE529
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube530]
+Name = CUBE530
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube531]
+Name = CUBE531
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube532]
+Name = CUBE532
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube533]
+Name = CUBE533
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube534]
+Name = CUBE534
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube535]
+Name = CUBE535
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube536]
+Name = CUBE536
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube537]
+Name = CUBE537
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube538]
+Name = CUBE538
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube539]
+Name = CUBE539
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube540]
+Name = CUBE540
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube541]
+Name = CUBE541
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube542]
+Name = CUBE542
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube543]
+Name = CUBE543
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube544]
+Name = CUBE544
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube545]
+Name = CUBE545
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube546]
+Name = CUBE546
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube547]
+Name = CUBE547
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube548]
+Name = CUBE548
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube549]
+Name = CUBE549
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube550]
+Name = CUBE550
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube551]
+Name = CUBE551
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube552]
+Name = CUBE552
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube553]
+Name = CUBE553
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube554]
+Name = CUBE554
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube555]
+Name = CUBE555
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube556]
+Name = CUBE556
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube557]
+Name = CUBE557
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube558]
+Name = CUBE558
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube559]
+Name = CUBE559
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube560]
+Name = CUBE560
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube561]
+Name = CUBE561
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube562]
+Name = CUBE562
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube563]
+Name = CUBE563
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube564]
+Name = CUBE564
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube565]
+Name = CUBE565
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube566]
+Name = CUBE566
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube567]
+Name = CUBE567
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube568]
+Name = CUBE568
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube569]
+Name = CUBE569
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube570]
+Name = CUBE570
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube571]
+Name = CUBE571
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube572]
+Name = CUBE572
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube573]
+Name = CUBE573
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube574]
+Name = CUBE574
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube575]
+Name = CUBE575
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube576]
+Name = CUBE576
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube577]
+Name = CUBE577
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube578]
+Name = CUBE578
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube579]
+Name = CUBE579
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube580]
+Name = CUBE580
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube581]
+Name = CUBE581
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube582]
+Name = CUBE582
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube583]
+Name = CUBE583
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube584]
+Name = CUBE584
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube585]
+Name = CUBE585
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube586]
+Name = CUBE586
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube587]
+Name = CUBE587
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube588]
+Name = CUBE588
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube589]
+Name = CUBE589
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube590]
+Name = CUBE590
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube591]
+Name = CUBE591
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube592]
+Name = CUBE592
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube593]
+Name = CUBE593
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube594]
+Name = CUBE594
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube595]
+Name = CUBE595
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube596]
+Name = CUBE596
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube597]
+Name = CUBE597
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube598]
+Name = CUBE598
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube599]
+Name = CUBE599
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube600]
+Name = CUBE600
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube601]
+Name = CUBE601
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube602]
+Name = CUBE602
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube603]
+Name = CUBE603
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube604]
+Name = CUBE604
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube605]
+Name = CUBE605
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube606]
+Name = CUBE606
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube607]
+Name = CUBE607
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube608]
+Name = CUBE608
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube609]
+Name = CUBE609
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube610]
+Name = CUBE610
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube611]
+Name = CUBE611
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube612]
+Name = CUBE612
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube613]
+Name = CUBE613
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube614]
+Name = CUBE614
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube615]
+Name = CUBE615
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube616]
+Name = CUBE616
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube617]
+Name = CUBE617
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube618]
+Name = CUBE618
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube619]
+Name = CUBE619
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube620]
+Name = CUBE620
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube621]
+Name = CUBE621
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube622]
+Name = CUBE622
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube623]
+Name = CUBE623
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube624]
+Name = CUBE624
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube625]
+Name = CUBE625
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube626]
+Name = CUBE626
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube627]
+Name = CUBE627
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube628]
+Name = CUBE628
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube629]
+Name = CUBE629
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube630]
+Name = CUBE630
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube631]
+Name = CUBE631
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube632]
+Name = CUBE632
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube633]
+Name = CUBE633
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube634]
+Name = CUBE634
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube635]
+Name = CUBE635
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube636]
+Name = CUBE636
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube637]
+Name = CUBE637
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube638]
+Name = CUBE638
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube639]
+Name = CUBE639
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube640]
+Name = CUBE640
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube641]
+Name = CUBE641
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube642]
+Name = CUBE642
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube643]
+Name = CUBE643
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube644]
+Name = CUBE644
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube645]
+Name = CUBE645
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube646]
+Name = CUBE646
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube647]
+Name = CUBE647
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube648]
+Name = CUBE648
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube649]
+Name = CUBE649
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube650]
+Name = CUBE650
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube651]
+Name = CUBE651
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube652]
+Name = CUBE652
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube653]
+Name = CUBE653
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube654]
+Name = CUBE654
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube655]
+Name = CUBE655
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube656]
+Name = CUBE656
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube657]
+Name = CUBE657
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube658]
+Name = CUBE658
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube659]
+Name = CUBE659
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube660]
+Name = CUBE660
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube661]
+Name = CUBE661
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube662]
+Name = CUBE662
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube663]
+Name = CUBE663
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube664]
+Name = CUBE664
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube665]
+Name = CUBE665
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube666]
+Name = CUBE666
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube667]
+Name = CUBE667
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube668]
+Name = CUBE668
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube669]
+Name = CUBE669
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube670]
+Name = CUBE670
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube671]
+Name = CUBE671
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube672]
+Name = CUBE672
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube673]
+Name = CUBE673
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube674]
+Name = CUBE674
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube675]
+Name = CUBE675
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube676]
+Name = CUBE676
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube677]
+Name = CUBE677
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube678]
+Name = CUBE678
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube679]
+Name = CUBE679
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube680]
+Name = CUBE680
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube681]
+Name = CUBE681
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube682]
+Name = CUBE682
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube683]
+Name = CUBE683
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube684]
+Name = CUBE684
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube685]
+Name = CUBE685
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube686]
+Name = CUBE686
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube687]
+Name = CUBE687
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube688]
+Name = CUBE688
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube689]
+Name = CUBE689
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube690]
+Name = CUBE690
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube691]
+Name = CUBE691
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube692]
+Name = CUBE692
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube693]
+Name = CUBE693
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube694]
+Name = CUBE694
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube695]
+Name = CUBE695
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube696]
+Name = CUBE696
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube697]
+Name = CUBE697
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube698]
+Name = CUBE698
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube699]
+Name = CUBE699
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube700]
+Name = CUBE700
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube701]
+Name = CUBE701
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube702]
+Name = CUBE702
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube703]
+Name = CUBE703
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube704]
+Name = CUBE704
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube705]
+Name = CUBE705
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube706]
+Name = CUBE706
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube707]
+Name = CUBE707
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube708]
+Name = CUBE708
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube709]
+Name = CUBE709
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube710]
+Name = CUBE710
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube711]
+Name = CUBE711
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube712]
+Name = CUBE712
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube713]
+Name = CUBE713
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube714]
+Name = CUBE714
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube715]
+Name = CUBE715
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube716]
+Name = CUBE716
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube717]
+Name = CUBE717
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube718]
+Name = CUBE718
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube719]
+Name = CUBE719
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube720]
+Name = CUBE720
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube721]
+Name = CUBE721
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube722]
+Name = CUBE722
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube723]
+Name = CUBE723
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube724]
+Name = CUBE724
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube725]
+Name = CUBE725
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube726]
+Name = CUBE726
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube727]
+Name = CUBE727
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube728]
+Name = CUBE728
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube729]
+Name = CUBE729
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube730]
+Name = CUBE730
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube731]
+Name = CUBE731
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube732]
+Name = CUBE732
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube733]
+Name = CUBE733
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube734]
+Name = CUBE734
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube735]
+Name = CUBE735
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube736]
+Name = CUBE736
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube737]
+Name = CUBE737
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube738]
+Name = CUBE738
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube739]
+Name = CUBE739
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube740]
+Name = CUBE740
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube741]
+Name = CUBE741
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube742]
+Name = CUBE742
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube743]
+Name = CUBE743
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube744]
+Name = CUBE744
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube745]
+Name = CUBE745
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube746]
+Name = CUBE746
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube747]
+Name = CUBE747
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube748]
+Name = CUBE748
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube749]
+Name = CUBE749
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube750]
+Name = CUBE750
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube751]
+Name = CUBE751
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube752]
+Name = CUBE752
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube753]
+Name = CUBE753
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube754]
+Name = CUBE754
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube755]
+Name = CUBE755
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube756]
+Name = CUBE756
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube757]
+Name = CUBE757
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube758]
+Name = CUBE758
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube759]
+Name = CUBE759
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube760]
+Name = CUBE760
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube761]
+Name = CUBE761
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube762]
+Name = CUBE762
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube763]
+Name = CUBE763
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube764]
+Name = CUBE764
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube765]
+Name = CUBE765
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube766]
+Name = CUBE766
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube767]
+Name = CUBE767
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube768]
+Name = CUBE768
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube769]
+Name = CUBE769
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube770]
+Name = CUBE770
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube771]
+Name = CUBE771
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube772]
+Name = CUBE772
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube773]
+Name = CUBE773
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube774]
+Name = CUBE774
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube775]
+Name = CUBE775
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube776]
+Name = CUBE776
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube777]
+Name = CUBE777
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube778]
+Name = CUBE778
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube779]
+Name = CUBE779
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube780]
+Name = CUBE780
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube781]
+Name = CUBE781
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube782]
+Name = CUBE782
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube783]
+Name = CUBE783
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube784]
+Name = CUBE784
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube785]
+Name = CUBE785
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube786]
+Name = CUBE786
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube787]
+Name = CUBE787
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube788]
+Name = CUBE788
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube789]
+Name = CUBE789
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube790]
+Name = CUBE790
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube791]
+Name = CUBE791
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube792]
+Name = CUBE792
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube793]
+Name = CUBE793
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube794]
+Name = CUBE794
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube795]
+Name = CUBE795
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube796]
+Name = CUBE796
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube797]
+Name = CUBE797
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube798]
+Name = CUBE798
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube799]
+Name = CUBE799
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube800]
+Name = CUBE800
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube801]
+Name = CUBE801
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube802]
+Name = CUBE802
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube803]
+Name = CUBE803
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube804]
+Name = CUBE804
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube805]
+Name = CUBE805
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube806]
+Name = CUBE806
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube807]
+Name = CUBE807
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube808]
+Name = CUBE808
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube809]
+Name = CUBE809
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube810]
+Name = CUBE810
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube811]
+Name = CUBE811
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube812]
+Name = CUBE812
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube813]
+Name = CUBE813
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube814]
+Name = CUBE814
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube815]
+Name = CUBE815
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube816]
+Name = CUBE816
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube817]
+Name = CUBE817
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube818]
+Name = CUBE818
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube819]
+Name = CUBE819
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube820]
+Name = CUBE820
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube821]
+Name = CUBE821
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube822]
+Name = CUBE822
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube823]
+Name = CUBE823
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube824]
+Name = CUBE824
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube825]
+Name = CUBE825
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube826]
+Name = CUBE826
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube827]
+Name = CUBE827
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube828]
+Name = CUBE828
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube829]
+Name = CUBE829
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube830]
+Name = CUBE830
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube831]
+Name = CUBE831
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube832]
+Name = CUBE832
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube833]
+Name = CUBE833
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube834]
+Name = CUBE834
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube835]
+Name = CUBE835
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube836]
+Name = CUBE836
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube837]
+Name = CUBE837
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube838]
+Name = CUBE838
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube839]
+Name = CUBE839
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube840]
+Name = CUBE840
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube841]
+Name = CUBE841
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube842]
+Name = CUBE842
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube843]
+Name = CUBE843
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube844]
+Name = CUBE844
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube845]
+Name = CUBE845
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube846]
+Name = CUBE846
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube847]
+Name = CUBE847
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube848]
+Name = CUBE848
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube849]
+Name = CUBE849
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube850]
+Name = CUBE850
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube851]
+Name = CUBE851
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube852]
+Name = CUBE852
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube853]
+Name = CUBE853
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube854]
+Name = CUBE854
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube855]
+Name = CUBE855
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube856]
+Name = CUBE856
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube857]
+Name = CUBE857
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube858]
+Name = CUBE858
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube859]
+Name = CUBE859
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube860]
+Name = CUBE860
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube861]
+Name = CUBE861
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube862]
+Name = CUBE862
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube863]
+Name = CUBE863
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube864]
+Name = CUBE864
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube865]
+Name = CUBE865
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube866]
+Name = CUBE866
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube867]
+Name = CUBE867
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube868]
+Name = CUBE868
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube869]
+Name = CUBE869
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube870]
+Name = CUBE870
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube871]
+Name = CUBE871
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube872]
+Name = CUBE872
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube873]
+Name = CUBE873
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube874]
+Name = CUBE874
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube875]
+Name = CUBE875
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube876]
+Name = CUBE876
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube877]
+Name = CUBE877
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube878]
+Name = CUBE878
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube879]
+Name = CUBE879
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube880]
+Name = CUBE880
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube881]
+Name = CUBE881
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube882]
+Name = CUBE882
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube883]
+Name = CUBE883
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube884]
+Name = CUBE884
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube885]
+Name = CUBE885
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube886]
+Name = CUBE886
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube887]
+Name = CUBE887
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube888]
+Name = CUBE888
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube889]
+Name = CUBE889
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube890]
+Name = CUBE890
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube891]
+Name = CUBE891
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube892]
+Name = CUBE892
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube893]
+Name = CUBE893
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube894]
+Name = CUBE894
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube895]
+Name = CUBE895
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube896]
+Name = CUBE896
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube897]
+Name = CUBE897
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube898]
+Name = CUBE898
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube899]
+Name = CUBE899
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube900]
+Name = CUBE900
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube901]
+Name = CUBE901
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube902]
+Name = CUBE902
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube903]
+Name = CUBE903
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube904]
+Name = CUBE904
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube905]
+Name = CUBE905
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube906]
+Name = CUBE906
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube907]
+Name = CUBE907
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube908]
+Name = CUBE908
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube909]
+Name = CUBE909
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube910]
+Name = CUBE910
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube911]
+Name = CUBE911
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube912]
+Name = CUBE912
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube913]
+Name = CUBE913
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube914]
+Name = CUBE914
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube915]
+Name = CUBE915
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube916]
+Name = CUBE916
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube917]
+Name = CUBE917
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube918]
+Name = CUBE918
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube919]
+Name = CUBE919
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube920]
+Name = CUBE920
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube921]
+Name = CUBE921
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube922]
+Name = CUBE922
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube923]
+Name = CUBE923
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube924]
+Name = CUBE924
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube925]
+Name = CUBE925
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube926]
+Name = CUBE926
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube927]
+Name = CUBE927
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube928]
+Name = CUBE928
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube929]
+Name = CUBE929
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube930]
+Name = CUBE930
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube931]
+Name = CUBE931
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube932]
+Name = CUBE932
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube933]
+Name = CUBE933
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube934]
+Name = CUBE934
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube935]
+Name = CUBE935
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube936]
+Name = CUBE936
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube937]
+Name = CUBE937
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube938]
+Name = CUBE938
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube939]
+Name = CUBE939
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube940]
+Name = CUBE940
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube941]
+Name = CUBE941
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube942]
+Name = CUBE942
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube943]
+Name = CUBE943
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube944]
+Name = CUBE944
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube945]
+Name = CUBE945
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube946]
+Name = CUBE946
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube947]
+Name = CUBE947
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube948]
+Name = CUBE948
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube949]
+Name = CUBE949
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube950]
+Name = CUBE950
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube951]
+Name = CUBE951
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube952]
+Name = CUBE952
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube953]
+Name = CUBE953
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube954]
+Name = CUBE954
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube955]
+Name = CUBE955
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube956]
+Name = CUBE956
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube957]
+Name = CUBE957
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube958]
+Name = CUBE958
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube959]
+Name = CUBE959
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube960]
+Name = CUBE960
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube961]
+Name = CUBE961
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube962]
+Name = CUBE962
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube963]
+Name = CUBE963
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube964]
+Name = CUBE964
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube965]
+Name = CUBE965
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube966]
+Name = CUBE966
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube967]
+Name = CUBE967
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube968]
+Name = CUBE968
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube969]
+Name = CUBE969
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube970]
+Name = CUBE970
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube971]
+Name = CUBE971
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube972]
+Name = CUBE972
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube973]
+Name = CUBE973
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube974]
+Name = CUBE974
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube975]
+Name = CUBE975
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube976]
+Name = CUBE976
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube977]
+Name = CUBE977
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube978]
+Name = CUBE978
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube979]
+Name = CUBE979
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube980]
+Name = CUBE980
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube981]
+Name = CUBE981
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube982]
+Name = CUBE982
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube983]
+Name = CUBE983
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube984]
+Name = CUBE984
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube985]
+Name = CUBE985
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube986]
+Name = CUBE986
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube987]
+Name = CUBE987
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube988]
+Name = CUBE988
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube989]
+Name = CUBE989
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube990]
+Name = CUBE990
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube991]
+Name = CUBE991
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube992]
+Name = CUBE992
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube993]
+Name = CUBE993
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube994]
+Name = CUBE994
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube995]
+Name = CUBE995
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube996]
+Name = CUBE996
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube997]
+Name = CUBE997
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube998]
+Name = CUBE998
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube999]
+Name = CUBE999
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1000]
+Name = CUBE1000
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1001]
+Name = CUBE1001
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1002]
+Name = CUBE1002
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1003]
+Name = CUBE1003
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1004]
+Name = CUBE1004
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1005]
+Name = CUBE1005
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1006]
+Name = CUBE1006
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1007]
+Name = CUBE1007
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1008]
+Name = CUBE1008
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1009]
+Name = CUBE1009
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1010]
+Name = CUBE1010
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1011]
+Name = CUBE1011
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1012]
+Name = CUBE1012
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1013]
+Name = CUBE1013
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1014]
+Name = CUBE1014
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1015]
+Name = CUBE1015
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1016]
+Name = CUBE1016
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1017]
+Name = CUBE1017
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1018]
+Name = CUBE1018
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1019]
+Name = CUBE1019
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1020]
+Name = CUBE1020
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1021]
+Name = CUBE1021
+Textures =   0   0   0   0   0   0
+Flags =      0   0   0   0   0   0
+
+[cube1022]
+Name = CUBE1022
 Textures =   0   0   0   0   0   0
 Flags =      0   0   0   0   0   0

--- a/src/config.h
+++ b/src/config.h
@@ -35,7 +35,6 @@ struct GameCampaign;
 #define LEVELNUMBER_ERROR            -2
 
 #define MIN_CONFIG_FILE_SIZE          4
-#define MAX_CONFIG_FILE_SIZE      65535
 
 #define LANDVIEW_MAP_WIDTH         1280
 #define LANDVIEW_MAP_HEIGHT         960

--- a/src/config_creature.c
+++ b/src/config_creature.c
@@ -1660,12 +1660,6 @@ TbBool load_creaturetypes_config_file(const char *textname, const char *fname, u
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -2375,12 +2375,6 @@ TbBool load_creaturemodel_config_file(long crtr_model,const char *textname,const
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_crtrstates.c
+++ b/src/config_crtrstates.c
@@ -207,12 +207,6 @@ TbBool load_creaturestates_config_file(const char *textname, const char *fname, 
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_cubes.c
+++ b/src/config_cubes.c
@@ -164,7 +164,7 @@ TbBool parse_cubes_cube_blocks(char *buf, long len, const char *config_textname,
             continue;
         }
         objst = &cube_conf.cube_cfgstats[i];
-        struct CubeAttribs* cubed = &game.cubes_data[i];
+        struct CubeAttribs* cubed = &gameadd.cubes_data[i];
 #define COMMAND_TEXT(cmd_num) get_conf_parameter_text(cubes_cube_commands,cmd_num)
         while (pos<len)
         {
@@ -254,12 +254,13 @@ TbBool load_cubes_config_file(const char *textname, const char *fname, unsigned 
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
+    // Need a much larger .cfg file for extended cubes count, so skip this max size check.
+    /*if (len > MAX_CONFIG_FILE_SIZE)
     {
         if ((flags & CnfLd_IgnoreErrors) == 0)
             WARNMSG("The %s file \"%s\" is too large.",textname,fname);
         return false;
-    }
+    }*/
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;
@@ -337,7 +338,7 @@ void clear_cubes(void)
 {
     for (int i = 0; i < CUBE_ITEMS_MAX; i++)
     {
-        struct CubeAttribs* cubed = &game.cubes_data[i];
+        struct CubeAttribs* cubed = &gameadd.cubes_data[i];
         int n;
         for (n = 0; n < CUBE_TEXTURES; n++)
         {
@@ -392,7 +393,7 @@ long load_cube_file(void)
         struct CubeAttribs* cubuf = (struct CubeAttribs*)&buf[4];
         for (long i = 0; i < count; i++)
         {
-            struct CubeAttribs* cubed = &game.cubes_data[i];
+            struct CubeAttribs* cubed = &gameadd.cubes_data[i];
             int n;
             for (n=0; n < CUBE_TEXTURES; n++) {
                 cubed->texture_id[n] = cubuf->texture_id[n];

--- a/src/config_cubes.c
+++ b/src/config_cubes.c
@@ -254,13 +254,6 @@ TbBool load_cubes_config_file(const char *textname, const char *fname, unsigned 
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    // Need a much larger .cfg file for extended cubes count, so skip this max size check.
-    /*if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }*/
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;
@@ -365,11 +358,6 @@ long load_cube_file(void)
     if (len < MIN_CONFIG_FILE_SIZE)
     {
         WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
-        return false;
-    }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        WARNMSG("The %s file \"%s\" is too large.",textname,fname);
         return false;
     }
     char* buf = (char*)LbMemoryAlloc(len + 256);

--- a/src/config_cubes.h
+++ b/src/config_cubes.h
@@ -37,7 +37,7 @@ extern "C" {
 /******************************************************************************/
 #pragma pack(1)
 
-struct CubeAttribs {
+struct CubeAttribs { // sizeof=0x12
     unsigned short texture_id[CUBE_TEXTURES];
     unsigned char field_C[CUBE_TEXTURES];
 };

--- a/src/config_cubes.h
+++ b/src/config_cubes.h
@@ -29,14 +29,15 @@
 extern "C" {
 #endif
 /******************************************************************************/
+#define CUBE_ITEMS_MAX_OLD 512
+#define CUBE_ITEMS_MAX 1024
 
-#define CUBE_ITEMS_MAX 512
 #define CUBE_TEXTURES 6
 
 /******************************************************************************/
 #pragma pack(1)
 
-struct CubeAttribs { // sizeof=0x12
+struct CubeAttribs {
     unsigned short texture_id[CUBE_TEXTURES];
     unsigned char field_C[CUBE_TEXTURES];
 };

--- a/src/config_effects.c
+++ b/src/config_effects.c
@@ -373,12 +373,6 @@ TbBool load_effects_config_file(const char *textname, const char *fname, unsigne
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_lenses.c
+++ b/src/config_lenses.c
@@ -315,12 +315,6 @@ TbBool load_lenses_config_file(const char *textname, const char *fname, unsigned
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_magic.c
+++ b/src/config_magic.c
@@ -1823,12 +1823,6 @@ TbBool load_magic_config_file(const char *textname, const char *fname, unsigned 
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_objects.c
+++ b/src/config_objects.c
@@ -561,12 +561,6 @@ TbBool load_objects_config_file(const char *textname, const char *fname, unsigne
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -2247,12 +2247,6 @@ TbBool load_rules_config_file(const char *textname, const char *fname, unsigned 
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_terrain.c
+++ b/src/config_terrain.c
@@ -1163,12 +1163,6 @@ TbBool load_terrain_config_file(const char *textname, const char *fname, unsigne
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -974,12 +974,6 @@ TbBool load_trapdoor_config_file(const char *textname, const char *fname, unsign
             WARNMSG("The %s file \"%s\" doesn't exist or is too small.",textname,fname);
         return false;
     }
-    if (len > MAX_CONFIG_FILE_SIZE)
-    {
-        if ((flags & CnfLd_IgnoreErrors) == 0)
-            WARNMSG("The %s file \"%s\" is too large.",textname,fname);
-        return false;
-    }
     char* buf = (char*)LbMemoryAlloc(len + 256);
     if (buf == NULL)
         return false;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -3734,7 +3734,7 @@ void do_a_plane_of_engine_columns_perspective(long stl_x, long stl_y, long plane
         height_bit = 1;
         while (height_bit <= solidmsk_center)
         {
-            texturing = &game.cubes_data[*cubenum_ptr];
+            texturing = &gameadd.cubes_data[*cubenum_ptr];
             if ((solidmsk_center & height_bit) != 0)
             {
               if ((solidmsk_top & height_bit) == 0)
@@ -3771,7 +3771,7 @@ void do_a_plane_of_engine_columns_perspective(long stl_x, long stl_y, long plane
         if (ecpos > 0)
         {
             cubenum_ptr = &colmn->cubes[ecpos-1];
-            texturing = &game.cubes_data[*cubenum_ptr];
+            texturing = &gameadd.cubes_data[*cubenum_ptr];
             textr_idx = engine_remap_texture_blocks((center_block_idx%(map_subtiles_x+1)), (center_block_idx/(map_subtiles_x+1)), texturing->texture_id[4]);
             do_a_trig_gourad_tr(&bec[0].cors[ecpos], &bec[1].cors[ecpos], &fec[1].cors[ecpos], textr_idx, -1);
             do_a_trig_gourad_bl(&fec[1].cors[ecpos], &fec[0].cors[ecpos], &bec[0].cors[ecpos], textr_idx, -1);
@@ -3787,7 +3787,7 @@ void do_a_plane_of_engine_columns_perspective(long stl_x, long stl_y, long plane
         if (ecpos > 0)
         {
             cubenum_ptr = &colmn->cubes[ecpos-1];
-            texturing = &game.cubes_data[*cubenum_ptr];
+            texturing = &gameadd.cubes_data[*cubenum_ptr];
             textr_idx = engine_remap_texture_blocks((center_block_idx%(map_subtiles_x+1)), (center_block_idx/(map_subtiles_x+1)), texturing->texture_id[4]);
             do_a_trig_gourad_tr(&bec[0].cors[ecpos], &bec[1].cors[ecpos], &fec[1].cors[ecpos], textr_idx, -1);
             do_a_trig_gourad_bl(&fec[1].cors[ecpos], &fec[0].cors[ecpos], &bec[0].cors[ecpos], textr_idx, -1);
@@ -4153,7 +4153,7 @@ void do_a_plane_of_engine_columns_cluedo(long stl_x, long stl_y, long plane_star
         {
             unsigned short textr_id;
             struct CubeAttribs *cubed;
-            cubed = &game.cubes_data[cur_colmn->cubes[ncor]];
+            cubed = &gameadd.cubes_data[cur_colmn->cubes[ncor]];
             if ((mask & solidmsk_cur) == 0)
             {
                 continue;
@@ -4204,7 +4204,7 @@ void do_a_plane_of_engine_columns_cluedo(long stl_x, long stl_y, long plane_star
              {
                 if ((ncor_raw > 0) && (ncor_raw <= COLUMN_STACK_HEIGHT))
                 {
-                    struct CubeAttribs * cubed = &game.cubes_data[cur_colmn->cubes[ncor_raw-1]];
+                    struct CubeAttribs * cubed = &gameadd.cubes_data[cur_colmn->cubes[ncor_raw-1]];
                     unsigned short textr_id = engine_remap_texture_blocks(stl_x + xaval + xidx, stl_y, cubed->texture_id[4]);
                     // Top surface in cluedo mode
                     do_a_gpoly_gourad_tr(&bec[0].cors[ncor], &bec[1].cors[ncor], &fec[1].cors[ncor], textr_id, -1);
@@ -4229,7 +4229,7 @@ void do_a_plane_of_engine_columns_cluedo(long stl_x, long stl_y, long plane_star
         if ((ncor > 0) && (ncor <= COLUMN_STACK_HEIGHT))
         {
             struct CubeAttribs * cubed;
-            cubed = &game.cubes_data[cur_colmn->cubes[ncor-1]];
+            cubed = &gameadd.cubes_data[cur_colmn->cubes[ncor-1]];
             unsigned short textr_id = engine_remap_texture_blocks(stl_x + xaval + xidx, stl_y, cubed->texture_id[4]);
             do_a_gpoly_gourad_tr(&bec[0].cors[ncor], &bec[1].cors[ncor], &fec[1].cors[ncor], textr_id, -1);
             do_a_gpoly_gourad_bl(&fec[1].cors[ncor], &fec[0].cors[ncor], &bec[0].cors[ncor], textr_id, -1);
@@ -4341,7 +4341,7 @@ void do_a_plane_of_engine_columns_isometric(long stl_x, long stl_y, long plane_s
         {
             unsigned short textr_id;
             struct CubeAttribs *cubed;
-            cubed = &game.cubes_data[cur_colmn->cubes[ncor]];
+            cubed = &gameadd.cubes_data[cur_colmn->cubes[ncor]];
             if ((mask & solidmsk_cur) == 0)
             {
                 continue;
@@ -4384,7 +4384,7 @@ void do_a_plane_of_engine_columns_isometric(long stl_x, long stl_y, long plane_s
             else if ((cur_mapblk->flags & (SlbAtFlg_TaggedValuable|SlbAtFlg_Unexplored)) == 0)
             {
                 struct CubeAttribs * cubed;
-                cubed = &game.cubes_data[*(short *)((char *)&cur_colmn->baseblock + 2 * ncor + 1)];
+                cubed = &gameadd.cubes_data[*(short *)((char *)&cur_colmn->baseblock + 2 * ncor + 1)];
                 unsigned short textr_id = engine_remap_texture_blocks(stl_x + xaval + xidx, stl_y, cubed->texture_id[4]);
                 // Top surface on full iso mode
                 do_a_gpoly_gourad_tr(&bec[0].cors[ncor], &bec[1].cors[ncor], &fec[1].cors[ncor], textr_id, -1);
@@ -4414,7 +4414,7 @@ void do_a_plane_of_engine_columns_isometric(long stl_x, long stl_y, long plane_s
         if (ncor > 0)
         {
             struct CubeAttribs * cubed;
-            cubed = &game.cubes_data[*(short *)((char *)&cur_colmn->baseblock + 2 * ncor + 1)];
+            cubed = &gameadd.cubes_data[*(short *)((char *)&cur_colmn->baseblock + 2 * ncor + 1)];
             unsigned short textr_id = engine_remap_texture_blocks(stl_x + xaval + xidx, stl_y, cubed->texture_id[4]);
             do_a_gpoly_gourad_tr(&bec[0].cors[ncor], &bec[1].cors[ncor], &fec[1].cors[ncor], textr_id, -1);
             do_a_gpoly_gourad_bl(&fec[1].cors[ncor], &fec[0].cors[ncor], &bec[0].cors[ncor], textr_id, -1);
@@ -6935,7 +6935,7 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
       if (col->cubes[tc] == 0)
         break;
       y -= delta_y;
-      unkstrcp = &game.cubes_data[col->cubes[tc]];
+      unkstrcp = &gameadd.cubes_data[col->cubes[tc]];
       if (*ymax > y)
       {
         *ymax = y;
@@ -6985,7 +6985,7 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
             if (col->cubes[tc] == 0)
               break;
             y -= delta_y;
-            unkstrcp = &game.cubes_data[col->cubes[tc]];
+            unkstrcp = &gameadd.cubes_data[col->cubes[tc]];
             if (*ymax > y)
             {
               textr_idx = engine_remap_texture_blocks(stl_x, stl_y, unkstrcp->texture_id[cube_itm]);

--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -135,13 +135,13 @@ char numfield_1A;
     unsigned char numfield_1B;
     struct PlayerInfo players[PLAYERS_COUNT];
     struct Column columns_data[COLUMNS_COUNT];
-    struct CubeAttribs cubes_data[CUBE_ITEMS_MAX];
+    struct CubeAttribs cubes_data_UNUSED[CUBE_ITEMS_MAX_OLD];
     struct ObjectConfig objects_config[OBJECT_TYPES_COUNT_ORIGINAL];
 struct ObjectConfig objects_config_UNUSED[103];
 char field_117DA[14];
     // Traps and doors config; note that eventually we'll want to merge it with trapdoor_conf
-    struct ManfctrConfig traps_config_[TRAP_TYPES_COUNT];
-    struct ManfctrConfig doors_config_[DOOR_TYPES_COUNT_OLD];
+    struct ManfctrConfig traps_config_UNUSED[TRAP_TYPES_COUNT];
+    struct ManfctrConfig doors_config_UNUSED[DOOR_TYPES_COUNT_OLD];
     struct SpellConfig spells_config[30];
     struct Things things;
     struct Persons persons;

--- a/src/game_merge.h
+++ b/src/game_merge.h
@@ -23,6 +23,7 @@
 #include "bflib_basics.h"
 #include "globals.h"
 
+#include "config_cubes.h"
 #include "config_creature.h"
 #include "config_crtrmodel.h"
 #include "config_objects.h"
@@ -182,6 +183,7 @@ struct GameAdd {
     unsigned short disease_to_temple_pct;
     TbBool place_traps_on_subtiles;
     unsigned long gold_per_hoard;
+    struct CubeAttribs cubes_data[CUBE_ITEMS_MAX];
 
 #define TRAPDOOR_TYPES_MAX 128
 

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -2284,12 +2284,12 @@ long element_top_face_texture(struct Map *mapblk)
         }
         if ( (col->bitfields & CLF_CEILING_MASK) != 0 )
         {
-            cubed = &game.cubes_data[col->cubes[COLUMN_STACK_HEIGHT-get_column_ceiling_filled_subtiles(col)-1]];
+            cubed = &gameadd.cubes_data[col->cubes[COLUMN_STACK_HEIGHT-get_column_ceiling_filled_subtiles(col)-1]];
             return cubed->texture_id[4];
         }
         else if ((col->bitfields & CLF_FLOOR_MASK) != 0)
         {
-            cubed = &game.cubes_data[col->cubes[get_column_floor_filled_subtiles(col) - 1]];
+            cubed = &gameadd.cubes_data[col->cubes[get_column_floor_filled_subtiles(col) - 1]];
             return cubed->texture_id[4];
         }
         else

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -526,7 +526,7 @@ void init_top_texture_to_cube_table(void)
         for (i=1; i < CUBE_ITEMS_MAX; i++)
         {
             struct CubeAttribs * cubed;
-            cubed = &game.cubes_data[i];
+            cubed = &gameadd.cubes_data[i];
             if (cubed->texture_id[4] == n) {
                 game.field_14BB65[n] = i;
                 break;


### PR DESCRIPTION
In Unearth you can place custom slabs which contain custom columns which use cubes that are defined inside /fxdata/cubes.cfg

Extended beyond 511 to 1023, but it can be set to whatever value by adjusting `CUBE_ITEMS_MAX` and cubes.cfg