### PR TITLE
Neutral creatures colliding with doors no longer break them

### DIFF
--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1827,7 +1827,7 @@ TngUpdateRet process_creature_state(struct Thing *thing)
                 long x = stl_num_decode_x(cctrl->collided_door_subtile);
                 long y = stl_num_decode_y(cctrl->collided_door_subtile);
                 struct Thing* doortng = get_door_for_position(x, y);
-                if (!thing_is_invalid(doortng))
+                if ((!thing_is_invalid(doortng)) && (thing->owner != neutral_player_number))
                 {
                     if (thing->owner != doortng->owner)
                     {
@@ -1842,6 +1842,7 @@ TngUpdateRet process_creature_state(struct Thing *thing)
                 {
                     // If the door does not exist, clear this field too.
                     cctrl->collided_door_subtile = 0;
+                    set_start_state(thing);
                 }
             }
         }


### PR DESCRIPTION
this would happen when they where placed on the door slab by the mapmaker