### PR TITLE
Fixed warning in src/bflib_netlisten_udp.cpp

### DIFF
--- a/src/bflib_netlisten_udp.cpp
+++ b/src/bflib_netlisten_udp.cpp
@@ -33,7 +33,7 @@ UDP_NetListener::UDP_NetListener() :
 	sessionsMutex(SDL_CreateMutex()),
 	criticalError(false)
 {
-	thread = SDL_CreateThread(reinterpret_cast<int (*)(void *)>(threadFunc), "UDP_NetListener", this);
+	thread = SDL_CreateThread(threadFunc, "UDP_NetListener", this);
 	if (thread == NULL) {
 		ERRORLOG("Failure to create session listener thread");
 		criticalError = true; //would be better with exception handling but...
@@ -47,13 +47,14 @@ UDP_NetListener::~UDP_NetListener()
 	SDL_DestroyMutex(sessionsMutex);
 }
 
-void UDP_NetListener::threadFunc(UDP_NetListener * sh)
+int UDP_NetListener::threadFunc(void * ptr)
 {
+	auto sh = static_cast<UDP_NetListener *>(ptr);
 	// Create UDP socket.
 	UDPsocket socket = SDLNet_UDP_Open(LISTENER_PORT_NUMBER);
 	if (socket == NULL) {
 		NETMSG("Failed to open UDP socket: %s", SDLNet_GetError());
-		return;
+		return 0;
 	}
 
 	// Create packet.
@@ -62,7 +63,7 @@ void UDP_NetListener::threadFunc(UDP_NetListener * sh)
 	if (packet == NULL) {
 		NETMSG("Failed to create UDP packet: %s", SDLNet_GetError());
 		SDLNet_UDP_Close(socket);
-		return;
+		return 0;
 	}
 
 	sh->cond.lock();
@@ -103,6 +104,7 @@ void UDP_NetListener::threadFunc(UDP_NetListener * sh)
 
 	SDLNet_FreePacket(packet);
 	SDLNet_UDP_Close(socket);
+	return 0;
 }
 
 TbNetworkSessionNameEntry * UDP_NetListener::reportSession(const IPaddress & addr, const char * namestr)

--- a/src/bflib_netlisten_udp.hpp
+++ b/src/bflib_netlisten_udp.hpp
@@ -38,7 +38,7 @@ private:
 	SDL_Thread * thread;
 	ThreadCond cond;
 
-	static void threadFunc(UDP_NetListener * sh);
+	static int threadFunc(void *);
 
 	struct Session
 	{


### PR DESCRIPTION
Fixes warning:
```
src/bflib_netlisten_udp.cpp: In constructor ‘UDP_NetListener::UDP_NetListener()’:
src/bflib_netlisten_udp.cpp:36:28: warning: cast between incompatible function types from ‘void (*)(UDP_NetListener*)’ to ‘int (*)(void*)’ [-Wcast-function-type]
   36 |  thread = SDL_CreateThread(reinterpret_cast<int (*)(void *)>(threadFunc), "UDP_NetListener", this);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sdl/include/SDL2/SDL_thread.h:132:59: note: in definition of macro ‘SDL_CreateThread’
  132 | #define SDL_CreateThread(fn, name, data) SDL_CreateThread(fn, name, data, (pfnSDL_CurrentBeginThread)SDL_beginthread, (pfnSDL_CurrentEndThread)SDL_endthread)
      |
```