### PR TITLE
Fixed looking for neutral dungeon on moving objects

### DIFF
--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1933,8 +1933,16 @@ TngUpdateRet move_object(struct Thing *thing)
             long blocked_flags = get_thing_blocked_flags_at(thing, &pos);
             if (blocked_flags & SlbBloF_WalledZ)
             {
-                struct Dungeon* dungeon = get_dungeon(thing->owner);
-                if (dungeon->sight_casted_thing_idx != thing->index)
+                TbBool is_sight_of_evil = false;
+                if (thing->owner != PLAYER_NEUTRAL)
+                {
+                    struct Dungeon* dungeon = get_dungeon(thing->owner);
+                    if (dungeon->sight_casted_thing_idx == thing->index)
+                    {
+                        is_sight_of_evil = true;
+                    }
+                }
+                if (!is_sight_of_evil)
                 {
                     if (!find_free_position_on_slab(thing, &pos))
                     {


### PR DESCRIPTION
Issue introduced in 2c456e4cffb24fc9641258a68660fc31b318c062, causes log errors like:
```
Error: get_dungeon_f: move_object: Tried to get non-existing dungeon 5!
```