### PR TITLE
Shots explode on hearts too, when applicable

### DIFF
--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -843,6 +843,10 @@ static TbBool shot_hit_object_at(struct Thing *shotng, struct Thing *target, str
     if (target->health < 0) {
         shot_kill_object(shotng, target);
     }
+    if (!shotst->hit_door.withstand)
+    {
+        return detonate_shot(shotng);
+    }
     if (shotst->destroy_on_first_hit) {
         delete_thing_structure(shotng, 0);
         // If thing was deleted something was hit


### PR DESCRIPTION
Exploding shots are not used by creatures against objects in general, to avoid friendly units in the explosion. But now that makes sense. Behavior similar to attacking doors.