### PR TITLE
Armageddon teleports units in torture, no units from portal while active

### DIFF
--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -437,7 +437,7 @@ unsigned short shot_shift_z;
     unsigned char battle_id;
     unsigned char alarm_stl_x;
     unsigned char alarm_stl_y;
-    unsigned long field_2FA;
+    unsigned long alarm_over_turn;
     unsigned long field_2FE;
     unsigned char stopped_for_hand_turns;
     long following_leader_since;

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -926,7 +926,7 @@ short arrive_at_alarm(struct Thing *creatng)
 {
     TRACE_THING(creatng);
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
-    if (cctrl->field_2FA < (unsigned long)game.play_gameturn)
+    if (cctrl->alarm_over_turn < (unsigned long)game.play_gameturn)
     {
         set_start_state(creatng);
         return 1;

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -1148,8 +1148,8 @@ void redraw_display(void)
         if (game.armageddon.count_down + game.armageddon_cast_turn <= game.play_gameturn)
         {
             i = 0;
-            if (game.armageddon_field_15035A - game.armageddon.duration <= game.play_gameturn)
-                i = game.armageddon_field_15035A - game.play_gameturn;
+            if (game.armageddon_over_turn - game.armageddon.duration <= game.play_gameturn)
+                i = game.armageddon_over_turn - game.play_gameturn;
       } else
       {
         i = game.play_gameturn - game.armageddon_cast_turn - game.armageddon.count_down;

--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -309,7 +309,7 @@ unsigned long pay_day_progress;
     unsigned char disease_lose_percentage_health;
     unsigned char disease_lose_health_time;
     unsigned long armageddon_cast_turn;
-unsigned long armageddon_field_15035A;
+    unsigned long armageddon_over_turn;
     unsigned char armageddon_caster_idx;
     unsigned long hold_audience_time;
     unsigned long armagedon_teleport_your_time_gap;

--- a/src/magic.c
+++ b/src/magic.c
@@ -910,7 +910,7 @@ TbResult magic_use_power_armageddon(PlayerNumber plyr_idx, unsigned long mod_fla
     }
     if (enemy_time_gap <= your_time_gap)
         enemy_time_gap = your_time_gap;
-    game.armageddon_field_15035A = game.armageddon.duration + enemy_time_gap;
+    game.armageddon_over_turn = game.armageddon.duration + enemy_time_gap;
     struct PowerConfigStats *powerst;
     powerst = get_power_model_stats(PwrK_ARMAGEDDON);
     play_non_3d_sample(powerst->select_sound_idx);
@@ -1919,10 +1919,10 @@ void process_dungeon_power_magic(void)
             }
             if (game.armageddon_cast_turn > 0)
             {
-                if (game.play_gameturn > game.armageddon_field_15035A)
+                if (game.play_gameturn > game.armageddon_over_turn)
                 {
                   game.armageddon_cast_turn = 0;
-                  game.armageddon_field_15035A = 0;
+                  game.armageddon_over_turn = 0;
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -413,7 +413,7 @@ void affect_nearby_friends_with_alarm(struct Thing *traptng)
                     if (setup_person_move_to_position(thing, traptng->mappos.x.stl.num, traptng->mappos.y.stl.num, 0))
                     {
                         thing->continue_state = CrSt_ArriveAtAlarm;
-                        cctrl->field_2FA = game.play_gameturn + 800;
+                        cctrl->alarm_over_turn = game.play_gameturn + 800;
                         cctrl->alarm_stl_x = traptng->mappos.x.stl.num;
                         cctrl->alarm_stl_y = traptng->mappos.y.stl.num;
                     }

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -183,7 +183,7 @@ static void init_level(void)
     ambient_sound_prepare();
     zero_messages();
     game.armageddon_cast_turn = 0;
-    game.armageddon_field_15035A = 0;
+    game.armageddon_over_turn = 0;
     init_messages();
     game.creatures_tend_imprison = 0;
     game.creatures_tend_flee = 0;

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -1066,14 +1066,7 @@ TbBool process_creature_in_dungeon_hand(struct Dungeon *dungeon, struct Thing *t
             cctrl->armageddon_teleport_turn = 0;
             if (remove_creature_from_power_hand(thing, dungeon->owner))
             {
-                create_effect(&thing->mappos, imp_spangle_effects[thing->owner], thing->owner);
-                move_thing_in_map(thing, &game.armageddon.mappos);
-                reset_interpolation_of_thing(thing);
-                initialise_thing_state(thing, CrSt_ArriveAtAlarm);
-                cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;
-                cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
-                cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
-                //originally move was to get_player_soul_container(game.armageddon_caster_idx) mappos
+                teleport_armageddon_influenced_creature(thing);
                 return false;
             }
         }

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -1069,6 +1069,10 @@ TbBool process_creature_in_dungeon_hand(struct Dungeon *dungeon, struct Thing *t
                 create_effect(&thing->mappos, imp_spangle_effects[thing->owner], thing->owner);
                 move_thing_in_map(thing, &game.armageddon.mappos);
                 reset_interpolation_of_thing(thing);
+                initialise_thing_state(thing, CrSt_ArriveAtAlarm);
+                cctrl->alarm_over_turn = game.play_gameturn + 800;
+                cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
+                cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
                 //originally move was to get_player_soul_container(game.armageddon_caster_idx) mappos
                 return false;
             }

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -1070,7 +1070,7 @@ TbBool process_creature_in_dungeon_hand(struct Dungeon *dungeon, struct Thing *t
                 move_thing_in_map(thing, &game.armageddon.mappos);
                 reset_interpolation_of_thing(thing);
                 initialise_thing_state(thing, CrSt_ArriveAtAlarm);
-                cctrl->alarm_over_turn = game.play_gameturn + 800;
+                cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;
                 cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
                 cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
                 //originally move was to get_player_soul_container(game.armageddon_caster_idx) mappos

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -166,6 +166,7 @@ void teleport_armageddon_influenced_creature(struct Thing* creatng)
     cleanup_current_thing_state(creatng);
     reset_interpolation_of_thing(creatng);
     initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
+    creatng->continue_state = CrSt_ArriveAtAlarm;
     cctrl->alarm_over_turn = game.armageddon.duration + game.armageddon_cast_turn;
     cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
     cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -166,7 +166,7 @@ void teleport_armageddon_influenced_creature(struct Thing* creatng)
     cleanup_current_thing_state(creatng);
     reset_interpolation_of_thing(creatng);
     initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
-    cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;
+    cctrl->alarm_over_turn = game.armageddon.duration + game.armageddon_cast_turn;
     cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
     cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
 }

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -170,11 +170,11 @@ void process_armageddon_influencing_creature(struct Thing *creatng)
                 cctrl->armageddon_teleport_turn = 0;
                 create_effect(&creatng->mappos, imp_spangle_effects[creatng->owner], creatng->owner);
                 move_thing_in_map(creatng, &game.armageddon.mappos);
-                if (creature_is_kept_in_custody(creatng))
-                {
-                    set_start_state(creatng);
-                }
                 reset_interpolation_of_thing(creatng);
+                initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
+                cctrl->alarm_over_turn = game.play_gameturn + 800;
+                cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
+                cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
             }
         }
     }

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -165,11 +165,6 @@ void teleport_armageddon_influenced_creature(struct Thing* creatng)
     move_thing_in_map(creatng, &game.armageddon.mappos);
     cleanup_current_thing_state(creatng);
     reset_interpolation_of_thing(creatng);
-    initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
-    creatng->continue_state = CrSt_ArriveAtAlarm;
-    cctrl->alarm_over_turn = game.armageddon.duration + game.armageddon_cast_turn;
-    cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
-    cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
 }
 
 void process_armageddon_influencing_creature(struct Thing *creatng)

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -157,6 +157,20 @@ void process_armageddon(void)
     }
 }
 
+void teleport_armageddon_influenced_creature(struct Thing* creatng)
+{
+    struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
+    cctrl->armageddon_teleport_turn = 0;
+    create_effect(&creatng->mappos, imp_spangle_effects[creatng->owner], creatng->owner);
+    move_thing_in_map(creatng, &game.armageddon.mappos);
+    cleanup_current_thing_state(creatng);
+    reset_interpolation_of_thing(creatng);
+    initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
+    cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;
+    cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
+    cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
+}
+
 void process_armageddon_influencing_creature(struct Thing *creatng)
 {
     if (game.armageddon_cast_turn != 0)
@@ -165,15 +179,7 @@ void process_armageddon_influencing_creature(struct Thing *creatng)
         // If Armageddon is on, teleport creature to its position
         if ((cctrl->armageddon_teleport_turn != 0) && (cctrl->armageddon_teleport_turn <= game.play_gameturn))
         {
-            cctrl->armageddon_teleport_turn = 0;
-            create_effect(&creatng->mappos, imp_spangle_effects[creatng->owner], creatng->owner);
-            move_thing_in_map(creatng, &game.armageddon.mappos);
-            cleanup_current_thing_state(creatng);
-            reset_interpolation_of_thing(creatng);
-            initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
-            cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;
-            cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
-            cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
+            teleport_armageddon_influenced_creature(creatng);
         }
     }
 }

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -172,7 +172,7 @@ void process_armageddon_influencing_creature(struct Thing *creatng)
                 move_thing_in_map(creatng, &game.armageddon.mappos);
                 reset_interpolation_of_thing(creatng);
                 initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
-                cctrl->alarm_over_turn = game.play_gameturn + 800;
+                cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;
                 cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
                 cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
             }

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -165,17 +165,15 @@ void process_armageddon_influencing_creature(struct Thing *creatng)
         // If Armageddon is on, teleport creature to its position
         if ((cctrl->armageddon_teleport_turn != 0) && (cctrl->armageddon_teleport_turn <= game.play_gameturn))
         {
-            if (cctrl->instance_id == CrInst_NULL) // Avoid corruption from in progress instances, like claiming floors.
-            {
-                cctrl->armageddon_teleport_turn = 0;
-                create_effect(&creatng->mappos, imp_spangle_effects[creatng->owner], creatng->owner);
-                move_thing_in_map(creatng, &game.armageddon.mappos);
-                reset_interpolation_of_thing(creatng);
-                initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
-                cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;
-                cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
-                cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
-            }
+            cctrl->instance_id = CrInst_NULL; // Avoid corruption from in progress instances, like claiming floors.
+            cctrl->armageddon_teleport_turn = 0;
+            create_effect(&creatng->mappos, imp_spangle_effects[creatng->owner], creatng->owner);
+            move_thing_in_map(creatng, &game.armageddon.mappos);
+            reset_interpolation_of_thing(creatng);
+            initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
+            cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;
+            cctrl->alarm_stl_x = game.armageddon.mappos.x.stl.num;
+            cctrl->alarm_stl_y = game.armageddon.mappos.y.stl.num;
         }
     }
 }

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -165,10 +165,10 @@ void process_armageddon_influencing_creature(struct Thing *creatng)
         // If Armageddon is on, teleport creature to its position
         if ((cctrl->armageddon_teleport_turn != 0) && (cctrl->armageddon_teleport_turn <= game.play_gameturn))
         {
-            cctrl->instance_id = CrInst_NULL; // Avoid corruption from in progress instances, like claiming floors.
             cctrl->armageddon_teleport_turn = 0;
             create_effect(&creatng->mappos, imp_spangle_effects[creatng->owner], creatng->owner);
             move_thing_in_map(creatng, &game.armageddon.mappos);
+            cleanup_current_thing_state(creatng);
             reset_interpolation_of_thing(creatng);
             initialise_thing_state(creatng, CrSt_ArriveAtAlarm);
             cctrl->alarm_over_turn = game.armageddon.count_down + game.armageddon_cast_turn;

--- a/src/power_process.h
+++ b/src/power_process.h
@@ -48,6 +48,7 @@ void process_disease(struct Thing *thing);
 TbBool player_uses_power_armageddon(PlayerNumber plyr_idx);
 void process_armageddon(void);
 void process_armageddon_influencing_creature(struct Thing *creatng);
+void teleport_armageddon_influenced_creature(struct Thing *creatng);
 
 void update_god_lightning_ball(struct Thing *thing);
 void god_lightning_choose_next_creature(struct Thing *thing);

--- a/src/room_entrance.c
+++ b/src/room_entrance.c
@@ -123,6 +123,8 @@ TbBool generation_available_to_dungeon(const struct Dungeon * dungeon)
     SYNCDBG(9,"Starting");
     if (!dungeon_has_room(dungeon, RoK_ENTRANCE))
         return false;
+    if (game.armageddon.count_down + game.armageddon_cast_turn < game.play_gameturn)
+        return false;
     return ((long)dungeon->num_active_creatrs < (long)dungeon->max_creatures_attracted);
 }
 

--- a/src/room_entrance.c
+++ b/src/room_entrance.c
@@ -123,7 +123,7 @@ TbBool generation_available_to_dungeon(const struct Dungeon * dungeon)
     SYNCDBG(9,"Starting");
     if (!dungeon_has_room(dungeon, RoK_ENTRANCE))
         return false;
-    if (game.armageddon.count_down + game.armageddon_cast_turn < game.play_gameturn)
+    if (game.armageddon.count_down + game.armageddon_cast_turn > game.play_gameturn) //No new creatures during armageddon
         return false;
     return ((long)dungeon->num_active_creatrs < (long)dungeon->max_creatures_attracted);
 }


### PR DESCRIPTION
- No new creatures to break the check for 0 creatures
- Fixed bug of not teleporting tortured units
- Named a var