### PR TITLE
fixed creatures making a lair elsewhere if they are standing on a lair totem

### DIFF
--- a/src/creature_states_lair.c
+++ b/src/creature_states_lair.c
@@ -167,14 +167,14 @@ long process_lair_enemy(struct Thing *thing, struct Room *room)
     return 1;
 }
 
-long creature_add_lair_to_room(struct Thing *creatng, struct Room *room)
+CrStateRet creature_add_lair_to_room(struct Thing *creatng, struct Room *room)
 {
     if (!room_has_enough_free_capacity_for_creature_job(room, creatng, Job_TAKE_SLEEP))
-        return 0;
+        return CrStRet_ResetFail;
     // Make sure we don't already have a lair on that position
     struct Thing* lairtng = find_creature_lair_totem_at_subtile(creatng->mappos.x.stl.num, creatng->mappos.y.stl.num, 0);
     if (!thing_is_invalid(lairtng))
-        return 0;
+        return CrStRet_Unchanged;
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     room->content_per_model[creatng->model]++;
     room->used_capacity += get_required_room_capacity_for_object(RoRoF_LairStorage, 0, creatng->model);
@@ -196,7 +196,7 @@ long creature_add_lair_to_room(struct Thing *creatng, struct Room *room)
         ERRORLOG("Could not create lair totem");
         remove_thing_from_mapwho(creatng);
         place_thing_in_mapwho(creatng);
-        return 1; // Return that so we won't try to redo the action over and over
+        return CrStRet_Modified; // Return that so we won't try to redo the action over and over
     }
     lairtng->mappos.z.val = get_thing_height_at(lairtng, &lairtng->mappos);
     // Associate creature with the lair
@@ -214,7 +214,7 @@ long creature_add_lair_to_room(struct Thing *creatng, struct Room *room)
     anger_set_creature_anger(creatng, 0, AngR_NoLair);
     remove_thing_from_mapwho(creatng);
     place_thing_in_mapwho(creatng);
-    return 1;
+    return CrStRet_ResetOk;
 }
 
 CrStateRet creature_at_changed_lair(struct Thing *creatng)
@@ -232,9 +232,13 @@ CrStateRet creature_at_changed_lair(struct Thing *creatng)
         set_start_state(creatng);
         return CrStRet_ResetFail;
     }
-    if (!creature_add_lair_to_room(creatng, room)) {
-        internal_set_thing_state(creatng, CrSt_CreatureChooseRoomForLairSite);
-        return CrStRet_Modified;
+
+    CrStateRet laircreated = creature_add_lair_to_room(creatng, room);
+    if (laircreated != CrStRet_ResetOk)
+    {
+        if (laircreated != CrStRet_Modified)
+            internal_set_thing_state(creatng, CrSt_CreatureChooseRoomForLairSite);
+        return laircreated;
     }
     // All done - finish the state
     set_start_state(creatng);
@@ -251,11 +255,15 @@ CrStateRet creature_at_new_lair(struct Thing *creatng)
         set_start_state(creatng);
         return CrStRet_ResetFail;
     }
-    if (!creature_add_lair_to_room(creatng, room))
+
+    CrStateRet laircreated = creature_add_lair_to_room(creatng, room);
+    if (laircreated != CrStRet_ResetOk)
     {
-        internal_set_thing_state(creatng, CrSt_CreatureChooseRoomForLairSite);
-        return CrStRet_Modified;
+        if (laircreated != CrStRet_Modified)
+            internal_set_thing_state(creatng, CrSt_CreatureChooseRoomForLairSite);
+        return laircreated;
     }
+    // All done - finish the state
     set_start_state(creatng);
     return CrStRet_ResetOk;
 }


### PR DESCRIPTION
Dropping units into a lair with enough capacity would sometimes have a unit try to make a bed in another lair room, because another bed was in their way. Now they will look for another spot in the same room, provided there is still capacity.