### PR TITLE
Stop log warning spam when exploring already explored map

### DIFF
--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -822,6 +822,7 @@ void init_players(void)
 TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
 {
     SYNCDBG(16,"Starting");
+    struct Thing* heartng;
     MapSubtlCoord stl_x = stl_num_decode_x(stl_num);
     MapSubtlCoord stl_y = stl_num_decode_y(stl_num);
     if (wandr->wandr_slot == CrWaS_WithinDungeon)
@@ -834,7 +835,18 @@ TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
             if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && ((get_navigation_map(stl_x, stl_y) & NAVMAP_UNSAFE_SURFACE) == 0)
              && players_creatures_tolerate_each_other(wandr->plyr_idx,slabmap_owner(slb)))
             {
-                return true;
+                heartng = get_player_soul_container(wandr->plyr_idx);
+                if (!thing_is_invalid(heartng))
+                {
+                    struct Coord3d dstpos;
+                    dstpos.x.val = subtile_coord_center(stl_x);
+                    dstpos.y.val = subtile_coord_center(stl_y);
+                    dstpos.z.val = subtile_coord(1, 0);
+                    if (navigation_points_connected(&heartng->mappos, &dstpos))
+                    {
+                        return true;
+                    }
+                }
             }
         }
     } else
@@ -845,7 +857,7 @@ TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
         {
             if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && ((get_navigation_map(stl_x, stl_y) & NAVMAP_UNSAFE_SURFACE) == 0))
             {
-                struct Thing* heartng = get_player_soul_container(wandr->plyr_idx);
+                heartng = get_player_soul_container(wandr->plyr_idx);
                 if (!thing_is_invalid(heartng))
                 {
                     struct Coord3d dstpos;
@@ -853,7 +865,9 @@ TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
                     dstpos.y.val = subtile_coord_center(stl_y);
                     dstpos.z.val = subtile_coord(1,0);
                     if (navigation_points_connected(&heartng->mappos, &dstpos))
-                      return true;
+                    {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -823,22 +823,25 @@ TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
 {
     SYNCDBG(16,"Starting");
     struct Thing* heartng;
+    struct Map* mapblk;
+    struct Coord3d dstpos;
+    struct SlabMap* slb;
     MapSubtlCoord stl_x = stl_num_decode_x(stl_num);
     MapSubtlCoord stl_y = stl_num_decode_y(stl_num);
     if (wandr->wandr_slot == CrWaS_WithinDungeon)
     {
-        struct Map* mapblk = get_map_block_at_pos(stl_num);
+        mapblk = get_map_block_at_pos(stl_num);
         // Add only tiles which are revealed to the wandering player, unless it's heroes - for them, add all
         if ((wandr->plyr_idx == game.hero_player_num) || map_block_revealed(mapblk, wandr->plyr_idx))
         {
-            struct SlabMap* slb = get_slabmap_for_subtile(stl_x, stl_y);
+            slb = get_slabmap_for_subtile(stl_x, stl_y);
             if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && ((get_navigation_map(stl_x, stl_y) & NAVMAP_UNSAFE_SURFACE) == 0)
              && players_creatures_tolerate_each_other(wandr->plyr_idx,slabmap_owner(slb)))
             {
                 heartng = get_player_soul_container(wandr->plyr_idx);
                 if (!thing_is_invalid(heartng))
                 {
-                    struct Coord3d dstpos;
+                    
                     dstpos.x.val = subtile_coord_center(stl_x);
                     dstpos.y.val = subtile_coord_center(stl_y);
                     dstpos.z.val = subtile_coord(1, 0);
@@ -851,7 +854,7 @@ TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
         }
     } else
     {
-        struct Map* mapblk = get_map_block_at_pos(stl_num);
+        mapblk = get_map_block_at_pos(stl_num);
         // Add only tiles which are not revealed to the wandering player, unless it's heroes - for them, do nothing
         if ((wandr->plyr_idx != game.hero_player_num) && !map_block_revealed(mapblk, wandr->plyr_idx))
         {
@@ -860,7 +863,6 @@ TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
                 heartng = get_player_soul_container(wandr->plyr_idx);
                 if (!thing_is_invalid(heartng))
                 {
-                    struct Coord3d dstpos;
                     dstpos.x.val = subtile_coord_center(stl_x);
                     dstpos.y.val = subtile_coord_center(stl_y);
                     dstpos.z.val = subtile_coord(1,0);


### PR DESCRIPTION
To reproduce the issue, start a map early in the campaign, claim the portal, use the reveal cheat then frameskip while the fly explores.

Come back to hundreds of log lines like this:
```
Sync: [935] creature_explore_dungeon: The creature FLY owned by player 0 can't navigate to subtile (196,112) for exploring
Sync: [937] creature_explore_dungeon: The creature FLY owned by player 0 can't navigate to subtile (187,121) for exploring
Sync: [939] creature_explore_dungeon: The creature FLY owned by player 0 can't navigate to subtile (136,127) for exploring
```