### PR TITLE
seperate the revealed bitflag from mapblk data field

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -187,6 +187,8 @@ typedef int ScreenCoord;
 typedef int RealScreenCoord;
 /** Player identification number, or owner of in-game thing/room/slab. */
 typedef signed char PlayerNumber;
+/** bitflag where each bit represents a player */
+typedef unsigned char PlayerBitFlag;
 /** Type which stores thing class. */
 typedef unsigned char ThingClass;
 /** Type which stores thing model. */

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -686,9 +686,9 @@ TbBool load_map_data_file(LevelNumber lv_num)
             mapblk = get_map_block_at(x,y);
             unsigned short* wptr = &game.lish.subtile_lightness[get_subtile_number(x, y)];
             *wptr = 32;
-            mapblk->data &= 0xFFC007FFu;
-            mapblk->data &= ~0x0F000000;
-            mapblk->data &= ~0xF0000000;
+            mapblk->mapwho = 0;
+            mapblk->data &= ~0x0F000000; //filled subtiles
+            mapblk->revealed = 0;
         }
     }
     return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3095,10 +3095,10 @@ void update_block_pointed(int i,long x, long x_frac, long y, long y_frac)
     {
       mapblk = get_map_block_at(x,y);
       visible = map_block_revealed_bit(mapblk, player_bit);
-      if ((!visible) || ((mapblk->data & 0x7FF) > 0))
+      if ((!visible) || (get_mapblk_column_index(mapblk) > 0))
       {
         if (visible)
-          k = mapblk->data & 0x7FF;
+          k = get_mapblk_column_index(mapblk);
         else
           k = game.unrevealed_column_idx;
         colmn = get_column(k);
@@ -3106,7 +3106,7 @@ void update_block_pointed(int i,long x, long x_frac, long y, long y_frac)
         if ((temp_cluedo_mode) && (smask != 0))
         {
           if (visible)
-            k = mapblk->data & 0x7FF;
+            k = get_mapblk_column_index(mapblk);
           else
             k = game.unrevealed_column_idx;
           colmn = get_column(k);

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -374,7 +374,7 @@ TbBool set_slab_explored(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord
 }
 
 // only used by mine_out_block
-void set_slab_explored_flags(PlayerBitFlag flag, long slb_x, long slb_y)
+void set_slab_explored_flags(PlayerBitFlag flag, MapSlabCoord slb_x, MapSlabCoord slb_y)
 {
     MapSubtlCoord stl_y = STL_PER_SLB * slb_y;
     MapSubtlCoord stl_x = STL_PER_SLB * slb_x;

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -374,44 +374,24 @@ TbBool set_slab_explored(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord
 }
 
 // only used by mine_out_block
-void set_slab_explored_flags(unsigned char flag, long slb_x, long slb_y)
+void set_slab_explored_flags(PlayerBitFlag flag, long slb_x, long slb_y)
 {
-
     MapSubtlCoord stl_y = STL_PER_SLB * slb_y;
     MapSubtlCoord stl_x = STL_PER_SLB * slb_x;
 
     struct Map *mapblk = get_map_block_at(stl_x, stl_y);
 
-
-    if (mapblk->data >> 28 != flag)
+    if (mapblk->revealed != flag)
     {
-        int shifted_flag = flag << 28;
-        get_map_block_at(stl_x,     stl_y    )->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x,     stl_y    )->data |= shifted_flag;
-            
-        get_map_block_at(stl_x + 1, stl_y    )->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x + 1, stl_y    )->data |= shifted_flag;
-            
-        get_map_block_at(stl_x + 2, stl_y    )->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x + 2, stl_y    )->data |= shifted_flag;
-        
-        get_map_block_at(stl_x,     stl_y + 1)->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x,     stl_y + 1)->data |= shifted_flag;
-        
-        get_map_block_at(stl_x + 1, stl_y + 1)->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x + 1, stl_y + 1)->data |= shifted_flag;
-        
-        get_map_block_at(stl_x + 2, stl_y + 1)->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x + 2, stl_y + 1)->data |= shifted_flag;
-        
-        get_map_block_at(stl_x,     stl_y + 2)->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x,     stl_y + 2)->data |= shifted_flag;
-        
-        get_map_block_at(stl_x + 1, stl_y + 2)->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x + 1, stl_y + 2)->data |= shifted_flag;
-        
-        get_map_block_at(stl_x + 2, stl_y + 2)->data &= 0xFFFFFFFu;
-        get_map_block_at(stl_x + 2, stl_y + 2)->data |= shifted_flag;
+        get_map_block_at(stl_x,     stl_y    )->revealed = flag;
+        get_map_block_at(stl_x + 1, stl_y    )->revealed = flag;
+        get_map_block_at(stl_x + 2, stl_y    )->revealed = flag;
+        get_map_block_at(stl_x,     stl_y + 1)->revealed = flag;
+        get_map_block_at(stl_x + 1, stl_y + 1)->revealed = flag;
+        get_map_block_at(stl_x + 2, stl_y + 1)->revealed = flag;
+        get_map_block_at(stl_x,     stl_y + 2)->revealed = flag;
+        get_map_block_at(stl_x + 1, stl_y + 2)->revealed = flag;
+        get_map_block_at(stl_x + 2, stl_y + 2)->revealed = flag;
 
         pannel_map_update(stl_x, stl_y, STL_PER_SLB, STL_PER_SLB);
     }

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -43,14 +43,14 @@ struct Column *get_column_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
   mapblk = get_map_block_at(stl_x, stl_y);
   if (map_block_invalid(mapblk))
     return INVALID_COLUMN;
-  return game.columns.lookup[mapblk->data & 0x7FF];
+  return game.columns.lookup[get_mapblk_column_index(mapblk)];
 }
 
 struct Column *get_map_column(const struct Map *mapblk)
 {
   if (map_block_invalid(mapblk))
     return INVALID_COLUMN;
-  return game.columns.lookup[mapblk->data & 0x7FF];
+  return game.columns.lookup[get_mapblk_column_index(mapblk)];
 }
 
 TbBool column_invalid(const struct Column *colmn)

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -675,10 +675,6 @@ void reveal_map_area(PlayerNumber plyr_idx,MapSubtlCoord start_x,MapSubtlCoord e
 
 void conceal_map_area(PlayerNumber plyr_idx,MapSubtlCoord start_x,MapSubtlCoord end_x,MapSubtlCoord start_y,MapSubtlCoord end_y, TbBool all)
 {
-    unsigned long nflag = (1 << plyr_idx);
-    nflag <<= 28;
-    nflag = ~nflag;
-
     start_x = stl_slab_starting_subtile(start_x);
     start_y = stl_slab_starting_subtile(start_y);
     end_x = stl_slab_ending_subtile(end_x)+1;
@@ -703,7 +699,7 @@ void conceal_map_area(PlayerNumber plyr_idx,MapSubtlCoord start_x,MapSubtlCoord 
                         break;
                 }
             }
-            mapblk->data &= nflag;
+            mapblk->revealed &= ~(1 << plyr_idx);
         }
     }
     pannel_map_update(start_x,start_y,end_x,end_y);

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -142,15 +142,13 @@ long get_ceiling_height(const struct Coord3d *pos)
     return ((game.map[i].data & 0xF000000u) >> 24) << 8;
 }
 
-long get_mapwho_thing_index(const struct Map *mapblk)
+ThingIndex get_mapwho_thing_index(const struct Map *mapblk)
 {
   return mapblk->mapwho;
-  //could also be ((mapblk->data & 0x3FF800) >> 11);
 }
 
-void set_mapwho_thing_index(struct Map *mapblk, long thing_idx)
+void set_mapwho_thing_index(struct Map *mapblk, ThingIndex thing_idx)
 {
-
   mapblk->mapwho = thing_idx;
 }
 
@@ -216,10 +214,9 @@ void set_mapblk_filled_subtiles(struct Map *mapblk, long height)
 
 void reveal_map_subtile(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx)
 {
-    unsigned short nflag = (1 << plyr_idx);
+    PlayerBitFlag nflag = (1 << plyr_idx);
     struct Map* mapblk = get_map_block_at(stl_x, stl_y);
-    unsigned long i = (mapblk->data >> 28) | nflag;
-    mapblk->data |= (i & 0x0F) << 28;
+    mapblk->revealed |= nflag;
 }
 
 TbBool subtile_revealed(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx)
@@ -230,9 +227,8 @@ TbBool subtile_revealed(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber p
 
 void reveal_map_block(struct Map *mapblk, PlayerNumber plyr_idx)
 {
-    unsigned short nflag = (1 << plyr_idx);
-    unsigned long i = (mapblk->data >> 28) | nflag;
-    mapblk->data |= (i & 0x0F) << 28;
+    PlayerBitFlag nflag = (1 << plyr_idx);
+    mapblk->revealed |= nflag;
 }
 
 TbBool slabs_reveal_slab_and_corners(MapSlabCoord slab_x, MapSlabCoord slab_y, MaxCoordFilterParam param)
@@ -328,7 +324,7 @@ TbBool map_block_revealed(const struct Map *mapblk, PlayerNumber plyr_idx)
 {
     if (map_block_invalid(mapblk))
         return false;
-    unsigned short plyr_bit;
+    PlayerBitFlag plyr_bit;
     if (gameadd.allies_share_vision)
     {
         for (PlayerNumber i = 0; i < PLAYERS_COUNT; i++)
@@ -336,7 +332,7 @@ TbBool map_block_revealed(const struct Map *mapblk, PlayerNumber plyr_idx)
             if (players_are_mutual_allies(plyr_idx, i))
             {
                 plyr_bit = (1 << i);
-                if ((mapblk->data >> 28) & plyr_bit)
+                if ((mapblk->revealed) & plyr_bit)
                 return true;
             }
         }
@@ -344,7 +340,7 @@ TbBool map_block_revealed(const struct Map *mapblk, PlayerNumber plyr_idx)
     else
     {
         plyr_bit = (1 << plyr_idx);
-        if ((mapblk->data >> 28) & plyr_bit)
+        if ((mapblk->revealed) & plyr_bit)
         return true;
     }
     return false;
@@ -363,14 +359,14 @@ TbBool map_block_revealed_bit(const struct Map *mapblk, long plyr_bit)
         {
             if (players_are_mutual_allies(plyr_idx, i))
             {
-                if ((mapblk->data >> 28) & (1 << i))
+                if ((mapblk->revealed) & (1 << i))
                 return true;
             }
         }
     }
     else
     {
-        if ((mapblk->data >> 28) & plyr_bit)
+        if ((mapblk->revealed) & plyr_bit)
         {
             return true;
         }
@@ -579,26 +575,9 @@ void clear_mapwho(void)
         for (MapSubtlCoord x = 0; x < (gameadd.map_subtiles_x + 1); x++)
         {
             struct Map* mapblk = &game.map[get_subtile_number(x, y)];
-            mapblk->data &= 0xFFC007FFu;
+            mapblk->mapwho = 0;
         }
   }
-}
-
-void clear_mapmap_soft(void)
-{
-    for (MapSubtlCoord y = 0; y < (gameadd.map_subtiles_y + 1); y++)
-    {
-        for (MapSubtlCoord x = 0; x < (gameadd.map_subtiles_x + 1); x++)
-        {
-            struct Map* mapblk = &game.map[get_subtile_number(x, y)];
-            mapblk->data &= 0xFF3FFFFFu;
-            mapblk->data &= 0xFFFFF800u;
-            mapblk->data &= 0xFFC007FFu;
-            mapblk->data &= 0x0FFFFFFFu;
-            mapblk->flags = 0;
-        }
-    }
-    clear_subtiles_lightness(&game.lish);
 }
 
 void clear_mapmap(void)

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -38,9 +38,10 @@ enum MapCoordClipFlags {
 };
 
 struct Map {
-      unsigned char flags;
-      unsigned long data;
-      unsigned long mapwho;
+      unsigned char flags; // flags in enum SlabAttrFlags
+      unsigned long data; // 4b unused 4b filled_subtiles 2b wibble_value 11b unused 11b column
+      ThingIndex mapwho;
+      PlayerBitFlag revealed;
 };
 
 #define INVALID_MAP_BLOCK (&bad_map_block)
@@ -90,8 +91,8 @@ TbBool map_block_revealed_bit(const struct Map *mapblk, long plyr_bit);
 
 TbBool valid_dig_position(PlayerNumber plyr_idx, long stl_x, long stl_y);
 long get_ceiling_height(const struct Coord3d *pos);
-long get_mapwho_thing_index(const struct Map *mapblk);
-void set_mapwho_thing_index(struct Map *map, long thing_idx);
+ThingIndex get_mapwho_thing_index(const struct Map *mapblk);
+void set_mapwho_thing_index(struct Map *map, ThingIndex thing_idx);
 long get_mapblk_column_index(const struct Map *map);
 void set_mapblk_column_index(struct Map *map, long column_idx);
 long get_mapblk_filled_subtiles(const struct Map *mapblk);

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -570,7 +570,7 @@ void fill_in_explored_area(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
         for(MapSubtlCoord lpstl_x = 0;lpstl_x < gameadd.map_subtiles_x;lpstl_x++)
         {
             struct Map *mapblk = get_map_block_at(lpstl_x,lpstl_y);
-            mapblk->data = ((~(1 << plyr_idx) << 28) | 0xFFFFFFF) & mapblk->data;
+            mapblk->revealed &= (~(1 << plyr_idx));
         }
     }
 

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -634,7 +634,6 @@ void update_explored_flags_for_power_sight(struct PlayerInfo *player)
 void remove_explored_flags_for_power_sight(struct PlayerInfo *player)
 {
     SYNCDBG(9, "Starting");
-    int data;
     unsigned char backup_flags;
     struct Dungeon *dungeon = get_players_dungeon(player);
 
@@ -655,11 +654,10 @@ void remove_explored_flags_for_power_sight(struct PlayerInfo *player)
                 if (!map_block_invalid(mapblk))
                 {
                     unsigned long plyr_bit = (1 << player->id_number);
-                    data = mapblk->data & (~(plyr_bit << 28) );
                     backup_flags = backup_explored[soe_y][soe_x];
-                    mapblk->data = data;
+                    mapblk->revealed &= ~plyr_bit;
                     if ((backup_flags & 1) != 0)
-                        mapblk->data = data | (plyr_bit << 28);
+                        mapblk->revealed |= plyr_bit ;
                     if ((backup_flags & 2) != 0)
                         mapblk->flags |= SlbAtFlg_Unexplored;
                     if ((backup_flags & 4) != 0)


### PR DESCRIPTION
purely for readability, shouldn't impact functionality