### PR TITLE
Allow negative increase level from script

### DIFF
--- a/src/lvl_script_commands_old.c
+++ b/src/lvl_script_commands_old.c
@@ -1205,32 +1205,24 @@ static void command_kill_creature(long plr_range_id, const char *crtr_name, cons
 static void command_level_up_creature(long plr_range_id, const char *crtr_name, const char *criteria, int count)
 {
     SCRIPTDBG(11, "Starting");
-    if (count <= 0)
+    if (count == 0)
     {
         SCRPTERRLOG("Bad count, %d", count);
         return;
-  }
-  long crtr_id = parse_creature_name(crtr_name);
-  if (crtr_id == CREATURE_NONE)
-  {
-    SCRPTERRLOG("Unknown creature, '%s'", crtr_name);
-    return;
-  }
-  long select_id = parse_criteria(criteria);
-  if (select_id == -1) {
-    SCRPTERRLOG("Unknown select criteria, '%s'", criteria);
-    return;
-  }
-  if (count < 1)
-  {
-    SCRPTERRLOG("Parameter has no positive value; discarding command");
-    return;
-  }
-  if (count > 9)
-  {
-      count = 9;
-  }
-  command_add_value(Cmd_LEVEL_UP_CREATURE, plr_range_id, crtr_id, select_id, count);
+    }
+    long crtr_id = parse_creature_name(crtr_name);
+    if (crtr_id == CREATURE_NONE)
+    {
+        SCRPTERRLOG("Unknown creature, '%s'", crtr_name);
+        return;
+    }
+    long select_id = parse_criteria(criteria);
+    if (select_id == -1) 
+    {
+        SCRPTERRLOG("Unknown select criteria, '%s'", criteria);
+        return;
+    }
+    command_add_value(Cmd_LEVEL_UP_CREATURE, plr_range_id, crtr_id, select_id, count);
 }
 
 static void command_use_power_on_creature(long plr_range_id, const char *crtr_name, const char *criteria, long caster_plyr_idx, const char *magname, int splevel, char free)

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -122,7 +122,7 @@ TbBool script_level_up_creature(PlayerNumber plyr_idx, long crmodel, long criter
         SYNCDBG(5,"No matching player %d creature of model %d (%s) found to level up",(int)plyr_idx,(int)crmodel, creature_code_name(crmodel));
         return false;
     }
-    creature_increase_multiple_levels(thing,count);
+    creature_change_multiple_levels(thing,count);
     return true;
 }
 

--- a/src/power_specials.c
+++ b/src/power_specials.c
@@ -140,7 +140,7 @@ void increase_level(struct PlayerInfo *player, int count)
         }
         i = cctrl->players_next_creature_idx;
         // Thing list loop body
-        if (count > 1) creature_increase_multiple_levels(thing, count);
+        if (count != 1) creature_change_multiple_levels(thing, count);
         else creature_increase_level(thing);
         // Thing list loop body ends
         k++;
@@ -164,7 +164,7 @@ void increase_level(struct PlayerInfo *player, int count)
         }
         i = cctrl->players_next_creature_idx;
         // Thing list loop body
-        if (count > 1) creature_increase_multiple_levels(thing, count);
+        if (count > 1) creature_change_multiple_levels(thing, count);
         else creature_increase_level(thing);
         // Thing list loop body ends
         k++;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3875,7 +3875,6 @@ TbBool creature_change_multiple_levels(struct Thing *thing, int count)
         {
             set_creature_level(thing, cctrl->explevel + count);
         }
-        thing->health = cctrl->max_health;
         return true;
     }
 }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3833,34 +3833,51 @@ TbBool creature_increase_level(struct Thing *thing)
   return false;
 }
 
-TbBool creature_increase_multiple_levels(struct Thing *thing, int count)
+TbBool creature_change_multiple_levels(struct Thing *thing, int count)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     if (creature_control_invalid(cctrl))
     {
         ERRORLOG("Invalid creature control; no action");
         return false;
-  }
-  struct Dungeon* dungeon = get_dungeon(thing->owner);
-  int k = 0;
-  for (int i = 0; i < count; i++)
-  {
-    if (dungeon->creature_max_level[thing->model] > cctrl->explevel)
-    {
-        struct CreatureStats* crstat = creature_stats_get_from_thing(thing);
-        if ((cctrl->explevel < CREATURE_MAX_LEVEL - 1) || (crstat->grow_up != 0))
-        {
-            cctrl->spell_flags |= CSAfF_ExpLevelUp;
-            update_creature_levels(thing);
-            k++;
-      }
     }
-  }
-  if (k > 0)
-  {
-      return true;
-  }
-  return false;
+    struct Dungeon* dungeon = get_dungeon(thing->owner);
+    int k = 0;
+    if (count > 0)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            if (dungeon->creature_max_level[thing->model] > cctrl->explevel)
+            {
+                struct CreatureStats* crstat = creature_stats_get_from_thing(thing);
+                if ((cctrl->explevel < CREATURE_MAX_LEVEL - 1) || (crstat->grow_up != 0))
+                {
+                    cctrl->spell_flags |= CSAfF_ExpLevelUp;
+                    update_creature_levels(thing);
+                    k++;
+                }
+            }
+        }
+        if (k != 0)
+        {
+            return true;
+        }
+        return false;
+    }
+    else
+    {
+        remove_creature_score_from_owner(thing);
+        if (cctrl->explevel < abs(count))
+        {
+            set_creature_level(thing, 0);
+        }
+        else
+        {
+            set_creature_level(thing, cctrl->explevel + count);
+        }
+        thing->health = cctrl->max_health;
+        return true;
+    }
 }
 
 /**

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -91,7 +91,7 @@ TbBool create_random_hero_creature(MapCoord x, MapCoord y, PlayerNumber owner, C
 struct Thing *create_owned_special_digger(MapCoord x, MapCoord y, PlayerNumber owner);
 
 TbBool creature_increase_level(struct Thing *thing);
-TbBool creature_increase_multiple_levels(struct Thing *thing, int count);
+TbBool creature_change_multiple_levels(struct Thing *thing, int count);
 void set_creature_level(struct Thing *thing, long nlvl);
 void init_creature_level(struct Thing *thing, long nlev);
 long get_creature_speed(const struct Thing *thing);


### PR DESCRIPTION
SET_CREATURE_LEVEL now accepts negative values. Example:
`LEVEL_UP_CREATURE(PLAYER0,BILE_DEMON,MOST_EXPERIENCED,-7)`

Also, allows values over 9, so level ups can be done a lot more in case of growing up creatures.