### PR TITLE
Only very rarely look for player to attack, if the map is unchanged.

### DIFF
--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -975,7 +975,12 @@ short good_doing_nothing(struct Thing *creatng)
             cctrl->hero.byte_8C = 1;
         }
         nturns = game.play_gameturn - cctrl->hero.look_for_enemy_dungeon_turn;
-        if (nturns > 64)
+        if ((nturns > 64) && (cctrl->unknown.byte_8B == 1))
+        {
+            cctrl->hero.look_for_enemy_dungeon_turn = game.play_gameturn;
+            cctrl->party.target_plyr_idx = good_find_best_enemy_dungeon(creatng);
+        }
+        else if (nturns > 900)
         {
             cctrl->hero.look_for_enemy_dungeon_turn = game.play_gameturn;
             cctrl->party.target_plyr_idx = good_find_best_enemy_dungeon(creatng);
@@ -1337,7 +1342,6 @@ short tunneller_doing_nothing(struct Thing *creatng)
         return 1;
     }
 
-    // int plyr_idx = get_best_dungeon_to_tunnel_to(creatng);
     int plyr_idx = get_best_dungeon_to_tunnel_to(creatng);
     if (CurrentTarget != -1)
     {

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -990,7 +990,7 @@ short good_doing_nothing(struct Thing *creatng)
         {
             SYNCDBG(4,"No enemy dungeon to perform %s index %d task",
                 thing_model_name(creatng),(int)creatng->index);
-            cctrl->wait_to_turn = game.play_gameturn + 16;
+            cctrl->wait_to_turn = game.play_gameturn + 128;
             if (creature_choose_random_destination_on_valid_adjacent_slab(creatng))
             {
                 creatng->continue_state = CrSt_GoodDoingNothing;


### PR DESCRIPTION
partial fix for #2432 

Stops heroes looking for targets as often when the map is unchanged. Fixes performance in that case, but performance issues remain when any player is building or digging