### PR TITLE
_lrotr is non-standard

### DIFF
--- a/src/bflib_math.c
+++ b/src/bflib_math.c
@@ -748,7 +748,7 @@ unsigned long LbRandomSeries(unsigned long range, unsigned long *seed, const cha
   if (range == 0)
     return 0;
   unsigned long i = 9377 * (*seed) + 9439;
-  *seed = _lrotr(i, 13);
+  *seed = (i >> 13) | (i << ((sizeof(long) * 8) - 13));
   i = (*seed) % range;
 #ifdef AUTOTESTING
   evm_stat(0, "rnd.%s,fn=%s,range=%ld val=%ld,range=%ld", tag, func_name, range, i, range);


### PR DESCRIPTION
Replaced calls to _lrotr with equivalent implementation.