### PR TITLE
Initialize high_score_entry_input_active to fix minor issue with high…

### DIFF
--- a/src/front_highscore.c
+++ b/src/front_highscore.c
@@ -43,7 +43,7 @@ static long high_score_entry_index;
 
 char high_score_entry[64];
 int fe_high_score_table_from_main_menu;
-long high_score_entry_input_active;
+long high_score_entry_input_active = -1;
 /******************************************************************************/
 
 void draw_high_score_entry(int idx, long pos_x, long pos_y, int col1_width, int col2_width, int col3_width, int col4_width, int units_per_px)


### PR DESCRIPTION
… score screen

Currently when I enter the High Scores Screen I am prompted to update the top score.  This appears to because the  high_score_entry_input_active variable is implicitly initialized to 0.  Minor issue but I thought I would offer a very small change to address this.