### PR TITLE
bugs fixed: CTA minimap flag circles, onscreen message time, tagging

### DIFF
--- a/src/frontmenu_ingame_map.c
+++ b/src/frontmenu_ingame_map.c
@@ -94,7 +94,12 @@ void draw_call_to_arms_circle(unsigned char owner, long x1, long y1, long x2, lo
     center_x = i + x2;
     center_y = i + y2;
     long long cscale;
-    float circle_time = ((game.play_gameturn + owner) & 7) + gameadd.process_turn_time;
+    float circle_time;
+    if ((game.operation_flags & GOF_Paused) == 0) {
+        circle_time = ((game.play_gameturn + owner) & 7) + gameadd.process_turn_time;
+    } else {
+        circle_time = ((game.play_gameturn + owner) & 7);
+    }
     cscale = circle_time * pwrdynst->strength[dungeon->cta_splevel];
     int dxq1;
     int dyq1;

--- a/src/gui_topmsg.c
+++ b/src/gui_topmsg.c
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 /******************************************************************************/
 char onscreen_msg_text[255]="";
-int onscreen_msg_turns = 0;
+float render_onscreen_msg_time;
 
 struct ErrorStatistics erstat[] = {
     {0, 0, "Out of thing slots"},
@@ -68,13 +68,13 @@ TbBool show_onscreen_msg_va(int nturns, const char *fmt_str, va_list arg)
 {
     vsprintf(onscreen_msg_text, fmt_str, arg);
     SYNCMSG("Onscreen message: %s",onscreen_msg_text);
-    onscreen_msg_turns = nturns;
+    render_onscreen_msg_time = (float)nturns;
     return true;
 }
 
 TbBool is_onscreen_msg_visible(void)
 {
-    return (onscreen_msg_turns > 0);
+    return (render_onscreen_msg_time > 0.0);
 }
 
 TbBool show_onscreen_msg(int nturns, const char *fmt_str, ...)
@@ -124,11 +124,11 @@ TbBool draw_onscreen_direct_messages(void)
         tx_units_per_px = scale_ui_value_lofi(16);
     }
     // Display in-game message for debug purposes
-    if ((onscreen_msg_turns > 0) || erstat_check())
+    if ((render_onscreen_msg_time > 0.0) || erstat_check())
     {
         if ( LbScreenIsLocked() )
       LbTextDrawResized(scale_value_by_horizontal_resolution(160), 0, tx_units_per_px, onscreen_msg_text);
-        onscreen_msg_turns--;
+        render_onscreen_msg_time -= gameadd.delta_time;
     }
     unsigned int msg_pos = scale_value_by_vertical_resolution(200);
     if ((game.system_flags & GSF_NetGameNoSync) != 0)

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -55,6 +55,7 @@ extern TbBool packets_process_cheats(
 
 extern void update_double_click_detection(long plyr_idx);
 
+short fix_previous_cursor_subtile_when_offmap;
 void remember_cursor_subtile(struct PlayerInfo *player) {
     struct PlayerInfoAdd* playeradd = get_playeradd(player->id_number);
     struct Packet* pckt = get_packet_direct(player->packet_num);
@@ -62,6 +63,16 @@ void remember_cursor_subtile(struct PlayerInfo *player) {
     playeradd->previous_cursor_subtile_y = playeradd->cursor_subtile_y;
     playeradd->cursor_subtile_x = coord_subtile(((unsigned short)pckt->pos_x));
     playeradd->cursor_subtile_y = coord_subtile(((unsigned short)pckt->pos_y));
+
+    // This fixes an issue of moving the mouse off map from one position then back onto the map far elsewhere
+    if (playeradd->mouse_is_offmap == true) {
+        fix_previous_cursor_subtile_when_offmap = 2;
+    }
+    if (fix_previous_cursor_subtile_when_offmap > 0) {
+        fix_previous_cursor_subtile_when_offmap -= 1;
+        playeradd->previous_cursor_subtile_x = playeradd->cursor_subtile_x;
+        playeradd->previous_cursor_subtile_y = playeradd->cursor_subtile_y;
+    }
 }
 
 void set_tag_untag_mode(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -932,7 +932,6 @@ void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspa
 {
     struct PlayerInfo* player = get_player(plyr_idx);
     struct PlayerInfoAdd* playeradd = get_playeradd(plyr_idx);
-    
     struct Dungeon* dungeon = get_players_dungeon(player);
     TbBool tag_for_digging = ((player->allocflags & PlaF_ChosenSlabHasActiveTask) == 0);
     int task_allowance = MAPTASKS_COUNT - task_allowance_reduction;

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -932,6 +932,12 @@ void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspa
 {
     struct PlayerInfo* player = get_player(plyr_idx);
     struct PlayerInfoAdd* playeradd = get_playeradd(plyr_idx);
+    
+    if (playeradd->mouse_is_offmap == true)
+    {
+        return;
+    }
+    
     struct Dungeon* dungeon = get_players_dungeon(player);
     TbBool tag_for_digging = ((player->allocflags & PlaF_ChosenSlabHasActiveTask) == 0);
     int task_allowance = MAPTASKS_COUNT - task_allowance_reduction;

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -933,11 +933,6 @@ void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspa
     struct PlayerInfo* player = get_player(plyr_idx);
     struct PlayerInfoAdd* playeradd = get_playeradd(plyr_idx);
     
-    if (playeradd->mouse_is_offmap == true)
-    {
-        return;
-    }
-    
     struct Dungeon* dungeon = get_players_dungeon(player);
     TbBool tag_for_digging = ((player->allocflags & PlaF_ChosenSlabHasActiveTask) == 0);
     int task_allowance = MAPTASKS_COUNT - task_allowance_reduction;


### PR DESCRIPTION
- Fixed Call to Arms flag circles on minimap juddering while paused
- Onscreen message time now correctly affected by delta time
- While holding left-click to tag slabs, moving the cursor off the map and then back onto the map somewhere else caused a massive line of slabs to be tagged. That's now fixed with `fix_previous_cursor_subtile_when_offmap` variable.