### PR TITLE
fixed time spent flashing red when thing receives damage

### DIFF
--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4472,13 +4472,12 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
 {
     unsigned short flg_mem;
     unsigned char alpha_mem;
-    struct PlayerInfo *player;
-    struct Thing *thing;
+    struct PlayerInfo *player = get_my_player();
+    struct Thing *thing = jspr->thing;
+    struct ThingAdd* thingadd = get_thingadd(thing->index);
     short angle;
     flg_mem = lbDisplay.DrawFlags;
     alpha_mem = EngineSpriteDrawUsingAlpha;
-    thing = jspr->thing;
-    player = get_my_player();
     if (keepersprite_rotable(thing->anim_sprite))
     {
         angle = thing->move_angle_xy - cam->orient_a; // orient_a maybe short
@@ -4535,7 +4534,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
             EngineSpriteDrawUsingAlpha = 1;
             break;
     }
-//
+    
     if ((thing->class_id == TCls_Creature)
         || (thing->class_id == TCls_Object)
         || (thing->class_id == TCls_DeadCreature)
@@ -4545,12 +4544,18 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
         {
             lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
             lbSpriteReMapPtr = white_pal;
-        }
-        else if ((thing->field_4F & TF4F_Unknown80) != 0)
-        {
-            lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
-            lbSpriteReMapPtr = red_pal;
-            thing->field_4F &= ~TF4F_Unknown80;
+        } else {
+            if ((thing->field_4F & TF4F_BeingHit) != 0)
+            {
+                lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+                lbSpriteReMapPtr = red_pal;
+                thingadd->time_spent_displaying_hurt_colour += gameadd.delta_time;
+                if (thingadd->time_spent_displaying_hurt_colour >= 1.0)
+                {
+                    thingadd->time_spent_displaying_hurt_colour = 0;
+                    thing->field_4F &= ~TF4F_BeingHit; // Turns off red damage colour tint
+                }
+            }
         }
         thing_being_displayed_is_creature = 1;
         thing_being_displayed = thing;
@@ -7708,18 +7713,17 @@ void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
 {
     unsigned short flg_mem;
     unsigned char alpha_mem;
-    struct PlayerInfo *player;
-    struct Thing *thing;
+    struct PlayerInfo *player = get_my_player();
+    struct Thing *thing = jspr->thing;
+    struct ThingAdd* thingadd = get_thingadd(thing->index);
     long angle;
     long scale;
     flg_mem = lbDisplay.DrawFlags;
     alpha_mem = EngineSpriteDrawUsingAlpha;
-    thing = jspr->thing;
-    player = get_my_player();
     if (keepersprite_rotable(thing->anim_sprite))
     {
       angle = thing->move_angle_xy - spr_map_angle;
-      angle += 256 * (long)((get_thingadd(thing->index)->flags & TAF_ROTATED_MASK) >> TAF_ROTATED_SHIFT);
+      angle += 256 * (long)((thingadd->flags & TAF_ROTATED_MASK) >> TAF_ROTATED_SHIFT);
     }
     else
       angle = thing->move_angle_xy;
@@ -7775,12 +7779,18 @@ void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
                   }
               }
           }
-        } else
-        if ((thing->field_4F & TF4F_Unknown80) != 0)
-        {
-            lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
-            lbSpriteReMapPtr = red_pal;
-            thing->field_4F &= ~TF4F_Unknown80;
+        } else {
+            if ((thing->field_4F & TF4F_BeingHit) != 0)
+            {
+                lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+                lbSpriteReMapPtr = red_pal;
+                thingadd->time_spent_displaying_hurt_colour += gameadd.delta_time;
+                if (thingadd->time_spent_displaying_hurt_colour >= 1.0)
+                {
+                    thingadd->time_spent_displaying_hurt_colour = 0;
+                    thing->field_4F &= ~TF4F_BeingHit; // Turns off red damage colour tint
+                }
+            }
         }
         thing_being_displayed_is_creature = 1;
         thing_being_displayed = thing;

--- a/src/light_data.c
+++ b/src/light_data.c
@@ -161,7 +161,7 @@ long light_create_light(struct InitLight *ilght)
     lgt->field_12 = ilght->field_12;
 
     struct LightAdd* lightadd = get_lightadd(lgt->index);
-    lightadd->interp_initialize = true;
+    LbMemorySet(lightadd, 0, sizeof(struct LightAdd)); // Clear any previously used LightAdd stuff
 
     return lgt->index;
 }
@@ -1534,8 +1534,8 @@ static char light_render_light(struct Light* lgt)
   struct LightAdd* lightadd = get_lightadd(lgt->index);
   int remember_original_lgt_mappos_x = lgt->mappos.x.val;
   int remember_original_lgt_mappos_y = lgt->mappos.y.val;
-  if (lightadd->interp_initialize == true) {
-    lightadd->interp_initialize = false;
+  if (lightadd->interp_has_been_initialized == false) {
+    lightadd->interp_has_been_initialized = true;
     lightadd->interp_mappos.x.val = lgt->mappos.x.val;
     lightadd->interp_mappos.y.val = lgt->mappos.y.val;
     lightadd->previous_mappos.x.val = lgt->mappos.x.val;

--- a/src/thing_data.c
+++ b/src/thing_data.c
@@ -87,6 +87,10 @@ struct Thing *allocate_free_thing_structure_f(unsigned char allocflags, const ch
     game.free_things[game.free_things_start_index] = 0;
     game.free_things_start_index++;
     TRACE_THING(thing);
+
+    struct ThingAdd* thingadd = get_thingadd(thing->index);
+    LbMemorySet(thingadd, 0, sizeof(struct ThingAdd)); // Clear any previously used ThingAdd stuff
+    
     return thing;
 }
 

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -70,7 +70,7 @@ enum ThingFlags4F {
     TF4F_Transpar_Flags = 0x30,
 
     TF4F_Unknown40     = 0x40,    // Unconscious
-    TF4F_Unknown80     = 0x80,    // Being hit (draw red sometimes)
+    TF4F_BeingHit      = 0x80,    // Being hit (draw red sometimes)
 };
 
 enum FreeThingAllocFlags {
@@ -292,7 +292,7 @@ struct ThingAdd // Additional thing data
 {
     unsigned long flags; //ThingAddFlags
     long last_turn_drawn;
-
+    float time_spent_displaying_hurt_colour;
     // Used for delta time interpolated render position
     unsigned short previous_floor_height;
     unsigned short interp_floor_height;
@@ -302,7 +302,7 @@ struct ThingAdd // Additional thing data
 
 struct LightAdd // Additional light data
 {
-    TbBool interp_initialize;
+    TbBool interp_has_been_initialized;
     struct Coord3d previous_mappos;
     struct Coord3d interp_mappos;
 };

--- a/src/thing_stats.c
+++ b/src/thing_stats.c
@@ -710,7 +710,7 @@ static HitPoints apply_damage_to_creature(struct Thing *thing, HitPoints dmg)
       cdamage = 1;
     // Apply damage to the thing
     thing->health -= cdamage;
-    thing->field_4F |= TF4F_Unknown80;
+    thing->field_4F |= TF4F_BeingHit;
     // Red palette if the possessed creature is hit very strong
     if (is_thing_some_way_controlled(thing))
     {
@@ -734,7 +734,7 @@ static HitPoints apply_damage_to_object(struct Thing *thing, HitPoints dmg)
 {
     HitPoints cdamage = dmg;
     thing->health -= cdamage;
-    thing->field_4F |= TF4F_Unknown80;
+    thing->field_4F |= TF4F_BeingHit;
     return cdamage;
 }
 


### PR DESCRIPTION
- added `thingadd->time_spent_displaying_hurt_colour` so flashing red lasts the correct amount of time
- clear ThingAdd and LightAdd whenever creating a new Thing or Light
- altered `lightadd->interp_initialize` so it doesn't need setting for each new light
- renamed TF4F_Unknown80 to TF4F_BeingHit