### PR TITLE
Cmd line options and config

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -60,6 +60,9 @@ ATMOS_SAMPLES=1014 1034 1013
 ; Censorship - originally was ON only if language is german.
 CENSORSHIP=OFF
 
+; Play the music from a folder on the disk.
+MUSIC_FROM_DISK=ON
+
 ; The amount of Music tracks the game can support. Max 50.
 MUSIC_TRACKS=7
 

--- a/src/config.c
+++ b/src/config.c
@@ -139,6 +139,7 @@ const struct NamedCommand conf_commands[] = {
   {"CREATURE_STATUS_SIZE"          , 26},
   {"MAX_ZOOM_DISTANCE"             , 27},
   {"DISPLAY_NUMBER"                , 28},
+  {"MUSIC_FROM_DISK"               , 29},
   {NULL,                   0},
   };
 
@@ -1101,6 +1102,19 @@ short load_configuration(void)
               CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",COMMAND_TEXT(cmd_num),config_textname);
           }
           break;
+      case 29: // MUSIC_FROM_DISK
+          i = recognize_conf_parameter(buf,&pos,len,logicval_type);
+          if (i <= 0)
+          {
+              CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
+                COMMAND_TEXT(cmd_num),config_textname);
+            break;
+          }
+          if (i == 1)
+              features_enabled |= Ft_NoCdMusic;
+          else
+              features_enabled &= ~Ft_NoCdMusic;
+          break;
       case 0: // comment
           break;
       case -1: // end of buffer
@@ -1148,6 +1162,19 @@ short load_configuration(void)
   }
   // Returning if the setting are valid
   return (install_info.lang_id > 0) && (install_info.inst_path[0] != '\0');
+}
+
+/** CmdLine overrides allow settings from the command line to override the deafault settings, or those set in the config file.
+ * 
+ * See enum CmdLineOverrides and struct StartupParameters -> TbBool overrides[CMDLINE_OVERRIDES].
+ */
+void process_cmdline_overrides(void)
+{
+  // Use CD for music rather than OGG files
+  if (start_params.overrides[Clo_CDMusic])
+  {
+    features_enabled &= ~Ft_NoCdMusic;
+  }
 }
 
 char *prepare_file_path_buf(char *ffullpath,short fgroup,const char *fname)

--- a/src/config.c
+++ b/src/config.c
@@ -1173,7 +1173,7 @@ short load_configuration(void)
   return (install_info.lang_id > 0) && (install_info.inst_path[0] != '\0');
 }
 
-/** CmdLine overrides allow settings from the command line to override the deafault settings, or those set in the config file.
+/** CmdLine overrides allow settings from the command line to override the default settings, or those set in the config file.
  * 
  * See enum CmdLineOverrides and struct StartupParameters -> TbBool overrides[CMDLINE_OVERRIDES].
  */

--- a/src/config.c
+++ b/src/config.c
@@ -714,16 +714,25 @@ short load_configuration(void)
   install_info.field_9A = 0;
   // Set default runtime directory and load the config file
   strcpy(keeper_runtime_directory,".");
-  const char* fname = prepare_file_path(FGrp_Main, keeper_config_file);
+  const char* sname;
+  if (start_params.overrides[Clo_ConfigFile])
+  {
+    sname = start_params.config_file;
+  }
+  else
+  {
+    sname = keeper_config_file;
+  }
+  const char* fname = prepare_file_path(FGrp_Main, sname);
   long len = LbFileLengthRnc(fname);
   if (len < 2)
   {
-    WARNMSG("%s file \"%s\" doesn't exist or is too small.",config_textname,keeper_config_file);
+    WARNMSG("%s file \"%s\" doesn't exist or is too small.",config_textname,sname);
     return false;
   }
   if (len > 65536)
   {
-    WARNMSG("%s file \"%s\" is too large.",config_textname,keeper_config_file);
+    WARNMSG("%s file \"%s\" is too large.",config_textname,sname);
     return false;
   }
   char* buf = (char*)LbMemoryAlloc(len + 256);

--- a/src/config.h
+++ b/src/config.h
@@ -218,6 +218,7 @@ TbBool lock_cursor_in_possession(void);
 TbBool pause_music_when_game_paused(void);
 TbBool mute_audio_on_focus_lost(void);
 short load_configuration(void);
+void process_cmdline_overrides(void);
 short calculate_moon_phase(short do_calculate,short add_to_log);
 void load_or_create_high_score_table(void);
 TbBool load_high_score_table(void);

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -62,6 +62,11 @@ extern "C" {
 #define LENSES_COUNT           15
 #define SPELL_POINTER_GROUPS   14
 #define ZOOM_KEY_ROOMS_COUNT   15
+#define CMDLINE_OVERRIDES      1
+
+enum CmdLineOverrides {
+    Clo_CDMusic = 0,
+};
 
 enum ModeFlags {
     MFlg_IsDemoMode         =  0x01,
@@ -128,6 +133,7 @@ struct StartupParameters {
     unsigned char force_ppro_poly;
     int frame_skip;
     char selected_campaign[CMDLN_MAXLEN+1];
+    TbBool overrides[CMDLINE_OVERRIDES];
 #ifdef AUTOTESTING
     unsigned char autotest_flags;
     unsigned long autotest_exit_turn;

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -62,10 +62,12 @@ extern "C" {
 #define LENSES_COUNT           15
 #define SPELL_POINTER_GROUPS   14
 #define ZOOM_KEY_ROOMS_COUNT   15
-#define CMDLINE_OVERRIDES      1
+#define CMDLINE_OVERRIDES      2
 
+/** Command Line overrides for config settings. Checked after the config file is loaded. */
 enum CmdLineOverrides {
-    Clo_CDMusic = 0,
+    Clo_ConfigFile = 0, /**< Special: handled before the config file is loaded. */
+    Clo_CDMusic,
 };
 
 enum ModeFlags {
@@ -134,6 +136,7 @@ struct StartupParameters {
     int frame_skip;
     char selected_campaign[CMDLN_MAXLEN+1];
     TbBool overrides[CMDLINE_OVERRIDES];
+    char config_file[CMDLN_MAXLEN+1];
 #ifdef AUTOTESTING
     unsigned char autotest_flags;
     unsigned long autotest_exit_turn;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4089,6 +4089,12 @@ short process_command_line(unsigned short argc, char *argv[])
           }
           narg++;
       }
+      else if ( strcasecmp(parstr,"config") == 0 )
+      {
+        strcpy(start_params.config_file, pr2str);
+        start_params.overrides[Clo_ConfigFile] = true;
+        narg++;
+      }
 #ifdef AUTOTESTING
       else if (strcasecmp(parstr, "exit_at_turn") == 0)
       {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3958,6 +3958,10 @@ short process_command_line(unsigned short argc, char *argv[])
       {
         start_params.no_intro = 1;
       } else
+      if (strcasecmp(parstr, "nocd") == 0) // kept for legacy reasons
+      {
+          WARNLOG("The -nocd commandline parameter is no longer functional. Game music from CD is a setting in keeperfx.cfg instead.");
+      } else
       if (strcasecmp(parstr, "cd") == 0)
       {
           start_params.overrides[Clo_CDMusic] = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1061,7 +1061,7 @@ short setup_game(void)
   // Enable features that require more resources
   update_features(mem_size);
 
-  //Default feature settings (in case the options are absent from keeperfx.cfg)
+  // Default feature settings (in case the options are absent from keeperfx.cfg)
   features_enabled &= ~Ft_FreezeOnLoseFocus; // don't freeze the game, if the game window loses focus
   features_enabled &= ~Ft_UnlockCursorOnPause; // don't unlock the mouse cursor from the window, if the user pauses the game
   features_enabled |= Ft_LockCursorInPossession; // lock the mouse cursor to the window, when the user enters possession mode (when the cursor is already unlocked)
@@ -1071,6 +1071,7 @@ short setup_game(void)
   features_enabled &= ~Ft_SkipSplashScreens; // don't skip splash screens
   features_enabled &= ~Ft_DisableCursorCameraPanning; // don't disable cursor camera panning
   features_enabled |= Ft_DeltaTime; // enable delta time
+  features_enabled |= Ft_NoCdMusic; // use music files (OGG) rather than CD music
 
   // Configuration file
   if ( !load_configuration() )
@@ -1078,6 +1079,9 @@ short setup_game(void)
       ERRORLOG("Configuration load error.");
       return 0;
   }
+
+  // Process CmdLine overrides
+  process_cmdline_overrides();
 
   LbIKeyboardOpen();
 
@@ -3954,9 +3958,9 @@ short process_command_line(unsigned short argc, char *argv[])
       {
         start_params.no_intro = 1;
       } else
-      if (strcasecmp(parstr, "nocd") == 0)
+      if (strcasecmp(parstr, "cd") == 0)
       {
-          features_enabled |= Ft_NoCdMusic;
+          start_params.overrides[Clo_CDMusic] = true;
       } else
       if (strcasecmp(parstr, "1player") == 0)
       {


### PR DESCRIPTION
* Can now override config file from command line
  * example: `-config foo.cfg` on the command line to load "foo.cfg" instead of "keeperfx.cfg"
* added `MUSIC_FROM_DISK=ON/OFF` config setting
* added `-cd` command line option
*  `-nocd` command line option no longer functions, and a warning is written to the log if it is used.
* default to music from files in a folder rather than CD
* added command line overrides functionality - so that a command line option can supersede a config option
  * the first of these is -`cd`

I'll finish #2535 in a separate PR - i.e. allow custom tracks to be played when triggered by "SET_MUSIC", no matter what `Ft_NoCdMusic` is set to.
