### PR TITLE
makefile: Compile times printed for 'make all'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,12 +413,17 @@ include prebuilds.mk
 
 # 'make all' calculates the current checksum of all .h and .hpp files, storing the checksum in a file. Then it decides whether to run 'make clean' or 'make standard' based on whether any .h and .hpp files have been altered
 HEADER_CHECKSUM_FILE=.header_checksum
+
 all:
-	@current_checksum=$$(find ./src/ -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 md5sum | md5sum | awk '{print $$1}'); \
+	@start_time=$$(date +%s.%N); \
+	current_checksum=$$(find ./src/ -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 cksum | cksum | awk '{print $$1}'); \
 	if [ ! -f $(HEADER_CHECKSUM_FILE) ] || [ "$$(cat $(HEADER_CHECKSUM_FILE))" != "$$current_checksum" ]; then \
 		$(MAKE) clean; \
 	fi; \
-	$(MAKE) standard && echo "$$current_checksum" > $(HEADER_CHECKSUM_FILE)
+	$(MAKE) standard && echo "$$current_checksum" > $(HEADER_CHECKSUM_FILE); \
+	end_time=$$(date +%s.%N); \
+	duration=$$(awk "BEGIN {print $$end_time - $$start_time}"); \
+	printf "\033[97mCompiled in: %0.2f seconds\033[0m\n" $$duration;
 
 standard: CXXFLAGS += $(STLOGFLAGS)
 standard: CFLAGS += $(STLOGFLAGS)


### PR DESCRIPTION
also using cksum instead of md5sum as it's 0.04 seconds faster https://github.com/dkfans/keeperfx/pull/2553#issuecomment-1691161141

![Untitled](https://github.com/dkfans/keeperfx/assets/15337628/c090d85e-7f45-40ee-a1db-b92d0e4ff15b)
