### PR TITLE
vscode tasks: when compilation fails, stop and show error message

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,14 +38,14 @@
 					"if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi;",
 					"jq --version > /dev/null 2>&1 || { echo -e '\\033[0;91mError: jq is not installed. Please install it using: sudo apt-get install jq\\033[0m'; exit 1; };",
 					"echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); if [ ! -d \"$game_dir\" ]; then echo -e '\\033[0;91mGame directory missing in .vscode/user.json. Please edit the file and update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_dir '\\033[0m'; fi;",
-					"make -j`nproc` all",
+					"make -j`nproc` all;",
 					"if [ $? -eq 0 ]; then",
 					"    echo -e '\\033[0;32mCompilation successful!\\033[0m';",
 					"    game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && cp \"${workspaceFolder}/bin/\"* .;",
 					"    game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); game_args=$(jq -r '.game_arguments' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe $game_args\"; else wine 'keeperfx.exe' $game_args; fi;",
 					"else",
 					"    echo -e '\\033[0;91mCompilation failed!\\033[0m';",
-					"    exit 1;",
+					"    exit 0;",
 					"fi"
 				]
 			},

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,9 @@
 					"wsl make -j`nproc` all;",
 					"if ($?) {",
 					"    Write-Host 'Compilation successful!' -ForegroundColor Green;",
+					"} else {",
+					"    Write-Host 'Compilation failed!' -ForegroundColor Red;",
+					"    return;",
 					"}",
 					"Stop-Process -Name 'keeperfx' -ErrorAction SilentlyContinue;",
 					"while (Get-Process -Name 'keeperfx' -ErrorAction SilentlyContinue) {",
@@ -35,9 +38,15 @@
 					"if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi;",
 					"jq --version > /dev/null 2>&1 || { echo -e '\\033[0;91mError: jq is not installed. Please install it using: sudo apt-get install jq\\033[0m'; exit 1; };",
 					"echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); if [ ! -d \"$game_dir\" ]; then echo -e '\\033[0;91mGame directory missing in .vscode/user.json. Please edit the file and update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_dir '\\033[0m'; fi;",
-					"make -j`nproc` all && echo -e '\\033[0;32mCompilation successful!\\033[0m';",
-					"game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && cp \"${workspaceFolder}/bin/\"* .;",
-					"game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); game_args=$(jq -r '.game_arguments' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe $game_args\"; else wine 'keeperfx.exe' $game_args; fi;"
+					"make -j`nproc` all",
+					"if [ $? -eq 0 ]; then",
+					"    echo -e '\\033[0;32mCompilation successful!\\033[0m';",
+					"    game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && cp \"${workspaceFolder}/bin/\"* .;",
+					"    game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); game_args=$(jq -r '.game_arguments' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe $game_args\"; else wine 'keeperfx.exe' $game_args; fi;",
+					"else",
+					"    echo -e '\\033[0;91mCompilation failed!\\033[0m';",
+					"    exit 1;",
+					"fi"
 				]
 			},
 			"problemMatcher": "$gcc",

--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,8 @@ all:
 	if [ ! -f $(HEADER_CHECKSUM_FILE) ] || [ "$$(cat $(HEADER_CHECKSUM_FILE))" != "$$current_checksum" ]; then \
 		$(MAKE) clean; \
 	fi; \
-	$(MAKE) standard && echo "$$current_checksum" > $(HEADER_CHECKSUM_FILE); \
+	$(MAKE) standard || exit 1; \
+	echo "$$current_checksum" > $(HEADER_CHECKSUM_FILE); \
 	end_time=$$(date +%s.%N); \
 	duration=$$(awk "BEGIN {print $$end_time - $$start_time}"); \
 	printf "\033[97mCompiled in: %0.2f seconds\033[0m\n" $$duration;


### PR DESCRIPTION
Unfortunately it's been launching the executable regardless of whether the compilation succeeds, creating confusion.
That's fixed now. A small edit also had to be made to the makefile to propagate the "make standard" error code to the "make all" request.
![Untitled](https://github.com/dkfans/keeperfx/assets/15337628/d3ed8aae-e23e-4c61-9477-a8ad69b286ab)
