### PR TITLE
Truncate save-files when they are too large

### DIFF
--- a/src/bflib_fileio.c
+++ b/src/bflib_fileio.c
@@ -259,7 +259,7 @@ TbFileHandle LbFileOpen(const char *fname, const unsigned char accmode)
       LbSyncLog("LbFileOpen: LBO_CREAT mode\n");
 #endif
         if (create_directory_for_file(fname)) {
-          rc = _sopen(fname, O_RDWR|O_CREAT|O_BINARY, SH_DENYNO, S_IREAD|S_IWRITE);
+          rc = _sopen(fname, O_RDWR|O_CREAT|O_BINARY|O_TRUNC, SH_DENYNO, S_IREAD|S_IWRITE);
         }
     };break;
   case Lb_FILE_MODE_OLD:


### PR DESCRIPTION
Should fix issues with corrupted continue saves sticking around.

Draft, because I have trouble reproducing the bug at this point. Need a corrupted continue save to test.