### PR TITLE
Invert mouse reflects modern standards

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -2180,10 +2180,11 @@ if (((MyScreenWidth >> 1) != GetMouseX()) || (GetMouseY() != y))
   {
     LbMouseSetPositionInitial((MyScreenWidth/pixel_size) >> 1, y/pixel_size); // use LbMouseSetPositionInitial because we don't want to keep moving the host cursor
   }
-    if (settings.first_person_move_invert)
-    pckt->pos_y = 255 * ((long)MyScreenHeight - y) / MyScreenHeight;
-    else
-    pckt->pos_y = 255 * y / MyScreenHeight;
+    if (settings.first_person_move_invert) {
+        pckt->pos_y = 255 * y / MyScreenHeight;
+    } else {
+        pckt->pos_y = 255 * ((long)MyScreenHeight - y) / MyScreenHeight;
+    }
     pckt->pos_x = 255 * x / MyScreenWidth;
     // Update the position based on current settings
     long i = settings.first_person_move_sensitivity + 1;


### PR DESCRIPTION
The game is so old that it's got the language of "inverted" backwards in the options menu, old flight sims are now what's considered inverted these days.
This also changes the default, KeeperFX is a modern port so it should cater to modern expectations.