### PR TITLE
Protection against a divide by 0 error on packet control

### DIFF
--- a/src/packets.c
+++ b/src/packets.c
@@ -331,8 +331,15 @@ void process_players_dungeon_control_packet_control(long plyr_idx)
     struct Packet* pckt = get_packet_direct(player->packet_num);
     SYNCDBG(6,"Processing player %d action %d",(int)plyr_idx,(int)pckt->action);
     struct Camera* cam = player->acamera;
+    if (cam == NULL)
+    {
+        ERRORLOG("No active camera");
+        return;
+    }
     long inter_val;
     int scroll_speed = cam->zoom;
+    if (scroll_speed <= 0)
+        scroll_speed = 1;
     switch (cam->view_mode)
     {
     case PVM_IsoWibbleView:


### PR DESCRIPTION
My game kept crashing when trying to start it. This fixed it.

I think my game got corrupted by loading a packet from somebody else where I was missing the map.