### PR TITLE
Any object can be a custom mystery box

### DIFF
--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -159,7 +159,7 @@ TbBool setup_object_tooltips(struct Coord3d *pos)
   if (!thing_is_invalid(thing))
   {
       update_gui_tooltip_target(thing);
-      if (thing->model == ObjMdl_SpecboxCustom)
+      if (thing_is_custom_special_box(thing))
       {
           // TODO: get it from Map script
           if (gameadd.box_tooltip[thing->custom_box.box_kind][0] == 0)

--- a/src/lvl_script_lib.c
+++ b/src/lvl_script_lib.c
@@ -83,11 +83,12 @@ struct Thing *script_process_new_object(long tngmodel, TbMapLocation location, l
             return INVALID_THING;
         }
     }
+    if (thing_is_special_box(thing) && !thing_is_hardcoded_special_box(thing))
+    {
+        thing->custom_box.box_kind = (unsigned char)arg;
+    }
     switch (tngmodel)
     {
-        case ObjMdl_SpecboxCustom: // Custom box from SPECBOX_HIDNWRL
-            thing->custom_box.box_kind = (unsigned char)arg;
-            break;
         case ObjMdl_GoldChest:
         case ObjMdl_GoldPot:
         case ObjMdl_Goldl:

--- a/src/power_specials.c
+++ b/src/power_specials.c
@@ -448,23 +448,29 @@ void activate_dungeon_special(struct Thing *cratetng, struct PlayerInfo *player)
           delete_thing_structure(cratetng, 0);
           break;
         case SpcKind_Custom:
-          if (gameadd.current_player_turn == game.play_gameturn)
-          {
-              WARNLOG("box activation rejected turn:%d", gameadd.current_player_turn);
-              // If two players suddenly activated box at same turn it is not that we want to
-              return;
-          }
-          gameadd.current_player_turn = game.play_gameturn;
-          gameadd.script_current_player = player->id_number;
-          memcpy(&gameadd.triggered_object_location, &pos, sizeof(struct Coord3d));
-          dungeonadd->box_info.activated[cratetng->custom_box.box_kind]++;
-          no_speech = true;
-          remove_events_thing_is_attached_to(cratetng);
-          used = 1;
-          delete_thing_structure(cratetng, 0);
-          break;
         default:
-          ERRORLOG("Invalid dungeon special (Model %d)", (int)cratetng->model);
+            if (thing_is_custom_special_box(cratetng))
+            {
+                if (gameadd.current_player_turn == game.play_gameturn)
+                {
+                    WARNLOG("box activation rejected turn:%d", gameadd.current_player_turn);
+                    // If two players suddenly activated box at same turn it is not that we want to
+                    return;
+                }
+                gameadd.current_player_turn = game.play_gameturn;
+                gameadd.script_current_player = player->id_number;
+                memcpy(&gameadd.triggered_object_location, &pos, sizeof(struct Coord3d));
+                dungeonadd->box_info.activated[cratetng->custom_box.box_kind]++;
+                no_speech = true;
+                remove_events_thing_is_attached_to(cratetng);
+                used = 1;
+                delete_thing_structure(cratetng, 0);
+                break;
+            }
+            else
+            {
+                ERRORLOG("Invalid dungeon special (Model %d)", (int)cratetng->model);
+            }
           break;
       }
       if ( used )

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6062,7 +6062,7 @@ void display_controlled_pick_up_thing_name(struct Thing *picktng, unsigned long 
     else if (thing_is_special_box(picktng))
     {
         char msg_buf[255];
-        if (picktng->model == ObjMdl_SpecboxCustom)
+        if (thing_is_custom_special_box(picktng))
         {
             if (gameadd.box_tooltip[picktng->custom_box.box_kind][0] == 0)
             {

--- a/src/thing_factory.c
+++ b/src/thing_factory.c
@@ -155,7 +155,7 @@ TbBool thing_create_thing(struct InitThing *itng)
             {
                 thing->hero_gate.number = itng->params[1];
             }
-            else if (thing->model == ObjMdl_SpecboxCustom)
+            else if (thing_is_custom_special_box(thing))
             {
                 thing->custom_box.box_kind = itng->params[1];
                 if (itng->params[1] > gameadd.max_custom_box_kind)
@@ -275,7 +275,7 @@ TbBool thing_create_thing_adv(VALUE *init_data)
                         thing->hero_gate.number = value_int32(gate);
                     }
                 }
-                else if (thing->model == ObjMdl_SpecboxCustom)
+                else if (thing_is_custom_special_box(thing))
                 {
                     int box_kind = value_int32(value_dict_get(init_data, "CustomBox"));
                     if (box_kind == -1)

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -518,6 +518,31 @@ TbBool thing_is_special_box(const struct Thing *thing)
     return (objst->genre == OCtg_SpecialBox);
 }
 
+TbBool thing_is_hardcoded_special_box(const struct Thing* thing)
+{
+    if (thing->class_id != TCls_Object)
+        return false;
+    switch (thing->model)
+    {
+    case ObjMdl_SpecboxRevealMap:
+    case ObjMdl_SpecboxResurect:
+    case ObjMdl_SpecboxTransfer:
+    case ObjMdl_SpecboxStealHero:
+    case ObjMdl_SpecboxMultiply:
+    case ObjMdl_SpecboxIncreaseLevel:
+    case ObjMdl_SpecboxMakeSafe:
+    case ObjMdl_SpecboxHiddenWorld:
+        return true;
+    default:
+        return false;
+    }
+}
+
+TbBool thing_is_custom_special_box(const struct Thing* thing)
+{
+    return (thing_is_special_box(thing) && !thing_is_hardcoded_special_box(thing));
+}
+
 TbBool thing_is_workshop_crate(const struct Thing *thing)
 {
     if (!thing_is_object(thing))

--- a/src/thing_objects.h
+++ b/src/thing_objects.h
@@ -192,6 +192,8 @@ TbBool object_is_room_inventory(const struct Thing *thing, RoomRole rrole);
 TbBool object_is_unaffected_by_terrain_changes(const struct Thing *thing);
 TbBool object_can_be_damaged(const struct Thing* thing);
 TbBool object_is_buoyant(const struct Thing* thing);
+TbBool thing_is_hardcoded_special_box(const struct Thing* thing);
+TbBool thing_is_custom_special_box(const struct Thing* thing);
 
 TbBool creature_remove_lair_totem_from_room(struct Thing *creatng, struct Room *room);
 TbBool delete_lair_totem(struct Thing *lairtng);


### PR DESCRIPTION
Allows mapmaker to give different custom boxes a different look.

To make it work:
- in objects.cfg add a new object with `Genre = SPECIALBOX`
- in magic.cfg increase the SpecialsCount and add a new special, where the artifact is the new object