### PR TITLE
Jobserver warning

### DIFF
--- a/tool_dkillconv.mk
+++ b/tool_dkillconv.mk
@@ -30,10 +30,10 @@ ifneq (,$(wildcard tools/dkillconv/src/dkillconv.cpp))
 
 # If we have source code of this tool, compile it
 $(DKILLTOLVL): tools/dkillconv/src/dkillconv.cpp
-	make -C tools/dkillconv
+	$(MAKE) -C tools/dkillconv
 
 clean-dkillconv:
-	make -C tools/dkillconv clean
+	$(MAKE) -C tools/dkillconv clean
 
 else ifneq (,$(findstring .tar.gz,$(DKILLCONV_PACKAGE)))
 

--- a/tool_peresec.mk
+++ b/tool_peresec.mk
@@ -30,10 +30,10 @@ ifneq (,$(wildcard tools/peresec/src/peresec.c))
 
 # If we have source code of this tool, compile it
 $(EXETODLL): tools/peresec/src/peresec.c
-	make -C tools/peresec
+	$(MAKE) -C tools/peresec
 
 clean-peresec:
-	make -C tools/peresec clean
+	$(MAKE) -C tools/peresec clean
 
 else ifneq (,$(findstring .tar.gz,$(PERESEC_PACKAGE)))
 

--- a/tool_png2bestpal.mk
+++ b/tool_png2bestpal.mk
@@ -30,10 +30,10 @@ ifneq (,$(wildcard tools/png2bestpal/src/png2bestpal.cpp))
 
 # If we have source code of this tool, compile it
 $(PNGTOBSPAL): tools/png2bestpal/src/png2bestpal.cpp
-	make -C tools/png2bestpal
+	$(MAKE) -C tools/png2bestpal
 
 clean-png2bestpal:
-	make -C tools/png2bestpal clean
+	$(MAKE) -C tools/png2bestpal clean
 
 else ifneq (,$(findstring .tar.gz,$(PNGTOBSPAL_PACKAGE)))
 

--- a/tool_png2ico.mk
+++ b/tool_png2ico.mk
@@ -30,10 +30,10 @@ ifneq (,$(wildcard tools/png2ico/png2ico.cpp))
 
 # If we have source code of this tool, compile it
 $(PNGTOICO): tools/png2ico/png2ico.cpp
-	make -C tools/png2ico
+	$(MAKE) -C tools/png2ico
 
 clean-png2ico:
-	make -C tools/png2ico clean
+	$(MAKE) -C tools/png2ico clean
 
 else ifneq (,$(findstring .tar.gz,$(PNGTOICO_PACKAGE)))
 

--- a/tool_pngpal2raw.mk
+++ b/tool_pngpal2raw.mk
@@ -30,10 +30,10 @@ ifneq (,$(wildcard tools/pngpal2raw/src/pngpal2raw.cpp))
 
 # If we have source code of this tool, compile it
 $(PNGTORAW): tools/pngpal2raw/src/pngpal2raw.cpp
-	make -C tools/pngpal2raw
+	$(MAKE) -C tools/pngpal2raw
 
 clean-pngpal2raw:
-	make -C tools/pngpal2raw clean
+	$(MAKE) -C tools/pngpal2raw clean
 
 else ifneq (,$(findstring .tar.gz,$(PNGTORAW_PACKAGE)))
 

--- a/tool_po2ngdat.mk
+++ b/tool_po2ngdat.mk
@@ -30,10 +30,10 @@ ifneq (,$(wildcard tools/po2ngdat/src/po2ngdat.cpp))
 
 # If we have source code of this tool, compile it
 $(POTONGDAT): tools/po2ngdat/src/po2ngdat.cpp
-	make -C tools/po2ngdat
+	$(MAKE) -C tools/po2ngdat
 
 clean-po2ngdat:
-	make -C tools/po2ngdat clean
+	$(MAKE) -C tools/po2ngdat clean
 
 else ifneq (,$(findstring .tar.gz,$(POTONGDAT_PACKAGE)))
 

--- a/tool_rnctools.mk
+++ b/tool_rnctools.mk
@@ -30,10 +30,10 @@ ifneq (,$(wildcard tools/rnctools/src/dernc.c))
 
 # If we have source code of this tool, compile it
 $(RNC) $(DERNC): tools/rnctools/src/rnc.c tools/rnctools/src/dernc.c
-	make -C tools/rnctools
+	$(MAKE) -C tools/rnctools
 
 clean-rnctools:
-	make -C tools/rnctools clean
+	$(MAKE) -C tools/rnctools clean
 
 else ifneq (,$(findstring .tar.gz,$(RNCTOOLS_PACKAGE)))
 

--- a/tool_sndbanker.mk
+++ b/tool_sndbanker.mk
@@ -30,10 +30,10 @@ ifneq (,$(wildcard tools/sndbanker/src/sndbanker.cpp))
 
 # If we have source code of this tool, compile it
 $(WAVTODAT): tools/sndbanker/src/sndbanker.cpp
-	make -C tools/sndbanker
+	$(MAKE) -C tools/sndbanker
 
 clean-sndbanker:
-	make -C tools/sndbanker clean
+	$(MAKE) -C tools/sndbanker clean
 
 else ifneq (,$(findstring .tar.gz,$(SNDBANKER_PACKAGE)))
 


### PR DESCRIPTION
Fixes the following warning:

`make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.`