### PR TITLE
Fixed warning in src/bflib_nethost_udp.cpp

### DIFF
--- a/src/bflib_client_tcp.cpp
+++ b/src/bflib_client_tcp.cpp
@@ -34,7 +34,7 @@ TCP_NetClient::TCP_NetClient(const char hostname[], ushort port) : TCP_NetBase()
 		return;
 	}
 
-	recvThread = SDL_CreateThread(reinterpret_cast<int (*)(void *)>(recvThreadFunc), "TCP_NetClient", this);
+	recvThread = SDL_CreateThread(recvThreadFunc, "TCP_NetClient", this);
 	if (recvThread == NULL) {
 		NETMSG("Failed to initialize TCP client receive thread");
 		setErrorFlag();
@@ -47,8 +47,10 @@ TCP_NetClient::~TCP_NetClient()
 	haltRecvThread();
 }
 
-void TCP_NetClient::recvThreadFunc(TCP_NetClient * cli)
+int TCP_NetClient::recvThreadFunc(void * ptr)
 {
+	auto cli = static_cast<TCP_NetClient *>(ptr);
+
 	for (;;) {
 		char header[TCP_HEADER_SIZE];
 		if (!receiveOnSocket(cli->mySocket, header, sizeof(header))) {
@@ -70,6 +72,7 @@ void TCP_NetClient::recvThreadFunc(TCP_NetClient * cli)
 
 		cli->addIntMessage(msg);
 	}
+	return 0;
 }
 
 void TCP_NetClient::haltRecvThread()

--- a/src/bflib_client_tcp.hpp
+++ b/src/bflib_client_tcp.hpp
@@ -29,7 +29,7 @@ class TCP_NetClient : public TCP_NetBase
 
 	SDL_Thread * recvThread;
 
-	static void recvThreadFunc(TCP_NetClient * cli);
+	static int recvThreadFunc(void *);
 	void haltRecvThread();
 public:
 	TCP_NetClient(const char hostname[], ushort port);

--- a/src/bflib_nethost_udp.cpp
+++ b/src/bflib_nethost_udp.cpp
@@ -31,7 +31,7 @@ UDP_NetHost::UDP_NetHost(const StringVector & broadcastAddresses) :
 	broadcastAddr(broadcastAddresses),
 	errorFlag(false)
 {
-	thread = SDL_CreateThread(reinterpret_cast<int (*)(void *)>(threadFunc), "UDP_NetHost", this);
+	thread = SDL_CreateThread(threadFunc, "UDP_NetHost", this);
 	if (thread == NULL) {
 		ERRORLOG("Failure to create session host thread");
 		errorFlag = true; //would be better with exception handling but...
@@ -44,14 +44,15 @@ UDP_NetHost::~UDP_NetHost()
 	SDL_WaitThread(thread, NULL);
 }
 
-void UDP_NetHost::threadFunc(UDP_NetHost * sh)
+int UDP_NetHost::threadFunc(void * ptr)
 {
+	auto sh = static_cast<UDP_NetHost *>(ptr);
 	// Create UDP socket.
 
 	UDPsocket socket = SDLNet_UDP_Open(HOST_PORT_NUMBER);
 	if (socket == NULL) {
 		NETMSG("Failed to open UDP socket: %s", SDLNet_GetError());
-		return;
+		return 0;
 	}
 
 	// Create packet.
@@ -60,7 +61,7 @@ void UDP_NetHost::threadFunc(UDP_NetHost * sh)
 	if (packet == NULL) {
 		NETMSG("Failed to create UDP packet: %s", SDLNet_GetError());
 		SDLNet_UDP_Close(socket);
-		return;
+		return 0;
 	}
 
 	sh->cond.lock();
@@ -109,4 +110,5 @@ void UDP_NetHost::threadFunc(UDP_NetHost * sh)
 
 	SDLNet_FreePacket(packet);
 	SDLNet_UDP_Close(socket);
+	return 0;
 }

--- a/src/bflib_nethost_udp.hpp
+++ b/src/bflib_nethost_udp.hpp
@@ -36,7 +36,7 @@ private:
 	SDL_Thread * thread;
 	ThreadCond cond;
 
-	static void threadFunc(UDP_NetHost * sh);
+	static int threadFunc(void *);
 
 	StringVector broadcastAddr;
 

--- a/src/bflib_netlisten_udp.cpp
+++ b/src/bflib_netlisten_udp.cpp
@@ -33,7 +33,7 @@ UDP_NetListener::UDP_NetListener() :
 	sessionsMutex(SDL_CreateMutex()),
 	criticalError(false)
 {
-	thread = SDL_CreateThread(reinterpret_cast<int (*)(void *)>(threadFunc), "UDP_NetListener", this);
+	thread = SDL_CreateThread(threadFunc, "UDP_NetListener", this);
 	if (thread == NULL) {
 		ERRORLOG("Failure to create session listener thread");
 		criticalError = true; //would be better with exception handling but...
@@ -47,13 +47,14 @@ UDP_NetListener::~UDP_NetListener()
 	SDL_DestroyMutex(sessionsMutex);
 }
 
-void UDP_NetListener::threadFunc(UDP_NetListener * sh)
+int UDP_NetListener::threadFunc(void * ptr)
 {
+	auto sh = static_cast<UDP_NetListener *>(ptr);
 	// Create UDP socket.
 	UDPsocket socket = SDLNet_UDP_Open(LISTENER_PORT_NUMBER);
 	if (socket == NULL) {
 		NETMSG("Failed to open UDP socket: %s", SDLNet_GetError());
-		return;
+		return 0;
 	}
 
 	// Create packet.
@@ -62,7 +63,7 @@ void UDP_NetListener::threadFunc(UDP_NetListener * sh)
 	if (packet == NULL) {
 		NETMSG("Failed to create UDP packet: %s", SDLNet_GetError());
 		SDLNet_UDP_Close(socket);
-		return;
+		return 0;
 	}
 
 	sh->cond.lock();
@@ -103,6 +104,7 @@ void UDP_NetListener::threadFunc(UDP_NetListener * sh)
 
 	SDLNet_FreePacket(packet);
 	SDLNet_UDP_Close(socket);
+	return 0;
 }
 
 TbNetworkSessionNameEntry * UDP_NetListener::reportSession(const IPaddress & addr, const char * namestr)

--- a/src/bflib_netlisten_udp.hpp
+++ b/src/bflib_netlisten_udp.hpp
@@ -38,7 +38,7 @@ private:
 	SDL_Thread * thread;
 	ThreadCond cond;
 
-	static void threadFunc(UDP_NetListener * sh);
+	static int threadFunc(void *);
 
 	struct Session
 	{


### PR DESCRIPTION
Fixes warning:
```
src/bflib_nethost_udp.cpp: In constructor ‘UDP_NetHost::UDP_NetHost(const StringVector&)’:
src/bflib_nethost_udp.cpp:34:28: warning: cast between incompatible function types from ‘void (*)(UDP_NetHost*)’ to ‘int (*)(void*)’ [-Wcast-function-type]
   34 |  thread = SDL_CreateThread(reinterpret_cast<int (*)(void *)>(threadFunc), "UDP_NetHost", this);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sdl/include/SDL2/SDL_thread.h:132:59: note: in definition of macro ‘SDL_CreateThread’
  132 | #define SDL_CreateThread(fn, name, data) SDL_CreateThread(fn, name, data, (pfnSDL_CurrentBeginThread)SDL_beginthread, (pfnSDL_CurrentEndThread)SDL_endthread)
      |  
```