### PR TITLE
Fixed crash when running command "!give.trap"

### DIFF
--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -1689,6 +1689,10 @@ PlayerNumber get_player_number_for_command(char *msg)
 
 TbBool parameter_is_number(const char* parstr)
 {
+    if (parstr == NULL)
+    {
+        return false;
+    }
     for (int i = 0; parstr[i] != '\0'; i++)
     {
         TbBool digit = (i == 0) ? ( (parstr[i] == 0x2D) || (isdigit(parstr[i])) ) : (isdigit(parstr[i]));


### PR DESCRIPTION
Running "!give.trap" would generate a crash as parameter passed to parameter_is_number would be NULL