### PR TITLE
Fixed get_player_list_nth_creature_of_model_on_territory

### DIFF
--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2290,6 +2290,7 @@ struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx,
 {
     long i = thing_idx;
     unsigned long k = 0;
+    struct Thing *nth_creature = INVALID_THING;
     while (i != 0)
     {
         struct Thing* thing = thing_get(i);
@@ -2300,6 +2301,10 @@ struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx,
         }
         struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
         i = cctrl->players_next_creature_idx;
+        if ((i == -1) || (crtr_idx ==-1))
+        {
+            return nth_creature;
+        }
         // Per creature code
         int slbwnr = get_slab_owner_thing_is_on(thing);
         int match = 0;
@@ -2325,12 +2330,9 @@ struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx,
             }
         }
 
-        if (((crmodel == 0) || (crmodel == CREATURE_ANY) || (thing->model == crmodel && crtr_idx <= 1)) && (match == 1))
+        if (((crmodel == 0) || (crmodel == CREATURE_ANY) || (thing->model == crmodel)) && (match == 1))
         {
-            return thing;
-        }
-        if ((crmodel == 0) || (crmodel == CREATURE_ANY) || ((thing->model == crmodel) && (match == 1)))
-        {
+            nth_creature = thing; 
             crtr_idx--;
         }
         // Per creature code ends

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2461,22 +2461,25 @@ struct Thing *get_random_players_creature_of_model(PlayerNumber plyr_idx, ThingM
 
 struct Thing *get_random_players_creature_of_model_on_territory(PlayerNumber plyr_idx, ThingModel crmodel, int friendly)
 {
+    long model_count;
     long total_count;
     TbBool is_spec_digger = ((crmodel > 0) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel));
     struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
     if (is_spec_digger)
     {
         total_count = count_player_list_creatures_of_model_on_territory(dungeon->digger_list_start, crmodel, friendly);
+        model_count = count_player_list_creatures_of_model(dungeon->digger_list_start, crmodel);
     }
     else
     {
         total_count = count_player_list_creatures_of_model_on_territory(dungeon->creatr_list_start, crmodel, friendly);
+        model_count = count_player_list_creatures_of_model(dungeon->creatr_list_start, crmodel);
     }
     if (total_count < 1)
     {
       return INVALID_THING;
     }
-    long crtr_idx = PLAYER_RANDOM(plyr_idx, total_count) + 1;
+    long crtr_idx = PLAYER_RANDOM(plyr_idx, model_count);
     if (is_spec_digger)
     {
         return get_player_list_nth_creature_of_model_on_territory(dungeon->digger_list_start, crmodel, crtr_idx, friendly);


### PR DESCRIPTION
Function would loop through only a small part of units.

```
NEXT_COMMAND_REUSABLE
USE_POWER_ON_CREATURE(PLAYER_GOOD,ANY_CREATURE,ON_ENEMY_GROUND,PLAYER0,POWER_CHICKEN,3,1)
```
This script command should convert all heroes on red ground to chickens. It did only a small part.