### PR TITLE
Fixes for interpolation and delta time, added mouse_is_offmap variable

### DIFF
--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -8144,6 +8144,8 @@ void draw_keepsprite_unscaled_in_buffer(unsigned short kspr_n, short angle, unsi
 
 static void update_frontview_pointed_block(unsigned long laaa, unsigned char qdrant, long w, long h, long qx, long qy)
 {
+    TbBool out_of_bounds = false;
+
     TbGraphicsWindow ewnd;
     struct Column *colmn;
     unsigned long mask;
@@ -8167,6 +8169,11 @@ static void update_frontview_pointed_block(unsigned long laaa, unsigned char qdr
         pos_y = (point_a / laaa) * y_step2[qdrant] + (point_b / laaa) * y_step1[qdrant] + (h << 8);
         slb_x = (pos_x >> 8) + x_offs[qdrant];
         slb_y = (pos_y >> 8) + y_offs[qdrant];
+        
+        if (slb_x < 0 || slb_x > 254 || slb_y < -2 || slb_y > 255) {
+            out_of_bounds = true;
+        }
+
         mapblk = get_map_block_at(slb_x, slb_y);
         if (!map_block_invalid(mapblk))
         {
@@ -8203,6 +8210,10 @@ static void update_frontview_pointed_block(unsigned long laaa, unsigned char qdr
         }
         point_b += delta;
     }
+    
+    struct PlayerInfo *player = get_my_player();
+    struct PlayerInfoAdd* playeradd = get_playeradd(player->id_number);
+    playeradd->mouse_is_offmap = out_of_bounds;
 }
 
 void create_frontview_map_volume_box(struct Camera *cam, unsigned char stl_width, TbBool single_subtile, long line_color)

--- a/src/light_data.h
+++ b/src/light_data.h
@@ -83,6 +83,7 @@ struct LightAdd // Additional light data
     struct Coord3d previous_mappos;
     struct Coord3d interp_mappos;
     long last_turn_drawn;
+    long disable_interp_for_turns;
 };
 
 struct InitLight { // sizeof=0x14

--- a/src/packets.c
+++ b/src/packets.c
@@ -692,6 +692,9 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       player->cameras[CamIV_Parchment].orient_a = pckt->actn_par1;
       player->cameras[CamIV_FrontView].orient_a = pckt->actn_par1;
       player->cameras[CamIV_Isometric].orient_a = pckt->actn_par1;
+      if (is_my_player(player)) {
+          reset_interpolation_of_camera();
+      }
       return 0;
   case PckA_SetPlyrState:
       set_player_state(player, pckt->actn_par1, pckt->actn_par2);

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -262,7 +262,8 @@ struct PlayerInfoAdd {
     short cursor_subtile_y;
     short previous_cursor_subtile_x;
     short previous_cursor_subtile_y;
-    };
+    TbBool mouse_is_offmap;
+};
 
 /******************************************************************************/
 DLLIMPORT extern unsigned char _DK_my_player_number;


### PR DESCRIPTION
- fixed Thing positions lagging for 1 turn when pressing middle mouse button to flip the camera in FrontView
- fixed an interpolation issue when moving the mouse off the map in one position then back onto map elsewhere
- added `playeradd->mouse_is_offmap`