### PR TITLE
Made non-player walls give 1 efficiency point

### DIFF
--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -474,6 +474,7 @@ long calculate_effeciency_score_for_room_slab(SlabCodedCoords slab_num, PlayerNu
                   case SlbT_WALLDRAPE:
                     if (slabmap_owner(round_slb) == slabmap_owner(slb))
                         eff_score += 2;
+                    eff_score++;
                     break;
                   case SlbT_DOORWOOD1:
                     if (slabmap_owner(round_slb) == slabmap_owner(slb))


### PR DESCRIPTION
Makes building up against a neutral/allied/enemy walls provide the same room efficiency as building up against dirt and rocks.

Non-owned doors still give 0 points..