### PR TITLE
Prevent ghost-crates when arming traps with found crates

### DIFF
--- a/src/creature_states_spdig.c
+++ b/src/creature_states_spdig.c
@@ -1883,6 +1883,10 @@ short creature_arms_trap(struct Thing *thing)
         return 0;
     }
     rearm_trap(traptng);
+    if (imp_will_soon_be_arming_trap(traptng)) //Another crate is still earmarked for this trap, refund it.
+    {
+        readd_workshop_item_to_amount_placeable(traptng->owner, traptng->class_id, traptng->model);
+    }
     dungeon = get_dungeon(thing->owner);
     dungeon->lvstats.traps_armed++;
     creature_drop_dragged_object(thing, cratetng);

--- a/src/creature_states_spdig.c
+++ b/src/creature_states_spdig.c
@@ -1657,12 +1657,14 @@ short creature_picks_up_trap_object(struct Thing *thing)
     SYNCDBG(18,"Moving %s index %d",thing_model_name(thing),(int)thing->index);
     if (room_exists(room))
     {
-        remove_workshop_object_from_workshop(room,cratetng);
-        if (!is_hero_thing(cratetng) && !is_neutral_thing(cratetng))
+        if (remove_workshop_object_from_workshop(room, cratetng))
         {
-            remove_workshop_item_from_amount_stored(cratetng->owner,
-                crate_thing_to_workshop_item_class(cratetng),
-                crate_thing_to_workshop_item_model(cratetng), WrkCrtF_NoOffmap);
+            if (!is_hero_thing(cratetng) && !is_neutral_thing(cratetng))
+            {
+                remove_workshop_item_from_amount_stored(cratetng->owner,
+                    crate_thing_to_workshop_item_class(cratetng),
+                    crate_thing_to_workshop_item_model(cratetng), WrkCrtF_NoOffmap);
+            }
         }
     }
     creature_drag_object(thing, cratetng);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1309,7 +1309,6 @@ void process_thing_spell_teleport_effects(struct Thing *thing, struct CastedSpel
                 else
                 {
                     creature_drop_dragged_object(thing, droptng);
-                    droptng->owner = game.neutral_player_num;
                 }
             }
             const struct Coord3d* newpos = NULL;
@@ -5828,7 +5827,6 @@ void controlled_creature_drop_thing(struct Thing *creatng, struct Thing *droptng
     else
     {
         creature_drop_dragged_object(creatng, droptng);
-        droptng->owner = game.neutral_player_num;
     }
     clear_messages_from_player(-81);
     clear_messages_from_player(-86);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1309,6 +1309,7 @@ void process_thing_spell_teleport_effects(struct Thing *thing, struct CastedSpel
                 else
                 {
                     creature_drop_dragged_object(thing, droptng);
+                    droptng->owner = game.neutral_player_num;
                 }
             }
             const struct Coord3d* newpos = NULL;
@@ -5827,6 +5828,7 @@ void controlled_creature_drop_thing(struct Thing *creatng, struct Thing *droptng
     else
     {
         creature_drop_dragged_object(creatng, droptng);
+        droptng->owner = game.neutral_player_num;
     }
     clear_messages_from_player(-81);
     clear_messages_from_player(-86);


### PR DESCRIPTION
When workers can't return a crate they found to the workshop - for example because of a locked door - but there is an unarmed trap on the map, they will use the crate to arm a trap. However, when the player placed the trap, the 'available traps' counter went down and a crate in the workshop was earmarked for arming it.
Using the found crate to arm the trap, the count is now too low, and a crate is stuck forever in the workshop.

Also, in much the same way, when a modder changes their game files to make other room types create crates, these will generally be used by imps to arm traps even when the workshop can be reached and create the same problem.

I fixed this by after arming a trap, checking if there is still a crate earmarked to arm the already armed trap, and if there is, 'refund' the crate that was 'taken' when the unarmed trap was placed.