### PR TITLE
Allow spawning effect elements through script again

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1588,7 +1588,7 @@ static void create_effect_process(struct ScriptContext *context)
     {
         pos.z.val += 128;
     }
-    struct Thing* efftng = create_used_effect_or_element(&pos, context->value->bytes[0], game.neutral_player_num);
+    struct Thing* efftng = create_used_effect_or_element(&pos, context->value->chars[0], game.neutral_player_num);
     if (!thing_is_invalid(efftng))
     {
         if (thing_in_wall_at(efftng, &efftng->mappos))


### PR DESCRIPTION
CREATE_EFFECT and similar commands would no longer create effect elements. Now it works again.

To test, spawn hearts on your heart:
```
        NEXT_COMMAND_REUSABLE
        CREATE_EFFECT(-45,PLAYER0)
```