### PR TITLE
Add missing extern to frontmenu_ingame_map.h

### DIFF
--- a/src/frontmenu_ingame_map.h
+++ b/src/frontmenu_ingame_map.h
@@ -78,7 +78,7 @@ struct InterpMinimap
     long previous_y;
     long get_previous;
 };
-struct InterpMinimap interp_minimap;
+extern struct InterpMinimap interp_minimap;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Needed to make this change to overcome error when linking `keeperfx.exe`.
Not sure why this doesn't fail on the CI or for other people.