### PR TITLE
Game now remembers which query menu was active when changing resolution

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -101,6 +101,7 @@ extern void __stdcall enum_sessions_callback(struct TbNetworkCallbackData *netcd
 TbClockMSec gui_message_timeout = 0;
 char gui_message_text[TEXT_BUFFER_LENGTH];
 static char path_string[178];
+MenuID vid_change_query_menu = GMnu_CREATURE_QUERY1;
 
 struct GuiButtonInit frontend_main_menu_buttons[] = {
   { 0,  0, 0, 0, NULL,               NULL,        NULL,                 0, 999,  26, 999,  26, 371, 46, frontend_draw_large_menu_button,  0, GUIStr_Empty,  0,       {1},            0, NULL },

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -132,6 +132,7 @@ extern unsigned char new_objective;
 extern int frontend_menu_state;
 extern int load_game_scroll_offset;
 extern unsigned char video_gamma_correction;
+extern MenuID vid_change_query_menu;
 
 // *** SPRITES ***
 extern struct TbSprite *font_sprites;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1414,20 +1414,31 @@ void toggle_hero_health_flowers(void)
 
 void reset_gui_based_on_player_mode(void)
 {
-    struct PlayerInfo *player;
-    player = get_my_player();
-    if ((player->view_type == PVT_CreatureContrl) || (player->view_type == PVT_CreaturePasngr))
+    struct PlayerInfo *player = get_my_player();
+    if (player->view_type == PVT_CreatureContrl)
     {
-        turn_on_menu(GMnu_CREATURE_QUERY1);
-    } else
+        turn_on_menu(vid_change_query_menu);
+    }
+    else if (player->view_type == PVT_CreaturePasngr)
+    {
+        turn_on_menu(vid_change_query_menu);
+        turn_off_query_menus();
+    }
+    else
     {
         turn_on_menu(GMnu_MAIN);
         if (game.active_panel_mnu_idx > 0)
         {
             initialise_tab_tags(game.active_panel_mnu_idx);
-            turn_on_menu(game.active_panel_mnu_idx);
-            MenuNumber mnuidx;
-            mnuidx = menu_id_to_number(GMnu_MAIN);
+            if ( (player->work_state == PSt_CreatrInfo) || (player->work_state == PSt_CreatrInfoAll) )
+            {
+                turn_on_menu(vid_change_query_menu);
+            }
+            else
+            {
+                turn_on_menu(game.active_panel_mnu_idx);
+            }
+            MenuNumber mnuidx = menu_id_to_number(GMnu_MAIN);
             if (mnuidx != MENU_INVALID_ID) {
                 setup_radio_buttons(&active_menus[mnuidx]);
             }

--- a/src/vidmode.c
+++ b/src/vidmode.c
@@ -969,6 +969,22 @@ TbScreenMode switch_to_next_video_mode(void)
     SYNCLOG("Switched video to %s (mode %d)", get_vidmode_name(scrmode),(int)scrmode);
     save_settings();
     TbBool reload_video = (menu_is_active(GMnu_VIDEO));
+    if (menu_is_active(GMnu_CREATURE_QUERY1))
+    {
+        vid_change_query_menu = GMnu_CREATURE_QUERY1;
+    }
+    else if (menu_is_active(GMnu_CREATURE_QUERY2))
+    {
+        vid_change_query_menu = GMnu_CREATURE_QUERY2;
+    }
+    else if (menu_is_active(GMnu_CREATURE_QUERY3))
+    {
+        vid_change_query_menu = GMnu_CREATURE_QUERY3;
+    }
+    else if (menu_is_active(GMnu_CREATURE_QUERY4))
+    {
+        vid_change_query_menu = GMnu_CREATURE_QUERY4;
+    }
     reinit_all_menus();
     init_custom_sprites(SPRITE_LAST_LEVEL);
     if (reload_video)


### PR DESCRIPTION
This applies to both querying and possession.

Fixes #2125