### PR TITLE
makefile: DEBUG=1 argument now affects checksum for 'make all'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,8 @@ HEADER_CHECKSUM_FILE=.header_checksum
 
 all:
 	@start_time=$$(date +%s.%N); \
-	current_checksum=$$(find ./src/ -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 cksum | cksum | awk '{print $$1}'); \
+	get_header_cksum=$$(find ./src/ -type f \( -name "*.h" -o -name "*.hpp" \) -print0 | sort -z | xargs -0 cksum | cksum | awk '{print $$1}'); \
+	current_checksum=$$(echo $$get_header_cksum $(DEBUG) | cksum | awk '{print $$1}'); \
 	if [ ! -f $(HEADER_CHECKSUM_FILE) ] || [ "$$(cat $(HEADER_CHECKSUM_FILE))" != "$$current_checksum" ]; then \
 		$(MAKE) clean; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ INCFLAGS =
 CV2PDB := $(shell PATH=`pwd`:$$PATH command -v cv2pdb.exe 2> /dev/null)
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
-  OPTFLAGS = -march=i686 -Og -fno-omit-frame-pointer
+  OPTFLAGS = -march=i686 -fno-omit-frame-pointer -O0
   DBGFLAGS = -g -DDEBUG
 else
   # frame pointer is required for ASM code to work


### PR DESCRIPTION
The issue was when you typed `make all -j8` followed by `make all -j8 DEBUG=1`, or vice versa, it was not doing a full compile, which is necessary for inserting/removing the debugger symbols. `make clean` needs to be called first.

I've made it so cleaning is handled automatically when you switch between DEBUG=1 and normal. and DEBUG=1 now uses `-O0` instead of `-Og`