### PR TITLE
Fixed braced doors placing weird keys

### DIFF
--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -1638,7 +1638,10 @@ void dump_slab_on_map(SlabKind slbkind, long slabct_num, MapSubtlCoord stl_x, Ma
                 //TODO this condition does not look consistent
                 if ((thing->class_id != TCls_Creature) || (floor_height <= 4))
                 {
-                    if (thing->model != 2) {
+                    //Suspect this has to do with object 2, torch, that needs to stay 4 cubes heigh. TCls_Door added later for braced door(model 2) key bug.
+                    //TODO investigate if doors need height 1 or 5, below code drops them to the floor
+                    if ((thing->model != 2) || (thing->class_id == TCls_Door)) 
+                    {
                         thing->mappos.z.val = subtile_coord(floor_height,0);
                     }
                 }


### PR DESCRIPTION
Recently (5a163dc2de644a04d08196f2be4da4d0e0aecd9c) keys got moved from height 4, to height 5, to be on top of doors. This introduced a bug with braced doors, that keys were thrown off.

Found code that moved all things on slab-change to floor height. This includes doors, which changes the door-things from height 5 to height 1. It however excluded things with model 2 (suspect this was for _object_ thing model 2, torch) that kept the original height. Braced door is door 2, and so this conflicted.

I kept the weird code as it is and only handled this specific case. I was unwilling to change more because at this point I have not investigated if:

- Door things should be height 5 or height 1, and if there are bugs related to either height
- If in the original game doors things had height 1 or height 5, and if that causes problems somehow.