### PR TITLE
Stop thing objects disappearing at certain angles while fully zoomed out

### DIFF
--- a/src/engine_render.h
+++ b/src/engine_render.h
@@ -33,8 +33,8 @@ extern "C" {
 #pragma pack(1)
 
 #define POLY_POOL_SIZE 16777216 // Originally 262144, adjusted for view distance
-#define BUCKETS_COUNT 4224 // Originally 704, adjusted for view distance
-#define Z_DRAW_DISTANCE_MAX 35000 // Originally 11232, adjusted for view distance
+#define Z_DRAW_DISTANCE_MAX 65536 // Originally 11232, adjusted for view distance
+#define BUCKETS_COUNT 4098 // Originally 704, adjusted for view distance. (65536/16)+2
 
 #define KEEPSPRITE_LENGTH 9149
 #define KEEPERSPRITE_ADD_OFFSET 16384


### PR DESCRIPTION
Also set BUCKETS_COUNT to correct value. (this shouldn't matter much)