### PR TITLE
Make sure human player is 0 if it's not specified in campaign config

### DIFF
--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -395,6 +395,7 @@ short parse_campaign_common_blocks(struct GameCampaign *campgn,char *buf,long le
   LbMemoryFree(campgn->hiscore_table);
   campgn->hiscore_table = NULL;
   campgn->hiscore_count = VISIBLE_HIGH_SCORES_COUNT;
+  campgn->human_player = 0;
   // Find the block
   char block_buf[32];
   sprintf(block_buf, "common");


### PR DESCRIPTION
To reproduce the issue:
1) Start up a campaign where the player is not red. ((example)[https://keeperklan.com/threads/7384])
2) Exit the campaign
3) Start a campaign where the human player is not specified. (Basically any campaign besides the original one)
-> notice you start as the non-red player