### PR TITLE
Stopped units from shooting through corner

### DIFF
--- a/src/creature_senses.c
+++ b/src/creature_senses.c
@@ -561,7 +561,7 @@ TbBool jonty_line_of_sight_3d_including_lava_check_ignoring_own_door(const struc
     nextpos.y.val = prevpos.y.val + increase_y;
     nextpos.z.val = prevpos.z.val + increase_z;
 
-    while (distance > 1)
+    while (distance > 0) //At 0 so units won't shoot through walled corners.
     {
         if (get_point_in_map_solid_flags_ignoring_own_door(&nextpos, plyr_idx) & 0x01) {
             SYNCDBG(17, "Player %d cannot see through (%d,%d) due to linear path solid flags (downcount %d)",


### PR DESCRIPTION
when target is pushed into corner itself

To reproduce the bug, have a room like this: 
![image](https://user-images.githubusercontent.com/13840686/180849364-c242b861-ca51-4c93-b3cb-6b0975f98c7e.png)

Then walk a unit into the corner from outside the room, as if you would want to wall-clip, and units inside would shoot at you from inside the room.