### PR TITLE
New script commands: MOVE_CREATURE, COUNT_CREATURES_AT_ACTION_POINT

### DIFF
--- a/src/config_effects.c
+++ b/src/config_effects.c
@@ -57,6 +57,10 @@ long const imp_spangle_effects[] = {
     TngEff_ImpSpangleRed, TngEff_ImpSpangleBlue, TngEff_ImpSpangleGreen, TngEff_ImpSpangleYellow, TngEff_None, TngEff_None,
 };
 
+long const ball_puff_effects[] = {
+    TngEff_BallPuffRed, TngEff_BallPuffBlue, TngEff_BallPuffGreen, TngEff_BallPuffYellow, TngEff_BallPuffWhite, TngEff_BallPuffWhite,
+};
+
 /******************************************************************************/
 struct EffectsConfig effects_conf;
 struct NamedCommand effect_desc[EFFECTS_TYPES_MAX];

--- a/src/config_effects.h
+++ b/src/config_effects.h
@@ -47,6 +47,7 @@ DLLIMPORT long _DK_imp_spangle_effects[];
 extern const char keeper_effects_file[];
 extern struct NamedCommand effect_desc[EFFECTS_TYPES_MAX];
 extern long const imp_spangle_effects[];
+extern long const ball_puff_effects[];
 extern struct EffectsConfig effects_conf;
 /******************************************************************************/
 TbBool load_effects_config(const char *conf_fname,unsigned short flags);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1263,6 +1263,7 @@ static void move_creature_process(struct ScriptContext* context)
             cctrl = creature_control_get_from_thing(thing);
 
             create_effect(&thing->mappos, effect_id, game.neutral_player_num);
+            create_effect(&pos, effect_id, game.neutral_player_num);
             move_thing_in_map(thing, &pos);
             reset_interpolation_of_thing(thing);
             initialise_thing_state(thing, CrSt_CreatureDoingNothing);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -38,6 +38,8 @@
 #include "creature_instances.h"
 #include "power_hand.h"
 #include "power_specials.h"
+#include "creature_states.h"
+#include "map_blocks.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -972,6 +974,63 @@ static void set_hand_rule_check(const struct ScriptLine* scline)
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
+static void move_creature_check(const struct ScriptLine* scline)
+{
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
+
+    long crmodel = parse_creature_name(scline->tp[1]);
+    if (crmodel == CREATURE_NONE)
+    {
+        SCRPTERRLOG("Unknown creature, '%s'", scline->tp[1]);
+        return;
+    }
+    long select_id = parse_criteria(scline->tp[2]);
+    if (select_id == -1) {
+        SCRPTERRLOG("Unknown select criteria, '%s'", scline->tp[2]);
+        return;
+    }
+
+    long count = scline->np[3];
+    if (count <= 0)
+    {
+        SCRPTERRLOG("Bad creatures count, %d", count);
+        return;
+    }
+
+    TbMapLocation location;
+    if (!get_map_location_id(scline->tp[4], &location))
+    {
+        SCRPTWRNLOG("Invalid location: %s", scline->tp[4]);
+        return;
+    }
+
+    const char *effect_name = scline->tp[5];
+    long effct_id = 0;
+    if (scline->tp[5][0] != '\0')
+    {
+        effct_id = get_rid(effect_desc, effect_name);
+        if (effct_id == -1)
+        {
+            if (parameter_is_number(effect_name))
+            {
+                effct_id = atoi(effect_name);
+            }
+            else
+            {
+                SCRPTERRLOG("Unrecognised effect: %s", effect_name);
+                return;
+            }
+        }
+    }
+    value->uarg0 = location;
+    value->arg1 = select_id;
+    value->shorts[4] = effct_id;
+    value->bytes[10] = count;
+    value->bytes[11] = crmodel;
+
+    PROCESS_SCRIPT_VALUE(scline->command);
+}
+
 void refresh_trap_anim(long trap_id)
 {
     int k = 0;
@@ -1140,6 +1199,45 @@ static void set_hand_rule_process(struct ScriptContext* context)
             {
                 dungeonadd->hand_rules[ci][hand_rule_slot].enabled = hand_rule_action == HandRuleAction_Enable;
             }
+        }
+    }
+}
+
+static void move_creature_process(struct ScriptContext* context)
+{
+    TbMapLocation location = context->value->uarg0;
+    long select_id = context->value->arg1;
+    long effect_id = context->value->shorts[4];
+    long count = context->value->bytes[10];
+    long crmodel = context->value->bytes[11];
+
+    for (int i = context->plr_start; i < context->plr_end; i++)
+    {
+        for (int count_i = 0; count_i < count; count_i++)
+        {
+            struct Thing *thing = script_get_creature_by_criteria(i, crmodel, select_id);
+            if (thing_is_invalid(thing) || thing_is_picked_up(thing)) {
+                continue;
+            }
+
+            if (!effect_id) {
+                effect_id = ball_puff_effects[thing->owner];
+            }
+
+            struct Coord3d pos;
+            if(!get_coords_at_location(&pos,location)) {
+                SYNCDBG(5,"No valid coords for location",(int)location);
+                return;
+            }
+            struct CreatureControl *cctrl;
+            cctrl = creature_control_get_from_thing(thing);
+
+            create_effect(&thing->mappos, effect_id, game.neutral_player_num);
+            move_thing_in_map(thing, &pos);
+            reset_interpolation_of_thing(thing);
+            initialise_thing_state(thing, CrSt_CreatureDoingNothing);
+            cctrl->turns_at_job = -1;
+            check_map_explored(thing, thing->mappos.x.stl.num, thing->mappos.y.stl.num);
         }
     }
 }
@@ -2867,6 +2965,7 @@ const struct CommandDesc command_desc[] = {
   {"SET_DOOR",                          "ANN     ", Cmd_SET_DOOR, &set_door_check, &set_door_process},
   {"SET_CREATURE_INSTANCE",             "CNAN    ", Cmd_SET_CREATURE_INSTANCE, &set_creature_instance_check, &set_creature_instance_process},
   {"SET_HAND_RULE",                     "PC!Aaaa ", Cmd_SET_HAND_RULE, &set_hand_rule_check, &set_hand_rule_process},
+  {"MOVE_CREATURE",                     "PC!ANLa ", Cmd_MOVE_CREATURE, &move_creature_check, &move_creature_process},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1250,7 +1250,8 @@ static void move_creature_process(struct ScriptContext* context)
                 continue;
             }
 
-            if (!effect_id) {
+            if (effect_id < 0)
+            {
                 effect_id = ball_puff_effects[thing->owner];
             }
 
@@ -1262,8 +1263,11 @@ static void move_creature_process(struct ScriptContext* context)
             struct CreatureControl *cctrl;
             cctrl = creature_control_get_from_thing(thing);
 
-            create_effect(&thing->mappos, effect_id, game.neutral_player_num);
-            create_effect(&pos, effect_id, game.neutral_player_num);
+            if (effect_id > 0)
+            {
+                create_effect(&thing->mappos, effect_id, game.neutral_player_num);
+                create_effect(&pos, effect_id, game.neutral_player_num);
+            }
             move_thing_in_map(thing, &pos);
             reset_interpolation_of_thing(thing);
             initialise_thing_state(thing, CrSt_CreatureDoingNothing);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1022,6 +1022,10 @@ static void move_creature_check(const struct ScriptLine* scline)
             }
         }
     }
+    else
+    {
+        effct_id = -1;
+    }
     value->uarg0 = location;
     value->arg1 = select_id;
     value->shorts[4] = effct_id;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1031,17 +1031,17 @@ static void move_creature_check(const struct ScriptLine* scline)
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
-static void count_creatures_in_range_check(const struct ScriptLine* scline)
+static void count_creatures_at_action_point_check(const struct ScriptLine* scline)
 {
-    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[1]);
 
-    long crmodel = parse_creature_name(scline->tp[1]);
+    long crmodel = parse_creature_name(scline->tp[2]);
     if (crmodel == CREATURE_NONE)
     {
-        SCRPTERRLOG("Unknown creature, '%s'", scline->tp[1]);
+        SCRPTERRLOG("Unknown creature, '%s'", scline->tp[2]);
         return;
     }
-    long ap_num = scline->np[2];
+    long ap_num = scline->np[0];
     long flag_player_id = scline->np[3];
     const char *flag_name = scline->tp[4];
 
@@ -1272,7 +1272,7 @@ static void move_creature_process(struct ScriptContext* context)
     }
 }
 
-static void count_creatures_in_range_process(struct ScriptContext* context)
+static void count_creatures_at_action_point_process(struct ScriptContext* context)
 {
     long ap_num = context->value->shorts[0];
     long crmodel = context->value->bytes[2];
@@ -3011,7 +3011,7 @@ const struct CommandDesc command_desc[] = {
   {"SET_CREATURE_INSTANCE",             "CNAN    ", Cmd_SET_CREATURE_INSTANCE, &set_creature_instance_check, &set_creature_instance_process},
   {"SET_HAND_RULE",                     "PC!Aaaa ", Cmd_SET_HAND_RULE, &set_hand_rule_check, &set_hand_rule_process},
   {"MOVE_CREATURE",                     "PC!ANLa ", Cmd_MOVE_CREATURE, &move_creature_check, &move_creature_process},
-  {"COUNT_CREATURES_IN_RANGE",          "PC!NPA  ", Cmd_COUNT_CREATURES_IN_RANGE, &count_creatures_in_range_check, &count_creatures_in_range_process},
+  {"COUNT_CREATURES_AT_ACTION_POINT",   "NPC!PA  ", Cmd_COUNT_CREATURES_AT_ACTION_POINT, &count_creatures_at_action_point_check, &count_creatures_at_action_point_process},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script_lib.c
+++ b/src/lvl_script_lib.c
@@ -22,6 +22,7 @@
 #include "thing_navigate.h"
 #include "dungeon_data.h"
 #include "lvl_filesdk1.h"
+#include "creature_states_pray.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,6 +86,38 @@ struct Thing *script_process_new_object(long tngmodel, TbMapLocation location, l
             break;
     }
     return thing;
+}
+
+void set_variable(int player_idx, long var_type, long var_idx, long new_val)
+{
+    struct Dungeon *dungeon = get_dungeon(player_idx);
+    struct DungeonAdd *dungeonadd = get_dungeonadd(player_idx);
+    struct Coord3d pos = {0};
+
+    switch (var_type)
+    {
+    case SVar_FLAG:
+        set_script_flag(player_idx, var_idx, new_val);
+        break;
+    case SVar_CAMPAIGN_FLAG:
+        intralvl.campaign_flags[player_idx][var_idx] = new_val;
+        break;
+    case SVar_BOX_ACTIVATED:
+        dungeonadd->box_info.activated[var_idx] = saturate_set_unsigned(new_val, 8);
+        break;
+    case SVar_SACRIFICED:
+        dungeon->creature_sacrifice[var_idx] = saturate_set_unsigned(new_val, 8);
+        if (find_temple_pool(player_idx, &pos))
+        {
+            process_sacrifice_creature(&pos, var_idx, player_idx, false);
+        }
+        break;
+    case SVar_REWARDED:
+        dungeonadd->creature_awarded[var_idx] = new_val;
+        break;
+    default:
+        WARNLOG("Unexpected type:%d",(int)var_type);
+    }
 }
 
 long parse_criteria(const char *criteria)

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -162,6 +162,7 @@ enum TbScriptCommands {
     Cmd_SET_CREATURE_INSTANCE             = 149,    
     Cmd_TRANSFER_CREATURE                 = 150,
     Cmd_SET_HAND_RULE                     = 151,
+    Cmd_MOVE_CREATURE                     = 152,
 };
 
 struct ScriptLine {

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -163,6 +163,7 @@ enum TbScriptCommands {
     Cmd_TRANSFER_CREATURE                 = 150,
     Cmd_SET_HAND_RULE                     = 151,
     Cmd_MOVE_CREATURE                     = 152,
+    Cmd_COUNT_CREATURES_IN_RANGE          = 153,
 };
 
 struct ScriptLine {
@@ -270,6 +271,7 @@ struct ScriptValue *allocate_script_value(void);
 struct Thing *script_process_new_object(long crmodel, TbMapLocation location, long arg, unsigned long plr_range_id);
 void command_init_value(struct ScriptValue* value, unsigned long var_index, unsigned long plr_range_id);
 void command_add_value(unsigned long var_index, unsigned long plr_range_id, long val2, long val3, long val4);
+void set_variable(int player_idx, long var_type, long var_idx, long new_val);
 #define get_players_range(plr_range_id, plr_start, plr_end) get_players_range_f(plr_range_id, plr_start, plr_end, __func__, text_line_number)
 long get_players_range_f(long plr_range_id, int *plr_start, int *plr_end, const char *func_name, long ln_num);
 TbBool parse_set_varib(const char *varib_name, long *varib_id, long *varib_type);

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -314,7 +314,7 @@ TbBool get_player_id_f(const char *plrname, long *plr_range_id, const char *func
 #define PROCESS_SCRIPT_VALUE(cmd) \
     if ((get_script_current_condition() == CONDITION_ALWAYS) && (next_command_reusable == 0)) \
     { \
-        script_process_value(cmd, 0, 0, 0, 0, value); \
+        script_process_value(cmd, value->plyr_range, 0, 0, 0, value); \
     }
 
 

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -163,7 +163,7 @@ enum TbScriptCommands {
     Cmd_TRANSFER_CREATURE                 = 150,
     Cmd_SET_HAND_RULE                     = 151,
     Cmd_MOVE_CREATURE                     = 152,
-    Cmd_COUNT_CREATURES_IN_RANGE          = 153,
+    Cmd_COUNT_CREATURES_AT_ACTION_POINT   = 153,
 };
 
 struct ScriptLine {

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -390,37 +390,6 @@ TbBool script_use_special_locate_hidden_world()
     return activate_bonus_level(get_player(my_player_number));
 }
 
-static void set_variable(int player_idx, long var_type, long var_idx, long new_val)
-{
-    struct Dungeon *dungeon = get_dungeon(player_idx);
-    struct DungeonAdd *dungeonadd = get_dungeonadd(player_idx);
-    struct Coord3d pos = {0};
-
-    switch (var_type)
-    {
-    case SVar_FLAG:
-        set_script_flag(player_idx, var_idx, new_val);
-        break;
-    case SVar_CAMPAIGN_FLAG:
-        intralvl.campaign_flags[player_idx][var_idx] = new_val;
-        break;
-    case SVar_BOX_ACTIVATED:
-        dungeonadd->box_info.activated[var_idx] = saturate_set_unsigned(new_val, 8);
-        break;
-    case SVar_SACRIFICED:
-        dungeon->creature_sacrifice[var_idx] = saturate_set_unsigned(new_val, 8);
-        if (find_temple_pool(player_idx, &pos))
-        {
-            process_sacrifice_creature(&pos, var_idx, player_idx, false);
-        }
-        break;
-    case SVar_REWARDED:
-        dungeonadd->creature_awarded[var_idx] = new_val;
-        break;
-    default:
-        WARNLOG("Unexpected type:%d",(int)var_type);
-    }
-}
 /**
  * Processes given VALUE immediately.
  * This processes given script command. It is used to process VALUEs at start when they have

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -288,6 +288,7 @@ TbBool perform_action_on_all_creatures_in_group(struct Thing *thing, Thing_Bool_
 
 struct Thing *creature_of_model_in_prison_or_tortured(ThingModel crmodel);
 long count_player_creatures_of_model(PlayerNumber plyr_idx, int crmodel);
+long count_player_creatures_of_model_in_action_point(PlayerNumber plyr_idx, int crmodel, long apt_index);
 long count_player_list_creatures_of_model(long thing_idx, ThingModel crmodel);
 long count_player_list_creatures_of_model_on_territory(long thing_idx, ThingModel crmodel, int friendly);
 GoldAmount compute_player_payday_total(const struct Dungeon *dungeon);


### PR DESCRIPTION
MOVE_CREATURE([player],[creature],[criterion],[count],[location],[effect]*)
Instantly moves [count] creatures fitting the criterion to [location].  Effect is optional, if unset, ball puff effect is used.

COUNT_CREATURES_AT_ACTION_POINT([action_point],[player],[creature],[target_flag_player],[target_flag])
Counts creatures in action point and stores the result in [target_flag].