### PR TITLE
No longer warn in the log when 0 is set as a speech played

### DIFF
--- a/src/config_magic.c
+++ b/src/config_magic.c
@@ -1898,7 +1898,7 @@ TbBool parse_magic_special_blocks(char *buf, long len, const char *config_textna
           if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
           {
               k = atoi(word_buf);
-              if (k > 0)
+              if (k >= 0)
               {
                   specst->speech = k;
                   n++;


### PR DESCRIPTION
Prevents this log entry:
Warning: parse_magic_special_blocks(line 1573): Incorrect value of "SPEECHPLAYED" parameter in [special9] block of global magic config file.