### PR TITLE
Fixed warnings in src/roomspace.c

### DIFF
--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -535,7 +535,6 @@ long computer_event_attack_door(struct Computer2* comp, struct ComputerEvent* ce
         return 0;
     }
 
-    struct Coord3d doorpos = thing->mappos;
     struct Coord3d freepos;
     if (!get_computer_drop_position_next_to_subtile(&freepos, comp->dungeon, coord_subtile(event->mappos_x), coord_subtile(event->mappos_y))) {
         SYNCDBG(18, "No drop position near (%d,%d) for %s", (int)coord_subtile(event->mappos_x), (int)coord_subtile(event->mappos_y), cevent->name);

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -1410,18 +1410,19 @@ void update_slab_grid(struct RoomSpace* roomspace, unsigned char mode, TbBool se
                 current_y = roomspace->top + y;
                 for (x = 0; x < roomspace->width; x++)
                 {
+                    TbBool * row = roomspace->slab_grid[x];
                     current_x = roomspace->left + x;
                     if (roomspace->is_roomspace_a_box || roomspace->slab_grid[x][y] == true) // only check slabs in the roomspace
                     {
                         can = (sell) ? ((subtile_is_sellable_room(roomspace->plyr_idx, slab_subtile(current_x,0), slab_subtile(current_y,0))) || (subtile_is_sellable_door_or_trap(roomspace->plyr_idx, slab_subtile(current_x,0), slab_subtile(current_y,0)))) : (roomspace_can_build_room_at_slab(roomspace->plyr_idx, roomspace->rkind, current_x, current_y));
                         if (can)
                         {
-                            roomspace->slab_grid[x][y] = true;
+                            row[y] = true;
                             roomspace->slab_count++;
                         }
                         else
                         {
-                            roomspace->slab_grid[x][y] = false;
+                            row[y] = false;
                             roomspace->invalid_slabs_count++;
                         }
                     }
@@ -1436,18 +1437,19 @@ void update_slab_grid(struct RoomSpace* roomspace, unsigned char mode, TbBool se
                 current_y = roomspace->bottom - y;
                 for (x = 0; x < roomspace->width; x++)
                 {
+                    TbBool * row = roomspace->slab_grid[(roomspace->width - 1) - x];
                     current_x = roomspace->right - x;
                     if (roomspace->is_roomspace_a_box || roomspace->slab_grid[(roomspace->width - 1) - x][(roomspace->height - 1) - y] == true) // only check slabs in the roomspace
                     {
                         can = (sell) ? ((subtile_is_sellable_room(roomspace->plyr_idx, slab_subtile(current_x,0), slab_subtile(current_y,0))) || (subtile_is_sellable_door_or_trap(roomspace->plyr_idx, slab_subtile(current_x,0), slab_subtile(current_y,0)))) : (roomspace_can_build_room_at_slab(roomspace->plyr_idx, roomspace->rkind, current_x, current_y));
                         if (can)
                         {
-                            roomspace->slab_grid[(roomspace->width - 1) - x][(roomspace->height - 1) - y] = true;
+                            row[(roomspace->height - 1) - y] = true;
                             roomspace->slab_count++;
                         }
                         else
                         {
-                            roomspace->slab_grid[(roomspace->width - 1) - x][(roomspace->height - 1) - y] = false;
+                            row[(roomspace->height - 1) - y] = false;
                             roomspace->invalid_slabs_count++;
                         }
                     }
@@ -1462,18 +1464,19 @@ void update_slab_grid(struct RoomSpace* roomspace, unsigned char mode, TbBool se
                 current_y = roomspace->top + y;
                 for (x = 0; x < roomspace->width; x++)
                 {
+                    TbBool * row = roomspace->slab_grid[(roomspace->width - 1) - x];
                     current_x = roomspace->right - x;
                     if (roomspace->is_roomspace_a_box || roomspace->slab_grid[(roomspace->width - 1) - x][y] == true) // only check slabs in the roomspace
                     {
                         can = (sell) ? ((subtile_is_sellable_room(roomspace->plyr_idx, slab_subtile(current_x,0), slab_subtile(current_y,0))) || (subtile_is_sellable_door_or_trap(roomspace->plyr_idx, slab_subtile(current_x,0), slab_subtile(current_y,0)))) : (roomspace_can_build_room_at_slab(roomspace->plyr_idx, roomspace->rkind, current_x, current_y));
                         if (can)
                         {
-                            roomspace->slab_grid[(roomspace->width - 1) - x][y] = true;
+                            row[y] = true;
                             roomspace->slab_count++;
                         }
                         else
                         {
-                            roomspace->slab_grid[(roomspace->width - 1) - x][y] = false;
+                            row[y] = false;
                             roomspace->invalid_slabs_count++;
                         }
                     }
@@ -1488,18 +1491,19 @@ void update_slab_grid(struct RoomSpace* roomspace, unsigned char mode, TbBool se
                 current_y = roomspace->bottom - y;
                 for (x = 0; x < roomspace->width; x++)
                 {
+                    TbBool * row = roomspace->slab_grid[x];
                     current_x = roomspace->left + x;
                     if (roomspace->is_roomspace_a_box || roomspace->slab_grid[x][(roomspace->height - 1) - y] == true) // only check slabs in the roomspace
                     {
                         can = (sell) ? ((subtile_is_sellable_room(roomspace->plyr_idx, slab_subtile(current_x,0), slab_subtile(current_y,0))) || (subtile_is_sellable_door_or_trap(roomspace->plyr_idx, slab_subtile(current_x,0), slab_subtile(current_y,0)))) : (roomspace_can_build_room_at_slab(roomspace->plyr_idx, roomspace->rkind, current_x, current_y));
                         if (can)
                         {
-                            roomspace->slab_grid[x][(roomspace->height - 1) - y] = true;
+                            row[(roomspace->height - 1) - y] = true;
                             roomspace->slab_count++;
                         }
                         else
                         {
-                            roomspace->slab_grid[x][(roomspace->height - 1) - y] = false;
+                            row[(roomspace->height - 1) - y] = false;
                             roomspace->invalid_slabs_count++;
                         }
                     }


### PR DESCRIPTION
Fixes the following warnings:
```
src/roomspace.c: In function ‘update_slab_grid’:
src/roomspace.c:1502:82: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1502 |                             roomspace->slab_grid[x][(roomspace->height - 1) - y] = false;
In file included from src/player_data.h:26,
                 from src/game_legacy.h:26,
                 from src/roomspace.c:24:
src/roomspace.h:71:12: note: at offset 0 to object ‘slab_grid’ with size 400 declared here
   71 |     TbBool slab_grid[MAX_ROOMSPACE_WIDTH][MAX_ROOMSPACE_WIDTH];
      |            ^~~~~~~~~
src/roomspace.c:1497:82: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1497 |                             roomspace->slab_grid[x][(roomspace->height - 1) - y] = true;
In file included from src/player_data.h:26,
                 from src/game_legacy.h:26,
                 from src/roomspace.c:24:
src/roomspace.h:71:12: note: at offset 0 to object ‘slab_grid’ with size 400 declared here
   71 |     TbBool slab_grid[MAX_ROOMSPACE_WIDTH][MAX_ROOMSPACE_WIDTH];
      |            ^~~~~~~~~
src/roomspace.c:1450:107: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1450 |                             roomspace->slab_grid[(roomspace->width - 1) - x][(roomspace->height - 1) - y] = false;
In file included from src/player_data.h:26,
                 from src/game_legacy.h:26,
                 from src/roomspace.c:24:
src/roomspace.h:71:12: note: at offset 0 to object ‘slab_grid’ with size 400 declared here
   71 |     TbBool slab_grid[MAX_ROOMSPACE_WIDTH][MAX_ROOMSPACE_WIDTH];
      |            ^~~~~~~~~
src/roomspace.c:1445:107: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1445 |                             roomspace->slab_grid[(roomspace->width - 1) - x][(roomspace->height - 1) - y] = true;
In file included from src/player_data.h:26,
                 from src/game_legacy.h:26,
                 from src/roomspace.c:24:
src/roomspace.h:71:12: note: at offset 0 to object ‘slab_grid’ with size 400 declared here
   71 |     TbBool slab_grid[MAX_ROOMSPACE_WIDTH][MAX_ROOMSPACE_WIDTH];
      |
```