### PR TITLE
allow choosing of display number via config file

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -16,7 +16,7 @@ FRONTEND_RES=640x480x32 640x480x32 640x480x32
 ; Original DK resolutions were INGAME_RES=320x200x8 640x400x8
 INGAME_RES=640x480x32 1366x768x32 1920x1080x32
 
-; The display number where the game will appear (1 for the main monitor, 2 for the second monitor)
+; The display number where the game will appear (1 for the main monitor, 2 for the second monitor, etc)
 DISPLAY_NUMBER=1
 
 ; Configures how the movies are displayed.

--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -16,6 +16,9 @@ FRONTEND_RES=640x480x32 640x480x32 640x480x32
 ; Original DK resolutions were INGAME_RES=320x200x8 640x400x8
 INGAME_RES=640x480x32 1366x768x32 1920x1080x32
 
+; The display number where the game will appear (1 for the main monitor, 2 for the second monitor)
+DISPLAY_NUMBER=1
+
 ; Configures how the movies are displayed.
 ; Options are: OFF, FIT, STRETCH, CROP, PIXELPERFECT, 4BY3, 4BY3PP
 RESIZE_MOVIES=ON

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -75,7 +75,7 @@ unsigned short pixel_size;
 unsigned short pixels_per_block;
 unsigned short units_per_pixel;
 
-unsigned short display_number = 0; // the display to use to display the game, 0 is the first (or only) screen, 1 is the second screen. Can be set in cfg file, or defaults to 0.
+unsigned short display_number = 1; //1 is the first (or only) screen, 2 is the second screen. Can be set in cfg file, or defaults to 1.
 
 static unsigned char fade_started;
 static unsigned char from_pal[PALETTE_SIZE];
@@ -412,6 +412,8 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
 {
     long hot_x;
     long hot_y;
+     // get the display index from the display number, if display number has been incorrectly set to 0, then treat this as id number 0
+    unsigned short display_id = (display_number == 0) ? display_number : display_number - 1;
 
     const struct TbSprite* msspr = NULL;
     LbExeReferenceNumber();
@@ -460,7 +462,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
             {
                 // reset window
                 SDL_DestroyWindow(lbWindow);
-                lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_CENTERED_DISPLAY(display_number), SDL_WINDOWPOS_CENTERED_DISPLAY(display_number), mdinfo->Width, mdinfo->Height, sdlFlags);
+                lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_CENTERED_DISPLAY(display_id), SDL_WINDOWPOS_CENTERED_DISPLAY(display_id), mdinfo->Width, mdinfo->Height, sdlFlags);
             }
         }
         int fullscreenMode = (((sdlFlags & SDL_WINDOW_FULLSCREEN) != 0) ? SDL_WINDOW_FULLSCREEN : 0);
@@ -489,7 +491,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
         }
     }
     if (lbWindow == NULL) { // Only create a new window if we don't have a valid one already
-        lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_CENTERED_DISPLAY(display_number), SDL_WINDOWPOS_CENTERED_DISPLAY(display_number), mdinfo->Width, mdinfo->Height, sdlFlags);
+        lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_CENTERED_DISPLAY(display_id), SDL_WINDOWPOS_CENTERED_DISPLAY(display_id), mdinfo->Width, mdinfo->Height, sdlFlags);
     }
     if (lbWindow == NULL) {
         ERRORLOG("SDL_CreateWindow: %s", SDL_GetError());

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -75,6 +75,8 @@ unsigned short pixel_size;
 unsigned short pixels_per_block;
 unsigned short units_per_pixel;
 
+unsigned short display_number = 0; // the display to use to display the game, 0 is the first (or only) screen, 1 is the second screen. Can be set in cfg file, or defaults to 0.
+
 static unsigned char fade_started;
 static unsigned char from_pal[PALETTE_SIZE];
 static unsigned char to_pal[PALETTE_SIZE];
@@ -458,7 +460,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
             {
                 // reset window
                 SDL_DestroyWindow(lbWindow);
-                lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, mdinfo->Width, mdinfo->Height, sdlFlags);
+                lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_CENTERED_DISPLAY(display_number), SDL_WINDOWPOS_CENTERED_DISPLAY(display_number), mdinfo->Width, mdinfo->Height, sdlFlags);
             }
         }
         int fullscreenMode = (((sdlFlags & SDL_WINDOW_FULLSCREEN) != 0) ? SDL_WINDOW_FULLSCREEN : 0);
@@ -487,7 +489,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
         }
     }
     if (lbWindow == NULL) { // Only create a new window if we don't have a valid one already
-        lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, mdinfo->Width, mdinfo->Height, sdlFlags);
+        lbWindow = SDL_CreateWindow(lbDrawAreaTitle, SDL_WINDOWPOS_CENTERED_DISPLAY(display_number), SDL_WINDOWPOS_CENTERED_DISPLAY(display_number), mdinfo->Width, mdinfo->Height, sdlFlags);
     }
     if (lbWindow == NULL) {
         ERRORLOG("SDL_CreateWindow: %s", SDL_GetError());

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -265,6 +265,8 @@ extern unsigned short pixel_size;
 extern unsigned short pixels_per_block;
 extern unsigned short units_per_pixel;
 
+extern unsigned short display_number;
+
 extern TbDisplayStruct lbDisplay;
 extern SDL_Window *lbWindow;
 /******************************************************************************/

--- a/src/config.c
+++ b/src/config.c
@@ -138,6 +138,7 @@ const struct NamedCommand conf_commands[] = {
   {"DELTA_TIME"                    , 25},
   {"CREATURE_STATUS_SIZE"          , 26},
   {"MAX_ZOOM_DISTANCE"             , 27},
+  {"DISPLAY_NUMBER"                , 28},
   {NULL,                   0},
   };
 
@@ -1085,6 +1086,17 @@ short load_configuration(void)
               if (i > 100) {i = 100;}
               zoom_distance_setting = lerp(4100, CAMERA_ZOOM_MIN, (float)i/100.0);
               frontview_zoom_distance_setting = lerp(16384, FRONTVIEW_CAMERA_ZOOM_MIN, (float)i/100.0);
+          } else {
+              CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",COMMAND_TEXT(cmd_num),config_textname);
+          }
+          break;
+      case 28: // DISPLAY_NUMBER
+          if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
+          {
+            i = atoi(word_buf);
+          }
+          if ((i >= 0) && (i <= 32768)) {
+              display_number = i;
           } else {
               CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",COMMAND_TEXT(cmd_num),config_textname);
           }


### PR DESCRIPTION
Default (with no value in cfg file) is 1, which is the primary/first/only display.

Setting `display_number=1` ( which will set `display_id=0`) is exactly the same as current master (i.e. `SDL_WINDOWPOS_CENTERED` is the same as `SDL_WINDOWPOS_CENTERED_DISPLAY(0)`)*

Usage:
e.g. putting the following in the config file will cause keeperfx to run on the 2nd monitor.
```
; The display to use for the game
DISPLAY_NUMBER=2
```
implements #2345

(commented updated to reflect new behaviour in b9bb953)
____
*_"Looking at the definition of SDL_WINDOWPOS_CENTERED in SDL_video.h we see it is defined as 
`#define SDL_WINDOWPOS_CENTERED         SDL_WINDOWPOS_CENTERED_DISPLAY(0)`
 so we could also use the macro SDL_WINDOWPOS_CENTERED_DISPLAY( n ) where n is the display index."_ - https://stackoverflow.com/questions/41745492/sdl2-how-to-position-a-window-on-a-second-monitor