### PR TITLE
resolve stack trace symbols and look up using address map file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ CU_OBJS = \
 # include and library directories
 LINKLIB =  -L"sdl/lib" -mwindows obj/enet.a \
 	-lwinmm -lmingw32 -limagehlp -lSDL2main -lSDL2 -lSDL2_mixer -lSDL2_net -lSDL2_image \
-	-L"deps/zlib" -lz -lws2_32
+	-L"deps/zlib" -lz -lws2_32 -ldbghelp
 INCS =  -I"sdl/include" -I"sdl/include/SDL2" -I"deps/enet/include" -I"deps/centijson/src" -I"deps/centitoml"
 CXXINCS =  $(INCS)
 

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -104,10 +104,10 @@ _backtrace(int depth , LPCONTEXT context)
     int64_t keeperFxBaseAddr = 0x00000000;
     char mapFileLine[512];
 
-    #if (BFDEBUG_LEVEL == 0)
-        FILE *mapFile = fopen("keeperfx.map", "r");
-    #else
+    #if (BFDEBUG_LEVEL > 7)
         FILE *mapFile = fopen("keeperfx_hvlog.map", "r");
+    #else
+        FILE *mapFile = fopen("keeperfx.map", "r");
     #endif
 
     if (mapFile)

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -253,14 +253,14 @@ _backtrace(int depth , LPCONTEXT context)
         pSymbol->MaxNameLen = MAX_SYM_NAME;
 
         // The distance between the original function and the call in the trace
-        int64_t displacement;
+        uint64_t sfaDisplacement;
 
         // First check if we can find the symbol by its address
         // This works if there are any debug symbols available and also works for most OS libraries
-        if (SymFromAddr(process, frame.AddrPC.Offset, &displacement, pSymbol))
+        if (SymFromAddr(process, frame.AddrPC.Offset, &sfaDisplacement, pSymbol))
         {
             LbJustLog("[#%-2d]  in %14-s : %-40s [%04x:%08x+0x%llx, base %08x] (symbol lookup)\n",
-                      depth, module_name, pSymbol->Name, context->SegCs, frame.AddrPC.Offset, displacement, module_base);
+                      depth, module_name, pSymbol->Name, context->SegCs, frame.AddrPC.Offset, sfaDisplacement, module_base);
         } 
         else
         {

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -110,7 +110,7 @@ _backtrace(int depth , LPCONTEXT context)
         // Get base address from map file
         while (fgets(mapFileLine, sizeof(mapFileLine), mapFile) != NULL)
         {
-            if (sscanf(mapFileLine, " %*llx __image_base__ = %llx", &keeperFxBaseAddr) == 1)
+            if (sscanf(mapFileLine, " %*x __image_base__ = %llx", &keeperFxBaseAddr) == 1)
             {
                 SYNCDBG(0, "KeeperFX base address in map file: %llx\n", keeperFxBaseAddr);
                 break;

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -117,11 +117,11 @@ _backtrace(int depth , LPCONTEXT context)
             }
         }
 
+        memset(mapFileLine, 0, sizeof(mapFileLine));
+
         if(keeperFxBaseAddr != 0x00000000)
         {
-            // Reset buffers
             fseek(mapFile, 0, SEEK_SET);
-            memset(mapFileLine, 0, sizeof(mapFileLine));
         }
         else
         {

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -146,7 +146,7 @@ _backtrace(int depth , LPCONTEXT context)
     HANDLE process = GetCurrentProcess();
     HANDLE thread = GetCurrentThread();
 
-    // Loop trough all traces in the stack
+    // Loop through all traces in the stack
     while (StackWalk(IMAGE_FILE_MACHINE_I386, process, thread, &frame, context, 0, SymFunctionTableAccess, SymGetModuleBase, 0))
     {
         --depth;
@@ -205,7 +205,7 @@ _backtrace(int depth , LPCONTEXT context)
                 DWORD64 prevAddr = 0x00000000;
                 char prevName[512];
 
-                // Loop trough all lines in the mapFile
+                // Loop through all lines in the mapFile
                 // This should be pretty fast on modern systems
                 while (fgets(mapFileLine, sizeof(mapFileLine), mapFile) != NULL)
                 {

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -197,7 +197,7 @@ _backtrace(int depth , LPCONTEXT context)
                 // This should be pretty fast on modern systems
                 while (fgets(mapFileLine, sizeof(mapFileLine), mapFile) != NULL)
                 {
-
+                    
                     int64_t addr;
                     char name[512];
                     if (
@@ -226,7 +226,6 @@ _backtrace(int depth , LPCONTEXT context)
                                 depth, module_name, prevName, prevAddr, displacement, context->SegCs, frame.AddrPC.Offset, module_base);
 
                             addrFound = true;
-
                             break;
                         }
                     }
@@ -264,11 +263,9 @@ _backtrace(int depth , LPCONTEXT context)
         } 
         else
         {
-
             // Fallback
             LbJustLog("[#%-2d]  in %13-s at %04x:%08x, base %08x\n", depth, module_name, context->SegCs, frame.AddrPC.Offset, module_base);
         }
-
     }
 
     if(mapFile){

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -189,7 +189,7 @@ _backtrace(int depth , LPCONTEXT context)
         // This works if there are any debug symbols available and also most OS libraries
         if (SymFromAddr(process, frame.AddrPC.Offset, &displacement, pSymbol))
         {
-            LbJustLog("[#%-2d]  in %14-s : %-40s [%04x:%08x+0x%llx, base %08x]\n",
+            LbJustLog("[#%-2d]  in %14-s : %-40s [%04x:%08x+0x%llx, base %08x] (symbol lookup)\n",
                       depth, module_name, pSymbol->Name, context->SegCs, frame.AddrPC.Offset, displacement, module_base);
             
             continue;

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -112,7 +112,7 @@ _backtrace(int depth , LPCONTEXT context)
         {
             if (sscanf(mapFileLine, " %*x __image_base__ = %llx", &keeperFxBaseAddr) == 1)
             {
-                SYNCDBG(0, "KeeperFX base address in map file: %llx\n", keeperFxBaseAddr);
+                SYNCDBG(0, "KeeperFX base address in map file: %llx", keeperFxBaseAddr);
                 break;
             }
         }
@@ -186,7 +186,7 @@ _backtrace(int depth , LPCONTEXT context)
         DWORD64 displacement;
 
         // First check if we can find the symbol by its address
-        // This works if there are any debug symbols available and also most OS libraries
+        // This works if there are any debug symbols available and also works for most OS libraries
         if (SymFromAddr(process, frame.AddrPC.Offset, &displacement, pSymbol))
         {
             LbJustLog("[#%-2d]  in %14-s : %-40s [%04x:%08x+0x%llx, base %08x] (symbol lookup)\n",
@@ -199,7 +199,7 @@ _backtrace(int depth , LPCONTEXT context)
             // Look up using the keeperfx.map file
             if(mapFile){
 
-                DWORD64 checkAddr = frame.AddrPC.Offset - (module_base - keeperFxBaseAddr);
+                DWORD64 checkAddr = frame.AddrPC.Offset - module_base + keeperFxBaseAddr;
 
                 bool addrFound = false;
                 DWORD64 prevAddr = 0x00000000;

--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -223,6 +223,16 @@ _backtrace(int depth , LPCONTEXT context)
                         {
                             displacement = checkAddr - prevAddr;
 
+                            // Handle library traces
+                            // Example: '0x123 lib/thing.o'
+                            // We don't want that size at the beginning, but we do want the library path.
+                            char *splitPos = strchr(prevName, ' ');
+                            if (strncmp(prevName, "0x", 2) == 0 && splitPos != NULL){
+                                memmove(prevName, splitPos + 1, strlen(splitPos)); // remove anything before the space
+                                memmove(prevName + 4, prevName, strlen(prevName) + 1); // make space for the arrow symbol
+                                memcpy(prevName, "-> ", 3); // prepend the arrow symbol
+                            }
+
                             LbJustLog(
                                 "[#%-2d]  in %14-s : %-40s [0x%llx+0x%llx] \t(map lookup for %04x:%08x, base: %08x)\n",
                                 depth, module_name, prevName, prevAddr, displacement, context->SegCs, frame.AddrPC.Offset, module_base);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4288,7 +4288,7 @@ LONG __stdcall Vex_handler(
     _EXCEPTION_POINTERS *ExceptionInfo
 )
 {
-    LbJustLog("=== Crash ===");
+    LbJustLog("=== Crash ===\n");
     LbCloseLog();
     return 0;
 }


### PR DESCRIPTION
Changes the stack trace code to include symbol names.

- Uses `SymFromAddr` to resolve OS calls
- If it doesn't find one it will try and use the map file
- Has an extra fallback if neither of the above worked

Before:
```
=== Crash ===Error: Attempt to read from inaccessible memory address.
  in msvcrt.dll at 0023:656d9cc7, base 65680000
  in keeperfx.exe at 0023:00436034, base 00400000
  in keeperfx.exe at 0023:00443aad, base 00400000
  in keeperfx.exe at 0023:005686a5, base 00400000
  in keeperfx.exe at 0023:0051a6ab, base 00400000
  in keeperfx.exe at 0023:00508026, base 00400000
  in keeperfx.exe at 0023:00527fb4, base 00400000
  in keeperfx.exe at 0023:004f663d, base 00400000
  in keeperfx.exe at 0023:0050a04c, base 00400000
  in keeperfx.exe at 0023:00600217, base 00400000
  in keeperfx.exe at 0023:006010da, base 00400000
  in keeperfx.exe at 0023:006013af, base 00400000
  in keeperfx.exe at 0023:00607b84, base 00400000
  in keeperfx.exe at 0023:00607c25, base 00400000
  in keeperfx.exe at 0023:00632afd, base 00400000
  in keeperfx.exe at 0023:00401396, base 00400000
```

After:
``` 
=== Crash ===
Error: Attempt to read from inaccessible memory address.
[#15]  in     msvcrt.dll : strchr                                   [0023:656d9cc7+0x17, base 65680000] (symbol lookup)
[#14]  in   keeperfx.exe : -> /obj/std/bflib_enet.o                 [0x438240+0x333] 	(map lookup for 0023:00438573, base: 00400000)
[#13]  in   keeperfx.exe : LbNetwork_Join                           [0x446c70+0x2d] 	(map lookup for 0023:00446c9d, base: 00400000)
[#12]  in   keeperfx.exe : network_session_join                     [0x573e80+0x36] 	(map lookup for 0023:00573eb6, base: 00400000)
[#11]  in   keeperfx.exe : frontnet_session_join                    [0x5269e0+0xb] 	(map lookup for 0023:005269eb, base: 00400000)
[#10]  in   keeperfx.exe : do_button_release_actions                [0x5148c0+0xee] 	(map lookup for 0023:005149ae, base: 00400000)
[#9 ]  in   keeperfx.exe : gui_button_release_inputs                [0x533d40+0x94] 	(map lookup for 0023:00533dd4, base: 00400000)
[#8 ]  in   keeperfx.exe : get_gui_inputs                           [0x502de0+0x275] 	(map lookup for 0023:00503055, base: 00400000)
[#7 ]  in   keeperfx.exe : frontend_input                           [0x5168d0+0x1ac] 	(map lookup for 0023:00516a7c, base: 00400000)
[#6 ]  in   keeperfx.exe : game_loop                                [0x609b20+0x588] 	(map lookup for 0023:0060a0a8, base: 00400000)
[#5 ]  in   keeperfx.exe : LbBullfrogMain                           [0x60ae20+0x1ca] 	(map lookup for 0023:0060afea, base: 00400000)
[#4 ]  in   keeperfx.exe : SDL_main                                 [0x60b190+0x4a] 	(map lookup for 0023:0060b1da, base: 00400000)
[#3 ]  in   keeperfx.exe : main_getcmdline                          [0023:00611b04+0x174, base 00400000] (symbol lookup)
[#2 ]  in   keeperfx.exe : WinMain                                  [0023:00611ba5+0x5, base 00400000] (symbol lookup)
[#1 ]  in   keeperfx.exe : main                                     [0x63d5a0+0xc4] 	(map lookup for 0023:0063d664, base: 00400000)
[#0 ]  in   keeperfx.exe : -> r/usr/lib/gcc/i686-w64-mingw32/12-win32/../../../../i686-w64-mingw32/lib/../lib/crt2.o [0x401000+0x2f0] 	(map lookup for 0023:004012f0, base: 00400000)
``` 

Probably needs more testing with other crashes and library calls. 

It should also try and figure out if the map file is actually the correct one. 