### PR TITLE
enable rewritten version of ceiling_init

### DIFF
--- a/src/map_ceiling.c
+++ b/src/map_ceiling.c
@@ -30,7 +30,6 @@ extern "C"
 {
 #endif
 
-DLLIMPORT long _DK_ceiling_init(unsigned long a1, unsigned long a2);
 static char ceiling_cache[256*256];
 
 static int find_column_height_including_lintels(struct Column *col)

--- a/src/map_ceiling.c
+++ b/src/map_ceiling.c
@@ -305,8 +305,6 @@ static int get_ceiling_or_floor_filled_subtiles(int stl_num)
 
 long ceiling_init(unsigned long a1, unsigned long a2)
 {
-    return _DK_ceiling_init(a1, a2);
-    //TODO Fix, then enable rewritten version
     MapSubtlCoord stl_x;
     MapSubtlCoord stl_y;
     for (stl_y=0; stl_y < map_subtiles_y; stl_y++)


### PR DESCRIPTION
last time I checked the last quater of the map the ceiling touched floor, now on same map this no longer happens, not sure what fixed it but seems fine now