### PR TITLE
Stop cave in from desyncing multiplayer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2687,8 +2687,8 @@ long update_cave_in(struct Thing *thing)
     turns_alive = game.play_gameturn - thing->creation_turn;
     if ((turns_alive != 0) && ((turns_between < 1) || (3 * turns_between / 4 == turns_alive % turns_between)))
     {
-        pos.x.val = thing->mappos.x.val + UNSYNC_RANDOM(128);
-        pos.y.val = thing->mappos.y.val + UNSYNC_RANDOM(128);
+        pos.x.val = thing->mappos.x.val + GAME_RANDOM(128); //pos is used later to do damage
+        pos.y.val = thing->mappos.y.val + GAME_RANDOM(128);
         pos.z.val = get_floor_height_at(&pos) + 384;
         create_effect(&pos, TngEff_HarmlessGas4, owner);
     }


### PR DESCRIPTION
an unsync random was used that later determined damage