### PR TITLE
Delete non-functional continue-game files to make continue save work again

### DIFF
--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -558,6 +558,11 @@ short save_continue_game(LevelNumber lvnum)
       set_continue_level_number(lvnum);
     SYNCDBG(6,"Continue set to level %d (loaded is %d)",(int)get_continue_level_number(),(int)get_loaded_level_number());
     char* fname = prepare_file_path(FGrp_Save, continue_game_filename);
+    if (!continue_game_available())
+    {
+        WARNLOG("No previous continue game available, deleting file");
+        LbFileDelete(fname);
+    }
     long fsize = LbFileSaveAt(fname, &game, sizeof(struct Game) + sizeof(struct IntralevelData));
     // Appending IntralevelData
     TbFileHandle fh = LbFileOpen(fname,Lb_FILE_MODE_NEW);

--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -560,7 +560,7 @@ short save_continue_game(LevelNumber lvnum)
     char* fname = prepare_file_path(FGrp_Save, continue_game_filename);
     if (!continue_game_available())
     {
-        WARNLOG("No previous continue game available, deleting file");
+        WARNLOG("No previous continue game available, deleting %s", fname);
         LbFileDelete(fname);
     }
     long fsize = LbFileSaveAt(fname, &game, sizeof(struct Game) + sizeof(struct IntralevelData));

--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -579,17 +579,17 @@ short read_continue_game_part(unsigned char *buf,long pos,long buf_len)
     {
         SYNCDBG(7, "No correct .SAV file; there's no continue");
         return false;
-  }
-  TbFileHandle fh = LbFileOpen(fname, Lb_FILE_MODE_READ_ONLY);
-  if (fh == -1)
-  {
-    SYNCDBG(7,"Can't open .SAV file; there's no continue");
-    return false;
-  }
-  LbFileSeek(fh, pos, Lb_FILE_SEEK_BEGINNING);
-  short result = (LbFileRead(fh, buf, buf_len) == buf_len);
-  LbFileClose(fh);
-  return result;
+    }
+    TbFileHandle fh = LbFileOpen(fname, Lb_FILE_MODE_READ_ONLY);
+    if (fh == -1)
+    {
+        SYNCDBG(7,"Can't open .SAV file; there's no continue");
+        return false;
+    }
+    LbFileSeek(fh, pos, Lb_FILE_SEEK_BEGINNING);
+    short result = (LbFileRead(fh, buf, buf_len) == buf_len);
+    LbFileClose(fh);
+    return result;
 }
 
 /**


### PR DESCRIPTION
Changing the game-structure can cause continue-saves to not work. Unfortunately, once that happens they may remain corrupt forever or until the user manually deletes the file.

Now the game deletes the file when it can't use it.