### PR TITLE
Removed warning message for delete from party

### DIFF
--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -629,7 +629,6 @@ TbBool delete_member_from_party(int party_id, long crtr_model, long crtr_level)
             return true;
         }
     }
-    WARNLOG("Creature not found party:%s model:%d level:%d", party->prtname, crtr_model, crtr_level);
     return false;
 }
 


### PR DESCRIPTION
This warn heavily spams the log when the command is used in a loop