### PR TITLE
Reference only: relabelled some pathfinding variables

### DIFF
--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -418,7 +418,7 @@ long init_navigation(void)
     init_navigation_map();
     triangulate_map(IanMap);
     nav_rulesA2B = navigation_rule_normal;
-    game.map_changed_for_nagivation = 1;
+    game.update_navigation = true;
     return 1;
 }
 
@@ -3338,7 +3338,7 @@ AriadneReturn ariadne_get_next_position_for_route(struct Thing *thing, struct Co
 AriadneReturn creature_follow_route_to_using_gates(struct Thing *thing, struct Coord3d *finalpos, struct Coord3d *nextpos, long speed, AriadneRouteFlags flags)
 {
     SYNCDBG(18,"Starting");
-    if (game.map_changed_for_nagivation)
+    if (game.update_navigation)
     {
         struct CreatureControl *cctrl;
         cctrl = creature_control_get_from_thing(thing);

--- a/src/ariadne_wallhug.h
+++ b/src/ariadne_wallhug.h
@@ -45,7 +45,7 @@ enum WallHugSideState {
 /******************************************************************************/
 
 /******************************************************************************/
-long slab_wall_hug_route(struct Thing *thing, struct Coord3d *pos, long a3);
+long slab_wall_hug_route(struct Thing *thing, struct Coord3d *pos, long max_val);
 long get_next_position_and_angle_required_to_tunnel_creature_to(struct Thing *creatng, struct Coord3d *pos, unsigned char a3);
 TbBool terrain_toxic_for_creature_at_position(const struct Thing *creatng, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 long dig_to_position(PlayerNumber plyr_idx, MapSubtlCoord basestl_x, MapSubtlCoord basestl_y, int direction_around, TbBool revside);

--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -206,7 +206,7 @@ unsigned char sound_flag;
   struct {
     char target_plyr_idx;
     unsigned char player_broken_into_flags;
-    long long_8B;
+    long tunnel_count;
     unsigned char byte_8F;
     SubtlCodedCoords member_pos_stl[5];
   } party;
@@ -226,19 +226,11 @@ unsigned char sound_flag;
     MapSubtlCoord stl_y;
   } patrol;
   struct {
-    char sbyte_89;
     unsigned char hero_gate_creation_turn;
-    TbBool byte_8B;
-    TbBool byte_8C;
+    TbBool update_navigation;
     long look_for_enemy_dungeon_turn;
     long wait_time;
   } hero;
-  struct {
-    char sbyte_89_unused;
-    unsigned char unused;
-    TbBool byte_8B;
-    TbBool byte_8C;
-  } unknown;
   };
 
   union {

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -1383,10 +1383,10 @@ long creature_tunnel_to(struct Thing *creatng, struct Coord3d *pos, short speed)
         creature_set_speed(creatng, 0);
         return 1;
     }
-    long i = cctrl->party.long_8B;
+    long i = cctrl->party.tunnel_count;
     if ((i > 0) && (i < LONG_MAX))
     {
-        cctrl->party.long_8B++;
+        cctrl->party.tunnel_count++;
     }
     if ((pos->x.val != cctrl->navi.pos_final.x.val)
      || (pos->y.val != cctrl->navi.pos_final.y.val)

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -71,10 +71,10 @@ TbBool has_available_enemy_dungeon_heart(struct Thing *thing, PlayerNumber plyr_
 {
     SYNCDBG(18,"Starting");
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-    if ((cctrl->hero.byte_8C != 0) || (cctrl->hero.byte_8B != 0))
+    if ((cctrl->party.tunnel_count != 0) || (cctrl->hero.update_navigation))
     {
-        cctrl->hero.byte_8C = 0;
-        cctrl->hero.byte_8B = 0;
+        cctrl->party.tunnel_count = 0;
+        cctrl->hero.update_navigation = false;
     }
     // Try accessing dungeon heart of undefeated enemy players
     if (!player_is_friendly_or_defeated(plyr_idx, thing->owner) && (creature_can_get_to_dungeon_heart(thing, plyr_idx)))
@@ -88,10 +88,10 @@ TbBool has_available_rooms_to_attack(struct Thing* thing, PlayerNumber plyr_idx)
 {
     SYNCDBG(18, "Starting");
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-    if ((cctrl->hero.byte_8C != 0) || (cctrl->hero.byte_8B != 0))
+    if ((cctrl->party.tunnel_count != 0) || (cctrl->hero.update_navigation))
     {
-        cctrl->hero.byte_8C = 0;
-        cctrl->hero.byte_8B = 0;
+        cctrl->party.tunnel_count = 0;
+        cctrl->hero.update_navigation = false;
     }
     if (players_are_enemies(thing->owner, plyr_idx) && creature_can_get_to_any_of_players_rooms(thing, plyr_idx))
     {
@@ -972,7 +972,7 @@ short good_doing_nothing(struct Thing *creatng)
         if (nturns > 400)
         {
             cctrl->hero.wait_time = game.play_gameturn;
-            cctrl->hero.byte_8C = 1;
+            cctrl->party.tunnel_count = 1;
         }
         nturns = game.play_gameturn - cctrl->hero.look_for_enemy_dungeon_turn;
         if (nturns > 64)

--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -228,7 +228,7 @@ unsigned int packet_file_pos;
     unsigned short nodungeon_creatr_list_start; /**< Linked list of creatures which have no dungeon (neutral and owned by nonexisting players) */
     GameTurnDelta food_generation_speed;
     enum GameKinds game_kind; /**< Kind of the game being played, from GameKinds enumeration. Originally was GameMode. */
-    TbBool map_changed_for_nagivation; // something with navigation
+    TbBool update_navigation; // navigation route(s) need to be updated, if this is true
     struct PerExpLevelValues creature_scores[CREATURE_TYPES_MAX];
     unsigned long default_max_crtrs_gen_entrance;
     unsigned long default_imp_dig_damage;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2762,7 +2762,7 @@ void update(void)
     }
     if (game.game_kind == GKind_Unknown1)
     {
-        game.map_changed_for_nagivation = 0;
+        game.update_navigation = false;
         return;
     }
     player = get_my_player();
@@ -2810,7 +2810,7 @@ void update(void)
     message_update();
     update_all_players_cameras();
     update_player_sounds();
-    game.map_changed_for_nagivation = 0;
+    game.update_navigation = false;
     SYNCDBG(6,"Finished");
 }
 

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -4516,7 +4516,7 @@ void replace_room_slab(struct Room *room, MapSlabCoord slb_x, MapSlabCoord slb_y
 
 struct Room *place_room(PlayerNumber owner, RoomKind rkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
-    game.map_changed_for_nagivation = 1;
+    game.update_navigation = true;
     if (subtile_coords_invalid(stl_x, stl_y))
         return INVALID_ROOM;
     long slb_x = subtile_slab(stl_x);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3788,8 +3788,8 @@ struct Thing *create_creature(struct Coord3d *pos, ThingModel model, PlayerNumbe
     cctrl->blood_type = CREATURE_RANDOM(crtng, BLOOD_TYPES_COUNT);
     if (owner == game.hero_player_num)
     {
-      cctrl->hero.sbyte_89 = -1;
-      cctrl->hero.byte_8C = 1;
+      cctrl->party.target_plyr_idx = -1;
+      cctrl->party.tunnel_count = 1;
     }
     cctrl->flee_pos.x.val = crtng->mappos.x.val;
     cctrl->flee_pos.y.val = crtng->mappos.y.val;
@@ -5381,8 +5381,8 @@ TngUpdateRet update_creature(struct Thing *thing)
         cctrl->frozen_on_hit--;
     if (cctrl->force_visible > 0)
         cctrl->force_visible--;
-    if (cctrl->unknown.byte_8B == 0)
-        cctrl->unknown.byte_8B = game.map_changed_for_nagivation;
+    if (!cctrl->hero.update_navigation)
+        cctrl->hero.update_navigation = game.update_navigation;
     if (cctrl->stopped_for_hand_turns == 0) {
         process_creature_instance(thing);
     }

--- a/src/thing_doors.c
+++ b/src/thing_doors.c
@@ -163,7 +163,7 @@ TbBool add_key_on_door(struct Thing *thing)
 void unlock_door(struct Thing *thing)
 {
     thing->door.is_locked = false;
-    game.map_changed_for_nagivation = 1;
+    game.update_navigation = true;
     update_navigation_triangulation(thing->mappos.x.stl.num-1, thing->mappos.y.stl.num-1,
       thing->mappos.x.stl.num+1, thing->mappos.y.stl.num+1);
     pannel_map_update(thing->mappos.x.stl.num-1, thing->mappos.y.stl.num-1, STL_PER_SLB, STL_PER_SLB);
@@ -180,7 +180,7 @@ void lock_door(struct Thing *doortng)
     doortng->active_state = DorSt_Closed;
     doortng->door.closing_counter = 0;
     doortng->door.is_locked = 1;
-    game.map_changed_for_nagivation = 1;
+    game.update_navigation = true;
     place_animating_slab_type_on_map(doorst->slbkind[doortng->door.orientation], 0, stl_x, stl_y, doortng->owner);
     update_navigation_triangulation(stl_x-1,  stl_y-1, stl_x+1,stl_y+1);
     pannel_map_update(stl_x-1, stl_y-1, STL_PER_SLB, STL_PER_SLB);


### PR DESCRIPTION
Named some of the variables from the party/digger/patrol/hero union in CreatureControl stuct. Also removed unused variables.

Cleared up the usage of some variables from above union.

Renamed game.map_changed_for_nagivation to game.update_navigation, and cleaned up usage.

Corrected parameter name in slab_wall_hug_route declaration.