### PR TITLE
Enhanced tasks for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/latex
 *.d
 *.Tpo
 res/keeperfx_icon.ico
+.header_checksum

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 build*/
 *.cache
 .vscode
+.vscode/settings.json
 /libexterns
 docs/html
 docs/latex

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
     // Set your Dungeon Keeper game directory here, using Linux formatting.
-	// Linux users example: "/home/username/.wine/drive_c/dungeonkeeper/"
-	// Windows Users: Ensure you use forward slashes and begin with '/mnt/' followed by the drive letter in lowercase.
-	// For example: "D:/Games/DungeonKeeper/" is written as: "/mnt/d/Games/DungeonKeeper/"
+    // Linux users example: "/home/username/.wine/drive_c/dungeonkeeper/"
+    // Windows Users: Ensure you use forward slashes and begin with '/mnt/' followed by the drive letter in lowercase.
+    // For example: "D:/Games/DungeonKeeper/" is written as: "/mnt/d/Games/DungeonKeeper/"
     "game.directory": "/path/goes/here/",
-	
+
     // Launch arguments, specify the map that is instantly loaded
     "game.arguments": "-level 00001 -campaign keeporig -nointro -alex -altinput",
-	
+
     "C_Cpp.intelliSenseEngine": "disabled",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
-    // Set your Dungeon Keeper game directory here, using Linux formatting.
-    // Linux users example: "/home/username/.wine/drive_c/dungeonkeeper/"
-    // Windows Users: Ensure you use forward slashes and begin with '/mnt/' followed by the drive letter in lowercase.
-    // For example: "D:/Games/DungeonKeeper/" is written as: "/mnt/d/Games/DungeonKeeper/"
-    "game.directory": "/path/goes/here/",
+	// Set your Dungeon Keeper game directory here, using Linux formatting.
+	// Linux users example: "/home/username/.wine/drive_c/dungeonkeeper/"
+	// Windows Users: Ensure you use forward slashes and begin with '/mnt/' followed by the drive letter in lowercase.
+	// For example: "D:/Games/DungeonKeeper/" is written as: "/mnt/d/Games/DungeonKeeper/"
+	"game.directory": "/path/goes/here/",
 
-    // Launch arguments, specify the map that is instantly loaded
-    "game.arguments": "-level 00001 -campaign keeporig -nointro -alex -altinput",
+	// Launch arguments, specify the map that is instantly loaded
+	"game.arguments": "-level 00001 -campaign keeporig -nointro -alex -altinput",
 
-    "C_Cpp.intelliSenseEngine": "disabled",
+	"C_Cpp.intelliSenseEngine": "disabled",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-	"C_Cpp.intelliSenseEngine": "disabled",
+    // Set your Dungeon Keeper game directory here, using Linux formatting.
+	// Linux users example: "/home/username/.wine/drive_c/dungeonkeeper/"
+	// Windows Users: Ensure you use forward slashes and begin with '/mnt/' followed by the drive letter in lowercase.
+	// For example: "D:/Games/DungeonKeeper/" is written as: "/mnt/d/Games/DungeonKeeper/"
+    "game.directory": "/path/goes/here/",
+	
+    // Launch arguments, specify the map that is instantly loaded
+    "game.arguments": "-level 00001 -campaign keeporig -nointro -alex -altinput",
+	
+    "C_Cpp.intelliSenseEngine": "disabled",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,27 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "Check For Game Directory",
+			// After the project is first opened, mark settings.json as being untracked
+			"label": "Prevent settings.json from being tracked",
 			"type": "shell",
-			"command": "echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; if [ ! -d \"${config:game.directory}\" ]; then echo -e '\\033[0;91mGame directory missing in settings.json. Please update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' ${config:game.directory} '\\033[0m'; fi",
+			"command": "git update-index --assume-unchanged .vscode/settings.json",
 			"problemMatcher": "$gcc",
 			"runOptions": {
 				"runOn": "folderOpen"
 			},
+			"group": "build",
+			"presentation": {
+				"echo": false,
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": false
+			}
+		},
+		{
+			"label": "Check For Game Directory",
+			"type": "shell",
+			"command": "echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; if [ ! -d \"${config:game.directory}\" ]; then echo -e '\\033[0;91mGame directory missing in /.vscode/settings.json. Please update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' ${config:game.directory} '\\033[0m'; fi",
+			"problemMatcher": "$gcc",
 			"group": "build",
 			"presentation": {
 				"echo": false,
@@ -83,7 +97,7 @@
 			"command": "make clean-build clean-tools && bear -- make -j2 standard",
 			"problemMatcher": "$gcc",
 			"group": "build",
-			"dependsOn": ["Compile"]
+			"dependsOn": "Compile",
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,32 +1,95 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=733558
-	// for the documentation about the tasks.json format
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"label": "Compile",
-			"type": "shell",
-			"command": "make -j`nproc` all",
-			"problemMatcher": "$gcc",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-		},
-		{
-			"label": "Clean",
-			"type": "shell",
-			"command": "make -j`nproc` clean",
-			"problemMatcher": "$gcc",
-			"group": "build",
-		},
-		{
-			"label": "Generate compile_commands.json",
-			"type": "shell",
-			"command": "make clean-build clean-tools && bear -- make -j2 standard",
-			"problemMatcher": "$gcc",
-			"group": "build",
-			"dependsOn": ["Compile"],
-		}
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Check For Game Directory",
+            "type": "shell",
+			"command": "game_directory=${config:game.directory}; echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; if [ ! -d \"$game_directory\" ]; then echo -e '\\033[0;91mGame directory missing in settings.json. Please update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_directory '\\033[0m'; fi",
+            "runOptions": {
+                "runOn": "folderOpen"
+            },
+            "group": "build",
+            "presentation": {
+                "echo": false,
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false
+            }
+        },
+        {
+            "label": "Compile",
+            "type": "shell",
+            "command": "make -j`nproc` all && echo -e '\\033[0;32mCompilation successful!\\033[0m'",
+            "dependsOn": "Check For Game Directory",
+            "group": "build",
+            "presentation": {
+                "echo": false,
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+            }
+        },
+        {
+            "label": "Copy Files",
+            "type": "shell",
+            "command": "game_directory=${config:game.directory} && cd \"$game_directory\" && cp \"${workspaceFolder}/bin/\"* .",
+            "dependsOn": "Compile",
+            "group": "build",
+            "presentation": {
+                "echo": false,
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+            }
+        },
+        {
+            "label": "Run Game",
+            "type": "shell",
+            "command": "cd \"${config:game.directory}\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe ${config:game.arguments}\"; else wine 'keeperfx.exe' ${config:game.arguments}; fi",
+            "dependsOn": "Copy Files",
+            "group": "build",
+            "presentation": {
+                "echo": false,
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+            }
+        },
+        {
+            "label": "Compile, Copy Files, Run Game",
+            "type": "shell",
+            "command": "",
+            "dependsOn": "Run Game",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": false,
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+            }
+        },
+        {
+            "label": "Log",
+            "type": "shell",
+            "command": "game_directory=${config:game.directory} && cd \"$game_directory\" && > keeperfx.log && less +F --mouse keeperfx.log",
+            "dependsOn": "Check For Game Directory",
+            "group": "build"
+        },
+        {
+            "label": "Clean",
+            "type": "shell",
+            "command": "make -j`nproc` clean",
+            "group": "build"
+        },
+        {
+            "label": "Generate compile_commands.json",
+            "type": "shell",
+            "command": "make clean-build clean-tools && bear -- make -j2 standard",
+            "group": "build",
+            "dependsOn": ["Compile"]
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,95 +1,89 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Check For Game Directory",
-            "type": "shell",
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Check For Game Directory",
+			"type": "shell",
 			"command": "echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; if [ ! -d \"${config:game.directory}\" ]; then echo -e '\\033[0;91mGame directory missing in settings.json. Please update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' ${config:game.directory} '\\033[0m'; fi",
+			"problemMatcher": "$gcc",
 			"runOptions": {
-                "runOn": "folderOpen"
-            },
-            "group": "build",
-            "presentation": {
-                "echo": false,
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false
-            }
-        },
-        {
-            "label": "Compile",
-            "type": "shell",
-            "command": "make -j`nproc` all && echo -e '\\033[0;32mCompilation successful!\\033[0m'",
-            "dependsOn": "Check For Game Directory",
-            "group": "build",
-            "presentation": {
-                "echo": false,
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-            }
-        },
-        {
-            "label": "Copy Files",
-            "type": "shell",
-			"command": "cd \"${config:game.directory}\" && cp \"${workspaceFolder}/bin/\"* .",
-			"dependsOn": "Compile",
-            "group": "build",
-            "presentation": {
-                "echo": false,
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-            }
-        },
-        {
-            "label": "Run Game",
-            "type": "shell",
-            "command": "cd \"${config:game.directory}\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe ${config:game.arguments}\"; else wine 'keeperfx.exe' ${config:game.arguments}; fi",
-            "dependsOn": "Copy Files",
-            "group": "build",
-            "presentation": {
-                "echo": false,
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-            }
-        },
-        {
-            "label": "Compile, Copy Files, Run Game",
-            "type": "shell",
-            "command": "",
-            "dependsOn": "Run Game",
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "presentation": {
-                "echo": false,
-                "focus": true,
-                "panel": "shared",
-                "showReuseMessage": false,
-            }
-        },
-        {
-            "label": "Log",
-            "type": "shell",
-			"command": "cd \"${config:game.directory}\" && > keeperfx.log && less +F --mouse keeperfx.log",
+				"runOn": "folderOpen"
+			},
+			"group": "build",
+			"presentation": {
+				"echo": false,
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": false
+			}
+		},
+		{
+			"label": "Compile",
+			"type": "shell",
+			"command": "make -j`nproc` all && echo -e '\\033[0;32mCompilation successful!\\033[0m'",
+			"problemMatcher": "$gcc",
 			"dependsOn": "Check For Game Directory",
-            "group": "build"
-        },
-        {
-            "label": "Clean",
-            "type": "shell",
-            "command": "make -j`nproc` clean",
-            "group": "build"
-        },
-        {
-            "label": "Generate compile_commands.json",
-            "type": "shell",
-            "command": "make clean-build clean-tools && bear -- make -j2 standard",
-            "group": "build",
-            "dependsOn": ["Compile"]
-        }
-    ]
+			"group": "build",
+			"presentation": {
+				"echo": false,
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": false,
+			}
+		},
+		{
+			"label": "Copy Files",
+			"type": "shell",
+			"command": "cd \"${config:game.directory}\" && cp \"${workspaceFolder}/bin/\"* .",
+			"problemMatcher": "$gcc",
+			"dependsOn": "Compile",
+			"group": "build",
+			"presentation": {
+				"echo": false,
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": false,
+			}
+		},
+		{
+			"label": "Compile, Copy Files, Run Game",
+			"type": "shell",
+			"command": "cd \"${config:game.directory}\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe ${config:game.arguments}\"; else wine 'keeperfx.exe' ${config:game.arguments}; fi",
+			"problemMatcher": "$gcc",
+			"dependsOn": "Copy Files",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"presentation": {
+				"echo": false,
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": false,
+			}
+		},
+		{
+			"label": "Log",
+			"type": "shell",
+			"command": "cd \"${config:game.directory}\" && > keeperfx.log && less +F --mouse keeperfx.log",
+			"problemMatcher": "$gcc",
+			"dependsOn": "Check For Game Directory",
+			"group": "build"
+		},
+		{
+			"label": "Clean",
+			"type": "shell",
+			"command": "make -j`nproc` clean",
+			"problemMatcher": "$gcc",
+			"group": "build"
+		},
+		{
+			"label": "Generate compile_commands.json",
+			"type": "shell",
+			"command": "make clean-build clean-tools && bear -- make -j2 standard",
+			"problemMatcher": "$gcc",
+			"group": "build",
+			"dependsOn": ["Compile"]
+		}
+	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
 		{
 			"label": "Compile",
 			"type": "shell",
-			"command": "make -j`nproc` standard",
+			"command": "make -j`nproc` all",
 			"problemMatcher": "$gcc",
 			"group": {
 				"kind": "build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 			// After the project is first opened, mark settings.json as being untracked
 			"label": "Prevent settings.json from being tracked",
 			"type": "shell",
-			"command": "git update-index --assume-unchanged .vscode/settings.json",
+			"command": "git update-index --skip-worktree .vscode/settings.json",
 			"problemMatcher": "$gcc",
 			"runOptions": {
 				"runOn": "folderOpen"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,8 +4,8 @@
         {
             "label": "Check For Game Directory",
             "type": "shell",
-			"command": "game_directory=${config:game.directory}; echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; if [ ! -d \"$game_directory\" ]; then echo -e '\\033[0;91mGame directory missing in settings.json. Please update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_directory '\\033[0m'; fi",
-            "runOptions": {
+			"command": "echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; if [ ! -d \"${config:game.directory}\" ]; then echo -e '\\033[0;91mGame directory missing in settings.json. Please update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' ${config:game.directory} '\\033[0m'; fi",
+			"runOptions": {
                 "runOn": "folderOpen"
             },
             "group": "build",
@@ -32,8 +32,8 @@
         {
             "label": "Copy Files",
             "type": "shell",
-            "command": "game_directory=${config:game.directory} && cd \"$game_directory\" && cp \"${workspaceFolder}/bin/\"* .",
-            "dependsOn": "Compile",
+			"command": "cd \"${config:game.directory}\" && cp \"${workspaceFolder}/bin/\"* .",
+			"dependsOn": "Compile",
             "group": "build",
             "presentation": {
                 "echo": false,
@@ -74,8 +74,8 @@
         {
             "label": "Log",
             "type": "shell",
-            "command": "game_directory=${config:game.directory} && cd \"$game_directory\" && > keeperfx.log && less +F --mouse keeperfx.log",
-            "dependsOn": "Check For Game Directory",
+			"command": "cd \"${config:game.directory}\" && > keeperfx.log && less +F --mouse keeperfx.log",
+			"dependsOn": "Check For Game Directory",
             "group": "build"
         },
         {

--- a/Makefile
+++ b/Makefile
@@ -410,9 +410,15 @@ include prebuilds.mk
 -include $(filter %.d,$(STDOBJS:%.o=%.d))
 -include $(filter %.d,$(HVLOGOBJS:%.o=%.d))
 
+# 'make all' calculates the current checksum of all .h and .hpp files, storing the checksum in a file. Then it decides whether to run 'make clean' or 'make standard' based on whether any .h and .hpp files have been altered
+HEADER_CHECKSUM_FILE=.header_checksum
+
 all:
-	@$(MAKE) clean
-	@$(MAKE) standard
+	@current_checksum=$$(find . -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $$1}'); \
+	if [ ! -f $(HEADER_CHECKSUM_FILE) ] || [ "$$(cat $(HEADER_CHECKSUM_FILE))" != "$$current_checksum" ]; then \
+		$(MAKE) clean; \
+	fi; \
+	$(MAKE) standard && echo "$$current_checksum" > $(HEADER_CHECKSUM_FILE)
 
 standard: CXXFLAGS += $(STLOGFLAGS)
 standard: CFLAGS += $(STLOGFLAGS)


### PR DESCRIPTION
I've added a lot to the VSCode default built task (`Ctrl`+`Shift`+`B`), it now compiles, copies the files to your game directory and runs the game, all automatically. I've tested on both Windows(WSL) and my Linux laptop, everything's working great and we don't even need to call any external bash scripts.

The one and only requirement is that every user needs to go fill out `settings.json` with their game directory. It's unfortunate we have this extra step but I believe this is the most user-friendly path we can take. In comparison, manually copying files from `//wsl$` directories is very unfriendly.

It's set up so that the build task will instantly fail and give you bright red text in the terminal that tells you to go fill it out. There's instructions to do so inside of `settings.json` and I'll also write it as a step for the wiki guide.

![Untitled](https://github.com/dkfans/keeperfx/assets/15337628/eb7113d0-6a67-4054-aa7d-d8cb4afa9973)
