### PR TITLE
Heroes also attack empty disconnected dungeon rooms

### DIFF
--- a/src/creature_battle.c
+++ b/src/creature_battle.c
@@ -182,7 +182,7 @@ long get_flee_position(struct Thing *creatng, struct Coord3d *pos)
         pos->z.val = lairtng->mappos.z.val;
     }
     else
-    if (creature_can_get_to_dungeon(creatng, creatng->owner))
+    if (creature_can_get_to_dungeon_heart(creatng, creatng->owner))
     {
         struct Thing* heartng = get_player_soul_container(creatng->owner);
         TRACE_THING(heartng);

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -865,8 +865,11 @@ short good_doing_nothing(struct Thing *creatng)
                 // Go to the previously chosen dungeon
                 if (!creature_can_get_to_dungeon_heart(creatng,target_plyr_idx))
                 {
-                    // Cannot get to the originally selected dungeon - reset it
-                    cctrl->party.target_plyr_idx = -1;
+                    if (!creature_can_get_to_any_of_players_rooms(creatng, target_plyr_idx) || (cctrl->party_objective != CHeroTsk_AttackRooms))
+                    {
+                        // Cannot get to the originally selected dungeon - reset it
+                        cctrl->party.target_plyr_idx = -1;
+                    }
                 }
             } else
             if (nturns >= 0)

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -76,7 +76,7 @@ TbBool has_available_enemy_dungeon_heart(struct Thing *thing, PlayerNumber plyr_
         cctrl->byte_8B = 0;
     }
     // Try accessing dungeon heart of undefeated enemy players
-    if (!player_is_friendly_or_defeated(plyr_idx, thing->owner) && (creature_can_get_to_dungeon(thing, plyr_idx)))
+    if (!player_is_friendly_or_defeated(plyr_idx, thing->owner) && (creature_can_get_to_dungeon_heart(thing, plyr_idx)))
     {
         return true;
     }
@@ -113,7 +113,7 @@ long good_find_best_enemy_dungeon(struct Thing* creatng)
         player = get_player(plyr_idx);
         if (gameadd.classic_bugs_flags & ClscBug_AlwaysTunnelToRed)
         {
-            if (creature_can_get_to_dungeon(creatng, plyr_idx))
+            if (creature_can_get_to_dungeon_heart(creatng, plyr_idx))
             {
                 if (player_is_friendly_or_defeated(plyr_idx, creatng->owner)) {
                     continue;
@@ -863,7 +863,7 @@ short good_doing_nothing(struct Thing *creatng)
             if (nturns > 400)
             {
                 // Go to the previously chosen dungeon
-                if (!creature_can_get_to_dungeon(creatng,target_plyr_idx))
+                if (!creature_can_get_to_dungeon_heart(creatng,target_plyr_idx))
                 {
                     // Cannot get to the originally selected dungeon - reset it
                     cctrl->party.target_plyr_idx = -1;

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -3186,6 +3186,50 @@ static long count_rooms_with_used_capacity_creature_can_navigate_to(struct Thing
  * @param n
  * @return
  */
+struct Room* find_room_of_kind_creature_can_navigate_to(struct Thing* thing, PlayerNumber owner, RoomKind rkind, unsigned char nav_flags)
+{
+    struct DungeonAdd* dungeonadd = get_dungeonadd(owner);
+    unsigned long k = 0;
+
+    int i = dungeonadd->room_kind[rkind];
+    while (i != 0)
+    {
+        struct Room* room = room_get(i);
+        if (room_is_invalid(room))
+        {
+            ERRORLOG("Jump to invalid room detected");
+            break;
+        }
+        i = room->next_of_owner;
+        // Per-room code
+        struct Coord3d pos;
+        if (find_first_valid_position_for_thing_anywhere_in_room(thing, room, &pos))
+        {
+            if (creature_can_navigate_to(thing, &pos, nav_flags))
+            {
+                return room;
+            }
+        }
+        // Per-room code ends
+        k++;
+        if (k > ROOMS_COUNT)
+        {
+            ERRORLOG("Infinite loop detected when sweeping rooms list");
+            break;
+        }
+    }
+    return INVALID_ROOM;
+}
+
+/**
+ * Gives the n-th room of given kind and owner where the creature can navigate to.
+ * @param thing
+ * @param owner
+ * @param kind
+ * @param nav_flags
+ * @param n
+ * @return
+ */
 struct Room* find_nth_room_of_kind_with_used_capacity_creature_can_navigate_to(struct Thing* thing, PlayerNumber owner, RoomKind rkind, unsigned char nav_flags, long n)
 {
     struct DungeonAdd* dungeonadd = get_dungeonadd(owner);
@@ -3293,7 +3337,7 @@ TbBool creature_can_get_to_any_of_players_rooms(struct Thing *thing, PlayerNumbe
 {
     for (RoomKind rkind = 1; rkind < slab_conf.room_types_count; rkind++)
     {
-        struct Room* room = find_nth_room_of_kind_with_used_capacity_creature_can_navigate_to(thing, owner, rkind, NavRtF_NoOwner, 0);
+        struct Room* room = find_room_of_kind_creature_can_navigate_to(thing, owner, rkind, NavRtF_NoOwner);
         if (!room_is_invalid(room))
             return true;
     }

--- a/src/thing_navigate.c
+++ b/src/thing_navigate.c
@@ -360,7 +360,7 @@ TbBool creature_can_navigate_to_f(const struct Thing *thing, struct Coord3d *dst
  * @return
  * @see creature_can_get_to_any_of_players_rooms() is a function used in similar manner.
  */
-TbBool creature_can_get_to_dungeon(struct Thing *creatng, PlayerNumber plyr_idx)
+TbBool creature_can_get_to_dungeon_heart(struct Thing *creatng, PlayerNumber plyr_idx)
 {
     SYNCDBG(18,"Starting");
     struct PlayerInfo* player = get_player(plyr_idx);

--- a/src/thing_navigate.h
+++ b/src/thing_navigate.h
@@ -82,7 +82,7 @@ TbBool creature_can_navigate_to_f(const struct Thing *thing, struct Coord3d *pos
 #define creature_can_navigate_to(thing,pos,flags) creature_can_navigate_to_f(thing,pos,flags,__func__)
 TbBool creature_can_navigate_to_with_storage_f(const struct Thing *crtng, const struct Coord3d *pos, NaviRouteFlags flags, const char *func_name);
 #define creature_can_navigate_to_with_storage(crtng,pos,flags) creature_can_navigate_to_with_storage_f(crtng,pos,flags,__func__)
-TbBool creature_can_get_to_dungeon(struct Thing *thing, PlayerNumber plyr_idx);
+TbBool creature_can_get_to_dungeon_heart(struct Thing *thing, PlayerNumber plyr_idx);
 TbBool creature_can_head_for_room(struct Thing *thing, struct Room *room, int flags);
 struct Thing *find_hero_door_hero_can_navigate_to(struct Thing *herotng);
 TbBool get_nearest_valid_position_for_creature_at(struct Thing *thing, struct Coord3d *pos);


### PR DESCRIPTION
Heroes wanting to attack rooms would not do so until they had access to filled rooms or rooms connected to the dungeon heart. Now they will attack the rooms when they can.