### PR TITLE
Fix keys falling off doors on strange maps

### DIFF
--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -399,6 +399,7 @@ struct Thing *create_object(const struct Coord3d *pos, unsigned short model, uns
         if ((thing->mappos.z.stl.num == 4) && (subtile_is_door(thing->mappos.x.stl.num, thing->mappos.y.stl.num)))
         {
             thing->mappos.z.stl.num = 5; // Move keys from old maps from inside to on top of the doors.
+            thing->mappos.z.stl.pos = 0;
         }
         break;
       default:


### PR DESCRIPTION
On certain old maps, keys have a position of 4.5, but when we were setting their new position to 5, we weren't setting the decimal place so they were at 5.5 which throws the key off the door.

#2523
#2525
#2547