### PR TITLE
Don't try to count the amount of slabs for neutral dungeons.

### DIFF
--- a/src/room_data.c
+++ b/src/room_data.c
@@ -207,6 +207,8 @@ long get_room_slabs_count(PlayerNumber plyr_idx, RoomKind rkind)
  */
 long get_room_of_role_slabs_count(PlayerNumber plyr_idx, RoomRole rrole)
 {
+    if (plyr_idx == game.neutral_player_num)
+        return -1;
     struct DungeonAdd* dungeonadd = get_dungeonadd(plyr_idx);
     long count = 0;
 
@@ -243,6 +245,8 @@ long get_room_of_role_slabs_count(PlayerNumber plyr_idx, RoomRole rrole)
 
 long count_slabs_of_room_type(PlayerNumber plyr_idx, RoomKind rkind)
 {
+    if (plyr_idx == game.neutral_player_num)
+        return -1;
     long nslabs = 0;
     struct DungeonAdd* dungeonadd = get_dungeonadd(plyr_idx);
     long i = dungeonadd->room_kind[rkind];


### PR DESCRIPTION
When using level script to change neutral rooms, the log would fill with errors like:
`Error: get_dungeonadd_f: count_slabs_of_room_type: Tried to get non-existing dungeon 5!`

This is because it would try to count the number of slabs the dungeon owned, but neutral is no real dungeon.