### PR TITLE
Made sure computer players drop at the correct location to destroy doors

### DIFF
--- a/src/map_utils.c
+++ b/src/map_utils.c
@@ -297,8 +297,8 @@ TbBool get_position_next_to_map_block_with_filter(struct Coord3d* retpos, MapCoo
     long maximizer = 0;
     for (int around_val = 0; around_val < SMALL_AROUND_LENGTH; around_val++)
     {
-        MapSubtlCoord sx = coord_subtile(x) + (small_around[around_val].delta_x * 2);
-        MapSubtlCoord sy = coord_subtile(y) + (small_around[around_val].delta_y * 2);
+        MapSubtlCoord sx = coord_subtile(x) + (small_around[around_val].delta_x * STL_PER_SLB);
+        MapSubtlCoord sy = coord_subtile(y) + (small_around[around_val].delta_y * STL_PER_SLB);
         struct Map* mapblk = get_map_block_at(sx, sy);
         if (!map_block_invalid(mapblk))
         {

--- a/src/map_utils.c
+++ b/src/map_utils.c
@@ -291,6 +291,39 @@ TbBool get_position_spiral_near_map_block_with_filter(struct Coord3d *retpos, Ma
     return (maximizer > 0);
 }
 
+TbBool get_position_next_to_map_block_with_filter(struct Coord3d* retpos, MapCoord x, MapCoord y, Coord_Maximizer_Filter filter, MaxCoordFilterParam param)
+{
+    SYNCDBG(19, "Starting");
+    long maximizer = 0;
+    for (int around_val = 0; around_val < SMALL_AROUND_LENGTH; around_val++)
+    {
+        MapSubtlCoord sx = coord_subtile(x) + (small_around[around_val].delta_x * 2);
+        MapSubtlCoord sy = coord_subtile(y) + (small_around[around_val].delta_y * 2);
+        struct Map* mapblk = get_map_block_at(sx, sy);
+        if (!map_block_invalid(mapblk))
+        {
+            long n = maximizer;
+            struct Coord3d newpos;
+            newpos.x.val = subtile_coord_center(sx);
+            newpos.y.val = subtile_coord_center(sy);
+            newpos.z.val = 0;
+            n = filter(&newpos, param, n);
+            if (n >= maximizer)
+            {
+                retpos->x.val = newpos.x.val;
+                retpos->y.val = newpos.y.val;
+                retpos->z.val = newpos.z.val;
+                maximizer = n;
+                if (maximizer == LONG_MAX)
+                {
+                    break;
+                }
+            }
+        }
+    }
+    return (maximizer > 0);
+}
+
 long slabs_count_near(MapSlabCoord tx, MapSlabCoord ty, long rad, SlabKind slbkind)
 {
     long count = 0;

--- a/src/map_utils.h
+++ b/src/map_utils.h
@@ -103,6 +103,7 @@ long near_coord_filter_battle_drop_point(const struct Coord3d *pos, MaxCoordFilt
 
 TbBool get_position_spiral_near_map_block_with_filter(struct Coord3d *retpos, MapCoord x, MapCoord y,
     long spiral_len, Coord_Maximizer_Filter filter, MaxCoordFilterParam param);
+TbBool get_position_next_to_map_block_with_filter(struct Coord3d* retpos, MapCoord x, MapCoord y, Coord_Maximizer_Filter filter, MaxCoordFilterParam param);
 
 long slabs_count_near(MapSlabCoord tx, MapSlabCoord ty, long rad, SlabKind slbkind);
 

--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -146,6 +146,22 @@ TbBool get_computer_drop_position_near_subtile(struct Coord3d *pos, struct Dunge
         81, near_coord_filter_battle_drop_point, &param);
 }
 
+TbBool get_computer_drop_position_next_to_subtile(struct Coord3d* pos, struct Dungeon* dungeon, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    if ((stl_x <= 0) || (stl_y <= 0)) {
+        return false;
+    }
+    struct CompoundCoordFilterParam param;
+    param.plyr_idx = dungeon->owner;
+    param.slab_kind = -1;
+    param.num1 = 0;
+    param.num2 = 0;
+    param.num3 = 0;
+    return get_position_next_to_map_block_with_filter(pos,
+        subtile_coord_center(stl_x), subtile_coord_center(stl_y),
+        near_coord_filter_battle_drop_point, &param);
+}
+
 long computer_event_battle(struct Computer2 *comp, struct ComputerEvent *cevent, struct Event *event)
 {
     SYNCDBG(18,"Starting for %s",cevent->name);
@@ -520,15 +536,9 @@ long computer_event_attack_door(struct Computer2* comp, struct ComputerEvent* ce
     }
 
     struct Coord3d doorpos = thing->mappos;
-
     struct Coord3d freepos;
-    if (!get_computer_drop_position_near_subtile(&freepos, comp->dungeon, coord_subtile(event->mappos_x), coord_subtile(event->mappos_y))) {
-        SYNCDBG(8, "No drop position near (%d,%d) for %s", (int)coord_subtile(event->mappos_x), (int)coord_subtile(event->mappos_y), cevent->name);
-        return 0;
-    }
-
-    if (!computer_find_safe_non_solid_block(comp, &freepos)) {
-        SYNCDBG(8, "Drop position is solid for %s", cevent->name);
+    if (!get_computer_drop_position_next_to_subtile(&freepos, comp->dungeon, coord_subtile(event->mappos_x), coord_subtile(event->mappos_y))) {
+        SYNCDBG(18, "No drop position near (%d,%d) for %s", (int)coord_subtile(event->mappos_x), (int)coord_subtile(event->mappos_y), cevent->name);
         return 0;
     }
 
@@ -546,7 +556,7 @@ long computer_event_attack_door(struct Computer2* comp, struct ComputerEvent* ce
             SYNCDBG(18, "Invalid creature selected", cevent->name);
             return 4;
         }
-        if(!create_task_move_creature_to_pos(comp, creatng, doorpos, CrSt_CreatureDoorCombat))
+        if(!create_task_move_creature_to_pos(comp, creatng, freepos, CrSt_CreatureDoorCombat))
         {
             SYNCDBG(18, "Cannot move to position for event %s", cevent->name);
             return 0;
@@ -562,8 +572,21 @@ long computer_event_attack_door(struct Computer2* comp, struct ComputerEvent* ce
             {
                 if (!create_task_magic_battle_call_to_arms(comp, &freepos, cevent->param2, cevent->param3))
                 {
-                    SYNCDBG(18, "Cannot call to arms for %s", cevent->name);
-                    return 0;
+                    if (computer_find_safe_non_solid_block(comp, &freepos))
+                    {
+                        if (!create_task_magic_battle_call_to_arms(comp, &freepos, cevent->param2, cevent->param3))
+                        {
+                            SYNCDBG(18, "Cannot call to arms for %s", cevent->name);
+                            return 0;
+                        }
+                        return 1;
+                    }
+                    else
+                    {
+                        SYNCDBG(8, "Drop position is solid for %s", cevent->name);
+                        return 0;
+                    }
+
                 }
                 return 1;
             }


### PR DESCRIPTION
also accept CTA positions where creatures cannot be dropped

Fixes #1894