### PR TITLE
Fixed load_map_slab_file looking only at SLAB_TYPES_COUNT

### DIFF
--- a/src/config_terrain.h
+++ b/src/config_terrain.h
@@ -31,8 +31,6 @@ extern "C" {
 /******************************************************************************/
 
 #define TERRAIN_ITEMS_MAX    256
-// Amount of possible types of slabs
-#define SLAB_TYPES_COUNT      58
 
 /******************************************************************************/
 #pragma pack(1)

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -1327,9 +1327,9 @@ short load_map_slab_file(unsigned long lv_num)
       {
         slb = get_slabmap_block(x,y);
         n = lword(&buf[i]);
-        if (n > SLAB_TYPES_COUNT)
+        if (n > TERRAIN_ITEMS_MAX)
         {
-          WARNMSG("Slab Type %d exceeds limit of %d",(int)n,SLAB_TYPES_COUNT);
+          WARNMSG("Slab Type %d exceeds limit of %d",(int)n, TERRAIN_ITEMS_MAX);
           n = SlbT_ROCK;
         }
         slb->kind = n;


### PR DESCRIPTION
Also deleted SLAB_TYPES_COUNT completely

Fixes log warnings on this map:
[map00999.zip](https://github.com/dkfans/keeperfx/files/12423710/map00999.zip)

