### PR TITLE
Use lair size when looking for room the heal in

### DIFF
--- a/src/room_util.c
+++ b/src/room_util.c
@@ -511,6 +511,7 @@ EventIndex update_cannot_find_room_of_role_wth_spare_capacity_event(PlayerNumber
         switch (rrole)
         {
         case RoRoF_LairStorage:
+        case RoRoF_CrHealSleep:
             // Find room with lair capacity
             {
                 struct CreatureStats* crstat = creature_stats_get_from_thing(creatng);


### PR DESCRIPTION
Fixes #1709

The lair has multiple roles, for regular sleeping the checks would consider the size of the lair needed, but to heal it checked only for 1 free capacity.