### PR TITLE
Delete attached effects when thing structure is deleted

### DIFF
--- a/src/thing_data.c
+++ b/src/thing_data.c
@@ -142,6 +142,7 @@ void delete_thing_structure_f(struct Thing *thing, long a2, const char *func_nam
     }
     if (!a2)
     {
+        delete_effects_attached_to_creature(thing);
         if (thing->light_id != 0) {
             light_delete_light(thing->light_id);
             thing->light_id = 0;


### PR DESCRIPTION
Fixes a bug with disease flies or armour lights not knowing where to go. To see the bug in action, add this to a level script and start the game with heart zoom enabled:

```
    NEXT_COMMAND_REUSABLE
    USE_SPELL_ON_PLAYERS_CREATURES(PLAYER0,ANY_CREATURE,SPELL_DISEASE,1)
 ```