### PR TITLE
Fixed issue with not loading custom music

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -3782,13 +3782,13 @@ static void set_music_check(const struct ScriptLine *scline)
         if (IsRedbookMusicActive())
         {
             SCRPTWRNLOG("Level script wants to play custom track from disk, but game is playing music from CD.");
+            DEALLOCATE_SCRIPT_VALUE
             return;
         }
         // See if a file with this name is already loaded, if so, reuse the same track
-        char* compare_fname;
-        for (int i = max_track + 1; i <= MUSIC_TRACKS_COUNT; i++)
+        char* compare_fname = prepare_file_fmtpath(FGrp_CmpgMedia, "%s", scline->tp[0]);
+        for (int i = max_track + 1; i <= game.last_audiotrack; i++)
         {
-            compare_fname = prepare_file_fmtpath(FGrp_CmpgMedia, "%s", scline->tp[0]);
             if (strcmp(compare_fname, game.loaded_track[i]) == 0)
             {
                 value->chars[0] = i;
@@ -3818,6 +3818,7 @@ static void set_music_check(const struct ScriptLine *scline)
         if (tracks[tracknumber] == NULL)
         {
             SCRPTERRLOG("Can't load track %ld (%s): %s", tracknumber, game.loaded_track[tracknumber], Mix_GetError());
+            DEALLOCATE_SCRIPT_VALUE
             return;
         }
         else


### PR DESCRIPTION
Fixes an issue with custom music not loading. To reproduce:
1) Download and install this campaign: https://www.file-upload.net/download-15181910/NeuerOrdner.zip.html
2) Launch the game with the -nocd command line option so that music can play
3) Start the second map of the campaign. Dig north to fight heroes or cheat units so that a battle starts.
-> battle music starts playing
4) Exit the level
5) Use cheats to start the first level of the campaign now
-> notice no music starts playing.

Music should start playing.