### PR TITLE
Use state as continue_state for defend rooms

### DIFF
--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -322,7 +322,7 @@ TbBool good_setup_defend_rooms(struct Thing* creatng)
         return false;
     }
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
-    creatng->continue_state = CHeroTsk_DefendRooms;
+    creatng->continue_state = CrSt_PatrolHere;
     cctrl->target_room_id = room->index;
     return true;
 }


### PR DESCRIPTION
Fixes bug where unit defending room tried to steal non-existing traps.

Enums CHeroTsk_DefendRooms and CrSt_CreaturePicksUpTrapObject  are both 11, so it took the wrong job.

Add this party to a level to test:
CREATE_PARTY(watchmen)
    ADD_TO_PARTY(watchmen,FAIRY,8,200,DEFEND_ROOMS,120)
    ADD_TO_PARTY(watchmen,THIEF,8,200,DEFEND_ROOMS,120)