### PR TITLE
Updated zlib to 1.2.13, fixed warning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,7 @@
 	url = https://github.com/randy408/libspng.git
 [submodule "deps/zlib"]
 	path = deps/zlib
-	url = https://github.com/madler/zlib.git
-        branch = master
+	url = https://github.com/xtremeqg/zlib.git
 [submodule "deps/centijson"]
 	path = deps/centijson
 	url = https://github.com/mity/centijson.git


### PR DESCRIPTION
Fixes warning:
```
deps/zlib/contrib/minizip/unzip.c: In function ‘unz64local_GetCurrentFileInfoInternal’:
deps/zlib/contrib/minizip/unzip.c:1041:63: warning: declaration of ‘uL’ shadows a previous local [-Wshadow]
 1041 |                                                         uLong uL;
      |                                                               ^~
deps/zlib/contrib/minizip/unzip.c:896:11: note: shadowed declaration is here
  896 |     uLong uL;
      |           ^~
```