### PR TITLE
Protect against neutral power sight crash

### DIFF
--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -232,14 +232,14 @@ unsigned long keepersprite_index(unsigned short n)
     return creature_list[n];
 }
 
-long get_lifespan_of_animation(long ani, long frameskip)
+long get_lifespan_of_animation(long ani, long speed)
 {
-    if (frameskip == 0)
+    if (speed == 0)
     {
         WARNLOG("Animation %d has no frameskip value", ani);
         return keepersprite_frames(ani);
     }
-    return (keepersprite_frames(ani) << 8) / frameskip;
+    return (keepersprite_frames(ani) << 8) / speed;
 }
 
 static struct KeeperSprite* sprite_by_frame(long kspr_frame)

--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -234,6 +234,11 @@ unsigned long keepersprite_index(unsigned short n)
 
 long get_lifespan_of_animation(long ani, long frameskip)
 {
+    if (frameskip == 0)
+    {
+        WARNLOG("Animation %d has no frameskip value", ani);
+        return keepersprite_frames(ani);
+    }
     return (keepersprite_frames(ani) << 8) / frameskip;
 }
 

--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -236,7 +236,7 @@ long get_lifespan_of_animation(long ani, long speed)
 {
     if (speed == 0)
     {
-        WARNLOG("Animation %d has no frameskip value", ani);
+        WARNLOG("Animation %d has no speed value", ani);
         return keepersprite_frames(ani);
     }
     return (keepersprite_frames(ani) << 8) / speed;

--- a/src/creature_graphics.h
+++ b/src/creature_graphics.h
@@ -115,7 +115,7 @@ struct KeeperSprite * keepersprite_array(unsigned short n);
 unsigned char keepersprite_frames(unsigned short n);
 unsigned char keepersprite_rotable(unsigned short n);
 void get_keepsprite_unscaled_dimensions(long kspr_anim, long angle, long frame, short *orig_w, short *orig_h, short *unsc_w, short *unsc_h);
-long get_lifespan_of_animation(long ani, long frameskip);
+long get_lifespan_of_animation(long ani, long speed);
 short get_creature_anim(struct Thing *thing, unsigned short frame);
 short get_creature_model_graphics(long crmodel, unsigned short frame);
 void set_creature_model_graphics(long crmodel, unsigned short frame, unsigned long val);

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -139,7 +139,7 @@ struct InitEffect effect_info[] = {
 
 struct EffectElementStats effect_element_stats[] = {
  //draw_class,	move_type,	unanimated,	lifespan,	lifespan_random,	sprite_idx,	sprite_size_min,	sprite_size_max,	rendering_flag,	sprite_speed_min,	sprite_speed_max,	animate_on_floor,	unshaded,	transparant,	
-    // field_15,	movement_flags,	size_change,	fall_acceleration,	field_19,	inertia_floor,	inertia_air,	subeffect_model,	subeffect_delay,	field_22,	effmodel_23,	solidgnd_snd_smpid,	solidgnd_loudness,
+    // field_15,	movement_flags,	size_change,	fall_acceleration,	field_19_unused,	inertia_floor,	inertia_air,	subeffect_model,	subeffect_delay,	field_22,	effmodel_23,	solidgnd_snd_smpid,	solidgnd_loudness,
         // solidgnd_destroy_on_impact,	water_effmodel,	water_snd_smpid,	water_loudness,	water_destroy_on_impact,	
             // lava_effmodel,	lava_snd_smpid,	lava_loudness,	lava_destroy_on_impact,	transform_model,	field_3A,	field_3C,	field_3D,	affected_by_wind
  {2,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	256,	0,	0,	0,	256,	0,	0,	0,	256,	0,	0,	0,	0,	0,	0},

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -138,7 +138,7 @@ struct InitEffect effect_info[] = {
 
 
 struct EffectElementStats effect_element_stats[] = {
- //draw_class,	field_1,	field_2,	numfield_3,	numfield_5,	sprite_idx,	sprite_size_min,	sprite_size_max,	field_D,	sprite_speed_min,	sprite_speed_max,	field_12,	unshaded,	transparant,	
+ //draw_class,	field_1,	field_2,	lifespan,	lifespan_random,	sprite_idx,	sprite_size_min,	sprite_size_max,	field_D,	sprite_speed_min,	sprite_speed_max,	field_12,	unshaded,	transparant,	
     // field_15,	field_16,	field_17,	fall_acceleration,	field_19,	inertia_floor,	inertia_air,	subeffect_model,	subeffect_delay,	field_22,	effmodel_23,	solidgnd_snd_smpid,	solidgnd_loudness,
         // solidgnd_destroy_on_impact,	water_effmodel,	water_snd_smpid,	water_loudness,	water_destroy_on_impact,	
             // lava_effmodel,	lava_snd_smpid,	lava_loudness,	lava_destroy_on_impact,	transform_model,	field_3A,	field_3C,	field_3D,	affected_by_wind
@@ -320,13 +320,20 @@ struct Thing *create_effect_element(const struct Coord3d *pos, unsigned short ee
     set_flag_byte(&thing->movement_flags,TMvF_Unknown10,eestat->field_16);
     thing->creation_turn = game.play_gameturn;
 
-    if (eestat->numfield_3 > 0)
+    if (eestat->lifespan > 0)
     {
-        i = EFFECT_RANDOM(thing, eestat->numfield_5 - (long)eestat->numfield_3 + 1);
-        thing->health = eestat->numfield_3 + i;
+        i = EFFECT_RANDOM(thing, eestat->lifespan_random - (long)eestat->lifespan + 1);
+        thing->health = eestat->lifespan + i;
     } else
     {
-        thing->health = get_lifespan_of_animation(thing->anim_sprite, thing->anim_speed);
+        if (thing->anim_speed > 0)
+        {
+            thing->health = get_lifespan_of_animation(thing->anim_sprite, thing->anim_speed);
+        }
+        else
+        {
+            thing->health = keepersprite_frames(thing->anim_sprite);
+        }
     }
 
     if (eestat->field_17 != 0)
@@ -609,10 +616,10 @@ void change_effect_element_into_another(struct Thing *thing, long nmodel)
     thing->fall_acceleration = eestat->fall_acceleration;
     thing->inertia_floor = eestat->inertia_floor;
     thing->inertia_air = eestat->inertia_air;
-    if (eestat->numfield_3 <= 0) {
+    if (eestat->lifespan <= 0) {
         thing->health = get_lifespan_of_animation(thing->anim_sprite, thing->anim_speed);
     } else {
-        thing->health = EFFECT_RANDOM(thing, eestat->numfield_5 - eestat->numfield_3 + 1) + eestat->numfield_3;
+        thing->health = EFFECT_RANDOM(thing, eestat->lifespan_random - eestat->lifespan + 1) + eestat->lifespan;
     }
     thing->max_frames = keepersprite_frames(thing->anim_sprite);
 }

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -138,8 +138,8 @@ struct InitEffect effect_info[] = {
 
 
 struct EffectElementStats effect_element_stats[] = {
- //draw_class,	field_1,	field_2,	lifespan,	lifespan_random,	sprite_idx,	sprite_size_min,	sprite_size_max,	field_D,	sprite_speed_min,	sprite_speed_max,	field_12,	unshaded,	transparant,	
-    // field_15,	field_16,	field_17,	fall_acceleration,	field_19,	inertia_floor,	inertia_air,	subeffect_model,	subeffect_delay,	field_22,	effmodel_23,	solidgnd_snd_smpid,	solidgnd_loudness,
+ //draw_class,	move_type,	unanimated,	lifespan,	lifespan_random,	sprite_idx,	sprite_size_min,	sprite_size_max,	rendering_flag,	sprite_speed_min,	sprite_speed_max,	animate_on_floor,	unshaded,	transparant,	
+    // field_15,	movement_flags,	size_change,	fall_acceleration,	field_19,	inertia_floor,	inertia_air,	subeffect_model,	subeffect_delay,	field_22,	effmodel_23,	solidgnd_snd_smpid,	solidgnd_loudness,
         // solidgnd_destroy_on_impact,	water_effmodel,	water_snd_smpid,	water_loudness,	water_destroy_on_impact,	
             // lava_effmodel,	lava_snd_smpid,	lava_loudness,	lava_destroy_on_impact,	transform_model,	field_3A,	field_3C,	field_3D,	affected_by_wind
  {2,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	0,	256,	0,	0,	0,	256,	0,	0,	0,	256,	0,	0,	0,	0,	0,	0},
@@ -307,7 +307,7 @@ struct Thing *create_effect_element(const struct Coord3d *pos, unsigned short ee
         set_thing_draw(thing, eestat->sprite_idx, eestat->sprite_speed_min + n, eestat->sprite_size_min + i, 0, 0, eestat->draw_class);
         set_flag_byte(&thing->rendering_flags,TRF_Unshaded,eestat->unshaded);
         thing->rendering_flags ^= (thing->rendering_flags ^ (TRF_Transpar_8 * eestat->transparant)) & (TRF_Transpar_Flags);
-        set_flag_byte(&thing->rendering_flags,TRF_AnimateOnce,eestat->field_D);
+        set_flag_byte(&thing->rendering_flags,TRF_AnimateOnce,eestat->rendering_flag);
     } else
     {
         set_flag_byte(&thing->rendering_flags,TRF_Unknown01,true);
@@ -317,7 +317,7 @@ struct Thing *create_effect_element(const struct Coord3d *pos, unsigned short ee
     thing->inertia_floor = eestat->inertia_floor;
     thing->inertia_air = eestat->inertia_air;
     thing->movement_flags |= TMvF_Unknown08;
-    set_flag_byte(&thing->movement_flags,TMvF_Unknown10,eestat->field_16);
+    set_flag_byte(&thing->movement_flags,TMvF_Unknown10,eestat->movement_flags);
     thing->creation_turn = game.play_gameturn;
 
     if (eestat->lifespan > 0)
@@ -336,11 +336,11 @@ struct Thing *create_effect_element(const struct Coord3d *pos, unsigned short ee
         }
     }
 
-    if (eestat->field_17 != 0)
+    if (eestat->size_change != 0)
     {
         thing->sprite_size_min = eestat->sprite_size_min;
         thing->sprite_size_max = eestat->sprite_size_max;
-        if (eestat->field_17 == 2)
+        if (eestat->size_change == 2)
         {
             thing->transformation_speed = 2 * (eestat->sprite_size_max - (long)eestat->sprite_size_min) / thing->health;
             thing->field_50 |= 0x02;
@@ -610,7 +610,7 @@ void change_effect_element_into_another(struct Thing *thing, long nmodel)
     int speed = eestat->sprite_speed_min + EFFECT_RANDOM(thing, eestat->sprite_speed_max - eestat->sprite_speed_min + 1);
     int scale = eestat->sprite_size_min + EFFECT_RANDOM(thing, eestat->sprite_size_max - eestat->sprite_size_min + 1);
     thing->model = nmodel;
-    set_thing_draw(thing, eestat->sprite_idx, speed, scale, eestat->field_D, 0, 2);
+    set_thing_draw(thing, eestat->sprite_idx, speed, scale, eestat->rendering_flag, 0, 2);
     thing->rendering_flags ^= (thing->rendering_flags ^ TRF_Unshaded * eestat->unshaded) & TRF_Unshaded;
     thing->rendering_flags ^= (thing->rendering_flags ^ TRF_Transpar_8 * eestat->transparant) & (TRF_Transpar_Flags);
     thing->fall_acceleration = eestat->fall_acceleration;
@@ -645,7 +645,7 @@ TngUpdateRet update_effect_element(struct Thing *elemtng)
     }
     elemtng->health = health-1;
     // Set dynamic properties of the effect
-    if (!eestats->field_12)
+    if (!eestats->animate_on_floor)
     {
         if (elemtng->floor_height >= (int)elemtng->mappos.z.val)
           elemtng->anim_speed = 0;
@@ -672,7 +672,7 @@ TngUpdateRet update_effect_element(struct Thing *elemtng)
           create_effect_element(&elemtng->mappos, eestats->subeffect_model, elemtng->owner);
       }
     }
-    switch (eestats->field_1)
+    switch (eestats->move_type)
     {
     case 1:
         move_effect_element(elemtng);
@@ -722,12 +722,12 @@ TngUpdateRet update_effect_element(struct Thing *elemtng)
     case 5:
         break;
     default:
-        ERRORLOG("Invalid effect element move type %d!",(int)eestats->field_1);
+        ERRORLOG("Invalid effect element move type %d!",(int)eestats->move_type);
         move_effect_element(elemtng);
         break;
     }
 
-    if (eestats->field_2 != 1)
+    if (eestats->unanimated != 1)
       return TUFRet_Modified;
     i = get_angle_yz_to_vec(&elemtng->veloc_base);
     if (i > LbFPMath_PI)

--- a/src/thing_effects.h
+++ b/src/thing_effects.h
@@ -252,24 +252,24 @@ struct EffectGeneratorStats { // sizeof = 57
 
 struct EffectElementStats { // sizeof = 79
   unsigned char draw_class;
-  unsigned char field_1;
-  unsigned char field_2;
+  unsigned char move_type;
+  unsigned char unanimated;
   short lifespan;
   short lifespan_random;
   short sprite_idx;
   short sprite_size_min;
   short sprite_size_max;
-  unsigned char field_D;
+  unsigned char rendering_flag;
   unsigned short sprite_speed_min;
   unsigned short sprite_speed_max;
-  unsigned char field_12;
+  TbBool animate_on_floor;
   unsigned char unshaded;
   unsigned char transparant;  // transparency flags in bits 4-5
   unsigned char field_15;
-  unsigned char field_16;
-  unsigned char field_17;
+  unsigned char movement_flags;
+  unsigned char size_change;
   unsigned char fall_acceleration;
-  unsigned char field_19;
+  unsigned char field_19_unused;
   short inertia_floor;
   short inertia_air;
   unsigned short subeffect_model;

--- a/src/thing_effects.h
+++ b/src/thing_effects.h
@@ -254,8 +254,8 @@ struct EffectElementStats { // sizeof = 79
   unsigned char draw_class;
   unsigned char field_1;
   unsigned char field_2;
-  short numfield_3;
-  short numfield_5;
+  short lifespan;
+  short lifespan_random;
   short sprite_idx;
   short sprite_size_min;
   short sprite_size_max;

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1700,7 +1700,12 @@ static TngUpdateRet object_update_power_sight(struct Thing *objtng)
 {
     int result; // eax
     objtng->health = 2;
-
+    if (is_neutral_thing(objtng))
+    {
+        ERRORLOG("Neutral %s index %d cannot be power sight.", thing_model_name(objtng), (int)objtng->index);
+        delete_thing_structure(objtng, 0);
+        return 0;
+    }
     struct Dungeon * dungeon = get_dungeon(objtng->owner);
     struct PowerConfigStats* powerst = get_power_model_stats(PwrK_SIGHT);
 


### PR DESCRIPTION
Protections against a crash with modded objects and or animations with no animation length.

To reproduce the bug, put this in a map script and wait 5 seconds for a crash:
```
IF(PLAYER0,GAME_TURN > 60)
    ADD_OBJECT_TO_LEVEL(SPECBOX_INCLEV,PLAYER0,0,PLAYER_NEUTRAL)
ENDIF
IF(PLAYER0,GAME_TURN > 100)
    SET_OBJECT_CONFIGURATION(SPECBOX_INCLEV,UpdateFunction,UPDATE_POWER_SIGHT)
ENDIF
```

Also named some effect element fields.