### PR TITLE
Scale back lightning palette fix

### DIFF
--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -110,9 +110,12 @@ TbBool detonate_shot(struct Thing *shotng)
     //TODO CONFIG shot model dependency, make config option instead
     switch (shotng->model)
     {
-    case ShM_Lightning:
     case ShM_GodLightning:
     case ShM_GodLightBall:
+        // Note: possibly sometimes breaks Hellhound and Vampire's palette when possessing them. Make it like ShM_Lightning's case to fix.
+        PaletteSetPlayerPalette(myplyr, engine_palette);
+        break;
+    case ShM_Lightning:
         if (lens_mode != 0) {
             PaletteSetPlayerPalette(myplyr, engine_palette);
         }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -112,7 +112,7 @@ TbBool detonate_shot(struct Thing *shotng)
     {
     case ShM_GodLightning:
     case ShM_GodLightBall:
-        // Note: possibly sometimes breaks Hellhound and Vampire's palette when possessing them. Make it like ShM_Lightning's case to fix.
+        // Note: possibly sometimes breaks Hellhound and Vampire's palette when possessing them. Make it like ShM_Lightning's case to fix (after doing proper testing).
         PaletteSetPlayerPalette(myplyr, engine_palette);
         break;
     case ShM_Lightning:


### PR DESCRIPTION
`case ShM_GodLightning:` and `case ShM_GodLightBall:` are untested, `case ShM_Lightning:` has been thoroughly tested, so only applying the fix to that one for now.

follow up to #1761