### PR TITLE
Last pixel missing when drawing scaled sprites

### DIFF
--- a/src/bflib_vidraw_spr_norm.c
+++ b/src/bflib_vidraw_spr_norm.c
@@ -662,7 +662,7 @@ TbResult LbSpriteDrawUsingScalingUpDataSolidLR(uchar *outbuf, int scanline, int 
                     {
                         xdup = xcurstep[1];
                         if (xcurstep[0]+xdup > abs(scanline))
-                            xdup = abs(scanline)-xcurstep[0];
+                            xdup = abs(scanline)-xcurstep[1];
                         if (xdup > 0)
                         {
                             unsigned char pxval;


### PR DESCRIPTION
Noticed on some tooltips that pixels directly adjacent to the clipping edge were not drawn.