### PR TITLE
Fixed warning in src/bflib_client_tcp.cpp

### DIFF
--- a/src/bflib_client_tcp.cpp
+++ b/src/bflib_client_tcp.cpp
@@ -34,7 +34,7 @@ TCP_NetClient::TCP_NetClient(const char hostname[], ushort port) : TCP_NetBase()
 		return;
 	}
 
-	recvThread = SDL_CreateThread(reinterpret_cast<int (*)(void *)>(recvThreadFunc), "TCP_NetClient", this);
+	recvThread = SDL_CreateThread(recvThreadFunc, "TCP_NetClient", this);
 	if (recvThread == NULL) {
 		NETMSG("Failed to initialize TCP client receive thread");
 		setErrorFlag();
@@ -47,8 +47,10 @@ TCP_NetClient::~TCP_NetClient()
 	haltRecvThread();
 }
 
-void TCP_NetClient::recvThreadFunc(TCP_NetClient * cli)
+int TCP_NetClient::recvThreadFunc(void * ptr)
 {
+	auto cli = static_cast<TCP_NetClient *>(ptr);
+
 	for (;;) {
 		char header[TCP_HEADER_SIZE];
 		if (!receiveOnSocket(cli->mySocket, header, sizeof(header))) {
@@ -70,6 +72,7 @@ void TCP_NetClient::recvThreadFunc(TCP_NetClient * cli)
 
 		cli->addIntMessage(msg);
 	}
+	return 0;
 }
 
 void TCP_NetClient::haltRecvThread()

--- a/src/bflib_client_tcp.hpp
+++ b/src/bflib_client_tcp.hpp
@@ -29,7 +29,7 @@ class TCP_NetClient : public TCP_NetBase
 
 	SDL_Thread * recvThread;
 
-	static void recvThreadFunc(TCP_NetClient * cli);
+	static int recvThreadFunc(void *);
 	void haltRecvThread();
 public:
 	TCP_NetClient(const char hostname[], ushort port);


### PR DESCRIPTION
Fixes warning:
```
src/bflib_client_tcp.cpp: In constructor ‘TCP_NetClient::TCP_NetClient(const char*, ushort)’:
src/bflib_client_tcp.cpp:37:32: warning: cast between incompatible function types from ‘void (*)(TCP_NetClient*)’ to ‘int (*)(void*)’ [-Wcast-function-type]
   37 |  recvThread = SDL_CreateThread(reinterpret_cast<int (*)(void *)>(recvThreadFunc), "TCP_NetClient", this);
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sdl/include/SDL2/SDL_thread.h:132:59: note: in definition of macro ‘SDL_CreateThread’
  132 | #define SDL_CreateThread(fn, name, data) SDL_CreateThread(fn, name, data, (pfnSDL_CurrentBeginThread)SDL_beginthread, (pfnSDL_CurrentEndThread)SDL_endthread)
      |    
```