### PR TITLE
Fixed mouse not reaching every spot on screen with -altinput

### DIFF
--- a/src/bflib_inputctrl.cpp
+++ b/src/bflib_inputctrl.cpp
@@ -530,8 +530,10 @@ void LbGrabMouseCheck(long grab_event)
                     grab_cursor = false;
                 }
                 break;
-            case MG_OnFocusGained:
             case MG_InitMouse:
+                grab_cursor = true;
+                break;
+            case MG_OnFocusGained:
                 grab_cursor = lbMouseGrab;
                 if (paused && unlock_cursor_when_game_paused())
                 {


### PR DESCRIPTION
Since e47a9172ff9852a062b55407ae7aadf5a6808e07 the behavior with -altinput is different. When I start up the game with the -altinput command line option, depending on where I have my cursor when it loads, the hardware cursor reaches the edge of the screen before the keeperfx cursor does, so I can not click the menu buttons in the bottom right of my screen.

This PR fixes this.