### PR TITLE
makefile: fix too much cleaning in new `make all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,15 +410,27 @@ include prebuilds.mk
 -include $(filter %.d,$(STDOBJS:%.o=%.d))
 -include $(filter %.d,$(HVLOGOBJS:%.o=%.d))
 
-# 'make all' calculates the current checksum of all .h and .hpp files, storing the checksum in a file. Then it decides whether to run 'make clean' or 'make standard' based on whether any .h and .hpp files have been altered
-HEADER_CHECKSUM_FILE=.header_checksum
 
+# 'make all' calculates the current checksum of all .h and .hpp files, storing them in a file. Then it decides whether to run 'make clean' or 'make standard' based on whether any .h and .hpp files have been altered
+HEADER_CHECKSUM_FILE=.header_checksum
 all:
-	@current_checksum=$$(find . -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $$1}'); \
-	if [ ! -f $(HEADER_CHECKSUM_FILE) ] || [ "$$(cat $(HEADER_CHECKSUM_FILE))" != "$$current_checksum" ]; then \
+	@if [ ! -f $(HEADER_CHECKSUM_FILE) ]; then \
+		echo "No previous .header_checksum file found."; \
+		find ./src/ -type f \( -name "*.h" -o -name "*.hpp" \) -exec sha256sum {} \; | sort > $(HEADER_CHECKSUM_FILE); \
 		$(MAKE) clean; \
+	else \
+		find ./src/ -type f \( -name "*.h" -o -name "*.hpp" \) -exec sha256sum {} \; | sort > .current_checksums; \
+		changed_files=$$(comm -23 .current_checksums $(HEADER_CHECKSUM_FILE) | awk '{print $$2}'); \
+		if [ ! -z "$$changed_files" ]; then \
+			echo "Changed header files:"; \
+			echo "\033[1;37m$$changed_files\033[0m"; \
+			$(MAKE) clean; \
+		else \
+			echo "No header files have been changed."; \
+		fi; \
+		mv .current_checksums $(HEADER_CHECKSUM_FILE); \
 	fi; \
-	$(MAKE) standard && echo "$$current_checksum" > $(HEADER_CHECKSUM_FILE)
+	$(MAKE) standard;
 
 standard: CXXFLAGS += $(STLOGFLAGS)
 standard: CFLAGS += $(STLOGFLAGS)


### PR DESCRIPTION
On a fresh install (git clone) on my Linux laptop it took upwards of 5 `make all` calls before it stopped calling 'clean', because .h files everywhere kept changing by themselves inbetween each compile (there's .h files inside folders such as `/deps/`, `/sdl/`, and `/obj/` sometimes). Not sure whether this is only a fresh install issue, but even if it is then that's a bad first impression that needs fixing.

Looking at only header files inside the `/src/` folder fixes the issue, on a fresh install it correctly stopped cleaning after the first compile. I've also adjusted the code to now output the names of any header files that have changed.