### PR TITLE
stop the list getting filled with errors due to not finding units

### DIFF
--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -2343,8 +2343,7 @@ struct Thing *get_player_list_nth_creature_of_model_on_territory(long thing_idx,
             return INVALID_THING;
         }
     }
-    ERRORLOG("Tried to get creature of index exceeding list");
-    return INVALID_THING;
+    return nth_creature;
 }
 
 /**


### PR DESCRIPTION
not finding anything is not an error, but it filled the log with thousands of errors saying:
```
Error: get_player_list_nth_creature_of_model_on_territory: Tried to get creature of index exceeding list
```