### PR TITLE
New script command: SET_HAND_RULE

### DIFF
--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -34,6 +34,8 @@
 #include "tasks_list.h"
 #include "thing_traps.h"
 #include "roomspace.h"
+#include "config_creature.h"
+#include "power_hand.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -328,7 +330,7 @@ struct DungeonAdd
     unsigned char         room_resrchable[TERRAIN_ITEMS_MAX];
     unsigned char         room_slabs_count[TERRAIN_ITEMS_MAX+1];
     unsigned short        backup_heart_idx;
-
+    struct HandRule       hand_rules[CREATURE_TYPES_MAX][HAND_RULE_SLOTS_COUNT];
 };
 /******************************************************************************/
 extern struct Dungeon bad_dungeon;

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -275,6 +275,7 @@ void init_keepers_map_exploration(void);
 void clear_creature_pool(void);
 void reset_creature_max_levels(void);
 void reset_script_timers_and_flags(void);
+void reset_hand_rules(void);
 void add_creature_to_pool(long kind, long amount, unsigned long a3);
 void draw_texture(long a1, long a2, long a3, long a4, long a5, long a6, long a7);
 

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -862,6 +862,7 @@ short load_script(long lvnum)
     game.flags_cd |= MFlg_DeadBackToPool;
     reset_creature_max_levels();
     reset_script_timers_and_flags();
+    reset_hand_rules();
     if ((game.operation_flags & GOF_ColumnConvert) != 0)
     {
         convert_old_column_file(lvnum);

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -160,7 +160,8 @@ enum TbScriptCommands {
     Cmd_HEART_LOST_OBJECTIVE              = 147,
     Cmd_SET_DOOR                          = 148,
     Cmd_SET_CREATURE_INSTANCE             = 149,    
-    Cmd_TRANSFER_CREATURE                 = 150
+    Cmd_TRANSFER_CREATURE                 = 150,
+    Cmd_SET_HAND_RULE                     = 151,
 };
 
 struct ScriptLine {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1809,6 +1809,16 @@ void reset_creature_max_levels(void)
     }
 }
 
+void reset_hand_rules(void)
+{
+    struct DungeonAdd* dungeonadd;
+    for (int i = 0; i < DUNGEONS_COUNT; i++)
+    {
+        dungeonadd = get_dungeonadd(i);
+        memset(dungeonadd->hand_rules, 0, sizeof(dungeonadd->hand_rules));
+    }
+}
+
 void change_engine_window_relative_size(long w_delta, long h_delta)
 {
     struct PlayerInfo *myplyr;

--- a/src/power_hand.h
+++ b/src/power_hand.h
@@ -33,6 +33,8 @@ struct Thing;
 struct PlayerInfo;
 struct Dungeon;
 
+#define HAND_RULE_SLOTS_COUNT 8
+
 #pragma pack()
 /******************************************************************************/
 void add_creature_to_sacrifice_list(PlayerNumber owner, long model, long explevel);
@@ -80,6 +82,41 @@ TbBool is_dangerous_drop_subtile(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 short can_place_thing_here(struct Thing *thing, long x, long y, long dngn_idx);
 TbBool can_drop_thing_here(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, unsigned long allow_unclaimed);
 TbBool armageddon_blocks_creature_pickup(const struct Thing *thing, PlayerNumber plyr_idx);
+TbBool thing_pickup_is_blocked_by_hand_rule(const struct Thing *thing_to_pick, PlayerNumber plyr_idx);
+
+enum HandRuleType {
+    // hand_rule_test_fns are indexed by these enum values -> reordering or adding new types affects test_fns
+    HandRule_Unset,
+    HandRule_Always,
+    HandRule_AgeLower,
+    HandRule_AgeHigher,
+    HandRule_LvlLower,
+    HandRule_LvlHigher,
+    HandRule_AtActionPoint,
+    HandRule_AffectedBy,
+    HandRule_Wandering,
+    HandRule_Working,
+    HandRule_Fighting,
+};
+
+enum HandRuleAction {
+    HandRuleAction_Deny,
+    HandRuleAction_Allow,
+    HandRuleAction_Enable,
+    HandRuleAction_Disable,
+};
+
+struct HandRule {
+    char type;
+    char enabled;
+    char allow; // allow: 1, deny: 0
+    long param;
+};
+
+TbBool eval_hand_rule_for_thing(struct HandRule *rule, const struct Thing *thing_to_pick);
+typedef TbBool (*HandTestFn) (struct HandRule *rule, const struct Thing *thing);
+#define HAND_RULE(body) ( {TbBool anon(struct HandRule *hand_rule, const struct Thing *thing) body; &anon; })
+
 /******************************************************************************/
 #ifdef __cplusplus
 }


### PR DESCRIPTION
SET_HAND_RULE([player],[creature],[rule_slot],[rule_action],[rule*],[param*])

Where:

[player] - The player’s name, e.g. PLAYER1.

[creature] - The creature name, e.g. BILE_DEMON. Includes ANY_CREATURE.

[rule_slot] - Rule slot a rule will be assigned to. There are 8 available slots per player's creature type: RULE0, RULE1, ..., RULE7

[rule_action] - ALLOW or DENY. Whether creatures that match the rule should be allowed/denied from being picked up. If you just want to disable or re-enable rule already stored in a slot, use DISABLE or ENABLE and leave the last two params (rule, param) empty.

[rule*] - only specify if rule_action is ALLOW/DENY. One of the following:
ALWAYS - all creatures match this rule until it is disabled or overridden
AGE_LOWER/AGE_HIGHER - only creatures whose time in dungeon (age) is lower/higher than [param] match this rule
LEVEL_LOWER/LEVEL_HIGHER - only creatures of level lower/higher than [param] match this rule
AT_ACTION_POINT - only creatures within action point [param] radius match this rule
AFFECTED_BY - only creatures affected by the spell in [param] match this rule
WANDERING/WORKING/FIGHTING - only creatures with these jobs match this rule

[param*] - rule parameter. See [rule] for usage info. Leave blank if rule does not use any param.

Rule checks are evaluated from the highest rule index (RULE7) to lowest (RULE0) and lower rules are ignored once a match is found.