### PR TITLE
Added sizes to states arrays

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -155,7 +155,7 @@ short creature_pick_up_spell_to_steal(struct Thing *creatng);
 //process_state, cleanup_state, move_from_slab, move_check,
 //override_feed, override_own_needs, override_sleep, override_fight_crtr, override_gets_salary, override_prev_fld1F, override_prev_fld20, override_escape, override_unconscious, override_anger_job, override_fight_object, override_fight_door, override_call2arms, override_follow,
     //state_type, field_1F, field_20, field_21, field_23, sprite_idx, field_26, field_27, react_to_cta
-struct StateInfo states[] = {
+struct StateInfo states[CREATURE_STATES_COUNT] = {
   {NULL, NULL, NULL, NULL,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  CrStTyp_Idle, 0, 0, 0, 0,  0, 0, 0, 0},
   {imp_doing_nothing, NULL, NULL, NULL,

--- a/src/creature_states.h
+++ b/src/creature_states.h
@@ -271,9 +271,9 @@ struct StateInfo { // sizeof = 41
 };
 
 /******************************************************************************/
-DLLIMPORT struct StateInfo _DK_states[];
+DLLIMPORT struct StateInfo _DK_states[145];
 //#define states _DK_states
-extern struct StateInfo states[];
+extern struct StateInfo states[CREATURE_STATES_COUNT];
 DLLIMPORT long _DK_r_stackpos;
 #define r_stackpos _DK_r_stackpos
 DLLIMPORT struct DiggerStack _DK_reinforce_stack[DIGGER_TASK_MAX_COUNT];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4442,7 +4442,7 @@ int main(int argc, char *argv[])
 //TODO DLL_CLEANUP delete when won't be needed anymore
   memcpy(_DK_menu_list,menu_list,40*sizeof(struct GuiMenu *));
   memcpy(_DK_player_instance_info,player_instance_info,17*sizeof(struct PlayerInstanceInfo));
-  memcpy(_DK_states,states,145*sizeof(struct StateInfo));
+  memcpy(_DK_states,states,sizeof(_DK_states));
 
 #if (BFDEBUG_LEVEL > 1)
   if (sizeof(struct Game) != SIZEOF_Game)


### PR DESCRIPTION
Generates warning:

```
src/creature_states.c:458:3: warning: excess elements in array initializer
  458 |   {NULL, NULL, NULL, NULL,
```

Either there are too many elements in states array or `CREATURE_STATES_COUNT` is too small.