### PR TITLE
Followers help attacking doors

### DIFF
--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -715,6 +715,23 @@ long process_obey_leader(struct Thing *thing)
             send_creature_to_room(thing, room, jobpref);
         }
         break;
+    case 3:
+        cctrl = creature_control_get_from_thing(thing);
+        leadctrl = creature_control_get_from_thing(leadtng);
+
+        struct Thing* obthing;
+        if ((leadctrl->combat.battle_enemy_idx > 0) && (cctrl->combat.battle_enemy_idx == 0))
+        {
+            obthing = thing_get(leadctrl->combat.battle_enemy_idx);
+            if (thing_is_deployed_door(obthing))
+            {
+                set_creature_door_combat(thing, obthing);
+            }
+        } else
+        if (thing->active_state != CrSt_CreatureFollowLeader) {
+            external_set_thing_state(thing, CrSt_CreatureFollowLeader);
+        }
+        break;
     default:
         break;
     }

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -331,7 +331,7 @@ struct StateInfo states[CREATURE_STATES_COUNT] = {
   {creature_follow_leader, NULL, NULL, NULL,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, CrStTyp_Follow, 0, 0, 0, 0,  0, 0, 0, 0},
   {creature_door_combat, cleanup_door_combat, NULL, NULL,
-    1, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, CrStTyp_FightDoor, 0, 0, 1, 0, 51, 1, 0, 0},
+    1, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, CrStTyp_FightDoor, 0, 0, 3, 0, 51, 1, 0, 0},
   {creature_combat_flee, NULL, NULL, NULL,
     1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1,  CrStTyp_Idle, 0, 0, 0, 0, 53, 1, 0, 0},
   {creature_sacrifice, NULL, NULL, NULL,


### PR DESCRIPTION
When a hero party reaches a door, all followers will now help destroy the door, instead of them all waiting while the leader takes it out.