### PR TITLE
Fixed one-click-marking with creatures in hand

### DIFF
--- a/src/packets.c
+++ b/src/packets.c
@@ -1003,7 +1003,6 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         {
             reset_dungeon_build_room_ui_variables(plyr_idx);
             playeradd->roomspace_width = playeradd->roomspace_height = pckt->actn_par2;
-            playeradd->pickup_all_gold = (pckt->additional_packet_values & PCAdV_RotatePressed);
         }
         playeradd->roomspace_no_default = true;
         return false;

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -283,6 +283,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         player->secondary_cursor_state = CSt_DefaultArrow;
     player->primary_cursor_state = (unsigned short)(pckt->additional_packet_values & PCAdV_ContextMask) >> 1; // get current cursor state from pckt->additional_packet_values
     playeradd->render_roomspace.highlight_mode = false; // reset one-click highlight mode
+    playeradd->pickup_all_gold = (pckt->additional_packet_values & PCAdV_RotatePressed);
 
     process_dungeon_power_hand_state(plyr_idx);
 

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -1355,12 +1355,12 @@ void process_highlight_roomspace_inputs(PlayerNumber plyr_idx)
     {
         par2 = 0;
     }
-    if ( (is_game_key_pressed(Gkey_BestRoomSpace, &keycode, true)) && (player->primary_cursor_state != CSt_PowerHand) ) // Use "modern" click and drag method
+    if ( (is_game_key_pressed(Gkey_BestRoomSpace, &keycode, true)) ) // Use "modern" click and drag method
     {
         par1 = 1;
         par2 = 0;
     }
-    else if ( (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true)) && (player->primary_cursor_state != CSt_PowerHand) ) // Use "modern" click and drag method
+    else if ( (is_game_key_pressed(Gkey_SquareRoomSpace, &keycode, true))  ) // Use "modern" click and drag method
     {
         par1 = 2;
         playeradd = get_playeradd(plyr_idx);


### PR DESCRIPTION
Fixes bug introduced on #2196

To reproduce the bug:
1) Pick up any unit
2) Try to mark/tag for digging with either Shift of Ctrl
-> Notice it does not go into one-click mode

I fixed it in a way that Ctrl-Pickup of gold hoards still works.