### PR TITLE
Fixed crash when heart is configured to be 0 health

### DIFF
--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1444,11 +1444,14 @@ static TngUpdateRet object_update_dungeon_heart(struct Thing *heartng)
               heartng->health = objconf->health;
             }
         }
-        long long k = ((heartng->health << 8) / objconf->health) << 7;
-        long i = (saturate_set_signed(k, 32) >> 8) + 128;
-        struct Objects* objdat = get_objects_data_for_thing(heartng);
-        heartng->sprite_size = i * (long)objdat->sprite_size_max >> 8;
-        heartng->clipbox_size_xy = i * (long)objdat->size_xy >> 8;
+        if (objconf->health > 0) //prevent divide by 0 crash
+        {
+            long long k = ((heartng->health << 8) / objconf->health) << 7;
+            long i = (saturate_set_signed(k, 32) >> 8) + 128;
+            struct Objects* objdat = get_objects_data_for_thing(heartng);
+            heartng->sprite_size = i * (long)objdat->sprite_size_max >> 8;
+            heartng->clipbox_size_xy = i * (long)objdat->size_xy >> 8;
+        }
     }
     else if ((dungeon != INVALID_DUNGEON) && (heartng->index == dungeon->dnheart_idx))
     {


### PR DESCRIPTION
Add this script to a map:
```
REM The red flag is now a dungeon heart, a beating heart with the update function and 18000 health
SET_OBJECT_CONFIGURATION(GUARDFLAG_RED,Health,18000)
ADD_OBJECT_TO_LEVEL(GUARDFLAG_RED,1,0,PLAYER0)
SET_OBJECT_CONFIGURATION(GUARDFLAG_RED,Properties,96)
SET_OBJECT_CONFIGURATION(GUARDFLAG_RED,UpdateFunction,UPDATE_DUNGEON_HEART)


IF(PLAYER0,GAME_TURN > 80)
	REM The soul container is just a regular object
	SET_OBJECT_CONFIGURATION(SOUL_CONTAINER,UpdateFunction,0)
	SET_OBJECT_CONFIGURATION(SOUL_CONTAINER,Health,0)
	SET_OBJECT_CONFIGURATION(SOUL_CONTAINER,Properties,4)
ENDIF
```

Run the map and notice a crash. `SET_OBJECT_CONFIGURATION(SOUL_CONTAINER,Health,0)` crashed it. Added some divide by 0 code.