### PR TITLE
Stop resetting heal_requirement to 0 for imps

### DIFF
--- a/src/config_creature.c
+++ b/src/config_creature.c
@@ -343,9 +343,9 @@ void check_and_auto_fix_stats(void)
     for (long model = 0; model < gameadd.crtr_conf.model_count; model++)
     {
         struct CreatureStats* crstat = creature_stats_get(model);
-        if ( (crstat->lair_size <= 0) && (crstat->heal_requirement != 0) )
+        if ( (crstat->lair_size <= 0) && (crstat->toking_recovery <= 0) && (crstat->heal_requirement != 0) )
         {
-            ERRORLOG("Creature model %d No LairSize But Heal Requirment - Fixing", (int)model);
+            ERRORLOG("Creature model %d has no LairSize and no TokingRecovery but has HealRequirment - Fixing", (int)model);
             crstat->heal_requirement = 0;
         }
         if (crstat->heal_requirement > crstat->heal_threshold)


### PR DESCRIPTION
It now allows a heal_requirement if a creature can make a lair or can go toking.