### PR TITLE
Added size to player_instance_info

### DIFF
--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -61,8 +61,6 @@ extern "C" {
 
 #define LENSES_COUNT           15
 #define SPELL_POINTER_GROUPS   14
-// Amount of instances; it's 17, 18 or 19
-#define PLAYER_INSTANCES_COUNT 19
 #define ZOOM_KEY_ROOMS_COUNT   15
 
 enum ModeFlags {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4441,7 +4441,7 @@ int main(int argc, char *argv[])
 
 //TODO DLL_CLEANUP delete when won't be needed anymore
   memcpy(_DK_menu_list,menu_list,40*sizeof(struct GuiMenu *));
-  memcpy(_DK_player_instance_info,player_instance_info,17*sizeof(struct PlayerInstanceInfo));
+  memcpy(_DK_player_instance_info, player_instance_info, PLAYER_INSTANCES_COUNT * sizeof(struct PlayerInstanceInfo));
   memcpy(_DK_states,states,145*sizeof(struct StateInfo));
 
 #if (BFDEBUG_LEVEL > 1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4441,7 +4441,7 @@ int main(int argc, char *argv[])
 
 //TODO DLL_CLEANUP delete when won't be needed anymore
   memcpy(_DK_menu_list,menu_list,40*sizeof(struct GuiMenu *));
-  memcpy(_DK_player_instance_info, player_instance_info, PLAYER_INSTANCES_COUNT * sizeof(struct PlayerInstanceInfo));
+  memcpy(_DK_player_instance_info, player_instance_info, sizeof(_DK_player_instance_info));
   memcpy(_DK_states,states,145*sizeof(struct StateInfo));
 
 #if (BFDEBUG_LEVEL > 1)

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -101,7 +101,7 @@ long pinstfs_zoom_to_position(struct PlayerInfo *player, long *n);
 long pinstfm_zoom_to_position(struct PlayerInfo *player, long *n);
 long pinstfe_zoom_to_position(struct PlayerInfo *player, long *n);
 
-struct PlayerInstanceInfo player_instance_info[] = {
+struct PlayerInstanceInfo player_instance_info[PLAYER_INSTANCES_COUNT] = {
   { 0, 0, NULL,                        NULL,                        NULL,                                {0}, {0}, 0, 0},
   { 3, 1, pinstfs_hand_grab,           pinstfm_hand_grab,           pinstfe_hand_grab,                   {0}, {0}, 0, 0},
   { 3, 1, pinstfs_hand_drop,           pinstfm_hand_drop,           pinstfe_hand_drop,                   {0}, {0}, 0, 0},

--- a/src/player_instances.h
+++ b/src/player_instances.h
@@ -77,13 +77,15 @@ struct PlayerInstanceInfo { // sizeof = 44
   long field_28;
 };
 
+#define PLAYER_INSTANCES_COUNT 19
+
 /******************************************************************************/
-DLLIMPORT struct PlayerInstanceInfo _DK_player_instance_info[];
+DLLIMPORT struct PlayerInstanceInfo _DK_player_instance_info[PLAYER_INSTANCES_COUNT];
 //#define player_instance_info _DK_player_instance_info
 
 #pragma pack()
 /******************************************************************************/
-extern struct PlayerInstanceInfo player_instance_info[];
+extern struct PlayerInstanceInfo player_instance_info[PLAYER_INSTANCES_COUNT];
 /******************************************************************************/
 void set_player_instance(struct PlayerInfo *player, long ninum, TbBool force);
 void process_player_instance(struct PlayerInfo *player);

--- a/src/player_instances.h
+++ b/src/player_instances.h
@@ -78,9 +78,10 @@ struct PlayerInstanceInfo { // sizeof = 44
 };
 
 #define PLAYER_INSTANCES_COUNT 19
+#define PLAYER_INSTANCES_COUNT_OLD 17
 
 /******************************************************************************/
-DLLIMPORT struct PlayerInstanceInfo _DK_player_instance_info[17];
+DLLIMPORT struct PlayerInstanceInfo _DK_player_instance_info[PLAYER_INSTANCES_COUNT_OLD];
 //#define player_instance_info _DK_player_instance_info
 
 #pragma pack()

--- a/src/player_instances.h
+++ b/src/player_instances.h
@@ -80,7 +80,7 @@ struct PlayerInstanceInfo { // sizeof = 44
 #define PLAYER_INSTANCES_COUNT 19
 
 /******************************************************************************/
-DLLIMPORT struct PlayerInstanceInfo _DK_player_instance_info[PLAYER_INSTANCES_COUNT];
+DLLIMPORT struct PlayerInstanceInfo _DK_player_instance_info[17];
 //#define player_instance_info _DK_player_instance_info
 
 #pragma pack()


### PR DESCRIPTION
Somewhat conflicting, `main` is copying the first 17 but there are 19 defined and indexing is done modulus `PLAYER_INSTANCES_COUNT` so I'm leaning towards it being 19.