### PR TITLE
VSCode tasks now support Windows (non-wsl) + some reorganizing

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,10 +2,72 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+			"label": "Compile, Copy Files, Launch",
+			"type": "shell",
+			"windows": {
+				"command": [
+					"Write-Host ('Source Code directory: ' + '${workspaceFolder}'.Replace('\\', '/')) -ForegroundColor White;",
+					"$jsonContent = Get-Content '${workspaceFolder}\\.vscode\\user.json' | ConvertFrom-Json;",
+					"$gameDir = ($jsonContent | Select-Object -ExpandProperty game_directory).TrimEnd('\\');",
+					"if (-not (Test-Path $gameDir)) {",
+					"    Write-Host 'Game directory missing in /.vscode/user.json, please edit the file and update it.' -ForegroundColor Red;",
+					"    Write-Host 'Example: D:/Games/DungeonKeeper/ (be sure to use forward slashes)' -ForegroundColor Red;",
+					"    return;",
+					"} else {",
+					"    Write-Host ('Game directory: ' + $gameDir) -ForegroundColor White;",
+					"}",
+					"wsl make -j`nproc` all;",
+					"if ($?) {",
+					"    Write-Host 'Compilation successful!' -ForegroundColor Green;",
+					"}",
+					"Stop-Process -Name 'keeperfx' -ErrorAction SilentlyContinue;",
+					"while (Get-Process -Name 'keeperfx' -ErrorAction SilentlyContinue) {",
+					"   Start-Sleep -Milliseconds 10;",
+					"}",
+					"copy \"${workspaceFolder}\\bin\\*\" \"$gameDir\";",
+					"$gameArgs = $jsonContent.game_arguments;",
+					"cd \"$gameDir\";",
+					"Start-Process keeperfx.exe -ArgumentList \"$gameArgs\""
+				]
+			},
+			"linux": {
+				"command": [
+					"if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi;",
+					"jq --version > /dev/null 2>&1 || { echo -e '\\033[0;91mError: jq is not installed. Please install it using: sudo apt-get install jq\\033[0m'; exit 1; };",
+					"echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); if [ ! -d \"$game_dir\" ]; then echo -e '\\033[0;91mGame directory missing in .vscode/user.json. Please edit the file and update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_dir '\\033[0m'; fi;",
+					"make -j`nproc` all && echo -e '\\033[0;32mCompilation successful!\\033[0m';",
+					"game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && cp \"${workspaceFolder}/bin/\"* .;",
+					"game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); game_args=$(jq -r '.game_arguments' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe $game_args\"; else wine 'keeperfx.exe' $game_args; fi;"
+				]
+			},
+			"problemMatcher": "$gcc",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"presentation": {
+				"echo": false,
+				"reveal": "always",
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": false
+			}
+		},
+		{
 			// After the project is first opened, user.json will be created
 			"label": "Create user.json",
 			"type": "shell",
-			"command": "if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi",
+			"windows": {
+				"command": [
+					"if (-not (Test-Path '${workspaceFolder}\\.vscode\\user.json')) {",
+					"    Copy-Item '${workspaceFolder}\\.vscode\\defaultuser' '${workspaceFolder}\\.vscode\\user.json';",
+					"    Write-Host '/.vscode/user.json was created, please edit it and fill in your game directory.';",
+					"}"
+				]
+			},
+			"linux": {
+				"command": "if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi"
+			},
 			"problemMatcher": "$gcc",
 			"runOptions": {
 				"runOn": "folderOpen"
@@ -19,86 +81,19 @@
 			}
 		},
 		{
-			"label": "Check For jq Installation",
-			"type": "shell",
-			"command": "jq --version > /dev/null 2>&1 || (echo -e '\\033[0;91mError: jq is not installed. Please install it using: sudo apt-get install jq\\033[0m' && exit 1)",
-			"problemMatcher": "$gcc",
-			"group": "build",
-			"presentation": {
-				"echo": false,
-				"reveal": "always",
-				"focus": true,
-				"panel": "shared",
-				"showReuseMessage": false
-			}
-		},
-		{
-			"label": "Check For Game Directory",
-			"type": "shell",
-			"command": "echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); if [ ! -d \"$game_dir\" ]; then echo -e '\\033[0;91mGame directory missing in .vscode/user.json. Please edit the file and update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_dir '\\033[0m'; fi",
-			"problemMatcher": "$gcc",
-			"dependsOn": "Check For jq Installation",
-			"group": "build",
-			"presentation": {
-				"echo": false,
-				"reveal": "always",
-				"focus": true,
-				"panel": "shared",
-				"showReuseMessage": false
-			}
-		},
-		{
-			"label": "Compile",
-			"type": "shell",
-			"command": "make -j`nproc` all && echo -e '\\033[0;32mCompilation successful!\\033[0m'",
-			"problemMatcher": "$gcc",
-			"dependsOn": "Check For Game Directory",
-			"group": "build",
-			"presentation": {
-				"echo": false,
-				"reveal": "always",
-				"focus": true,
-				"panel": "shared",
-				"showReuseMessage": false,
-			}
-		},
-		{
-			"label": "Copy Files",
-			"type": "shell",
-			"command": "game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && cp \"${workspaceFolder}/bin/\"* .",
-			"problemMatcher": "$gcc",
-			"dependsOn": "Compile",
-			"group": "build",
-			"presentation": {
-				"echo": false,
-				"reveal": "always",
-				"focus": true,
-				"panel": "shared",
-				"showReuseMessage": false,
-			}
-		},
-		{
-			"label": "Compile, Copy Files, Run Game",
-			"type": "shell",
-			"command": "game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); game_args=$(jq -r '.game_arguments' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe $game_args\"; else wine 'keeperfx.exe' $game_args; fi",
-			"problemMatcher": "$gcc",
-			"dependsOn": "Copy Files",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"presentation": {
-				"echo": false,
-				"reveal": "always",
-				"focus": true,
-				"panel": "shared",
-				"showReuseMessage": false,
-			}
-		},
-		{
 			"label": "Log",
 			"type": "shell",
-			"command": "game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && > keeperfx.log && less +F --mouse keeperfx.log",
+			"windows": {
+				"command": [
+					"$gameDir = (Get-Content '${workspaceFolder}\\.vscode\\user.json' | ConvertFrom-Json).game_directory;",
+					"cd $gameDir;",
+					"Clear-Content keeperfx.log;",
+					"Get-Content keeperfx.log -Wait"
+				]
+			},
+			"linux": {
+				"command": "game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && > keeperfx.log && less +F --mouse keeperfx.log"
+			},
 			"problemMatcher": "$gcc",
 			"dependsOn": "Check For Game Directory",
 			"group": "build"
@@ -106,14 +101,27 @@
 		{
 			"label": "Clean",
 			"type": "shell",
-			"command": "make -j`nproc` clean",
+			"windows": {
+				"command": "wsl make -j`nproc` clean"
+			},
+			"linux": {
+				"command": "make -j`nproc` clean"
+			},
 			"problemMatcher": "$gcc",
 			"group": "build"
 		},
 		{
 			"label": "Generate compile_commands.json",
 			"type": "shell",
-			"command": "make clean-build clean-tools && bear -- make -j2 standard",
+			"windows": {
+				"command": [
+					"wsl make clean-build clean-tools;",
+					"wsl bear -- make -j2 standard"
+				]
+			},
+			"linux": {
+				"command": "make clean-build clean-tools && bear -- make -j2 standard"
+			},
 			"problemMatcher": "$gcc",
 			"group": "build",
 			"dependsOn": "Compile",


### PR DESCRIPTION
The tasks.json now supports three OS configurations:

- Linux
- Windows WSL (VSCode in WSL mode)
- Windows

I also made a discovery, tasks are slow as hell when you string them together. It was adding ~1.5 seconds while in WSL mode and ~7 seconds in Windows mode. Something as simple as printing using echo 5 times like this is very slow:
```
{
	"version": "2.0.0",
	"tasks": [
		{
			"label": "Check For jq Installation",
			"type": "shell",
			"command": "echo 1",
		},
		{
			"label": "Check For Game Directory",
			"type": "shell",
			"command": "echo 2",
			"dependsOn": "Check For jq Installation",
		},
		{
			"label": "Compile",
			"type": "shell",
			"command": "echo 3",
			"dependsOn": "Check For Game Directory",
		},
		{
			"label": "Copy Files",
			"type": "shell",
			"command": "echo 4",
			"dependsOn": "Compile",
		},
		{
			"label": "Compile, Copy Files, Run Game",
			"type": "shell",
			"command": "echo 5",
			"dependsOn": "Copy Files",
			"group": {
				"kind": "build",
				"isDefault": true
			}
		}
	]
}
```
I think it's because it's opening up a new internal powershell every task, and "dependsOn" means it waits for the next shell to complete. As a result I've rewritten most of the tasks to instead just be an all-in-one task (I also thankfully learned "command" supports multiple lines).