### PR TITLE
Fixed crashes on starting a non-existing level

### DIFF
--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -30,6 +30,7 @@
 #include "config_strings.h"
 #include "lvl_filesdk1.h"
 #include "frontmenu_ingame_tabs.h"
+#include "map_data.h"
 
 #include "game_merge.h"
 #include "post_inc.h"
@@ -150,8 +151,8 @@ void clear_level_info(struct LevelInformation *lvinfo)
   lvinfo->options = LvOp_None;
   lvinfo->state = LvSt_Hidden;
   lvinfo->location = LvLc_VarLevels;
-  lvinfo->mapsize_x = 85;
-  lvinfo->mapsize_y = 85;
+  lvinfo->mapsize_x = DEFAULT_MAP_SIZE;
+  lvinfo->mapsize_y = DEFAULT_MAP_SIZE;
 }
 
 /**

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -2293,6 +2293,7 @@ void gui_set_button_flashing(long btn_idx, long gameturns)
 
 void update_room_tab_to_config(void)
 {
+    SYNCDBG(8, "Starting");
     int i;
     // Clear 4x4 area of buttons, but skip "sell" button at end
     for (i=0; i < 4*4-1; i++)
@@ -2330,6 +2331,7 @@ void update_room_tab_to_config(void)
 
 void update_trap_tab_to_config(void)
 {
+    SYNCDBG(8, "Starting");
     int i;
     // Clear 4x4 area of buttons, but skip "sell" button at end
     for (i=0; i < 4*4-1; i++)
@@ -2383,6 +2385,7 @@ void update_trap_tab_to_config(void)
 
 void update_powers_tab_to_config(void)
 {
+    SYNCDBG(8, "Starting");
     int i;
     // Clear 4x4 area of buttons, no "sell" button at end
     for (i=0; i < 4*4; i++)

--- a/src/game_merge.c
+++ b/src/game_merge.c
@@ -96,9 +96,9 @@ LevelNumber get_selected_level_number(void)
  */
 LevelNumber set_selected_level_number(LevelNumber lvnum)
 {
-  if (lvnum >= 0)
-    game.selected_level_number = lvnum;
-  return game.selected_level_number;
+    if (lvnum >= 0)
+        game.selected_level_number = lvnum;
+    return game.selected_level_number;
 }
 
 /**

--- a/src/light_data.c
+++ b/src/light_data.c
@@ -1526,6 +1526,7 @@ static void light_stat_light_map_clear_area(MapSubtlCoord start_stl_x, MapSubtlC
 
 void light_set_lights_on(char state)
 {
+    SYNCDBG(8, "Starting");
     if (state)
     {
         game.lish.global_ambient_light = 10;

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -875,7 +875,10 @@ void set_map_size(MapSlabCoord x,MapSlabCoord y)
 void init_map_size(LevelNumber lvnum)
 {
     struct LevelInformation* lvinfo = get_level_info(lvnum);
-    set_map_size(lvinfo->mapsize_x,lvinfo->mapsize_y);
+    if (lvinfo == NULL)
+        set_map_size(DEFAULT_MAP_SIZE, DEFAULT_MAP_SIZE);
+    else
+        set_map_size(lvinfo->mapsize_x,lvinfo->mapsize_y);
 }
 
 /******************************************************************************/

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -49,6 +49,7 @@ struct Map {
 #define STL_PER_SLB 3
 #define COORD_PER_STL 256
 #define FILLED_COLUMN_HEIGHT 1280
+#define DEFAULT_MAP_SIZE 85
 
 #pragma pack()
 /******************************************************************************/

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -1008,6 +1008,7 @@ void post_init_player(struct PlayerInfo *player)
 
 void post_init_players(void)
 {
+    SYNCDBG(8, "Starting");
     for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
     {
         struct PlayerInfo* player = get_player(plyr_idx);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -5192,6 +5192,7 @@ TbBool remove_creature_score_from_owner(struct Thing *thing)
 
 void init_creature_scores(void)
 {
+    SYNCDBG(8, "Starting");
     long i;
     long score;
     // compute maximum score


### PR DESCRIPTION
to reproduce the crash, start the game with a -level command line option to a level that does not exist.