### PR TITLE
can now use "DESKTOP" as a screen res in config file - provides a "borderless fullscreen window" mode

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -7,14 +7,13 @@ LANGUAGE=ENG
 ; File format in which screenshots are written; BMP or PNG.
 SCREENSHOT=PNG
 
-; Three frontend resolutions: failsafe, movies and menu resolution.
-; Original DK resolutions were FRONTEND_RES=320x200x8 320x200x8 640x480x8
-; Recommended to set movies and menu same as ingame resolution.
-FRONTEND_RES=640x480w32 1920x1080x32 1920x1080x32
+; Resolutions are in the format WxHx32 for fullscreen, WxHw32 for windowed: 1920x1080x32
+; Use "DESKTOP" for borderless window, DESKTOP_FULL for full screen, DESKTOP_FULL to spread across windows.
+; Three frontend resolutions: failsafe, movies and menu resolution. Set movies and menu same as ingame resolution.
+FRONTEND_RES=640x480w32 DESKTOP DESKTOP
 
 ; List of in-game resolutions. ALT+R will switch between them.
-; Original DK resolutions were INGAME_RES=320x200x8 640x400x8
-INGAME_RES=1920x1080x32 2560x1440x32 1920x1080w32 
+INGAME_RES=DESKTOP DESKTOP_FULL 1920x1080x32 
 
 ; The display number where the game will appear (1 for the main monitor, 2 for the second monitor, etc)
 DISPLAY_NUMBER=1

--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -7,8 +7,9 @@ LANGUAGE=ENG
 ; File format in which screenshots are written; BMP or PNG.
 SCREENSHOT=PNG
 
-; Resolutions are in the format WxHx32 for fullscreen, WxHw32 for windowed: 1920x1080x32
-; Use "DESKTOP" for borderless window, DESKTOP_FULL for full screen, DESKTOP_FULL to spread across windows.
+; Video resolutions are in the format WxHx32 for fullscreen, WxHw32 for windowed: e.g. 1920x1080x32
+; You can also use: "DESKTOP" for a borderless fullscreen window, or "DESKTOP_FULL" for real fullscreen at desktop res.
+
 ; Three frontend resolutions: failsafe, movies and menu resolution. Set movies and menu same as ingame resolution.
 FRONTEND_RES=640x480w32 DESKTOP DESKTOP
 

--- a/src/bflib_inputctrl.cpp
+++ b/src/bflib_inputctrl.cpp
@@ -378,9 +378,9 @@ static void process_event(const SDL_Event *ev)
         {
             isMouseActive = false;
         }
-        else if (ev->window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
+        /* else if (ev->window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
              // todo (allow window to be freely scaled): add window resize function that does what is needed, and call this new function from window init function too
-        }
+        } */
         break;
     case SDL_JOYAXISMOTION:
     case SDL_JOYBALLMOTION:

--- a/src/bflib_inputctrl.cpp
+++ b/src/bflib_inputctrl.cpp
@@ -378,6 +378,9 @@ static void process_event(const SDL_Event *ev)
         {
             isMouseActive = false;
         }
+        else if (ev->window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
+             // todo (allow window to be freely scaled): add window resize function that does what is needed, and call this new function from window init function too
+        }
         break;
     case SDL_JOYAXISMOTION:
     case SDL_JOYBALLMOTION:

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -334,7 +334,7 @@ static TbBool LbHwCheckIsModeAvailable(TbScreenMode mode)
         if (SDL_GetDesktopDisplayMode(display_id, &desktop_display_mode) != 0)
         {
             ERRORLOG("SDL_GetDesktopDisplayMode failed: %s", SDL_GetError());
-            return false; // fo some reason we can't get the current desktop resolution!
+            return false; // for some reason we can't get the current desktop resolution!
         }
         // update the mode's width and height to the desktop resolution of the current monitor
         mdinfo->Width = desktop_display_mode.w;
@@ -854,7 +854,7 @@ TbBool LbScreenIsModeAvailable(TbScreenMode mode)
   }
   else
   {
-    LbHwCheckIsModeAvailable(mode); // we need to recheck modes, as we can change dispplays, and each display may support different modes
+    LbHwCheckIsModeAvailable(mode); // we need to recheck modes, as we can change displays, and each display may support different modes
   }
   TbScreenModeInfo* mdinfo = LbScreenGetModeInfo(mode);
   return mdinfo->Available;

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -880,6 +880,10 @@ TbResult LbScreenSetGraphicsWindow(long x, long y, long width, long height)
 
 TbBool LbScreenIsModeAvailable(TbScreenMode mode, unsigned short display)
 {
+  if (mode == Lb_SCREEN_MODE_INVALID)
+  {
+    return false;
+  } 
   if (!LbHwCheckIsModeAvailable(mode, display))
   {
     TbScreenModeInfo* mdinfo = LbScreenGetModeInfo(mode);

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -331,7 +331,7 @@ static TbBool LbHwCheckIsModeAvailable(TbScreenMode mode)
     {
         // Get current desktop display width and height (after DPI scaling)
         SDL_DisplayMode desktop_display_mode;
-        if (SDL_GetCurrentDisplayMode(display_id, &desktop_display_mode) != 0)
+        if (SDL_GetDesktopDisplayMode(display_id, &desktop_display_mode) != 0)
         {
             ERRORLOG("SDL_GetDesktopDisplayMode failed: %s", SDL_GetError());
             return false; // fo some reason we can't get the current desktop resolution!

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -491,7 +491,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
             (int)mdinfo->Width,(int)mdinfo->Height,(int)mode);
         return Lb_FAIL;
     }
-    // initialise the SDL flags 
+    // initialise the SDL flags
     Uint32 sdlFlags = 0; // default to an normal window
     if (!(mdinfo->VideoFlags & Lb_VF_WINDOWED))
     {
@@ -504,7 +504,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
             sdlFlags |= SDL_WINDOW_FULLSCREEN; // real fullscreen
         }
     }
-    //sdlFlags |= SDL_WINDOW_RESIZABLE; // todo later in the PR
+    //sdlFlags |= SDL_WINDOW_RESIZABLE; // todo (allow window to be freely scaled) - needs window resize function triggered by SDL_WINDOWEVENT_SIZE_CHANGED
     
     // If the game window already exists
     if (lbWindow != NULL)

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -108,6 +108,7 @@ enum TbVideoModeFlags {
     Lb_VF_TRUCOLOR    = 0x0002,
     Lb_VF_PALETTE     = 0x0004,
     Lb_VF_WINDOWED    = 0x0010,
+    Lb_VF_BORDERLESS  = 0x0020,
 };
 
 struct GraphicsWindow {
@@ -265,7 +266,7 @@ extern unsigned short pixel_size;
 extern unsigned short pixels_per_block;
 extern unsigned short units_per_pixel;
 
-extern unsigned short display_number;
+extern unsigned short display_id;
 
 extern TbDisplayStruct lbDisplay;
 extern SDL_Window *lbWindow;

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -109,6 +109,8 @@ enum TbVideoModeFlags {
     Lb_VF_PALETTE     = 0x0004,
     Lb_VF_WINDOWED    = 0x0010,
     Lb_VF_BORDERLESS  = 0x0020,
+    Lb_VF_DESKTOP     = 0x0040,
+    Lb_VF_FILLALL     = 0x0080,
 };
 
 struct GraphicsWindow {
@@ -131,6 +133,12 @@ struct ScreenModeInfo {
     int Available;
     /** Video mode flags. */
     unsigned long VideoFlags;
+     /** Window position X. */
+    int window_pos_x;
+     /** Window position Y. */
+    int window_pos_y;
+    /** SDL window flags. */
+    Uint32 sdlFlags;
     /** Text description of the mode. */
     char Desc[23];
 };
@@ -278,8 +286,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
     unsigned char *palette, short buffers_count, TbBool wscreen_vid);
 TbResult LbScreenReset(void);
 
-TbResult LbScreenFindVideoModes(void);
-TbBool LbScreenIsModeAvailable(TbScreenMode mode);
+TbBool LbScreenIsModeAvailable(TbScreenMode mode, unsigned short display);
 TbScreenMode LbRecogniseVideoModeString(const char *desc);
 TbScreenMode LbRegisterVideoMode(const char *desc, TbScreenCoord width, TbScreenCoord height,
     unsigned short bpp, unsigned long flags);
@@ -300,6 +307,7 @@ TbBool LbScreenIsLocked(void);
 TbResult LbScreenSwap(void);
 TbResult LbScreenClear(TbPixel colour);
 TbResult LbScreenWaitVbi(void);
+unsigned short LbGetCurrentDisplayIndex();
 
 long LbPaletteFade(unsigned char *pal, long n, enum TbPaletteFadeFlag flg);
 TbResult LbPaletteStopOpenFade(void);

--- a/src/config.c
+++ b/src/config.c
@@ -799,19 +799,7 @@ short load_configuration(void)
           {
             if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
             {
-              // check if the user wants to use the failsafe resolution
-              if (strncasecmp(word_buf, "SAME", 4) == 0)
-              {
-                k = get_failsafe_vidmode();
-                if (i == 0)
-                {
-                  CONFWRNLOG("Don't use SAME for failsafe video mode (unless you want 320x200x8). Error  in \"%s\" command of %s file.", COMMAND_TEXT(cmd_num),config_textname);
-                }
-              }
-              else
-              {
-                k = LbRegisterVideoModeString(word_buf);
-              }
+              k = LbRegisterVideoModeString(word_buf);
             }
               
             else
@@ -841,15 +829,7 @@ short load_configuration(void)
           {
             if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
             {
-              // check if the user wants to use the failsafe resolution
-              if (strncasecmp(word_buf, "SAME", 4) == 0)
-              {
-                k = get_failsafe_vidmode();
-              }
-              else
-              {
-                k = LbRegisterVideoModeString(word_buf);
-              }
+              k = LbRegisterVideoModeString(word_buf);
               if (k > 0)
                 set_game_vidmode(i,k);
               else

--- a/src/config.c
+++ b/src/config.c
@@ -1096,7 +1096,7 @@ short load_configuration(void)
             i = atoi(word_buf);
           }
           if ((i >= 0) && (i <= 32768)) {
-              display_number = i;
+              display_id = ((i == 0) ? 0 : (i - 1));
           } else {
               CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",COMMAND_TEXT(cmd_num),config_textname);
           }

--- a/src/config.c
+++ b/src/config.c
@@ -788,7 +788,22 @@ short load_configuration(void)
           for (i=0; i<3; i++)
           {
             if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
-              k = LbRegisterVideoModeString(word_buf);
+            {
+              // check if the user wants to use the failsafe resolution
+              if (strncasecmp(word_buf, "SAME", 4) == 0)
+              {
+                k = get_failsafe_vidmode();
+                if (i == 0)
+                {
+                  CONFWRNLOG("Don't use SAME for failsafe video mode (unless you want 320x200x8). Error  in \"%s\" command of %s file.", COMMAND_TEXT(cmd_num),config_textname);
+                }
+              }
+              else
+              {
+                k = LbRegisterVideoModeString(word_buf);
+              }
+            }
+              
             else
               k = -1;
             if (k<=0)
@@ -816,7 +831,15 @@ short load_configuration(void)
           {
             if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
             {
-              k = LbRegisterVideoModeString(word_buf);
+              // check if the user wants to use the failsafe resolution
+              if (strncasecmp(word_buf, "SAME", 4) == 0)
+              {
+                k = get_failsafe_vidmode();
+              }
+              else
+              {
+                k = LbRegisterVideoModeString(word_buf);
+              }
               if (k > 0)
                 set_game_vidmode(i,k);
               else

--- a/src/config.c
+++ b/src/config.c
@@ -810,32 +810,32 @@ short load_configuration(void)
             switch (i)
             {
             case 0:
-                set_failsafe_vidmode(k);
+                set_failsafe_vidmode((TbScreenMode)k);
                 break;
             case 1:
-                set_movies_vidmode(k);
+                set_movies_vidmode((TbScreenMode)k);
                 break;
             case 2:
-                set_frontend_vidmode(k);
+                set_frontend_vidmode((TbScreenMode)k);
                 break;
             }
           }
           break;
       case 7: // INGAME_RES
-          for (i=0; i<max_game_vidmode_count(); i++)
+          for (i=0; i<MAX_GAME_VIDMODE_COUNT; i++)
           {
             if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
             {
               k = LbRegisterVideoModeString(word_buf);
               if (k > 0)
-                set_game_vidmode(i,k);
+                set_game_vidmode((uint)i,(TbScreenMode)k);
               else
                   CONFWRNLOG("Couldn't recognize video mode %d in \"%s\" command of %s file.",
                     i+1,COMMAND_TEXT(cmd_num),config_textname);
             } else
             {
               if (i > 0)
-                set_game_vidmode(i,Lb_SCREEN_MODE_INVALID);
+                set_game_vidmode((uint)i,Lb_SCREEN_MODE_INVALID);
               else
                   CONFWRNLOG("Video modes list empty in \"%s\" command of %s file.",
                     COMMAND_TEXT(cmd_num),config_textname);

--- a/src/config.c
+++ b/src/config.c
@@ -798,10 +798,7 @@ short load_configuration(void)
           for (i=0; i<3; i++)
           {
             if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
-            {
               k = LbRegisterVideoModeString(word_buf);
-            }
-              
             else
               k = -1;
             if (k<=0)

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -112,11 +112,11 @@ void setup_default_settings(void)
     LbMemoryCopy(&settings, &default_settings, sizeof(struct GameSettings));
     struct CPU_INFO cpu_info;
     cpu_detect(&cpu_info);
-    settings.video_scrnmode = get_next_vidmode(Lb_SCREEN_MODE_INVALID);
+    settings.video_scrnmode = Lb_SCREEN_MODE_320_200_8;
     if ((cpu_get_family(&cpu_info) > CPUID_FAMILY_PENTIUM) && (is_feature_on(Ft_HiResVideo)))
     {
         SYNCDBG(6,"Updating to hires video mode");
-        settings.video_scrnmode = get_higher_vidmode(settings.video_scrnmode);
+        settings.video_scrnmode = Lb_SCREEN_MODE_640_480_8;
     }
 }
 

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -110,14 +110,7 @@ void setup_default_settings(void)
      127,                       // mentor_volume
     };
     LbMemoryCopy(&settings, &default_settings, sizeof(struct GameSettings));
-    struct CPU_INFO cpu_info;
-    cpu_detect(&cpu_info);
-    settings.video_scrnmode = Lb_SCREEN_MODE_320_200_8;
-    if ((cpu_get_family(&cpu_info) > CPUID_FAMILY_PENTIUM) && (is_feature_on(Ft_HiResVideo)))
-    {
-        SYNCDBG(6,"Updating to hires video mode");
-        settings.video_scrnmode = Lb_SCREEN_MODE_640_480_8;
-    }
+    settings.switching_vidmodes_index = 0;
 }
 
 TbBool load_settings(void)

--- a/src/config_settings.h
+++ b/src/config_settings.h
@@ -47,7 +47,7 @@ struct GameSettings { // KFX settings
     unsigned char redbook_volume;
     unsigned char roomflags_on;
     unsigned short gamma_correction;
-    int video_scrnmode;
+    int video_scrnmode; // change to TbScreenMode
     struct GameKey kbkeys[GAME_KEYS_COUNT];
     unsigned char tooltips_on;
     unsigned char first_person_move_invert;

--- a/src/config_settings.h
+++ b/src/config_settings.h
@@ -47,7 +47,7 @@ struct GameSettings { // KFX settings
     unsigned char redbook_volume;
     unsigned char roomflags_on;
     unsigned short gamma_correction;
-    int video_scrnmode; // change to TbScreenMode
+    int switching_vidmodes_index; /**< The current position in the list of video modes to switch between with Alt+R (-1 means the index is unset). */
     struct GameKey kbkeys[GAME_KEYS_COUNT];
     unsigned char tooltips_on;
     unsigned char first_person_move_invert;

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -360,7 +360,7 @@ void gui_switch_video_mode(struct GuiButton *gbtn)
 
 void gui_display_current_resolution(struct GuiButton *gbtn)
 {
-    char* mode = get_vidmode_name(lbDisplay.ScreenMode);
+    char* mode = get_vidmode_name(LbScreenActiveMode());
     show_onscreen_msg(40, "%s", mode);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1087,13 +1087,6 @@ short setup_game(void)
       return 0;
   }
 
-  // Check the failsafe mode
-  if (!LbScreenIsModeAvailable(get_failsafe_vidmode(), display_id))
-  {
-      ERRORLOG("Failsafe video mode is invalid");
-      return 0;
-  }
-
   // View the legal screen
   if (!setup_screen_mode_zero(get_frontend_vidmode()))
   {
@@ -1154,9 +1147,7 @@ short setup_game(void)
   // Setup the intro video mode
   if ( result && (!game.no_intro) )
   {
-      LbPaletteDataFillBlack(engine_palette);
-      int mode_ok = LbScreenSetup(get_movies_vidmode(), 320, 200, engine_palette, 2, 0);
-      if (mode_ok != 1)
+      if (!setup_screen_mode_zero(get_movies_vidmode()))
       {
         ERRORLOG("Can't enter movies screen mode to play intro");
         result=0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1087,6 +1087,13 @@ short setup_game(void)
       return 0;
   }
 
+  // Check the failsafe mode
+  if (!LbScreenIsModeAvailable(get_failsafe_vidmode(), display_id))
+  {
+      ERRORLOG("Failsafe video mode is invalid");
+      return 0;
+  }
+
   // View the legal screen
   if (!setup_screen_mode_zero(get_frontend_vidmode()))
   {
@@ -1144,8 +1151,7 @@ short setup_game(void)
     }
 
   result = 1;
-  // The 320x200 mode is required only for the intro;
-  // loading and no CD screens can run in both 320x2?0 and 640x4?0.
+  // Setup the intro video mode
   if ( result && (!game.no_intro) )
   {
       LbPaletteDataFillBlack(engine_palette);

--- a/src/packets.c
+++ b/src/packets.c
@@ -668,7 +668,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
   case PckA_SwitchScrnRes:
       if (is_my_player(player))
       {
-          switch_to_next_video_mode();
+          switch_to_next_video_mode_wrapper();
       }
       return 1;
   case PckA_TogglePause:

--- a/src/vidmode.c
+++ b/src/vidmode.c
@@ -595,6 +595,13 @@ TbScreenMode setup_screen_mode(TbScreenMode nmode, TbBool failsafe)
 {
   SYNCDBG(4,"Setting up mode %d",(int)nmode);
   TbScreenModeInfo* new_mdinfo = LbScreenGetModeInfo(nmode);
+  TbScreenMode old_mode = LbScreenActiveMode();
+  TbScreenModeInfo* old_mdinfo = LbScreenGetModeInfo(old_mode);
+  // we don't want to get the current display when using the "fill all" mode, we want to keep the old version
+  if (!(old_mdinfo->VideoFlags & Lb_VF_FILLALL))
+  {
+    display_id = LbGetCurrentDisplayIndex(); // get current display
+  }
   // Check that the desired mode is available for the current display
   if (!LbScreenIsModeAvailable(nmode, display_id))
   {
@@ -615,7 +622,6 @@ TbScreenMode setup_screen_mode(TbScreenMode nmode, TbBool failsafe)
     }
     new_mdinfo = LbScreenGetModeInfo(nmode);
   }
-  TbScreenMode old_mode = LbScreenActiveMode();
   if (!force_video_mode_reset)
   {
     if ((nmode == old_mode) && (!MinimalResolutionSetup))
@@ -649,11 +655,6 @@ TbScreenMode setup_screen_mode(TbScreenMode nmode, TbBool failsafe)
       LbDataFreeAll(hi_res ? gui_load_files_640 : gui_load_files_320);
     if (!hi_res) ERRORLOG("MCGA Minimal not allowed (Reset)");
     MinimalResolutionSetup = false;
-  }
-  TbScreenModeInfo* old_mdinfo = LbScreenGetModeInfo(LbScreenActiveMode());
-  if (!(old_mdinfo->VideoFlags & Lb_VF_FILLALL))
-  {
-      display_id = LbGetCurrentDisplayIndex();
   }
   hi_res = ((new_mdinfo->Height < 400) ? false : true);
   if (new_mdinfo->Height < 200)
@@ -760,6 +761,13 @@ TbScreenMode setup_screen_mode_minimal(TbScreenMode nmode)
 {
   SYNCDBG(4,"Setting up mode %d",(int)nmode);
   TbScreenModeInfo* new_mdinfo = LbScreenGetModeInfo(nmode);
+  // we don't want to get the current display when using the "fill all" mode, we want to keep the old version
+  TbScreenMode old_mode = LbScreenActiveMode();
+  TbScreenModeInfo* old_mdinfo = LbScreenGetModeInfo(old_mode);
+  if (!(old_mdinfo->VideoFlags & Lb_VF_FILLALL))
+  {
+    display_id = LbGetCurrentDisplayIndex(); // get current display
+  }
   // Check that the desired mode is available for the current display
   if (!LbScreenIsModeAvailable(nmode, display_id))
   {
@@ -772,7 +780,6 @@ TbScreenMode setup_screen_mode_minimal(TbScreenMode nmode)
       }
       new_mdinfo = LbScreenGetModeInfo(nmode);
   }
-  TbScreenMode old_mode = LbScreenActiveMode();
   if (!force_video_mode_reset)
   {
     if ((nmode == old_mode) && (MinimalResolutionSetup))
@@ -813,12 +820,6 @@ TbScreenMode setup_screen_mode_minimal(TbScreenMode nmode)
         LbDataFreeAll(gui_load_files_320);
     }
     MinimalResolutionSetup = false;
-  }
-  // we don't want to get the current display when using the "fill all" mode, we want to keep the old version
-  TbScreenModeInfo* old_mdinfo = LbScreenGetModeInfo(old_mode);
-  if (!(old_mdinfo->VideoFlags & Lb_VF_FILLALL))
-  {
-      display_id = LbGetCurrentDisplayIndex(); // get current display
   }
   hi_res = ((new_mdinfo->Height < 400) ? false : true);
   if (new_mdinfo->Height < 200)
@@ -878,6 +879,13 @@ TbScreenMode setup_screen_mode_zero(TbScreenMode nmode)
 {
   SYNCDBG(4,"Setting up mode %d",(int)nmode);
   TbScreenModeInfo* new_mdinfo = LbScreenGetModeInfo(nmode);
+  // we don't want to get the current display when using the "fill all" mode, we want to keep the old version
+  TbScreenMode old_mode = LbScreenActiveMode();
+  TbScreenModeInfo* old_mdinfo = LbScreenGetModeInfo(old_mode);
+  if (!(old_mdinfo->VideoFlags & Lb_VF_FILLALL))
+  {
+    display_id = LbGetCurrentDisplayIndex(); // get current display
+  }
   // Check that the desired mode is available for the current display
   if (!LbScreenIsModeAvailable(nmode, display_id))
   {

--- a/src/vidmode.h
+++ b/src/vidmode.h
@@ -142,26 +142,25 @@ extern struct TbAlphaTables alpha_sprite_table;
 extern unsigned char white_pal[256];
 extern unsigned char red_pal[256];
 
-extern int MinimalResolutionSetup;
+extern TbBool MinimalResolutionSetup;
 /******************************************************************************/
 TbScreenMode switch_to_next_video_mode(void);
-void set_game_vidmode(unsigned short i,unsigned short nmode);
+void set_game_vidmode(unsigned short i, TbScreenMode nmode);
 unsigned short max_game_vidmode_count(void);
 TbScreenMode reenter_video_mode(void);
 TbScreenMode get_next_vidmode(TbScreenMode mode);
-TbScreenMode get_higher_vidmode(TbScreenMode curr_mode);
 TbScreenMode validate_vidmode(TbScreenMode mode);
 TbScreenMode get_failsafe_vidmode(void);
 TbScreenMode get_movies_vidmode(void);
 TbScreenMode get_frontend_vidmode(void);
-void set_failsafe_vidmode(unsigned short nmode);
-void set_movies_vidmode(unsigned short nmode);
-void set_frontend_vidmode(unsigned short nmode);
-char *get_vidmode_name(unsigned short mode);
+void set_failsafe_vidmode(TbScreenMode nmode);
+void set_movies_vidmode(TbScreenMode nmode);
+void set_frontend_vidmode(TbScreenMode nmode);
+char *get_vidmode_name(TbScreenMode mode);
 
-TbBool setup_screen_mode(unsigned short nmode);
-short setup_screen_mode_minimal(unsigned short nmode);
-TbBool setup_screen_mode_zero(unsigned short nmode);
+TbBool setup_screen_mode(TbScreenMode nmode);
+TbBool setup_screen_mode_minimal(TbScreenMode nmode);
+TbBool setup_screen_mode_zero(TbScreenMode nmode);
 
 short LoadMcgaData(void);
 short LoadMcgaDataMinimal(void);

--- a/src/vidmode.h
+++ b/src/vidmode.h
@@ -31,6 +31,8 @@
 extern "C" {
 #endif
 
+#define MAX_GAME_VIDMODE_COUNT 6 /**< the size of the switching_vidmodes array. */
+
 enum MousePointerGraphics {
     MousePG_Invisible = 0,
     MousePG_Arrow,
@@ -144,12 +146,11 @@ extern unsigned char red_pal[256];
 
 extern TbBool MinimalResolutionSetup;
 /******************************************************************************/
-TbScreenMode switch_to_next_video_mode(void);
-void set_game_vidmode(unsigned short i, TbScreenMode nmode);
-unsigned short max_game_vidmode_count(void);
+void switch_to_next_video_mode_wrapper(void);
+TbBool switch_to_next_video_mode(void);
+void set_game_vidmode(uint i, TbScreenMode nmode);
+TbScreenMode get_game_vidmode(uint i);
 TbScreenMode reenter_video_mode(void);
-TbScreenMode get_next_vidmode(TbScreenMode mode);
-TbScreenMode validate_vidmode(TbScreenMode mode);
 TbScreenMode get_failsafe_vidmode(void);
 TbScreenMode get_movies_vidmode(void);
 TbScreenMode get_frontend_vidmode(void);

--- a/src/vidmode.h
+++ b/src/vidmode.h
@@ -158,9 +158,9 @@ void set_movies_vidmode(TbScreenMode nmode);
 void set_frontend_vidmode(TbScreenMode nmode);
 char *get_vidmode_name(TbScreenMode mode);
 
-TbBool setup_screen_mode(TbScreenMode nmode);
-TbBool setup_screen_mode_minimal(TbScreenMode nmode);
-TbBool setup_screen_mode_zero(TbScreenMode nmode);
+TbScreenMode setup_screen_mode(TbScreenMode nmode);
+TbScreenMode setup_screen_mode_minimal(TbScreenMode nmode);
+TbScreenMode setup_screen_mode_zero(TbScreenMode nmode);
 
 short LoadMcgaData(void);
 short LoadMcgaDataMinimal(void);

--- a/src/vidmode.h
+++ b/src/vidmode.h
@@ -158,7 +158,7 @@ void set_movies_vidmode(TbScreenMode nmode);
 void set_frontend_vidmode(TbScreenMode nmode);
 char *get_vidmode_name(TbScreenMode mode);
 
-TbScreenMode setup_screen_mode(TbScreenMode nmode);
+TbScreenMode setup_screen_mode(TbScreenMode nmode, TbBool failsafe);
 TbScreenMode setup_screen_mode_minimal(TbScreenMode nmode);
 TbScreenMode setup_screen_mode_zero(TbScreenMode nmode);
 


### PR DESCRIPTION
* New config settings for screen resolutions:
  * "DESKTOP" can be used for a borderless window that fills the whole screen (fake fullscreen).
  * "DESKTOP_FULL" can be used for a real fullscreen mode that matches the current desktop.
  * "ALL" can be used for a borderless window that fills all screens. YMMV.
* WxHx32 still gives real fullscreen at the given res.
* WxHw32 still gives a normal window at the given res.
* Launcher Settings already allows you to type these new settings, and will not complain*.
* `LbHwCheckIsModeAvailable` now actually checks the modes again (previously it just returned true without checking)
* screen mode is checked every time before switching, as different displays may support different modes.
* `display_id` stored internally instead of `display_number` - Config setting remains the same.
* Game now remembers the last used display. Can toggle from fullscreen to a window, move window to other display, then toggle to fullscreen and it sticks to the new window.
* **Doesn't destroy windows at all anymore. Streams shouldn't crash if screen res is changed.**
* Can no longer switch to a fullscreen mode that the display does not support. This stop the creation of incorrect windows.
* added `sdlFlags` to `struct ScreenModeInfo`
* added `window_pos_x/y` to `struct ScreenModeInfo` (need for the "ALL" mode)
* added `LbGetCurrentDisplayIndex()` to get the current display
* added `LbRegisterModernVideoModes()` to setup "modern" video "modes"
* intro vid setup properly
* settings.dat now saves a "slot number" instead of a "mode number"
* in-game res always tries other provided resolutions before the failsafe.
* The failsafe is now only used in an emergency.
* Many(sic) Refactoring!
* Bug noticed: failsafe res is only used once we are in a level. [fixed in f673295]
* Bug noticed: When switching res in level with Alt+R, you can't switch past an invalid reg, failsafe is used, but the cycle stays in the same position. [fixed in 2e78c21]
* **Note: if the failsafe res is not available, and if the game tries to rely on the failsafe res, the game will still crash.**
* **_Minor nuisance_** - when changing modes it seems that there is a frame where the window is half the old mode, half the new mode (e.g. switching from window to fullscreen I can see the window moved to the top left corner of the screen for a frame before it fills the whole screen). _This seems to be an "SDL thing" as I can see the same behaviour in ScummVM._ 

Todo in other PRs:
* (maybe) sanity check/correction for undesirable non-fullscreen window resolutions [maybe not: as there are fringe cases for making windows larger than the current display].
* fix mouse behaviour (positioning and grabbing on focus loss/gain and res change)
* *Should add the new settings as selectable options in the launcher, and have information about them on hover.
* make window resizable (See commented out references to SDL_WINDOWEVENT_SIZE_CHANGED and SDL_WINDOW_RESIZABLE). Needs separate "window resized" event.