### PR TITLE
Set old eye height again

### DIFF
--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -469,6 +469,7 @@ void update_player_camera_fp(struct Camera *cam, struct Thing *thing)
     {
         eye_height = crstat->eye_height + (crstat->eye_height * gameadd.crtr_conf.exp.size_increase_on_exp * cctrl->explevel) / 100;
     }
+    creature_stats_OLD->eye_height = eye_height; //todo Remove when creature_stats_OLD value is no longer used in dll
 
     if ( thing_is_creature(thing) )
     {
@@ -582,7 +583,6 @@ void update_player_camera_fp(struct Camera *cam, struct Thing *thing)
             }
         }
     }
-    creature_stats_OLD->eye_height = eye_height;
 }
 
 void view_move_camera_left(struct Camera *cam, long distance)

--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -457,7 +457,7 @@ void update_player_camera_fp(struct Camera *cam, struct Thing *thing)
 {
     struct CreatureStats* crstat = creature_stats_get_from_thing(thing);
     struct CreatureControl *cctrl = creature_control_get_from_thing(thing);
-
+    struct CreatureStatsOLD* creature_stats_OLD = &game.creature_stats_OLD[thing->model];
     // adjust eye height based on creature level and chicken state
     int eye_height;
     if (creature_affected_by_spell(thing, SplK_Chicken))
@@ -582,7 +582,7 @@ void update_player_camera_fp(struct Camera *cam, struct Thing *thing)
             }
         }
     }
-
+    creature_stats_OLD->eye_height = eye_height;
 }
 
 void view_move_camera_left(struct Camera *cam, long distance)


### PR DESCRIPTION
It's in the dll and still needed. Fixes a bug where attacks in possession miss always.

To reproduce the bug, possess a lvl1 dragon and attack a lvl1 hero barbarian in possession. Notice you cannot hit him.