### PR TITLE
Enemy path no longer blocks digging

### DIFF
--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -130,6 +130,7 @@ TbBool block_has_diggable_side(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSla
   long i;
   for (i = 0; i < SMALL_AROUND_SLAB_LENGTH; i++)
   {
+    // slab_is_safe_land looks at the slab owner. We don't want that here.
     struct SlabMap* slb = get_slabmap_block(slb_x + small_around[i].delta_x, slb_y + small_around[i].delta_y);
     struct SlabAttr* slbattr = get_slab_attrs(slb);
     if (slbattr->is_safe_land)

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -125,7 +125,7 @@ const unsigned char  *against_to_case[] = {
 };
 
 /******************************************************************************/
-TbBool block_has_diggable_side(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y)
+TbBool block_has_diggable_side(MapSlabCoord slb_x, MapSlabCoord slb_y)
 {
   long i;
   for (i = 0; i < SMALL_AROUND_SLAB_LENGTH; i++)
@@ -139,14 +139,15 @@ TbBool block_has_diggable_side(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSla
   return false;
 }
 
-int block_count_diggable_sides(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y)
+int block_count_diggable_sides(MapSlabCoord slb_x, MapSlabCoord slb_y)
 {
-    int num_sides;
-    num_sides = 0;
-    long i;
-    for (i = 0; i < SMALL_AROUND_SLAB_LENGTH; i++)
+    int num_sides = 0;
+    for (long i = 0; i < SMALL_AROUND_SLAB_LENGTH; i++)
     {
-        if (slab_is_safe_land(plyr_idx, slb_x + small_around[i].delta_x, slb_y + small_around[i].delta_y)) {
+        // slab_is_safe_land looks at the slab owner. We don't want that here.
+        struct SlabMap* slb = get_slabmap_block(slb_x + small_around[i].delta_x, slb_y + small_around[i].delta_y);
+        struct SlabAttr* slbattr = get_slab_attrs(slb);
+        if (slbattr->is_safe_land) {
             num_sides++;
         }
     }

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -130,7 +130,9 @@ TbBool block_has_diggable_side(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSla
   long i;
   for (i = 0; i < SMALL_AROUND_SLAB_LENGTH; i++)
   {
-    if (slab_is_safe_land(plyr_idx, slb_x + small_around[i].delta_x, slb_y + small_around[i].delta_y))
+    struct SlabMap* slb = get_slabmap_block(slb_x + small_around[i].delta_x, slb_y + small_around[i].delta_y);
+    struct SlabAttr* slbattr = get_slab_attrs(slb);
+    if (slbattr->is_safe_land)
       return true;
   }
   return false;

--- a/src/map_blocks.h
+++ b/src/map_blocks.h
@@ -34,8 +34,8 @@ struct Map;
 
 #pragma pack()
 /******************************************************************************/
-TbBool block_has_diggable_side(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y);
-int block_count_diggable_sides(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y);
+TbBool block_has_diggable_side(MapSlabCoord slb_x, MapSlabCoord slb_y);
+int block_count_diggable_sides(MapSlabCoord slb_x, MapSlabCoord slb_y);
 long tag_blocks_for_digging_in_rectangle_around(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx);
 void untag_blocks_for_digging_in_rectangle_around(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx);
 TbBool tag_blocks_for_digging_in_area(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx);

--- a/src/player_compchecks.c
+++ b/src/player_compchecks.c
@@ -307,7 +307,7 @@ static TbBool any_digger_is_digging_indestructible_valuables(struct Dungeon *dun
 }
 
 /**
- * Returns amount of diggable faces of indestructible valuables marked for digging.
+ * Returns number of diggable faces of indestructible valuables marked for digging.
  * In standard configuration, indestructible valuables are simply slabs with gems.
  * @param dungeon
  * @return
@@ -331,7 +331,7 @@ static int count_faces_of_indestructible_valuables_marked_for_dig(struct Dungeon
             const struct SlabAttr* slbattr = get_slab_attrs(slb);
             if (((slbattr->block_flags & SlbAtFlg_Valuable) != 0) && slab_kind_is_indestructible(slb->kind))
             {
-                num_faces += block_count_diggable_sides(dungeon->owner, subtile_slab_fast(stl_x), subtile_slab_fast(stl_y));
+                num_faces += block_count_diggable_sides(subtile_slab_fast(stl_x), subtile_slab_fast(stl_y));
             }
         }
     }

--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -1066,7 +1066,7 @@ int add_undug_to_imp_stack(struct Dungeon *dungeon, int max_tasks)
         slb = get_slabmap_for_subtile(stl_x, stl_y);
         if (!slab_kind_is_indestructible(slb->kind)) // Add only blocks which can be destroyed by digging
         {
-            if ( block_has_diggable_side(dungeon->owner, subtile_slab_fast(stl_x), subtile_slab_fast(stl_y)) )
+            if ( block_has_diggable_side(subtile_slab_fast(stl_x), subtile_slab_fast(stl_y)) )
             {
                 add_to_imp_stack_using_pos(mtask->coords, DigTsk_DigOrMine, dungeon);
                 remain_num--;
@@ -1100,7 +1100,7 @@ int add_gems_to_imp_stack(struct Dungeon *dungeon, int max_tasks)
             slb = get_slabmap_for_subtile(stl_x, stl_y);
             if (slab_kind_is_indestructible(slb->kind)) // Add only blocks which cannot be destroyed by digging
             {
-                if ( block_has_diggable_side(dungeon->owner, subtile_slab_fast(stl_x), subtile_slab_fast(stl_y)) )
+                if ( block_has_diggable_side(subtile_slab_fast(stl_x), subtile_slab_fast(stl_y)) )
                 {
                     add_to_imp_stack_using_pos(mtask->coords, DigTsk_DigOrMine, dungeon);
                     remain_num--;
@@ -2052,7 +2052,7 @@ long check_place_to_dig_and_get_drop_position(PlayerNumber plyr_idx, SubtlCodedC
     SYNCDBG(18,"Starting");
     place_x = stl_num_decode_x(stl_num);
     place_y = stl_num_decode_y(stl_num);
-    if (!block_has_diggable_side(plyr_idx, subtile_slab_fast(place_x), subtile_slab_fast(place_y)))
+    if (!block_has_diggable_side(subtile_slab_fast(place_x), subtile_slab_fast(place_y)))
         return 0;
     place_slb = get_slabmap_for_subtile(place_x,place_y);
     n = PLAYER_RANDOM(plyr_idx, SMALL_AROUND_SLAB_LENGTH);
@@ -2109,7 +2109,7 @@ long check_place_to_dig_and_get_position(struct Thing *thing, SubtlCodedCoords s
     SYNCDBG(18,"Starting");
     place_x = stl_num_decode_x(stl_num);
     place_y = stl_num_decode_y(stl_num);
-    if (!block_has_diggable_side(thing->owner, subtile_slab_fast(place_x), subtile_slab_fast(place_y)))
+    if (!block_has_diggable_side(subtile_slab_fast(place_x), subtile_slab_fast(place_y)))
         return 0;
     nstart = get_nearest_small_around_side_of_slab(subtile_coord_center(place_x), subtile_coord_center(place_y), thing->mappos.x.val, thing->mappos.y.val);
     place_slb = get_slabmap_for_subtile(place_x,place_y);


### PR DESCRIPTION
Fixes #760. slab_is_safe_land checks the owner and returns true only if it's the specified player or neutral. We don't want that here.