### PR TITLE
No longer scared of temple floor when sacrificing

### DIFF
--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -3460,7 +3460,7 @@ TbBool create_task_move_creature_to_pos(struct Computer2 *comp, const struct Thi
     ctask->move_to_pos.pos_86.y.val = pos.y.val;
     ctask->move_to_pos.pos_86.z.val = pos.z.val;
     ctask->move_to_pos.target_thing_idx = thing->index;
-    ctask->move_to_pos.target_state = CrSt_CreatureSacrifice;
+    ctask->move_to_pos.target_state = dst_state;
     ctask->created_turn = game.play_gameturn;
     return true;
 }

--- a/src/player_computer.h
+++ b/src/player_computer.h
@@ -440,7 +440,7 @@ struct ComputerTask { // sizeof = 148
         short word_78;
         short field_7Ac;
         long repeat_num;
-        short word_80;
+        short target_state;
         short word_82;
         unsigned char field_84[2];
         struct Coord3d pos_86;


### PR DESCRIPTION
A recent bugfix made computers avoid temples and portals when dropping units, this made them unable to sacrifice since they avoided temple pools.

Now I skip the 'dangerous drop site' check when sacrificing. Fixes #2589