### PR TITLE
USE_SPELL_ON_PLAYERS_CREATURES script command

### DIFF
--- a/src/creature_states_pray.c
+++ b/src/creature_states_pray.c
@@ -259,15 +259,27 @@ long force_complete_current_manufacturing(long plyr_idx)
     return 0;
 }
 
-void apply_spell_effect_to_players_creatures(PlayerNumber plyr_idx, long spl_idx, long overchrg)
+void apply_spell_effect_to_players_creatures(PlayerNumber plyr_idx, long crmodel, long spl_idx, long overchrg)
 {
     SYNCDBG(8,"Starting");
     struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
     unsigned long k = 0;
-    int i = dungeon->creatr_list_start;
+
+    TbBool need_spec_digger = (crmodel > 0) && creature_kind_is_for_dungeon_diggers_list(plyr_idx, crmodel);
+    struct Thing* thing = INVALID_THING;
+    int i;
+    if ((!need_spec_digger) || (crmodel == CREATURE_ANY) || (crmodel == CREATURE_NOT_A_DIGGER))
+    {
+        i = dungeon->creatr_list_start;
+    }
+    else
+    {
+        i = dungeon->digger_list_start;
+    }
+
     while (i != 0)
     {
-        struct Thing* thing = thing_get(i);
+        thing = thing_get(i);
         TRACE_THING(thing);
         struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
         if (thing_is_invalid(thing) || creature_control_invalid(cctrl))
@@ -277,7 +289,10 @@ void apply_spell_effect_to_players_creatures(PlayerNumber plyr_idx, long spl_idx
         }
         i = cctrl->players_next_creature_idx;
         // Thing list loop body
-        apply_spell_effect_to_thing(thing, spl_idx, overchrg);
+        if (creature_matches_model(thing,crmodel))
+        {      
+            apply_spell_effect_to_thing(thing, spl_idx, overchrg);
+        }
         // Thing list loop body ends
         k++;
         if (k > CREATURES_COUNT)
@@ -528,12 +543,12 @@ long process_sacrifice_award(struct Coord3d *pos, long model, PlayerNumber plyr_
             break;
         case SacA_NegSpellAll:
             if (explevel > SPELL_MAX_LEVEL) explevel = SPELL_MAX_LEVEL;
-            apply_spell_effect_to_players_creatures(plyr_idx, sac->param, explevel);
+            apply_spell_effect_to_players_creatures(plyr_idx, CREATURE_NOT_A_DIGGER, sac->param, explevel);
             ret = SacR_Punished;
             break;
         case SacA_PosSpellAll:
             if (explevel > SPELL_MAX_LEVEL) explevel = SPELL_MAX_LEVEL;
-            apply_spell_effect_to_players_creatures(plyr_idx, sac->param, explevel);
+            apply_spell_effect_to_players_creatures(plyr_idx, CREATURE_NOT_A_DIGGER, sac->param, explevel);
             ret = SacR_Awarded;
             break;
         case SacA_NegUniqFunc:

--- a/src/creature_states_pray.h
+++ b/src/creature_states_pray.h
@@ -45,6 +45,7 @@ short creature_sacrifice(struct Thing *thing);
 short creature_being_summoned(struct Thing *thing);
 
 void kill_all_players_chickens(PlayerNumber plyr_idx);
+void apply_spell_effect_to_players_creatures(PlayerNumber plyr_idx, long spl_idx, long overchrg);
 
 TbBool find_temple_pool(int player_idx, struct Coord3d *pos);
 void process_sacrifice_creature(struct Coord3d *pos, int model, int owner, TbBool partial);

--- a/src/creature_states_pray.h
+++ b/src/creature_states_pray.h
@@ -45,7 +45,7 @@ short creature_sacrifice(struct Thing *thing);
 short creature_being_summoned(struct Thing *thing);
 
 void kill_all_players_chickens(PlayerNumber plyr_idx);
-void apply_spell_effect_to_players_creatures(PlayerNumber plyr_idx, long spl_idx, long overchrg);
+void apply_spell_effect_to_players_creatures(PlayerNumber plyr_idx,long crmodel, long spl_idx, long overchrg);
 
 TbBool find_temple_pool(int player_idx, struct Coord3d *pos);
 void process_sacrifice_creature(struct Coord3d *pos, int model, int owner, TbBool partial);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2656,7 +2656,6 @@ static void reveal_map_location_process(struct ScriptContext *context)
         reveal_map_area(context->player_idx, x-(r>>1), x+(r>>1)+(r&1), y-(r>>1), y+(r>>1)+(r&1));
 }
 
-//USE_SPELL_ON_PLAYERS_CREATURES([player],[spell],[level])
 static void use_spell_on_creature_check(const struct ScriptLine* scline)
 {
     ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
@@ -3275,8 +3274,8 @@ const struct CommandDesc command_desc[] = {
   {"IF_SLAB_TYPE",                      "NNS     ", Cmd_IF_SLAB_TYPE, NULL, NULL},
   {"QUICK_MESSAGE",                     "NAA     ", Cmd_QUICK_MESSAGE, NULL, NULL},
   {"DISPLAY_MESSAGE",                   "NA      ", Cmd_DISPLAY_MESSAGE, NULL, NULL},
-  {"USE_SPELL_ON_CREATURE",             "PC!AAN  ", Cmd_USE_SPELL_ON_CREATURE, NULL, NULL},
-  {"USE_SPELL_ON_PLAYERS_CREATURES",    "PAN     ", Cmd_USE_SPELL_ON_PLAYERS_CREATURES, &use_spell_on_creature_check, &use_spell_on_creature_process },
+  {"USE_SPELL_ON_CREATURE",             "PC!AAn  ", Cmd_USE_SPELL_ON_CREATURE, NULL, NULL},
+  {"USE_SPELL_ON_PLAYERS_CREATURES",    "PAn     ", Cmd_USE_SPELL_ON_PLAYERS_CREATURES, &use_spell_on_creature_check, &use_spell_on_creature_process },
   {"SET_HEART_HEALTH",                  "PN      ", Cmd_SET_HEART_HEALTH, &set_heart_health_check, &set_heart_health_process},
   {"ADD_HEART_HEALTH",                  "PNn     ", Cmd_ADD_HEART_HEALTH, &add_heart_health_check, &add_heart_health_process},
   {"CREATURE_ENTRANCE_LEVEL",           "PN      ", Cmd_CREATURE_ENTRANCE_LEVEL, NULL, NULL},

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2656,6 +2656,55 @@ static void reveal_map_location_process(struct ScriptContext *context)
         reveal_map_area(context->player_idx, x-(r>>1), x+(r>>1)+(r&1), y-(r>>1), y+(r>>1)+(r&1));
 }
 
+//USE_SPELL_ON_PLAYERS_CREATURES([player],[spell],[level])
+static void use_spell_on_creature_check(const struct ScriptLine* scline)
+{
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
+    const char *mag_name = scline->tp[1];
+    short mag_id = get_rid(spell_desc, mag_name);
+    short splevel = scline->np[2];
+
+    if (mag_id == -1)
+    {
+        SCRPTERRLOG("Invalid spell: %s", mag_name);
+        return;
+    }
+
+    if (splevel < 1)
+    {
+        if ((mag_id == SplK_Heal) || (mag_id == SplK_Armour) || (mag_id == SplK_Speed) || (mag_id == SplK_Disease) || (mag_id == SplK_Invisibility) || (mag_id == SplK_Chicken))
+        {
+            SCRPTWRNLOG("Spell %s level too low: %d, setting to 1.", mag_name, splevel);
+        }
+        splevel = 1;
+    }
+    if (splevel > (MAGIC_OVERCHARGE_LEVELS + 1)) //Creatures cast spells from level 1 to 10, but 10=9.
+    {
+        SCRPTWRNLOG("Spell %s level too high: %d, setting to %d.", mag_name, splevel, (MAGIC_OVERCHARGE_LEVELS + 1));
+        splevel = MAGIC_OVERCHARGE_LEVELS;
+    }
+    splevel--;
+    if (mag_id == -1)
+    {
+        SCRPTERRLOG("Unknown magic, '%s'", mag_name);
+        return;
+    }
+
+    value->shorts[1] = mag_id;
+    value->shorts[2] = splevel;
+    PROCESS_SCRIPT_VALUE(scline->command);
+}
+
+static void use_spell_on_creature_process(struct ScriptContext* context)
+{
+    long spl_idx = context->value->shorts[1];
+    long overchrg = context->value->shorts[2];
+    for (int i = context->plr_start; i < context->plr_end; i++)
+    {
+        apply_spell_effect_to_players_creatures(i, spl_idx, overchrg);
+    }
+}
+
 static void set_creature_instance_check(const struct ScriptLine *scline)
 {
     ALLOCATE_SCRIPT_VALUE(scline->command, 0);
@@ -3227,6 +3276,7 @@ const struct CommandDesc command_desc[] = {
   {"QUICK_MESSAGE",                     "NAA     ", Cmd_QUICK_MESSAGE, NULL, NULL},
   {"DISPLAY_MESSAGE",                   "NA      ", Cmd_DISPLAY_MESSAGE, NULL, NULL},
   {"USE_SPELL_ON_CREATURE",             "PC!AAN  ", Cmd_USE_SPELL_ON_CREATURE, NULL, NULL},
+  {"USE_SPELL_ON_PLAYERS_CREATURES",    "PAN     ", Cmd_USE_SPELL_ON_PLAYERS_CREATURES, &use_spell_on_creature_check, &use_spell_on_creature_process },
   {"SET_HEART_HEALTH",                  "PN      ", Cmd_SET_HEART_HEALTH, &set_heart_health_check, &set_heart_health_process},
   {"ADD_HEART_HEALTH",                  "PNn     ", Cmd_ADD_HEART_HEALTH, &add_heart_health_check, &add_heart_health_process},
   {"CREATURE_ENTRANCE_LEVEL",           "PN      ", Cmd_CREATURE_ENTRANCE_LEVEL, NULL, NULL},

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -167,6 +167,7 @@ enum TbScriptCommands {
     Cmd_IF_ALLIED                         = 154,
     Cmd_SET_TEXTURE                       = 155,
     Cmd_HIDE_HERO_GATE                    = 156,
+    Cmd_USE_SPELL_ON_PLAYERS_CREATURES    = 157,
 };
 
 struct ScriptLine {


### PR DESCRIPTION
USE_SPELL_ON_PLAYERS_CREATURES([player],[creature],[spell],[spell_level]*)

Also changed the last param to be optional here:
USE_SPELL_ON_CREATURE([player],[creature],[criterion],[spell],[spell_level]*)