### PR TITLE
Made Pick Up Offset configurable

### DIFF
--- a/config/creatrs/archer.cfg
+++ b/config/creatrs/archer.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 0 82 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/avatar.cfg
+++ b/config/creatrs/avatar.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 4
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 14 76 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/barbarian.cfg
+++ b/config/creatrs/barbarian.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 2
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 38 134 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/bile_demon.cfg
+++ b/config/creatrs/bile_demon.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 4
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = -8 76 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/bug.cfg
+++ b/config/creatrs/bug.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 6
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 128
 CorpseVanishEffect = 0
+PickUpOffset = 22 60 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/dark_mistress.cfg
+++ b/config/creatrs/dark_mistress.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 6
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = -6 126 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/demonspawn.cfg
+++ b/config/creatrs/demonspawn.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 6
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 256
 CorpseVanishEffect = 0
+PickUpOffset = 0 50 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/dragon.cfg
+++ b/config/creatrs/dragon.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 6
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 200 550
 CorpseVanishEffect = 0
+PickUpOffset = 14 120 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/dwarfa.cfg
+++ b/config/creatrs/dwarfa.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 2
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 14 44 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/fairy.cfg
+++ b/config/creatrs/fairy.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 8 116 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/floating_spirit.cfg
+++ b/config/creatrs/floating_spirit.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 0
 CorpseVanishEffect = 0
+PickUpOffset = 0 0 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/fly.cfg
+++ b/config/creatrs/fly.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 6
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 128
 CorpseVanishEffect = 0
+PickUpOffset = 14 68 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/ghost.cfg
+++ b/config/creatrs/ghost.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 256
 CorpseVanishEffect = 0
+PickUpOffset = -8 60 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/giant.cfg
+++ b/config/creatrs/giant.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 10 90 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/hell_hound.cfg
+++ b/config/creatrs/hell_hound.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 6
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 256
 CorpseVanishEffect = 0
+PickUpOffset = -12 80 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/horny.cfg
+++ b/config/creatrs/horny.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 3
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 4 128 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -195,6 +195,8 @@ NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 256
 ; Effect or EffectElement(on negative numbers) which replaces the creature corpse when it disappears
 CorpseVanishEffect = -63
+; ??? todo
+PickUpOffset = -2 46 0 0
 
 [experience]
 ; Creature spells (instance names), and the creature level at which they're given (max 10)

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -195,7 +195,7 @@ NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 256
 ; Effect or EffectElement(on negative numbers) which replaces the creature corpse when it disappears
 CorpseVanishEffect = -63
-; ??? todo
+; Position of the 'PowerGrab' sprite relative to the hand sprite when picked up
 PickUpOffset = -2 46 0 0
 
 [experience]

--- a/config/creatrs/knight.cfg
+++ b/config/creatrs/knight.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 4
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 8 64 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/monk.cfg
+++ b/config/creatrs/monk.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = -1 69 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/orc.cfg
+++ b/config/creatrs/orc.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 2
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 5 121 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/samurai.cfg
+++ b/config/creatrs/samurai.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 5
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 4 104 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/skeleton.cfg
+++ b/config/creatrs/skeleton.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 4
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = -5 54 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/sorceror.cfg
+++ b/config/creatrs/sorceror.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = -8 84 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/spider.cfg
+++ b/config/creatrs/spider.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 6
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 256
 CorpseVanishEffect = 0
+PickUpOffset = 2 44 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/tentacle.cfg
+++ b/config/creatrs/tentacle.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 3
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 256
 CorpseVanishEffect = 0
+PickUpOffset = 0 74 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/thief.cfg
+++ b/config/creatrs/thief.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 4
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 10 102 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/troll.cfg
+++ b/config/creatrs/troll.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 4 96 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/tunneller.cfg
+++ b/config/creatrs/tunneller.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 2
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 12 50 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/vampire.cfg
+++ b/config/creatrs/vampire.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 0 70 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/witch.cfg
+++ b/config/creatrs/witch.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 6 74 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/config/creatrs/wizard.cfg
+++ b/config/creatrs/wizard.cfg
@@ -87,6 +87,7 @@ PossessSwipeIndex = 1
 NaturalDeathKind = NORMAL
 ShotOrigin = 0 0 384
 CorpseVanishEffect = 0
+PickUpOffset = 6 122 0 0
 
 [experience]
 ; Creature powers (spells), and the creature level at which they're given (max 10 spells).

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -1611,7 +1611,6 @@ TbBool parse_creaturemodel_appearance_blocks(long crtr_model,char *buf,long len,
             }
             break;
         case 7: // FOOTSTEPPITCH
-            JUSTMSG("testlog do footstep", crtr_model);
             if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
             {
                 k = atoi(word_buf);

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -1622,7 +1622,6 @@ TbBool parse_creaturemodel_appearance_blocks(long crtr_model,char *buf,long len,
             if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
             {
                 k = atoi(word_buf);
-                JUSTMSG("testlog set for model %d to %d", crtr_model, k);
                 creature_picked_up_offset[crtr_model].delta_x = k;
                 n++;
             }

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -166,6 +166,7 @@ const struct NamedCommand creatmodel_appearance_commands[] = {
   {"SHOTORIGIN",           5},
   {"CORPSEVANISHEFFECT",   6},
   {"FOOTSTEPPITCH",        7},
+  {"PICKUPOFFSET",         8},
   {NULL,                   0},
   };
 
@@ -1610,12 +1611,46 @@ TbBool parse_creaturemodel_appearance_blocks(long crtr_model,char *buf,long len,
             }
             break;
         case 7: // FOOTSTEPPITCH
+            JUSTMSG("testlog do footstep", crtr_model);
             if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
             {
                 k = atoi(word_buf);
                 crstat->footstep_pitch = k;
                 n++;
             }
+            break;
+        case 8: // PICKUPOFFSET
+            if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+            {
+                k = atoi(word_buf);
+                JUSTMSG("testlog set for model %d to %d", crtr_model, k);
+                creature_picked_up_offset[crtr_model].delta_x = k;
+                n++;
+            }
+            if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+            {
+                k = atoi(word_buf);
+                creature_picked_up_offset[crtr_model].delta_y = k;
+                n++;
+            }
+            if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+            {
+                k = atoi(word_buf);
+                creature_picked_up_offset[crtr_model].field_4 = k;
+                n++;
+            }
+            if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+            {
+                k = atoi(word_buf);
+                creature_picked_up_offset[crtr_model].field_6 = k;
+                n++;
+            }
+            if (n < 4)
+            {
+                CONFWRNLOG("Incorrect value of \"%s\" parameters in [%s] block of %s file.",
+                    COMMAND_TEXT(cmd_num), block_buf, config_textname);
+            }
+            break;
         case 0: // comment
             break;
         case -1: // end of buffer

--- a/src/creature_graphics.h
+++ b/src/creature_graphics.h
@@ -104,6 +104,7 @@ struct KeeperSpriteExt // More info for custom sprites
 //extern struct KeeperSprite *creature_table;
 extern struct KeeperSprite creature_table_add[];
 extern struct KeeperSpriteExt creatures_table_ext[];
+extern struct CreaturePickedUpOffset creature_picked_up_offset[];
 /******************************************************************************/
 DLLIMPORT struct KeeperSprite *_DK_creature_table;
 #define creature_table _DK_creature_table


### PR DESCRIPTION
Hardcoded value moved into unit configs, needed for SWAP_CREATURE command to work well, or for custom sprites in general.