### PR TITLE
Ranged traps rotate in the direction of the thing they shoot

### DIFF
--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -40,7 +40,6 @@
 #include "engine_render.h"
 #include "gui_topmsg.h"
 
-#include "thing_navigate.h"
 #include "keeperfx.hpp"
 #include "creature_senses.h"
 #include "cursor_tag.h"
@@ -572,7 +571,7 @@ void activate_trap(struct Thing *traptng, struct Thing *creatng)
         break;
     case TrpAcT_CreatureShot:
         creature_fire_shot(traptng, creatng, trapstat->created_itm_model, 1, THit_CrtrsNObjcts);
-        traptng->move_angle_xy = get_angle_xy_to(&traptng->mappos, &creatng->mappos) & LbFPMath_AngleMask;
+        traptng->move_angle_xy = get_angle_xy_to(&traptng->mappos, &creatng->mappos);
         break;
     case TrpAcT_CreatureSpawn:
         activate_trap_spawn_creature(traptng, trapstat->created_itm_model);

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -559,7 +559,7 @@ void activate_trap(struct Thing *traptng, struct Thing *creatng)
     {
     case TrpAcT_HeadforTarget90:
         activate_trap_shot_head_for_target90(traptng, creatng);
-        traptng->move_angle_xy = (get_angle_xy_to(&traptng->mappos, &creatng->mappos) & 4) * ANGLE_EAST;
+        traptng->move_angle_xy = (((get_angle_xy_to(&traptng->mappos, &creatng->mappos) + LbFPMath_PI/4) & LbFPMath_AngleMask) / (LbFPMath_PI/2)) * (LbFPMath_PI/2);
         break;
     case TrpAcT_EffectonTrap:
         activate_trap_effect_on_trap(traptng);

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -40,6 +40,7 @@
 #include "engine_render.h"
 #include "gui_topmsg.h"
 
+#include "thing_navigate.h"
 #include "keeperfx.hpp"
 #include "creature_senses.h"
 #include "cursor_tag.h"
@@ -558,6 +559,7 @@ void activate_trap(struct Thing *traptng, struct Thing *creatng)
     {
     case TrpAcT_HeadforTarget90:
         activate_trap_shot_head_for_target90(traptng, creatng);
+        traptng->move_angle_xy = (get_angle_xy_to(&traptng->mappos, &creatng->mappos) & 4) * ANGLE_EAST;
         break;
     case TrpAcT_EffectonTrap:
         activate_trap_effect_on_trap(traptng);
@@ -570,6 +572,7 @@ void activate_trap(struct Thing *traptng, struct Thing *creatng)
         break;
     case TrpAcT_CreatureShot:
         creature_fire_shot(traptng, creatng, trapstat->created_itm_model, 1, THit_CrtrsNObjcts);
+        traptng->move_angle_xy = get_angle_xy_to(&traptng->mappos, &creatng->mappos) & LbFPMath_AngleMask;
         break;
     case TrpAcT_CreatureSpawn:
         activate_trap_spawn_creature(traptng, trapstat->created_itm_model);


### PR DESCRIPTION
Cannot be seen on the default traps, would work on traps that look like a true cannon.