### PR TITLE
Creatures that can move over lava can now also see the sides of creatures

### DIFF
--- a/src/creature_senses.c
+++ b/src/creature_senses.c
@@ -647,6 +647,19 @@ TbBool jonty_creature_can_see_thing_including_lava_check(const struct Thing *cre
             tgtpos.z.val += thing->clipbox_size_yz;
             if (line_of_sight_3d(&eyepos, &tgtpos))
                 return true;
+            long angle = get_angle_xy_to(&tgtpos, &eyepos);
+            // Check left side
+            // We're checking point at 60 degrees left; could use 90 deg, but making even slim edge visible might not be a good idea
+            // Also 60 deg will shorten distance to the check point, which may better describe real visibility
+            tgtpos.x.val = thing->mappos.x.val + distance_with_angle_to_coord_x(thing->clipbox_size_xy / 2, angle + LbFPMath_PI / 3);
+            tgtpos.y.val = thing->mappos.y.val + distance_with_angle_to_coord_y(thing->clipbox_size_xy / 2, angle + LbFPMath_PI / 3);
+            if (sibling_line_of_sight(&eyepos, &tgtpos))
+                return true;
+            // Check right side
+            tgtpos.x.val = thing->mappos.x.val + distance_with_angle_to_coord_x(thing->clipbox_size_xy / 2, angle - LbFPMath_PI / 3);
+            tgtpos.y.val = thing->mappos.y.val + distance_with_angle_to_coord_y(thing->clipbox_size_xy / 2, angle - LbFPMath_PI / 3);
+            if (sibling_line_of_sight(&eyepos, &tgtpos))
+                return true;
             return false;
         } else
         {


### PR DESCRIPTION
Fixes issue with flying vampires on a guardpost (up high) not seeing units properly and deciding to flee.