### PR TITLE
Correctly position the little background in the imp menu

### DIFF
--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1751,8 +1751,9 @@ void gui_activity_background(struct GuiMenu *gmnu)
             }
         }
     }
+    int mm_units_per_px = (gmnu->width * 16 + 140 / 2) / 140;
     lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR4;
-    LbDrawBox(gmnu->pos_x + scale_ui_value(2), gmnu->pos_y + scale_ui_value(218), scale_ui_value(134), scale_ui_value(24), colours[0][0][0]);
+    LbDrawBox(gmnu->pos_x + scale_value_for_resolution_with_upp(2, mm_units_per_px), gmnu->pos_y + scale_value_for_resolution_with_upp(218, mm_units_per_px), scale_value_for_resolution_with_upp(134, mm_units_per_px), scale_value_for_resolution_with_upp(24, mm_units_per_px), colours[0][0][0]);
     lbDisplay.DrawFlags = flg_mem;
 }
 

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1752,8 +1752,7 @@ void gui_activity_background(struct GuiMenu *gmnu)
         }
     }
     lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR4;
-    int units_per_px = gmnu->width * 16 / 140;
-    LbDrawBox(gmnu->pos_x + 2*units_per_px/16, gmnu->pos_y + 218*units_per_px/16, 134*units_per_px/16, 24*units_per_px/16, colours[0][0][0]);
+    LbDrawBox(gmnu->pos_x + scale_ui_value(2), gmnu->pos_y + scale_ui_value(218), scale_ui_value(134), scale_ui_value(24), colours[0][0][0]);
     lbDisplay.DrawFlags = flg_mem;
 }
 


### PR DESCRIPTION
Good:
![image](https://github.com/dkfans/keeperfx/assets/13840686/82197110-76e9-4f0f-ab5d-21d6e23374bb)

Bad:
![image](https://github.com/dkfans/keeperfx/assets/13840686/243bbbbd-8547-43fe-b2a3-d55a02c63a65)

Should now be good in any resolution