### PR TITLE
VSCode debugging

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,7 +11,7 @@
             "cppStandard": "gnu++17",
             "intelliSenseMode": "windows-gcc-x86",
             //"configurationProvider": "ms-vscode.makefile-tools",
-            "compileCommands": "${workspaceFolder}/compile_commands.json",
+            //"compileCommands": "${workspaceFolder}/compile_commands.json",
         }
     ],
     "version": 4

--- a/.vscode/defaultlaunch
+++ b/.vscode/defaultlaunch
@@ -1,9 +1,11 @@
+// Please edit the "program" and "cwd" fields with your game directory.
+// Edit "args" to set the level and campaign you want to load.
 {
     "version": "0.2.0",
     "configurations": [
         {
-            "program": "${config:game_directory}keeperfx.exe",
-            "cwd": "${config:game_directory}",
+            "program": "D:/DungeonKeeper/keeperfx.exe",
+            "cwd": "D:/DungeonKeeper/",
             "args": [
                 "-level", "00001",
                 "-campaign", "keeporig",

--- a/.vscode/defaultlaunch
+++ b/.vscode/defaultlaunch
@@ -1,0 +1,38 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "program": "${config:game_directory}keeperfx.exe",
+            "cwd": "${config:game_directory}",
+            "args": [
+                "-level", "00033",
+                "-campaign", "personal",
+                "-nointro","-alex", "-nocd"
+            ],
+            "name": "Launch keeperfx.exe",
+            "preLaunchTask": "Compile, Copy Files",
+            "type": "cppdbg",
+            "request": "launch",
+            "externalConsole": true,
+            "stopAtEntry": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "gdb",
+            "internalConsoleOptions": "openOnSessionStart",
+            "logging": {
+                "moduleLoad": false
+            },
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/defaultlaunch
+++ b/.vscode/defaultlaunch
@@ -11,22 +11,27 @@
                 "-campaign", "keeporig",
                 "-nointro","-alex", "-nocd"
             ],
+            "windows": {
+                "miDebuggerPath": "${workspaceFolder}/.vscode/gdb.exe"
+            },
+            "linux": {
+                "miDebuggerPath": "winegdb"
+            },
+            "setupCommands": [
+                {"description": "Enable pretty-printing for gdb", "text": "-enable-pretty-printing", "ignoreFailures": true},
+                {"description": "Set Disassembly Flavor to Intel", "text": "-gdb-set disassembly-flavor intel", "ignoreFailures": true}
+            ],
+            "MIMode": "gdb",
             "name": "Compile, Copy Files, Launch keeperfx.exe",
             "preLaunchTask": "Compile, Copy Files",
             "type": "cppdbg",
             "request": "launch",
             "externalConsole": true,
             "stopAtEntry": false,
-            "MIMode": "gdb",
-            "miDebuggerPath": "${workspaceFolder}/.vscode/gdb.exe",
             "internalConsoleOptions": "openOnSessionStart",
             "logging": {
                 "moduleLoad": false
-            },
-            "setupCommands": [
-                {"description": "Enable pretty-printing for gdb", "text": "-enable-pretty-printing", "ignoreFailures": true},
-                {"description": "Set Disassembly Flavor to Intel", "text": "-gdb-set disassembly-flavor intel", "ignoreFailures": true}
-            ]
+            }
         }
     ],
     "inputs": [

--- a/.vscode/defaultlaunch
+++ b/.vscode/defaultlaunch
@@ -5,11 +5,11 @@
             "program": "${config:game_directory}keeperfx.exe",
             "cwd": "${config:game_directory}",
             "args": [
-                "-level", "00033",
-                "-campaign", "personal",
+                "-level", "00001",
+                "-campaign", "keeporig",
                 "-nointro","-alex", "-nocd"
             ],
-            "name": "Launch keeperfx.exe",
+            "name": "Compile, Copy Files, Launch keeperfx.exe",
             "preLaunchTask": "Compile, Copy Files",
             "type": "cppdbg",
             "request": "launch",
@@ -22,17 +22,18 @@
                 "moduleLoad": false
             },
             "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "Set Disassembly Flavor to Intel",
-                    "text": "-gdb-set disassembly-flavor intel",
-                    "ignoreFailures": true
-                }
+                {"description": "Enable pretty-printing for gdb", "text": "-enable-pretty-printing", "ignoreFailures": true},
+                {"description": "Set Disassembly Flavor to Intel", "text": "-gdb-set disassembly-flavor intel", "ignoreFailures": true}
             ]
+        }
+    ],
+    "inputs": [
+        {
+            "id": "compileOptions",
+            "type": "pickString",
+            "description": "Choose compile options:",
+            "options": ["make all -j8 DEBUG=1", "make all -j8"],
+            "default": "make all -j8 DEBUG=1"
         }
     ]
 }

--- a/.vscode/defaultlaunch
+++ b/.vscode/defaultlaunch
@@ -16,7 +16,7 @@
             "externalConsole": true,
             "stopAtEntry": false,
             "MIMode": "gdb",
-            "miDebuggerPath": "gdb",
+            "miDebuggerPath": "${workspaceFolder}/.vscode/gdb.exe",
             "internalConsoleOptions": "openOnSessionStart",
             "logging": {
                 "moduleLoad": false

--- a/.vscode/defaultlinuxscript
+++ b/.vscode/defaultlinuxscript
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+test

--- a/.vscode/defaultlinuxscript
+++ b/.vscode/defaultlinuxscript
@@ -2,7 +2,6 @@
 game_directory="/home/bot/.wine/drive_c/dk/"
 game_arguments="-level 00001 -campaign keeporig -nointro -alex -altinput"
 workspaceFolder="$1"
-debugOption="$2"
 
 echo "Source Code directory: $workspaceFolder"
 
@@ -13,11 +12,7 @@ fi
 
 echo "Game directory: $game_directory"
 
-if [ "$debugOption" == "Fast compile with DEBUG=1" ]; then
-    make all -j$(nproc) DEBUG=1
-else
-    make all -j$(nproc)
-fi
+make all -j$(nproc) DEBUG=1
 
 if [ $? -eq 0 ]; then
     echo 'Compilation successful!'

--- a/.vscode/defaultlinuxscript
+++ b/.vscode/defaultlinuxscript
@@ -1,6 +1,6 @@
 #!/bin/bash
 game_directory="/home/bot/.wine/drive_c/dk/"
-
+game_arguments="-level 00001 -campaign keeporig -nointro -alex -altinput"
 workspaceFolder="$1"
 debugOption="$2"
 
@@ -29,4 +29,9 @@ fi
 cp $workspaceFolder/bin/* "$game_directory"
 
 cd $game_directory
-wine winedbg --gdb keeperfx.exe
+
+# Use winedbg instead of wine if you want to see the line number that causes the crash. However, normal wine will launch the game faster.
+# When launching with winedbg, press 'C' then 'Enter' when prompted.
+
+#wine keeperfx.exe $game_arguments
+winedbg --gdb keeperfx.exe $game_arguments

--- a/.vscode/defaultlinuxscript
+++ b/.vscode/defaultlinuxscript
@@ -1,3 +1,32 @@
 #!/bin/bash
+game_directory="/home/bot/.wine/drive_c/dk/"
 
-test
+workspaceFolder="$1"
+debugOption="$2"
+
+echo "Source Code directory: $workspaceFolder"
+
+if [ ! -d "$game_directory" ]; then
+    echo 'The game_directory is incorrect, please edit it to match your game installation.'
+    exit 1
+fi
+
+echo "Game directory: $game_directory"
+
+if [ "$debugOption" == "Fast compile with DEBUG=1" ]; then
+    make all -j$(nproc) DEBUG=1
+else
+    make all -j$(nproc)
+fi
+
+if [ $? -eq 0 ]; then
+    echo 'Compilation successful!'
+else
+    echo 'Compilation failed!'
+    exit 1
+fi
+
+cp $workspaceFolder/bin/* "$game_directory"
+
+cd $game_directory
+wine winedbg --gdb keeperfx.exe

--- a/.vscode/defaultsettings
+++ b/.vscode/defaultsettings
@@ -1,3 +1,7 @@
 {
-	"C_Cpp.intelliSenseEngine": "disabled"
+	"C_Cpp.intelliSenseEngine": "disabled",
+	"files.associations": {
+		"defaultlaunch": "jsonc",
+		"defaultsettings": "jsonc"
+	}
 }

--- a/.vscode/defaultsettings
+++ b/.vscode/defaultsettings
@@ -1,5 +1,5 @@
 {
-	"C_Cpp.intelliSenseEngine": "disabled",
+	"C_Cpp.intelliSenseEngine": "default",
 	"files.associations": {
 		"defaultlaunch": "jsonc",
 		"defaultsettings": "jsonc",

--- a/.vscode/defaultsettings
+++ b/.vscode/defaultsettings
@@ -1,0 +1,5 @@
+{
+	"game_directory": "/path/goes/here/",
+	"game_arguments": "-level 00001 -campaign keeporig -nointro -alex -altinput",
+	"C_Cpp.intelliSenseEngine": "disabled"
+}

--- a/.vscode/defaultsettings
+++ b/.vscode/defaultsettings
@@ -1,5 +1,3 @@
 {
-	"game_directory": "/path/goes/here/",
-	"game_arguments": "-level 00001 -campaign keeporig -nointro -alex -altinput",
 	"C_Cpp.intelliSenseEngine": "disabled"
 }

--- a/.vscode/defaultsettings
+++ b/.vscode/defaultsettings
@@ -3,5 +3,9 @@
 	"files.associations": {
 		"defaultlaunch": "jsonc",
 		"defaultsettings": "jsonc"
-	}
+	},
+	"files.exclude": {
+        "**/.vscode/defaultlaunch": true,
+		"**/.vscode/defaultsettings": true
+    }
 }

--- a/.vscode/defaultsettings
+++ b/.vscode/defaultsettings
@@ -3,12 +3,12 @@
 	"files.associations": {
 		"defaultlaunch": "jsonc",
 		"defaultsettings": "jsonc",
-		"defaultlinuxscript": "jsonc"
+		"defaultlinuxscript": "bash"
 	},
 	"files.exclude": {
         "**/.vscode/defaultlaunch": true,
 		"**/.vscode/defaultsettings": true,
-		"**/.vscode/defaultlinuxscript": true
+		"**/.vscode/defaultlinuxscript": false
     },
 	"search.exclude": {
 		"**/.git": true,

--- a/.vscode/defaultsettings
+++ b/.vscode/defaultsettings
@@ -9,5 +9,14 @@
         "**/.vscode/defaultlaunch": true,
 		"**/.vscode/defaultsettings": true,
 		"**/.vscode/defaultlinuxscript": true
-    }
+    },
+	"search.exclude": {
+		"**/.git": true,
+		"**/.gitmodules": true,
+		"**/.github": true,
+		"**/deps": true,
+		"**/obj": true,
+		"**/sdl": true,
+		"**/tests": true
+	}
 }

--- a/.vscode/defaultsettings
+++ b/.vscode/defaultsettings
@@ -2,10 +2,12 @@
 	"C_Cpp.intelliSenseEngine": "disabled",
 	"files.associations": {
 		"defaultlaunch": "jsonc",
-		"defaultsettings": "jsonc"
+		"defaultsettings": "jsonc",
+		"defaultlinuxscript": "jsonc"
 	},
 	"files.exclude": {
         "**/.vscode/defaultlaunch": true,
-		"**/.vscode/defaultsettings": true
+		"**/.vscode/defaultsettings": true,
+		"**/.vscode/defaultlinuxscript": true
     }
 }

--- a/.vscode/defaultuser
+++ b/.vscode/defaultuser
@@ -1,4 +1,0 @@
-{
-	"game_directory": "/path/goes/here/",
-	"game_arguments": "-level 00001 -campaign keeporig -nointro -alex -altinput"
-}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
 	"recommendations": [
 		"ms-vscode.cpptools",
-		"llvm-vs-code-extensions.vscode-clangd",
 	],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"C_Cpp.intelliSenseEngine": "disabled",
-}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,11 @@
 					"    exit 1;",
 					"}",
 					"Write-Host ('Game directory: ' + $gameDir) -ForegroundColor White;",
-					"wsl make -j`nproc` DEBUG=1 all;",
+					"if ('${input:debugOption}' -eq 'Fast compile with DEBUG=1') {",
+					"    wsl make all -j`nproc` DEBUG=1;",
+					"} else {",
+					"    wsl make all -j`nproc`;",
+					"}",
 					"if ($?) {",
 					"    Write-Host 'Compilation successful!' -ForegroundColor Green;",
 					"} else {",
@@ -25,22 +29,6 @@
 					"copy \"${workspaceFolder}\\bin\\*\" \"$gameDir\";",
 				],
 			},
-			"linux": {
-				"command": [
-					"if [ ! -f \"${workspaceFolder}/.vscode/settings.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultsettings\" \"${workspaceFolder}/.vscode/settings.json\" && echo \"/.vscode/settings.json was created, please edit it and fill in your game directory.\"; fi;",
-					"echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m';",
-					"if [ ! -d \"$game_directory\" ]; then echo -e '\\033[0;91mGame directory missing in .vscode/settings.json. Please edit the file and update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_directory '\\033[0m'; fi;",
-					"make -j`nproc` all;",
-					"if [ $? -eq 0 ]; then",
-					"    echo -e '\\033[0;32mCompilation successful!\\033[0m';",
-					"    cd \"$game_directory\" && cp \"${workspaceFolder}/bin/\"* .;",
-					"    if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe $game_arguments\"; else wine 'keeperfx.exe' $game_arguments; fi;",
-					"else",
-					"    echo -e '\\033[0;91mCompilation failed!\\033[0m';",
-					"    exit 1;",
-					"fi"
-				]
-			},
 			"options": {
 				"env": {
 					"game_directory": "${config:game_directory}",
@@ -48,10 +36,7 @@
 				}
 			},
 			"problemMatcher": "$gcc",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
+			"group": {"kind": "build","isDefault": true},
 			"presentation": {
 				"clear": true,
 				"echo": false,
@@ -60,6 +45,7 @@
 				"panel": "shared",
 				"showReuseMessage": false
 			}
+			
 		},
 		{
 			// After the project is first opened, settings.json and launch.json will be created
@@ -84,13 +70,8 @@
 					"}"
 				]
 			},
-			"linux": {
-				"command": "if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi; if [ ! -f \"${workspaceFolder}/.vscode/launch.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultlaunch\" \"${workspaceFolder}/.vscode/launch.json\" && echo \"/.vscode/launch.json was created.\"; fi"
-			},
 			"problemMatcher": "$gcc",
-			"runOptions": {
-				"runOn": "folderOpen"
-			},
+			"runOptions": {"runOn": "folderOpen"},
 			"group": "build",
 			"presentation": {
 				"echo": false,
@@ -110,9 +91,6 @@
 					"Get-Content keeperfx.log -Wait"
 				]
 			},
-			"linux": {
-				"command": "game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && > keeperfx.log && less +F --mouse keeperfx.log"
-			},
 			"problemMatcher": "$gcc",
 			"dependsOn": "Check For Game Directory",
 			"group": "build"
@@ -121,10 +99,7 @@
 			"label": "Clean",
 			"type": "shell",
 			"windows": {
-				"command": "wsl make -j`nproc` clean"
-			},
-			"linux": {
-				"command": "make -j`nproc` clean"
+				"command": "wsl make clean -j`nproc`"
 			},
 			"problemMatcher": "$gcc",
 			"group": "build"
@@ -138,12 +113,18 @@
 					"wsl bear -- make -j2 standard"
 				]
 			},
-			"linux": {
-				"command": "make clean-build clean-tools && bear -- make -j2 standard"
-			},
 			"problemMatcher": "$gcc",
 			"group": "build",
 			"dependsOn": "Compile",
 		}
-	]
+	],
+	"inputs": [
+        {
+            "id": "debugOption",
+            "type": "pickString",
+            "description": "Choose compile options:",
+            "options": ["Fast compile with DEBUG=1", "Compile"],
+            "default": "Fast compile with DEBUG=1"
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,8 +7,8 @@
 			"windows": {
 				"command": [
 					"Write-Host ('Source Code directory: ' + '${workspaceFolder}'.Replace('\\', '/')) -ForegroundColor White;",
-					"$cleanedJson = Get-Content '${workspaceFolder}\\.vscode\\launch.json' | Where-Object { $_ -notmatch '^\\s*//' };",
-				    "$gameDir = ($cleanedJson | Out-String | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
+    				"$cleanedJson = (Get-Content -Raw '${workspaceFolder}\\.vscode\\launch.json' | ForEach-Object {$_ -replace ',\\s*}', '}' -replace '(?m)^\\s*//.*$', ''} | ConvertFrom-Json | ConvertTo-Json -Depth 100);",
+					"$gameDir = ($cleanedJson | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
 					"if (-not (Test-Path $gameDir)) {",
 					"    Write-Host 'The directories are incorrect in /.vscode/launch.json, please edit the file and update it.' -ForegroundColor Red;",
 					"    Write-Host 'Example: D:/Games/DungeonKeeper/ (be sure to use forward slashes)' -ForegroundColor Red;",
@@ -57,6 +57,19 @@
 					"}"
 				]
 			},
+			"linux": {
+				"command": [
+					"settingsPath='${workspaceFolder}/.vscode/settings.json';",
+					"if [ ! -f $settingsPath ]; then",
+					"    cp '${workspaceFolder}/.vscode/defaultsettings' $settingsPath;",
+					"    echo '/.vscode/settings.json was created.';",
+					"fi;",
+					"if [ ! -f '${workspaceFolder}/.vscode/launch.json' ]; then",
+					"    cp '${workspaceFolder}/.vscode/defaultlaunch' '${workspaceFolder}/.vscode/launch.json';",
+					"    echo '/.vscode/launch.json was created, please edit it and fill in your game directories.';",
+					"fi"
+				]
+			},
 			"problemMatcher": "$gcc",
 			"runOptions": {"runOn": "folderOpen"},
 			"group": "build",
@@ -72,8 +85,8 @@
 			"type": "shell",
 			"windows": {
 				"command": [
-					"$cleanedJson = Get-Content '${workspaceFolder}\\.vscode\\launch.json' | Where-Object { $_ -notmatch '^\\s*//' };",
-				    "$gameDir = ($cleanedJson | Out-String | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
+					"$cleanedJson = (Get-Content -Raw '${workspaceFolder}\\.vscode\\launch.json' | ForEach-Object {$_ -replace ',\\s*}', '}' -replace '(?m)^\\s*//.*$', ''} | ConvertFrom-Json | ConvertTo-Json -Depth 100);",
+					"$gameDir = ($cleanedJson | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
 					"cd $gameDir;",
 					"Clear-Content keeperfx.log;",
 					"Get-Content keeperfx.log -Wait"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,6 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			// For Linux users
 			"label": "Default task",
 			"type": "shell",
 			"windows": {
@@ -13,7 +12,7 @@
 			"linux": {
 				"command": [
 					"chmod +x '${workspaceFolder}/.vscode/linuxscript.sh';",
-					"'${workspaceFolder}/.vscode/linuxscript.sh' '${workspaceFolder}' '${input:debugOption}'"
+					"'${workspaceFolder}/.vscode/linuxscript.sh' '${workspaceFolder}'"
 				]
 			},
 			"problemMatcher": "$gcc",
@@ -42,11 +41,7 @@
 					"    exit 1;",
 					"}",
 					"Write-Host ('Game directory: ' + $gameDir) -ForegroundColor White;",
-					"if ('${input:debugOption}' -eq 'Fast compile with DEBUG=1') {",
-					"    wsl make all -j`nproc` DEBUG=1;",
-					"} else {",
-					"    wsl make all -j`nproc`;",
-					"}",
+					"wsl make all -j`nproc` DEBUG=1;",
 					"if ($?) {",
 					"    Write-Host 'Compilation successful!' -ForegroundColor Green;",
 					"} else {",
@@ -157,13 +152,4 @@
 			"dependsOn": "Compile",
 		}
 	],
-	"inputs": [
-        {
-            "id": "debugOption",
-            "type": "pickString",
-            "description": "Choose compile options:",
-            "options": ["Fast compile with DEBUG=1", "Compile"],
-            "default": "Fast compile with DEBUG=1"
-        }
-    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,33 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+			// For Linux users
+			"label": "Default task",
+			"type": "shell",
+			"windows": {
+				"command": [
+					"Write-Host 'Windows users should press F5 to compile and run the game.' -ForegroundColor White;"
+				],
+			},
+			"linux": {
+				"command": [
+					"chmod +x '${workspaceFolder}/.vscode/linuxscript.sh';",
+					"'${workspaceFolder}/.vscode/linuxscript.sh'"
+				]
+			},
+			"problemMatcher": "$gcc",
+			"group": {"kind": "build","isDefault": true},
+			"presentation": {
+				"clear": true,
+				"echo": false,
+				"reveal": "always",
+				"focus": true,
+				"panel": "shared",
+				"showReuseMessage": false
+			}
+		},
+		{
+			// Called by launch.json
 			"label": "Compile, Copy Files",
 			"type": "shell",
 			"windows": {
@@ -29,8 +56,9 @@
 					"copy \"${workspaceFolder}\\bin\\*\" \"$gameDir\";",
 				],
 			},
+			"linux": {"command": []},
 			"problemMatcher": "$gcc",
-			"group": {"kind": "build","isDefault": true},
+			"group": "build",
 			"presentation": {
 				"clear": true,
 				"echo": false,
@@ -66,7 +94,11 @@
 					"fi;",
 					"if [ ! -f '${workspaceFolder}/.vscode/launch.json' ]; then",
 					"    cp '${workspaceFolder}/.vscode/defaultlaunch' '${workspaceFolder}/.vscode/launch.json';",
-					"    echo '/.vscode/launch.json was created, please edit it and fill in your game directories.';",
+					"    echo '/.vscode/launch.json was created, but it won't work on linux. Use Ctrl+Shift+B instead.';",
+					"fi;",
+					"if [ ! -f '${workspaceFolder}/.vscode/linuxscript.sh' ]; then",
+					"    cp '${workspaceFolder}/.vscode/defaultlinuxscript' '${workspaceFolder}/.vscode/linuxscript.json';",
+					"    echo '/.vscode/linuxscript.json was created, please edit it and fill in your game directories.';",
 					"fi"
 				]
 			},
@@ -92,6 +124,7 @@
 					"Get-Content keeperfx.log -Wait"
 				]
 			},
+			"linux": {},
 			"problemMatcher": "$gcc",
 			"dependsOn": "Check For Game Directory",
 			"group": "build"
@@ -101,6 +134,9 @@
 			"type": "shell",
 			"windows": {
 				"command": "wsl make clean -j`nproc`"
+			},
+			"linux": {
+				"command": "make clean -j`nproc`"
 			},
 			"problemMatcher": "$gcc",
 			"group": "build"
@@ -113,6 +149,9 @@
 					"wsl make clean-build clean-tools;",
 					"wsl bear -- make -j2 standard"
 				]
+			},
+			"linux": {
+				"command": "make clean-build clean-tools && bear -- make -j2 standard"
 			},
 			"problemMatcher": "$gcc",
 			"group": "build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
 			"linux": {
 				"command": [
 					"chmod +x '${workspaceFolder}/.vscode/linuxscript.sh';",
-					"'${workspaceFolder}/.vscode/linuxscript.sh'"
+					"'${workspaceFolder}/.vscode/linuxscript.sh' '${workspaceFolder}' '${input:debugOption}'"
 				]
 			},
 			"problemMatcher": "$gcc",
@@ -87,18 +87,17 @@
 			},
 			"linux": {
 				"command": [
-					"settingsPath='${workspaceFolder}/.vscode/settings.json';",
-					"if [ ! -f $settingsPath ]; then",
-					"    cp '${workspaceFolder}/.vscode/defaultsettings' $settingsPath;",
-					"    echo '/.vscode/settings.json was created.';",
+					"if [ ! -f \"${workspaceFolder}/.vscode/settings.json\" ]; then",
+					"    cp \"${workspaceFolder}/.vscode/defaultsettings\" \"${workspaceFolder}/.vscode/settings.json\";",
+					"    echo \"/.vscode/settings.json was created.\";",
 					"fi;",
-					"if [ ! -f '${workspaceFolder}/.vscode/launch.json' ]; then",
-					"    cp '${workspaceFolder}/.vscode/defaultlaunch' '${workspaceFolder}/.vscode/launch.json';",
-					"    echo '/.vscode/launch.json was created, but it won't work on linux. Use Ctrl+Shift+B instead.';",
+					"if [ ! -f \"${workspaceFolder}/.vscode/launch.json\" ]; then",
+					"    cp \"${workspaceFolder}/.vscode/defaultlaunch\" \"${workspaceFolder}/.vscode/launch.json\";",
+					"    echo \"/.vscode/launch.json was created, but it won't work on linux. Use Ctrl+Shift+B instead.\";",
 					"fi;",
-					"if [ ! -f '${workspaceFolder}/.vscode/linuxscript.sh' ]; then",
-					"    cp '${workspaceFolder}/.vscode/defaultlinuxscript' '${workspaceFolder}/.vscode/linuxscript.json';",
-					"    echo '/.vscode/linuxscript.json was created, please edit it and fill in your game directories.';",
+					"if [ ! -f \"${workspaceFolder}/.vscode/linuxscript.sh\" ]; then",
+					"    cp \"${workspaceFolder}/.vscode/defaultlinuxscript\" \"${workspaceFolder}/.vscode/linuxscript.sh\";",
+					"    echo \"/.vscode/linuxscript.sh was created, please edit it and fill in your game directories.\";",
 					"fi"
 				]
 			},

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,8 @@
 			"windows": {
 				"command": [
 					"Write-Host ('Source Code directory: ' + '${workspaceFolder}'.Replace('\\', '/')) -ForegroundColor White;",
-					"$gameDir = (Get-Content '${workspaceFolder}\\.vscode\\launch.json' | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
+					"$cleanedJson = Get-Content '${workspaceFolder}\\.vscode\\launch.json' | Where-Object { $_ -notmatch '^\\s*//' };",
+				    "$gameDir = ($cleanedJson | Out-String | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
 					"if (-not (Test-Path $gameDir)) {",
 					"    Write-Host 'The directories are incorrect in /.vscode/launch.json, please edit the file and update it.' -ForegroundColor Red;",
 					"    Write-Host 'Example: D:/Games/DungeonKeeper/ (be sure to use forward slashes)' -ForegroundColor Red;",
@@ -71,7 +72,8 @@
 			"type": "shell",
 			"windows": {
 				"command": [
-					"$gameDir = (Get-Content '${workspaceFolder}\\.vscode\\launch.json' | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
+					"$cleanedJson = Get-Content '${workspaceFolder}\\.vscode\\launch.json' | Where-Object { $_ -notmatch '^\\s*//' };",
+				    "$gameDir = ($cleanedJson | Out-String | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
 					"cd $gameDir;",
 					"Clear-Content keeperfx.log;",
 					"Get-Content keeperfx.log -Wait"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,11 +6,10 @@
 			"type": "shell",
 			"windows": {
 				"command": [
-					"git rm --cached .vscode/settings.json;",
 					"Write-Host ('Source Code directory: ' + '${workspaceFolder}'.Replace('\\', '/')) -ForegroundColor White;",
-					"$gameDir = $env:game_directory.TrimEnd('\\');",
+					"$gameDir = (Get-Content '${workspaceFolder}\\.vscode\\launch.json' | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
 					"if (-not (Test-Path $gameDir)) {",
-					"    Write-Host 'The game directory is incorrect in /.vscode/settings.json, please edit the file and update it.' -ForegroundColor Red;",
+					"    Write-Host 'The directories are incorrect in /.vscode/launch.json, please edit the file and update it.' -ForegroundColor Red;",
 					"    Write-Host 'Example: D:/Games/DungeonKeeper/ (be sure to use forward slashes)' -ForegroundColor Red;",
 					"    exit 1;",
 					"}",
@@ -29,12 +28,6 @@
 					"copy \"${workspaceFolder}\\bin\\*\" \"$gameDir\";",
 				],
 			},
-			"options": {
-				"env": {
-					"game_directory": "${config:game_directory}",
-					"game_arguments": "${config:game_arguments}",
-				}
-			},
 			"problemMatcher": "$gcc",
 			"group": {"kind": "build","isDefault": true},
 			"presentation": {
@@ -45,7 +38,6 @@
 				"panel": "shared",
 				"showReuseMessage": false
 			}
-			
 		},
 		{
 			// After the project is first opened, settings.json and launch.json will be created
@@ -53,20 +45,14 @@
 			"type": "shell",
 			"windows": {
 				"command": [
-					"git rm --cached .vscode/settings.json;",
 					"$settingsPath = '${workspaceFolder}\\.vscode\\settings.json';",
 					"if (-not (Test-Path $settingsPath)) {",
 					"    Copy-Item '${workspaceFolder}\\.vscode\\defaultsettings' $settingsPath;",
-					"    Write-Host '/.vscode/settings.json was created, please edit it and fill in your game directory.';",
-					"}",
-					"$settingsContent = Get-Content $settingsPath | ConvertFrom-Json;",
-					"if ($null -eq $settingsContent.game_directory) {",
-					"    Copy-Item '${workspaceFolder}\\.vscode\\defaultsettings' $settingsPath -Force;",
-					"    Write-Host 'The outdated /.vscode/settings.json was missing the game_directory field. It has been replaced with the default settings. Please edit it and fill in your game directory.';",
+					"    Write-Host '/.vscode/settings.json was created.';",
 					"}",
 					"if (-not (Test-Path '${workspaceFolder}\\.vscode\\launch.json')) {",
 					"    Copy-Item '${workspaceFolder}\\.vscode\\defaultlaunch' '${workspaceFolder}\\.vscode\\launch.json';",
-					"    Write-Host '/.vscode/launch.json was created.';",
+					"    Write-Host '/.vscode/launch.json was created, please edit it and fill in your game directories.';",
 					"}"
 				]
 			},
@@ -85,7 +71,7 @@
 			"type": "shell",
 			"windows": {
 				"command": [
-					"$gameDir = (Get-Content '${workspaceFolder}\\.vscode\\user.json' | ConvertFrom-Json).game_directory;",
+					"$gameDir = (Get-Content '${workspaceFolder}\\.vscode\\launch.json' | ConvertFrom-Json).configurations[0].cwd.TrimEnd('\\');",
 					"cd $gameDir;",
 					"Clear-Content keeperfx.log;",
 					"Get-Content keeperfx.log -Wait"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,52 +2,50 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "Compile, Copy Files, Launch",
+			"label": "Compile, Copy Files",
 			"type": "shell",
 			"windows": {
 				"command": [
+					"git rm --cached .vscode/settings.json;",
 					"Write-Host ('Source Code directory: ' + '${workspaceFolder}'.Replace('\\', '/')) -ForegroundColor White;",
-					"$jsonContent = Get-Content '${workspaceFolder}\\.vscode\\user.json' | ConvertFrom-Json;",
-					"$gameDir = ($jsonContent | Select-Object -ExpandProperty game_directory).TrimEnd('\\');",
+					"$gameDir = $env:game_directory.TrimEnd('\\');",
 					"if (-not (Test-Path $gameDir)) {",
-					"    Write-Host 'Game directory missing in /.vscode/user.json, please edit the file and update it.' -ForegroundColor Red;",
+					"    Write-Host 'The game directory is incorrect in /.vscode/settings.json, please edit the file and update it.' -ForegroundColor Red;",
 					"    Write-Host 'Example: D:/Games/DungeonKeeper/ (be sure to use forward slashes)' -ForegroundColor Red;",
-					"    return;",
-					"} else {",
-					"    Write-Host ('Game directory: ' + $gameDir) -ForegroundColor White;",
+					"    exit 1;",
 					"}",
-					"wsl make -j`nproc` all;",
+					"Write-Host ('Game directory: ' + $gameDir) -ForegroundColor White;",
+					"wsl make -j`nproc` DEBUG=1 all;",
 					"if ($?) {",
 					"    Write-Host 'Compilation successful!' -ForegroundColor Green;",
 					"} else {",
 					"    Write-Host 'Compilation failed!' -ForegroundColor Red;",
-					"    return;",
-					"}",
-					"Stop-Process -Name 'keeperfx' -ErrorAction SilentlyContinue;",
-					"while (Get-Process -Name 'keeperfx' -ErrorAction SilentlyContinue) {",
-					"   Start-Sleep -Milliseconds 10;",
+					"    exit 1;",
 					"}",
 					"copy \"${workspaceFolder}\\bin\\*\" \"$gameDir\";",
-					"$gameArgs = $jsonContent.game_arguments;",
-					"cd \"$gameDir\";",
-					"Start-Process keeperfx.exe -ArgumentList \"$gameArgs\""
-				]
+				],
 			},
 			"linux": {
 				"command": [
-					"if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi;",
-					"jq --version > /dev/null 2>&1 || { echo -e '\\033[0;91mError: jq is not installed. Please install it using: sudo apt-get install jq\\033[0m'; exit 1; };",
-					"echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m'; game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); if [ ! -d \"$game_dir\" ]; then echo -e '\\033[0;91mGame directory missing in .vscode/user.json. Please edit the file and update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_dir '\\033[0m'; fi;",
+					"if [ ! -f \"${workspaceFolder}/.vscode/settings.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultsettings\" \"${workspaceFolder}/.vscode/settings.json\" && echo \"/.vscode/settings.json was created, please edit it and fill in your game directory.\"; fi;",
+					"echo -e '\\033[0;97mSource Code directory: ${workspaceFolder}\\033[0m';",
+					"if [ ! -d \"$game_directory\" ]; then echo -e '\\033[0;91mGame directory missing in .vscode/settings.json. Please edit the file and update it.\\033[0m'; exit 1; else echo -e '\\033[0;97mGame directory: ' $game_directory '\\033[0m'; fi;",
 					"make -j`nproc` all;",
 					"if [ $? -eq 0 ]; then",
 					"    echo -e '\\033[0;32mCompilation successful!\\033[0m';",
-					"    game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && cp \"${workspaceFolder}/bin/\"* .;",
-					"    game_dir=$(jq -r '.game_directory' ${workspaceFolder}/.vscode/user.json); game_args=$(jq -r '.game_arguments' ${workspaceFolder}/.vscode/user.json); cd \"$game_dir\" && if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe $game_args\"; else wine 'keeperfx.exe' $game_args; fi;",
+					"    cd \"$game_directory\" && cp \"${workspaceFolder}/bin/\"* .;",
+					"    if [ -n \"$WSL_DISTRO_NAME\" ]; then cmd.exe /C \"keeperfx.exe $game_arguments\"; else wine 'keeperfx.exe' $game_arguments; fi;",
 					"else",
 					"    echo -e '\\033[0;91mCompilation failed!\\033[0m';",
-					"    exit 0;",
+					"    exit 1;",
 					"fi"
 				]
+			},
+			"options": {
+				"env": {
+					"game_directory": "${config:game_directory}",
+					"game_arguments": "${config:game_arguments}",
+				}
 			},
 			"problemMatcher": "$gcc",
 			"group": {
@@ -55,6 +53,7 @@
 				"isDefault": true
 			},
 			"presentation": {
+				"clear": true,
 				"echo": false,
 				"reveal": "always",
 				"focus": true,
@@ -63,19 +62,30 @@
 			}
 		},
 		{
-			// After the project is first opened, user.json will be created
-			"label": "Create user.json",
+			// After the project is first opened, settings.json and launch.json will be created
+			"label": "Create settings.json and launch.json",
 			"type": "shell",
 			"windows": {
 				"command": [
-					"if (-not (Test-Path '${workspaceFolder}\\.vscode\\user.json')) {",
-					"    Copy-Item '${workspaceFolder}\\.vscode\\defaultuser' '${workspaceFolder}\\.vscode\\user.json';",
-					"    Write-Host '/.vscode/user.json was created, please edit it and fill in your game directory.';",
+					"git rm --cached .vscode/settings.json;",
+					"$settingsPath = '${workspaceFolder}\\.vscode\\settings.json';",
+					"if (-not (Test-Path $settingsPath)) {",
+					"    Copy-Item '${workspaceFolder}\\.vscode\\defaultsettings' $settingsPath;",
+					"    Write-Host '/.vscode/settings.json was created, please edit it and fill in your game directory.';",
+					"}",
+					"$settingsContent = Get-Content $settingsPath | ConvertFrom-Json;",
+					"if ($null -eq $settingsContent.game_directory) {",
+					"    Copy-Item '${workspaceFolder}\\.vscode\\defaultsettings' $settingsPath -Force;",
+					"    Write-Host 'The outdated /.vscode/settings.json was missing the game_directory field. It has been replaced with the default settings. Please edit it and fill in your game directory.';",
+					"}",
+					"if (-not (Test-Path '${workspaceFolder}\\.vscode\\launch.json')) {",
+					"    Copy-Item '${workspaceFolder}\\.vscode\\defaultlaunch' '${workspaceFolder}\\.vscode\\launch.json';",
+					"    Write-Host '/.vscode/launch.json was created.';",
 					"}"
 				]
 			},
 			"linux": {
-				"command": "if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi"
+				"command": "if [ ! -f \"${workspaceFolder}/.vscode/user.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultuser\" \"${workspaceFolder}/.vscode/user.json\" && echo \"/.vscode/user.json was created, please edit it and fill in your game directory.\"; fi; if [ ! -f \"${workspaceFolder}/.vscode/launch.json\" ]; then cp \"${workspaceFolder}/.vscode/defaultlaunch\" \"${workspaceFolder}/.vscode/launch.json\" && echo \"/.vscode/launch.json was created.\"; fi"
 			},
 			"problemMatcher": "$gcc",
 			"runOptions": {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3382,6 +3382,9 @@ TbBool keeper_wait_for_screen_focus(void)
 
 void gameplay_loop_logic()
 {
+    int* p = nullptr;
+    *p = 10;  // This will crash the program
+
     if (is_feature_on(Ft_DeltaTime) == true) {
         if (gameadd.process_turn_time < 1.0) {
             return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3382,9 +3382,6 @@ TbBool keeper_wait_for_screen_focus(void)
 
 void gameplay_loop_logic()
 {
-    int* p = nullptr;
-    *p = 10;  // This will crash the program
-
     if (is_feature_on(Ft_DeltaTime) == true) {
         if (gameadd.process_turn_time < 1.0) {
             return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1052,6 +1052,7 @@ short setup_game(void)
   {
       SYNCMSG("%s", &cpu_info.brand[0]);
   }
+  SYNCMSG("Build image base: %p", GetModuleHandle(NULL));
   v.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
   if (GetVersionEx(&v))
   {

--- a/src/music_player.c
+++ b/src/music_player.c
@@ -202,6 +202,7 @@ void music_reinit_after_load()
 
 void free_custom_music()
 {
+    if (exit_keeper == true) {return;}
     for (int i = (max_track + 1); i <= MUSIC_TRACKS_COUNT; i++)
     {
         Mix_Music *music = tracks[i];

--- a/src/music_player.c
+++ b/src/music_player.c
@@ -202,8 +202,7 @@ void music_reinit_after_load()
 
 void free_custom_music()
 {
-    if (exit_keeper == true) {return;}
-    for (int i = (max_track + 1); i <= MUSIC_TRACKS_COUNT; i++)
+    for (int i = (max_track + 1); i < MUSIC_TRACKS_COUNT; i++)
     {
         Mix_Music *music = tracks[i];
         if (music != NULL)

--- a/version.mk
+++ b/version.mk
@@ -1,5 +1,15 @@
-VER_MAJOR=0
-VER_MINOR=5
-VER_RELEASE=0
-VER_BUILD=3165
+ifeq ($(DEBUG), 1)
+	# Set version to 0.0.0.0 when compiling with DEBUG=1, to distinguish it from normal releases. DEBUG=1 makes the executable filesize huge when packing it with debug symbols.
+	VER_MAJOR=0
+	VER_MINOR=0
+	VER_RELEASE=0
+	VER_BUILD=0
+else
+	# Normal Versioning
+	VER_MAJOR=0
+	VER_MINOR=5
+	VER_RELEASE=0
+	VER_BUILD=3165
+endif
+
 PACKAGE_SUFFIX=


### PR DESCRIPTION
I've finally gotten gdb fully working (I only had it partially working before) and integrated with VSCode. The key part that took me a while to understand was to compile with `DEBUG=1` as an argument, like: `make -j8 DEBUG=1 all`. It now tells you the exact line which causes a crash.

`DEBUG=1` produces a much larger executable packed with debugger symbols, allowing the function names and line numbers to actually be read, and probably helps with whatever other features gdb has.

When you press F5 to run `launch.json`, it'll first run the `preLaunchTask: "Compile, Copy Files"` and if that succeeds then it'll launch the executable with debugging. Users need to edit and fill out `launch.json` with their game directories (or edit the linux script).

When there's a crash, the game executable stays open and to close it you have to press F5 twice, or `Shift`+`F5`.

That 3386 is the line number that caused the crash:
![Untitled](https://github.com/dkfans/keeperfx/assets/15337628/c1b7585a-3064-413a-abd8-2d21f1cad117)