### PR TITLE
No longer give error on two different combat filters giving different results

### DIFF
--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1574,7 +1574,7 @@ CrAttackType check_for_possible_combat_with_enemy_creature_within_distance(struc
         SYNCDBG(9,"Best enemy for %s index %d is %s index %d",thing_model_name(fightng),(int)fightng->index,thing_model_name(thing),(int)thing->index);
         // When counting distance, take size of creatures into account
         long distance = get_combat_distance(fightng, thing);
-        CrAttackType attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, 1, move_on_ground);
+        CrAttackType attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, move_on_ground, 0);
         if (attack_type > AttckT_Unset) 
         {
             *outenmtng = thing;
@@ -1585,7 +1585,7 @@ CrAttackType check_for_possible_combat_with_enemy_creature_within_distance(struc
             thing = get_highest_score_enemy_creature_within_distance_possible_to_attack_by(fightng, maxdist, move_on_ground);
             if (!thing_is_invalid(thing))
             {
-                attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, 1, move_on_ground);
+                attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, move_on_ground,0);
                 if (attack_type > AttckT_Unset)
                 {
                     *outenmtng = thing;

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1579,20 +1579,10 @@ CrAttackType check_for_possible_combat_with_enemy_creature_within_distance(struc
         {
             *outenmtng = thing;
             return attack_type;
-        } else 
+        } 
+        else 
         {
-            move_on_ground = 1;
-            thing = get_highest_score_enemy_creature_within_distance_possible_to_attack_by(fightng, maxdist, move_on_ground);
-            if (!thing_is_invalid(thing))
-            {
-                attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, move_on_ground,0);
-                if (attack_type > AttckT_Unset)
-                {
-                    *outenmtng = thing;
-                    return attack_type;
-                }
-                ERRORLOG("The %s index %d cannot fight with %s index %d returned as fight partner", thing_model_name(fightng), (int)fightng->index, thing_model_name(thing), (int)thing->index);
-            }
+            ERRORLOG("The %s index %d cannot fight with %s index %d returned as fight partner", thing_model_name(fightng), (int)fightng->index, thing_model_name(thing), (int)thing->index);
         }
     }
     return AttckT_Unset;

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1575,19 +1575,25 @@ CrAttackType check_for_possible_combat_with_enemy_creature_within_distance(struc
         // When counting distance, take size of creatures into account
         long distance = get_combat_distance(fightng, thing);
         CrAttackType attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, 1, move_on_ground);
-        if (attack_type <= AttckT_Unset) 
+        if (attack_type > AttckT_Unset) 
+        {
+            *outenmtng = thing;
+            return attack_type;
+        } else 
         {
             move_on_ground = 1;
             thing = get_highest_score_enemy_creature_within_distance_possible_to_attack_by(fightng, maxdist, move_on_ground);
-            attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, 1, move_on_ground);
-            if (attack_type <= AttckT_Unset)
+            if (!thing_is_invalid(thing))
             {
+                attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, 1, move_on_ground);
+                if (attack_type > AttckT_Unset)
+                {
+                    *outenmtng = thing;
+                    return attack_type;
+                }
                 ERRORLOG("The %s index %d cannot fight with %s index %d returned as fight partner", thing_model_name(fightng), (int)fightng->index, thing_model_name(thing), (int)thing->index);
-                return AttckT_Unset;
             }
-        } 
-        *outenmtng = thing;
-        return attack_type;
+        }
     }
     return AttckT_Unset;
 }

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -1575,14 +1575,11 @@ CrAttackType check_for_possible_combat_with_enemy_creature_within_distance(struc
         // When counting distance, take size of creatures into account
         long distance = get_combat_distance(fightng, thing);
         CrAttackType attack_type = creature_can_have_combat_with_creature(fightng, thing, distance, move_on_ground, 0);
-        if (attack_type > AttckT_Unset) 
-        {
+        if (attack_type > AttckT_Unset) {
             *outenmtng = thing;
             return attack_type;
-        } 
-        else 
-        {
-            ERRORLOG("The %s index %d cannot fight with %s index %d returned as fight partner", thing_model_name(fightng), (int)fightng->index, thing_model_name(thing), (int)thing->index);
+        } else {
+            ERRORLOG("The %s index %d cannot fight with %s index %d returned as fight partner",thing_model_name(fightng),(int)fightng->index,thing_model_name(thing),(int)thing->index);
         }
     }
     return AttckT_Unset;

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -1793,7 +1793,7 @@ struct Thing* get_nearest_enemy_object_possible_to_attack_by(struct Thing* creat
     return get_nth_thing_of_class_with_filter(filter, &param, 0);
 }
 
-struct Thing *get_highest_score_enemy_creature_within_distance_possible_to_attack_by(struct Thing *creatng, MapCoordDelta dist)
+struct Thing *get_highest_score_enemy_creature_within_distance_possible_to_attack_by(struct Thing *creatng, MapCoordDelta dist, long move_on_ground)
 {
     SYNCDBG(19,"Starting");
     Thing_Maximizer_Filter filter = highest_score_thing_filter_is_enemy_within_distance_which_can_be_attacked_by_creature;
@@ -1803,7 +1803,7 @@ struct Thing *get_highest_score_enemy_creature_within_distance_possible_to_attac
     param.plyr_idx = -1;
     param.num1 = creatng->index;
     param.num2 = dist;
-    param.num3 = 0;
+    param.num3 = move_on_ground;
     return get_nth_thing_of_class_with_filter(filter, &param, 0);
 }
 

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -267,7 +267,7 @@ struct Thing *get_random_door_of_model_owned_by_and_locked(ThingModel tngmodel, 
 struct Thing *find_gold_laying_in_dungeon(const struct Dungeon *dungeon);
 struct Thing *get_nearest_enemy_creature_possible_to_attack_by(struct Thing *creatng);
 #define find_nearest_enemy_creature(creatng) get_nearest_enemy_creature_possible_to_attack_by(creatng);
-struct Thing *get_highest_score_enemy_creature_within_distance_possible_to_attack_by(struct Thing *creatng, MapCoordDelta dist);
+struct Thing *get_highest_score_enemy_creature_within_distance_possible_to_attack_by(struct Thing *creatng, MapCoordDelta dist, long move_on_ground);
 struct Thing *get_nth_creature_owned_by_and_matching_bool_filter(PlayerNumber plyr_idx, Thing_Bool_Filter matcher_cb, long n);
 struct Thing *get_nth_creature_owned_by_and_failing_bool_filter(PlayerNumber plyr_idx, Thing_Bool_Filter matcher_cb, long n);
 struct Thing* get_nearest_enemy_object_possible_to_attack_by(struct Thing* creatng);


### PR DESCRIPTION
Many logs are filled with errors that state:
`Error: check_for_possible_combat_with_enemy_creature_within_distance: The creature GIANT index 204 cannot fight with creature IMP index 363 returned as fight partner`

This is because it uses the function `get_highest_score_enemy_creature_within_distance_possible_to_attack_by` uses `creature_can_have_combat_with_creature`, then later to check does `creature_can_have_combat_with_creature` and then considers it an error that the filter has found a creature it can in fact not have combat with.

But this happens because they get fed different values on the 'move_on_ground' param, so a different result is possible.