### PR TITLE
Fixed creatures not making lairs after extra creature did

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2533,7 +2533,7 @@ TbBool find_random_valid_position_for_thing_in_room_avoiding_object(struct Thing
                     }
                 }
             }
-            start_stl = (start_stl + 1) % 9;
+            start_stl = (start_stl + 1) % AROUND_TILES_COUNT;
         }
         // Per room tile code ends
         if (n+1 >= room->slabs_count)

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -2656,8 +2656,8 @@ TbBool find_random_valid_position_for_thing_in_room(struct Thing *thing, struct 
     {
         MapSlabCoord slb_x = slb_num_decode_x(slbnum);
         MapSlabCoord slb_y = slb_num_decode_y(slbnum);
-        int ssub = CREATURE_RANDOM(thing, 9);
-        for (int snum = 0; snum < 9; snum++)
+        int ssub = CREATURE_RANDOM(thing, MID_AROUND_LENGTH);
+        for (int snum = 0; snum < MID_AROUND_LENGTH; snum++)
         {
             MapSubtlCoord stl_x = slab_subtile(slb_x, ssub % 3);
             MapSubtlCoord stl_y = slab_subtile(slb_y, ssub / 3);
@@ -2674,7 +2674,7 @@ TbBool find_random_valid_position_for_thing_in_room(struct Thing *thing, struct 
                     }
                 }
             }
-            ssub = (ssub + 1) % 9;
+            ssub = (ssub + 1) % MID_AROUND_LENGTH;
         }
         slbnum = get_next_slab_number_in_room(slbnum);
         if (slbnum == 0) {

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -2656,8 +2656,8 @@ TbBool find_random_valid_position_for_thing_in_room(struct Thing *thing, struct 
     {
         MapSlabCoord slb_x = slb_num_decode_x(slbnum);
         MapSlabCoord slb_y = slb_num_decode_y(slbnum);
-        int ssub = CREATURE_RANDOM(thing, MID_AROUND_LENGTH);
-        for (int snum = 0; snum < MID_AROUND_LENGTH; snum++)
+        int ssub = CREATURE_RANDOM(thing, AROUND_TILES_COUNT);
+        for (int snum = 0; snum < AROUND_TILES_COUNT; snum++)
         {
             MapSubtlCoord stl_x = slab_subtile(slb_x, ssub % 3);
             MapSubtlCoord stl_y = slab_subtile(slb_y, ssub / 3);
@@ -2674,7 +2674,7 @@ TbBool find_random_valid_position_for_thing_in_room(struct Thing *thing, struct 
                     }
                 }
             }
-            ssub = (ssub + 1) % MID_AROUND_LENGTH;
+            ssub = (ssub + 1) % AROUND_TILES_COUNT;
         }
         slbnum = get_next_slab_number_in_room(slbnum);
         if (slbnum == 0) {

--- a/src/room_data.h
+++ b/src/room_data.h
@@ -20,6 +20,7 @@
 #define DK_ROOMDATA_H
 
 #include "bflib_basics.h"
+#include "config_creature.h"
 #include "globals.h"
 
 #ifdef __cplusplus
@@ -114,7 +115,7 @@ struct Room {
     struct {
       /** For rooms which store creatures, amount of each model.
        * Rooms which have such lists are lairs. */
-      unsigned char content_per_model[32];
+      unsigned char content_per_model[CREATURE_TYPES_MAX];
     };
     /* For hatchery; integrate with something else, if possible */
     struct {

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -210,8 +210,11 @@ void slabmap_set_wlb(struct SlabMap *slb, unsigned long wlbflag)
  */
 SlabCodedCoords get_next_slab_number_in_room(SlabCodedCoords slab_num)
 {
-    if (slab_num >= gameadd.map_tiles_x*gameadd.map_tiles_y)
+    if (slab_num >= gameadd.map_tiles_x * gameadd.map_tiles_y)
+    {
+        ERRORLOG("Slabnumber %d exceeds map dimensions %d*%d", slab_num, gameadd.map_tiles_x, gameadd.map_tiles_y);
         return 0;
+    }
     return game.slabmap[slab_num].next_in_room;
 }
 


### PR DESCRIPTION
The log provided errors: `Error: find_random_valid_position_for_thing_in_room: Taking random slab (40/57) in LAIR index 5 failed - internal inconsistency.`

And creatures would have trouble finding lairs in rooms when creatures with model number > 32 would already have a lair there.