### PR TITLE
makefile: Dynamically choose between 'make standard' and 'make clean'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/latex
 *.d
 *.Tpo
 res/keeperfx_icon.ico
+.header_checksum

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
 		{
 			"label": "Compile",
 			"type": "shell",
-			"command": "make -j`nproc` standard",
+			"command": "make -j`nproc` all",
 			"problemMatcher": "$gcc",
 			"group": {
 				"kind": "build",

--- a/Makefile
+++ b/Makefile
@@ -412,6 +412,7 @@ include prebuilds.mk
 
 # 'make autoclean' calculates the current checksum of all .h and .hpp files, storing the checksum in a file. Then it decides whether to run 'make clean' or 'make standard' based on whether any .h and .hpp files have been altered
 HEADER_CHECKSUM_FILE=.header_checksum
+
 autoclean:
 	@current_checksum=$$(find . -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $$1}'); \
 	if [ ! -f $(HEADER_CHECKSUM_FILE) ] || [ "$$(cat $(HEADER_CHECKSUM_FILE))" != "$$current_checksum" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -410,19 +410,15 @@ include prebuilds.mk
 -include $(filter %.d,$(STDOBJS:%.o=%.d))
 -include $(filter %.d,$(HVLOGOBJS:%.o=%.d))
 
-# 'make autoclean' calculates the current checksum of all .h and .hpp files, storing the checksum in a file. Then it decides whether to run 'make clean' or 'make standard' based on whether any .h and .hpp files have been altered
+# 'make all' calculates the current checksum of all .h and .hpp files, storing the checksum in a file. Then it decides whether to run 'make clean' or 'make standard' based on whether any .h and .hpp files have been altered
 HEADER_CHECKSUM_FILE=.header_checksum
 
-autoclean:
+all:
 	@current_checksum=$$(find . -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $$1}'); \
 	if [ ! -f $(HEADER_CHECKSUM_FILE) ] || [ "$$(cat $(HEADER_CHECKSUM_FILE))" != "$$current_checksum" ]; then \
 		$(MAKE) clean; \
 	fi; \
 	$(MAKE) standard && echo "$$current_checksum" > $(HEADER_CHECKSUM_FILE)
-
-all:
-	@$(MAKE) clean
-	@$(MAKE) standard
 
 standard: CXXFLAGS += $(STLOGFLAGS)
 standard: CFLAGS += $(STLOGFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,15 @@ include prebuilds.mk
 -include $(filter %.d,$(STDOBJS:%.o=%.d))
 -include $(filter %.d,$(HVLOGOBJS:%.o=%.d))
 
+# 'make autoclean' calculates the current checksum of all .h and .hpp files, storing the checksum in a file. Then it decides whether to run 'make clean' or 'make standard' based on whether any .h and .hpp files have been altered
+HEADER_CHECKSUM_FILE=.header_checksum
+autoclean:
+	@current_checksum=$$(find . -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $$1}'); \
+	if [ ! -f $(HEADER_CHECKSUM_FILE) ] || [ "$$(cat $(HEADER_CHECKSUM_FILE))" != "$$current_checksum" ]; then \
+		$(MAKE) clean; \
+	fi; \
+	$(MAKE) standard && echo "$$current_checksum" > $(HEADER_CHECKSUM_FILE)
+
 all:
 	@$(MAKE) clean
 	@$(MAKE) standard


### PR DESCRIPTION
Here's a method to call both `make clean` and `make standard` but only 'clean' when necessary. I haven't tested it super thoroughly yet, there could be problems with it.

I'll just go over the basics for anyone out of the loop:
- `make clean` is necessary to run whenever you edit a header file (.h, .hpp), otherwise massive issues occur.
- If you run `make standard` twice in a row, the second time will be much faster.
- If you run `make clean`, then `make standard` will be slow.
- `make all` currently runs `make clean` then `make standard` right after, so it's always slow.

There's a lot of benefits to having only one function to call both. Such as not running into bugs if you edit a header file but forget to call `make clean`. Having only one function to run will also work well with VSCode's 'run main build task' keybind.

As per Loobinex's suggestion, we'll update `make all` with this new functionality rather than adding a new command.

To test this, run `make all` twice in a row. (or 3 times in some circumstances - if you edit the makefile for example that will always cause `make standard` to want to do a full compile)