### PR TITLE
makefile: create configure.log file first to avoid (rare?) error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -584,6 +584,7 @@ deps/zlib/contrib/minizip/unzip.c deps/zlib/contrib/minizip/ioapi.c: build-befor
 
 deps/zlib/configure.log:
 	git submodule sync && git submodule update --init
+	touch deps/zlib/configure.log
 	cd deps/zlib && ./configure --static
 
 deps/zlib/libz.a: deps/zlib/configure.log


### PR DESCRIPTION
There's a bizarre issue that may only affect certain Windows PCs (not all) when attempting to compile the source code for the first time.

The error is at the bottom of this log:

```
D:\Github\keeperfx>wsl make standard
make -f libexterns.mk
make[1]: Entering directory '/mnt/d/Github/keeperfx'
Extracting package: sdl/SDL2-devel-2.28.1-mingw.tar.gz
# Grep is used to remove bogus error messages, return state of tar is also ignored
cd "sdl"; \
tar --strip-components=2 -zxmUf "SDL2-devel-2.28.1-mingw.tar.gz" SDL2-2.28.1/i686-w64-mingw32/bin SDL2-2.28.1/i686-w64-mingw32/include SDL2-2.28.1/i686-w64-mingw32/lib SDL2-2.28.1/i686-w64-mingw32/share 2>&1 | \
grep -v '^.*: Archive value .* is out of .* range.*$'
make[1]: [libexterns.mk:45: sdl/lib/libSDL2main.a] Error 1 (ignored)
Finished extracting: sdl/SDL2-devel-2.28.1-mingw.tar.gz

Extracting package: sdl/SDL2_net-devel-2.2.0-mingw.tar.gz
mkdir -p sdl/lib sdl/include/SDL2
cd "sdl"; \
tar -xzf "SDL2_net-devel-2.2.0-mingw.tar.gz"
mv -f sdl/SDL2_net-*/i686-w64-mingw32/include/SDL2/* sdl/include/SDL2/
cp -f -r sdl/SDL2_net-*/i686-w64-mingw32/lib/* sdl/lib/
Finished extracting: sdl/SDL2_net-devel-2.2.0-mingw.tar.gz
...
Extracting package: sdl/SDL2_image-devel-2.6.3-mingw.tar.gz
mkdir -p sdl/lib sdl/include/SDL2
cd "sdl"; \
tar -xzf "SDL2_image-devel-2.6.3-mingw.tar.gz"
mv -f sdl/SDL2_image-*/i686-w64-mingw32/include/SDL2/* sdl/include/SDL2/
cp -f -r sdl/SDL2_image-*/i686-w64-mingw32/lib/* sdl/lib/
Finished extracting: sdl/SDL2_image-devel-2.6.3-mingw.tar.gz

touch libexterns
make[1]: Leaving directory '/mnt/d/Github/keeperfx'
git submodule sync && git submodule update --init
Synchronizing submodule url for 'deps/centijson'
Synchronizing submodule url for 'deps/enet'
Synchronizing submodule url for 'deps/libspng'
Synchronizing submodule url for 'deps/zlib'
cd deps/zlib && ./configure --static
/bin/sh: 1: ./configure: not found
make: *** [Makefile:587: deps/zlib/configure.log] Error 127
```

If you ever experience this error, please comment below. It's very difficult to know how common it is, or what's causing it. A workaround is to create the `configure.log` file manually. Or in this PR's case, the line: `touch deps/zlib/configure.log` in the makefile will also create it. And this solves the compilation error.

Keep in mind, there's both a `/deps/zlib/configure` file and a `/deps/zlib/configure.log` file. The `configure` file is supposed to create the `configure.log` file I believe.