### PR TITLE
Fixed interpolation glitches

### DIFF
--- a/src/creature_states_scavn.c
+++ b/src/creature_states_scavn.c
@@ -192,6 +192,7 @@ short creature_scavenged_disappear(struct Thing *thing)
     if (find_random_valid_position_for_thing_in_room(thing, room, &pos))
     {
         move_thing_in_map(thing, &pos);
+        reset_interpolation_of_thing(thing);
         anger_set_creature_anger_all_types(thing, 0);
         if (is_my_player_number(thing->owner))
           output_message(SMsg_MinionScanvenged, 0, true);

--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -64,7 +64,7 @@ long interpolated_camera_zoom;
 #endif
 /******************************************************************************/
 
-void reset_camera_interpolation() {
+void reset_interpolation_of_camera() {
     struct PlayerInfo* player = get_my_player();
     struct Camera *cam = player->acamera;
     interpolated_camera_zoom = scale_camera_zoom_to_screen(cam->zoom);

--- a/src/engine_camera.h
+++ b/src/engine_camera.h
@@ -132,7 +132,7 @@ void view_set_camera_rotation_inertia(struct Camera *cam, long a2, long a3);
 void update_all_players_cameras(void);
 void init_player_cameras(struct PlayerInfo *player);
 void set_previous_camera_values();
-void reset_camera_interpolation();
+void reset_interpolation_of_camera();
 
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -164,7 +164,7 @@ static void do_map_who(short tnglist_idx);
 
 long interpolate(long variable_to_interpolate, long previous, long current)
 {
-    if (gameadd.delta_time == 1) {
+    if (is_feature_on(Ft_DeltaTime) == false) {
         return current;
     }
     // future: by using the predicted future position in the interpolation calculation, we can remove input lag (or visual lag).
@@ -176,7 +176,7 @@ long interpolate(long variable_to_interpolate, long previous, long current)
 
 long interpolate_angle(long variable_to_interpolate, long previous, long current)
 {
-    if (gameadd.delta_time == 1) {
+    if (is_feature_on(Ft_DeltaTime) == false) {
         return current;
     }
     long future = current + (current - previous);

--- a/src/magic.c
+++ b/src/magic.c
@@ -1018,6 +1018,7 @@ TbResult magic_use_power_hold_audience(PlayerNumber plyr_idx, unsigned long mod_
             const struct Coord3d *pos;
             pos = dungeon_get_essential_pos(thing->owner);
             move_thing_in_map(thing, pos);
+            reset_interpolation_of_thing(thing);
             initialise_thing_state(thing, CrSt_CreatureInHoldAudience);
             cctrl->turns_at_job = -1;
         }

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -625,7 +625,7 @@ long pinstfs_zoom_to_heart(struct PlayerInfo *player, long *n)
 
 long pinstfm_zoom_to_heart(struct PlayerInfo *player, long *n)
 {
-    reset_camera_interpolation();
+    reset_interpolation_of_camera();
     struct Thing* thing = thing_get(player->controlled_thing_idx);
     if (!thing_is_invalid(thing))
     {

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -924,6 +924,8 @@ void drop_held_thing_on_ground(struct Dungeon *dungeon, struct Thing *droptng, c
         droptng->continue_state = droptng->active_state;
         droptng->active_state = ObSt_BeingDropped;
     }
+
+    reset_interpolation_of_thing(droptng);
 }
 
 short dump_first_held_thing_on_map(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool update_hand)
@@ -1062,6 +1064,7 @@ TbBool process_creature_in_dungeon_hand(struct Dungeon *dungeon, struct Thing *t
             {
                 create_effect(&thing->mappos, imp_spangle_effects[thing->owner], thing->owner);
                 move_thing_in_map(thing, &game.armageddon.mappos);
+                reset_interpolation_of_thing(thing);
                 //originally move was to get_player_soul_container(game.armageddon_caster_idx) mappos
                 return false;
             }

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -170,6 +170,7 @@ void process_armageddon_influencing_creature(struct Thing *creatng)
                 cctrl->armageddon_teleport_turn = 0;
                 create_effect(&creatng->mappos, imp_spangle_effects[creatng->owner], creatng->owner);
                 move_thing_in_map(creatng, &game.armageddon.mappos);
+                reset_interpolation_of_thing(creatng);
             }
         }
     }

--- a/src/power_specials.c
+++ b/src/power_specials.c
@@ -230,6 +230,7 @@ TbBool steal_hero(struct PlayerInfo *player, struct Coord3d *pos)
     if (!thing_is_invalid(herotng))
     {
         move_thing_in_map(herotng, pos);
+        reset_interpolation_of_thing(herotng);
         change_creature_owner(herotng, player->id_number);
         SYNCDBG(3,"Converted %s to owner %d",thing_model_name(herotng),(int)player->id_number);
     }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1482,6 +1482,7 @@ void process_thing_spell_teleport_effects(struct Thing *thing, struct CastedSpel
         }
         pos.z.val += subtile_coord(2,0);
         move_thing_in_map(thing, &pos);
+        reset_interpolation_of_thing(thing);
         ariadne_invalidate_creature_route(thing);
         check_map_explored(thing, pos.x.stl.num, pos.y.stl.num);
         if ((thing->movement_flags & TMvF_Flying) == 0)

--- a/src/thing_navigate.c
+++ b/src/thing_navigate.c
@@ -47,6 +47,16 @@ DLLIMPORT long _DK_get_next_gap_creature_can_fit_in_below_point(struct Thing *cr
 }
 #endif
 /******************************************************************************/
+
+// Call this function if you don't want the creature/thing to (visually) fly across the map whenever suddenly moving a very far distance. (teleporting for example)
+void reset_interpolation_of_thing(struct Thing *thing) {
+    struct ThingAdd* thingadd = get_thingadd(thing->index);
+    thingadd->previous_mappos = thing->mappos;
+    thingadd->previous_floor_height = thing->floor_height;
+    thingadd->interp_mappos = thing->mappos;
+    thingadd->interp_floor_height = thing->floor_height;
+}
+
 TbBool creature_can_navigate_to_with_storage_f(const struct Thing *creatng, const struct Coord3d *pos, NaviRouteFlags flags, const char *func_name)
 {
     NAVIDBG(8,"%s: Route for %s index %d from %3d,%3d to %3d,%3d", func_name, thing_model_name(creatng),(int)creatng->index,

--- a/src/thing_navigate.c
+++ b/src/thing_navigate.c
@@ -48,8 +48,8 @@ DLLIMPORT long _DK_get_next_gap_creature_can_fit_in_below_point(struct Thing *cr
 #endif
 /******************************************************************************/
 
-// Call this function if you don't want the creature/thing to (visually) fly across the map whenever suddenly moving a very far distance. (teleporting for example)
 void reset_interpolation_of_thing(struct Thing *thing) {
+    // Call this function if you don't want the creature/thing to (visually) fly across the map whenever suddenly moving a very far distance. (teleporting for example)
     struct ThingAdd* thingadd = get_thingadd(thing->index);
     thingadd->previous_mappos = thing->mappos;
     thingadd->previous_floor_height = thing->floor_height;

--- a/src/thing_navigate.c
+++ b/src/thing_navigate.c
@@ -48,8 +48,8 @@ DLLIMPORT long _DK_get_next_gap_creature_can_fit_in_below_point(struct Thing *cr
 #endif
 /******************************************************************************/
 
+// Call this function if you don't want the creature/thing to (visually) fly across the map whenever suddenly moving a very far distance. (teleporting for example)
 void reset_interpolation_of_thing(struct Thing *thing) {
-    // Call this function if you don't want the creature/thing to (visually) fly across the map whenever suddenly moving a very far distance. (teleporting for example)
     struct ThingAdd* thingadd = get_thingadd(thing->index);
     thingadd->previous_mappos = thing->mappos;
     thingadd->previous_floor_height = thing->floor_height;

--- a/src/thing_navigate.h
+++ b/src/thing_navigate.h
@@ -58,6 +58,8 @@ enum ThingAngles {
 struct Thing;
 struct Room;
 
+void reset_interpolation_of_thing(struct Thing *thing);
+
 /******************************************************************************/
 DLLIMPORT long _DK_owner_player_navigating;
 #define owner_player_navigating _DK_owner_player_navigating

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1647,6 +1647,7 @@ TngUpdateRet object_update_call_to_arms(struct Thing *thing)
             pos.y.val = subtile_coord_center(dungeon->cta_stl_y);
             pos.z.val = get_thing_height_at(thing, &pos);
             move_thing_in_map(thing, &pos);
+            reset_interpolation_of_thing(thing);
             set_thing_draw(thing, ctagfx->birth_anim_idx, 256, objdat->sprite_size_max, 0, 0, 2);
             thing->call_to_arms_flag.state = CTAOL_Birthing;
             stop_thing_playing_sample(thing, powerst->select_sound_idx);


### PR DESCRIPTION
- Possibly fixes an issue with the camera shifting around that some users reported
- Reset interpolation position in certain situations when Thing position greatly changes so Things don't visually fly across the map: Creature dropped by CPU, Teleport ability, Hold Audience, Armageddon, Steal Hero, Scavenged creature, moving the Call to Arms flag.