### PR TITLE
change target arch from i686 to x86-64-v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,11 +359,11 @@ INCFLAGS =
 CV2PDB := $(shell PATH=`pwd`:$$PATH command -v cv2pdb.exe 2> /dev/null)
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
-  OPTFLAGS = -march=i686 -fno-omit-frame-pointer -O0
+  OPTFLAGS = -march=x86-64-v3 -fno-omit-frame-pointer -O0
   DBGFLAGS = -g -DDEBUG
 else
   # frame pointer is required for ASM code to work
-  OPTFLAGS = -march=i686 -fno-omit-frame-pointer -O3
+  OPTFLAGS = -march=x86-64-v3 -fno-omit-frame-pointer -O3
   # if we can create a separate debug info file then do it
   ifdef CV2PDB
     DBGFLAGS = -g


### PR DESCRIPTION
Changes the target architecture from i686 to x86-64-v3.

- This fixes compilation for some Linux users.
- Decreases output bin from 4.5MB to 4.2MB die to improved CPU instructions
- "There's barely any relevant hardware which doesn't support v3 (AVX)" - Trass3r

List of other options: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html