### PR TITLE
Fixed warning in libspng

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/dkfans/peresec.git
 [submodule "deps/libspng"]
 	path = deps/libspng
-	url = https://github.com/randy408/libspng.git
+	url = https://github.com/xtremeqg/libspng.git
 [submodule "deps/zlib"]
 	path = deps/zlib
 	url = https://github.com/madler/zlib.git


### PR DESCRIPTION
Fixes warning:
```
deps/libspng/spng/spng.c: In function ‘spng_ctx_free’:
deps/libspng/spng/spng.c:5002:19: warning: declaration of ‘free_func’ shadows a global declaration [-Wshadow]
 5002 |     spng_free_fn *free_func = ctx->alloc.free_fn;
      |                   ^~~~~~~~~
In file included from deps/libspng/spng/spng.c:21:
deps/zlib/zlib.h:82:18: note: shadowed declaration is here
   82 | typedef void   (*free_func)  OF((voidpf opaque, voidpf address));
      |    
```