### PR TITLE
Implement #776: Level script - fixed alliances

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2888,6 +2888,22 @@ static void if_controls_check(const struct ScriptLine *scline)
     }
 }
 
+static void if_allied_check(const struct ScriptLine *scline)
+{
+    long pA = scline->np[0];
+    long pB = scline->np[1];
+    long op = scline->np[2];
+    long val = scline->np[3];
+
+    if (gameadd.script.conditions_num >= CONDITIONS_COUNT)
+    {
+        SCRPTERRLOG("Too many (over %d) conditions in script", CONDITIONS_COUNT);
+        return;
+    }
+
+    command_add_condition(pA, op, SVar_ALLIED_PLAYER, pB, val);
+}
+
 /**
  * Descriptions of script commands for parser.
  * Arguments are: A-string, N-integer, C-creature model, P- player, R- room kind, L- location, O- operator, S- slab kind
@@ -3021,6 +3037,7 @@ const struct CommandDesc command_desc[] = {
   {"SET_HAND_RULE",                     "PC!Aaaa ", Cmd_SET_HAND_RULE, &set_hand_rule_check, &set_hand_rule_process},
   {"MOVE_CREATURE",                     "PC!ANLa ", Cmd_MOVE_CREATURE, &move_creature_check, &move_creature_process},
   {"COUNT_CREATURES_AT_ACTION_POINT",   "NPC!PA  ", Cmd_COUNT_CREATURES_AT_ACTION_POINT, &count_creatures_at_action_point_check, &count_creatures_at_action_point_process},
+  {"IF_ALLIED",                         "PPON    ", Cmd_IF_ALLIED, &if_allied_check, NULL},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script_conditions.c
+++ b/src/lvl_script_conditions.c
@@ -282,6 +282,11 @@ long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, unsigned 
     case SVar_CREATURES_TRANSFERRED:
         dungeonadd = get_dungeonadd(plyr_idx);
         return dungeonadd->creatures_transferred;
+    case SVar_ALLIED_PLAYER:
+    {
+        struct PlayerInfo* player = get_player(plyr_idx);
+        return player_allied_with(player, validx);
+    }
     default:
         break;
     };

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -164,6 +164,7 @@ enum TbScriptCommands {
     Cmd_SET_HAND_RULE                     = 151,
     Cmd_MOVE_CREATURE                     = 152,
     Cmd_COUNT_CREATURES_AT_ACTION_POINT   = 153,
+    Cmd_IF_ALLIED                         = 154,
 };
 
 struct ScriptLine {
@@ -255,6 +256,7 @@ enum ScriptVariables {
   SVar_TOTAL_SCORE                     = 75,
   SVar_BONUS_TIME                      = 76,
   SVar_CREATURES_TRANSFERRED           = 77,
+  SVar_ALLIED_PLAYER                   = 78,
  };
 
 

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -802,8 +802,10 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
   case Cmd_ALLY_PLAYERS:
       for (i=plr_start; i < plr_end; i++)
       {
-          set_ally_with_player(i, val2, val3);
-          set_ally_with_player(val2, i, val3);
+          set_ally_with_player(i, val2, (val3 & 1) ? true : false);
+          set_ally_with_player(val2, i, (val3 & 1) ? true : false);
+          set_player_ally_locked(i, val2, (val3 & 2) ? true : false);
+          set_player_ally_locked(val2, i, (val3 & 2) ? true : false);
       }
       break;
       break;

--- a/src/packets.c
+++ b/src/packets.c
@@ -899,8 +899,9 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       directly_cast_spell_on_thing(plyr_idx, pckt->actn_par1, pckt->actn_par2, i);
       return 0;
   case PckA_PlyrToggleAlly:
-      toggle_ally_with_player(plyr_idx, pckt->actn_par1);
-      return 0;
+      if (!is_player_ally_locked(plyr_idx, pckt->actn_par1))
+          toggle_ally_with_player(plyr_idx, pckt->actn_par1);
+      return false;
   case PckA_SaveViewType:
       if (player->acamera != NULL)
         player->view_mode_restore = player->acamera->view_mode;

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -246,6 +246,34 @@ TbBool set_ally_with_player(PlayerNumber plyridx, PlayerNumber ally_idx, TbBool 
     return true;
 }
 
+TbBool is_player_ally_locked(PlayerNumber plyridx, PlayerNumber ally_idx)
+{
+    struct PlayerInfo* player = get_player(plyridx);
+    if (player_invalid(player))
+        return false;
+
+    if (ally_idx < PLAYER1 || ally_idx > PLAYER3)
+        return false;
+
+    return player->allied_players & (0x20 << (ally_idx - PLAYER1));
+}
+
+void set_player_ally_locked(PlayerNumber plyridx, PlayerNumber ally_idx, TbBool value)
+{
+    struct PlayerInfo* player = get_player(plyridx);
+    if (player_invalid(player))
+        return;
+
+    if (ally_idx < PLAYER1 || ally_idx > PLAYER3)
+        return;
+
+    unsigned char mask = 0x20 << (ally_idx - PLAYER1);
+    if (value)
+        player->allied_players |= mask;
+    else
+        player->allied_players &= ~mask;
+}
+
 void set_player_state(struct PlayerInfo *player, short nwrk_state, long chosen_kind)
 {
   struct PlayerInfoAdd* playeradd;

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -159,7 +159,7 @@ struct PlayerInfo {
 unsigned char field_14;
     char field_15[20]; //size may be shorter
     unsigned char victory_state;
-    unsigned char allied_players;
+    unsigned char allied_players; // bit 0-4 (allies), bit 5-7 (locked allies)
     unsigned char id_number;
     unsigned char is_active;
     unsigned char field_2D[2];
@@ -302,6 +302,8 @@ TbBool players_creatures_tolerate_each_other(PlayerNumber plyr1_idx, PlayerNumbe
 TbBool player_is_friendly_or_defeated(PlayerNumber check_plyr_idx, PlayerNumber origin_plyr_idx);
 TbBool set_ally_with_player(PlayerNumber plyridx, PlayerNumber ally_idx, TbBool state);
 void toggle_ally_with_player(long plyridx, unsigned int allyidx);
+TbBool is_player_ally_locked(PlayerNumber plyridx, PlayerNumber ally_idx);
+void set_player_ally_locked(PlayerNumber plyridx, PlayerNumber ally_idx, TbBool value);
 
 void set_player_state(struct PlayerInfo *player, short a1, long a2);
 void set_player_mode(struct PlayerInfo *player, unsigned short nview);


### PR DESCRIPTION
Resolves #776 

Used the last 3 unused bits in `player->allied_players` to represent which allies (blue, green, yellow) are locked. This means that this functionality is currently limited to single player.

**Changes to `ALLY_PLAYERS`:**
* Unlocked enemy: `ALLY_PLAYERS(PLAYER1,PLAYER2,0)`
* Unlocked ally: `ALLY_PLAYERS(PLAYER1,PLAYER2,1)`
* Locked enemy: `ALLY_PLAYERS(PLAYER1,PLAYER2,2)`
* Locked ally: `ALLY_PLAYERS(PLAYER1,PLAYER2,3)`

**New command: `IF_ALLIED({PLAYER},{PLAYER}{OP}{VALUE})`:**
Allows you to check the ally status of any two players. This will allow all sorts of use cases, such as forming a reply alliance in single player, or special events in multiplayer if two particular players are allied.

**Example script:**
Add this to the end of Korros Tor (`levels\deepdngn\map00081.txt`) or any other 2 player map.

```basic
ALLY_PLAYERS(PLAYER0,PLAYER1,1)
IF_ALLIED(PLAYER0,PLAYER1==0)
    QUICK_OBJECTIVE(1,"Blue will not accept this betrayal, prepare for battle.",PLAYER1)

    REM no going back now, lock as enemies
    ALLY_PLAYERS(PLAYER0,PLAYER1,2)
ENDIF
IF_ALLIED(PLAYER0,PLAYER2==1)
    IF_ALLIED(PLAYER0,PLAYER1==1)
        QUICK_OBJECTIVE(2,"Blue will not accept your alliance with Green, prepare for battle.",PLAYER1)
        REM lock blue as enemy
        ALLY_PLAYERS(PLAYER0,PLAYER1,2)
    ENDIF

    REM lock green as ally
    ALLY_PLAYERS(PLAYER0,PLAYER2,3)
ENDIF
```

Allying with green causes the player to automatically win the level. I am not exactly sure why, since I would have thought the unally with blue would execute first, before the ally with green command. I guess there is something about the way scripts are executed which I don't quite understand.