### PR TITLE
Fixed CONCEAL_MAP_RECT for bigmaps and provided better log info

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -772,23 +772,20 @@ static void display_objective_process(struct ScriptContext *context)
 static void conceal_map_rect_check(const struct ScriptLine *scline)
 {
     ALLOCATE_SCRIPT_VALUE(scline->command, 0);
-    long all;
-    if (parameter_is_number(scline->tp[5]))
+    TbBool all = 0;
+
+    if ((strcmp(scline->tp[5], "") == 0) || (strcmp(scline->tp[5], "0") == 0))
     {
-        all = atoi(scline->tp[5]);
-        if (all > 1)
-        {
-            SCRPTWRNLOG("Hide value \"%s\" not recognized", scline->tp[5]);
-            all = 0;
-        }
+        all = 0;
+    }
+    else
+    if ((strcmp(scline->tp[5], "ALL") == 0) || (strcmp(scline->tp[5], "1") == 0))
+    {
+        all = 1;
     }
     else
     {
-        all = strcmp(scline->tp[5], "ALL") == 0;
-        if (!all && (strcmp(scline->tp[5], "") != 0))
-        {
-            SCRPTWRNLOG("Hide value \"%s\" not recognized", scline->tp[5]);
-        }
+        SCRPTWRNLOG("Hide value \"%s\" not recognized", scline->tp[5]);
     }
     
     MapSubtlCoord x = scline->np[1];

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -791,25 +791,43 @@ static void conceal_map_rect_check(const struct ScriptLine *scline)
         }
     }
     
+    MapSubtlCoord x = scline->np[1];
+    MapSubtlCoord y = scline->np[2];
+    MapSubtlDelta width = scline->np[3];
+    MapSubtlDelta height = scline->np[4];
+    TbBool conceal_all = (all ? 1 : 0);
+
+    MapSubtlCoord start_x = x - (width / 2);
+    MapSubtlCoord end_x = x + (width / 2) + (width & 1);
+    MapSubtlCoord start_y = y - (height / 2);
+    MapSubtlCoord end_y = y + (height / 2) + (height & 1);
+
+    if ((start_x < 0) || (end_x > gameadd.map_subtiles_x) || (start_y < 0) || (end_y > gameadd.map_subtiles_y))
+    {
+        SCRPTERRLOG("Conceal coordinates out of range, trying to conceal from (%d,%d) to (%d,%d) on map size %dx%d", start_x, start_y, end_x, end_y, gameadd.map_subtiles_x, gameadd.map_subtiles_y);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
+
     value->plyr_range = scline->np[0];
-    value->shorts[1] = scline->np[1];
-    value->shorts[2] = scline->np[2];
-    value->shorts[3] = scline->np[3];
-    value->shorts[4] = scline->np[4];
-    value->shorts[5] = (all ? 1 : 0);
+    value->shorts[1] = start_x;
+    value->shorts[2] = end_x;
+    value->shorts[3] = start_y;
+    value->shorts[4] = end_y;
+    value->shorts[5] = conceal_all;
     
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
 static void conceal_map_rect_process(struct ScriptContext *context)
 {
-    MapSubtlCoord x = context->value->shorts[1];
-    MapSubtlCoord y = context->value->shorts[2];
-    MapSubtlDelta width = context->value->shorts[3];
-    MapSubtlDelta height = context->value->shorts[4];
+    MapSubtlCoord start_x = context->value->shorts[1];
+    MapSubtlCoord end_x = context->value->shorts[2];
+    MapSubtlDelta start_y = context->value->shorts[3];
+    MapSubtlDelta end_y = context->value->shorts[4];
     TbBool conceal_all = context->value->shorts[5];
     
-    conceal_map_area(context->value->plyr_range, (x - (width/2)), (x + (width/2) + (width&1)),(y - (height/2)),(y + (height/2) + (height&1)), conceal_all);
+    conceal_map_area(context->value->plyr_range, start_x, end_x, start_y, end_y, conceal_all);
 }
 
 /**

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -771,6 +771,7 @@ static void display_objective_process(struct ScriptContext *context)
 
 static void conceal_map_rect_check(const struct ScriptLine *scline)
 {
+    ALLOCATE_SCRIPT_VALUE(scline->command, 0);
     TbBool all = strcmp(scline->tp[5], "ALL") == 0;
     if (!all)
     {
@@ -781,17 +782,25 @@ static void conceal_map_rect_check(const struct ScriptLine *scline)
         SCRPTWRNLOG("Hide value \"%s\" not recognized", scline->tp[5]);
     }
 
-    command_add_value(Cmd_CONCEAL_MAP_RECT, scline->np[0], scline->np[1], scline->np[2],
-                      (scline->np[4]<<16) | scline->np[3] | (all?1<<24:0));
+    value->plyr_range = scline->np[0];
+    value->shorts[1] = scline->np[1];
+    value->shorts[2] = scline->np[2];
+    value->shorts[3] = scline->np[3];
+    value->shorts[4] = scline->np[4];
+    value->shorts[5] = (all ? 1 : 0);
+    
+    PROCESS_SCRIPT_VALUE(scline->command);
 }
 
 static void conceal_map_rect_process(struct ScriptContext *context)
 {
-    long w = context->value->bytes[8];
-    long h = context->value->bytes[10];
-
-    conceal_map_area(context->value->plyr_range, context->value->arg0 - (w>>1), context->value->arg0 + (w>>1) + (w&1),
-                     context->value->arg1 - (h>>1), context->value->arg1 + (h>>1) + (h&1), context->value->bytes[11]);
+    MapSubtlCoord x = context->value->shorts[1];
+    MapSubtlCoord y = context->value->shorts[2];
+    MapSubtlDelta width = context->value->shorts[3];
+    MapSubtlDelta height = context->value->shorts[4];
+    TbBool conceal_all = context->value->shorts[5];
+    
+    conceal_map_area(context->value->plyr_range, (x - (width/2)), (x + (width/2) + (width&1)),(y - (height/2)),(y + (height/2) + (height&1)), conceal_all);
 }
 
 /**

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -772,16 +772,25 @@ static void display_objective_process(struct ScriptContext *context)
 static void conceal_map_rect_check(const struct ScriptLine *scline)
 {
     ALLOCATE_SCRIPT_VALUE(scline->command, 0);
-    TbBool all = strcmp(scline->tp[5], "ALL") == 0;
-    if (!all)
+    long all;
+    if (parameter_is_number(scline->tp[5]))
     {
-        all = strcmp(scline->tp[5], "1") == 0;
+        all = atoi(scline->tp[5]);
+        if (all > 1)
+        {
+            SCRPTWRNLOG("Hide value \"%s\" not recognized", scline->tp[5]);
+            all = 0;
+        }
     }
-    if (!all && strcmp(scline->tp[5], "") != 0)
+    else
     {
-        SCRPTWRNLOG("Hide value \"%s\" not recognized", scline->tp[5]);
+        all = strcmp(scline->tp[5], "ALL") == 0;
+        if (!all && (strcmp(scline->tp[5], "") != 0))
+        {
+            SCRPTWRNLOG("Hide value \"%s\" not recognized", scline->tp[5]);
+        }
     }
-
+    
     value->plyr_range = scline->np[0];
     value->shorts[1] = scline->np[1];
     value->shorts[2] = scline->np[2];

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -823,8 +823,8 @@ static void conceal_map_rect_process(struct ScriptContext *context)
 {
     MapSubtlCoord start_x = context->value->shorts[1];
     MapSubtlCoord end_x = context->value->shorts[2];
-    MapSubtlDelta start_y = context->value->shorts[3];
-    MapSubtlDelta end_y = context->value->shorts[4];
+    MapSubtlCoord start_y = context->value->shorts[3];
+    MapSubtlCoord end_y = context->value->shorts[4];
     TbBool conceal_all = context->value->shorts[5];
     
     conceal_map_area(context->value->plyr_range, start_x, end_x, start_y, end_y, conceal_all);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -823,7 +823,7 @@ static void conceal_map_rect_process(struct ScriptContext *context)
     MapSubtlCoord end_y = context->value->shorts[4];
     TbBool conceal_all = context->value->shorts[5];
     
-    conceal_map_area(context->value->plyr_range, start_x, end_x, start_y, end_y, conceal_all);
+    conceal_map_area(context->player_idx, start_x, end_x, start_y, end_y, conceal_all);
 }
 
 /**

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -772,16 +772,16 @@ static void display_objective_process(struct ScriptContext *context)
 static void conceal_map_rect_check(const struct ScriptLine *scline)
 {
     ALLOCATE_SCRIPT_VALUE(scline->command, 0);
-    TbBool all = 0;
+    TbBool conceal_all = 0;
 
     if ((strcmp(scline->tp[5], "") == 0) || (strcmp(scline->tp[5], "0") == 0))
     {
-        all = 0;
+        conceal_all = 0;
     }
     else
     if ((strcmp(scline->tp[5], "ALL") == 0) || (strcmp(scline->tp[5], "1") == 0))
     {
-        all = 1;
+        conceal_all = 1;
     }
     else
     {
@@ -792,7 +792,6 @@ static void conceal_map_rect_check(const struct ScriptLine *scline)
     MapSubtlCoord y = scline->np[2];
     MapSubtlDelta width = scline->np[3];
     MapSubtlDelta height = scline->np[4];
-    TbBool conceal_all = (all ? 1 : 0);
 
     MapSubtlCoord start_x = x - (width / 2);
     MapSubtlCoord end_x = x + (width / 2) + (width & 1);

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -283,8 +283,8 @@ long untag_blocks_for_digging_in_area(MapSubtlCoord stl_x, MapSubtlCoord stl_y, 
     long i;
     x = STL_PER_SLB * (stl_x/STL_PER_SLB);
     y = STL_PER_SLB * (stl_y/STL_PER_SLB);
-    if ( (x < 0) || (x >= gameadd.map_subtiles_x) || (y < 0) || (y >= gameadd.map_subtiles_y) ) {
-        ERRORLOG("Attempt to tag area outside of map");
+    if ( (x < 0) || (x > gameadd.map_subtiles_x) || (y < 0) || (y > gameadd.map_subtiles_y) ) {
+        ERRORLOG("Attempt to tag (%d,%d), which is outside of map",x,y);
         return 0;
     }
     i = get_subtile_number(x+1,y+1);


### PR DESCRIPTION
- Fixes #2631
- Gives a script error that is informative when out of range: `Error: conceal_map_rect_check(line 75): Conceal coordinates out of range, trying to conceal from (0,-20) to (360,325) on map size 360x345`
- Allows 0 as a value on [hide revealed] param
