### PR TITLE
Made placement sound of doors configurable

### DIFF
--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -22,6 +22,7 @@ Health = 0
 SlabKind = HARD HARD
 OpenSpeed = 256
 Properties = 
+PlaceSound = 0
 
 [door1]
 ; Name is the item identifier which should be used in level script
@@ -52,6 +53,7 @@ OpenSpeed = 256
 ;THICK this door is 3 subtiles thick instead of the normal 1
 ;RESIST_NON_MAGIC if it recieves damage from non magical source only 10% get applied
 Properties = 
+PlaceSound = 117
 
 [door2]
 Name = BRACED
@@ -68,6 +70,7 @@ Health = 1000
 SlabKind = DOOR_BRACE DOOR_BRACE2
 OpenSpeed = 256
 Properties = 
+PlaceSound = 117
 
 [door3]
 Name = STEEL
@@ -84,6 +87,7 @@ Health = 2500
 SlabKind = DOOR_STEEL DOOR_STEEL2
 OpenSpeed = 256
 Properties = 
+PlaceSound = 117
 
 [door4]
 Name = MAGIC
@@ -100,6 +104,7 @@ Health = 1250
 SlabKind = DOOR_MAGIC DOOR_MAGIC2
 OpenSpeed = 256
 Properties = RESIST_NON_MAGIC
+PlaceSound = 117
 
 [door5]
 Name = SECRET
@@ -116,6 +121,7 @@ Health = 1250
 SlabKind = DOOR_SECRET DOOR_SECRET2
 OpenSpeed = 256
 Properties = SECRET THICK
+PlaceSound = 117
 
 ; Traps configuration
 

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -63,6 +63,7 @@ const struct NamedCommand trapdoor_door_commands[] = {
   {"PANELTABINDEX",        12},
   {"OPENSPEED",            13},
   {"PROPERTIES",           14},
+  {"PLACESOUND",           15},
   {NULL,                    0},
 };
 
@@ -1039,6 +1040,8 @@ TbBool parse_trapdoor_door_blocks(char *buf, long len, const char *config_textna
           doorst->bigsym_sprite_idx = 0;
           doorst->medsym_sprite_idx = 0;
           doorst->pointer_sprite_idx = 0;
+          // Default door placement sound, so that placement sound isn't broken if custom doors is bundled into maps
+          doorst->place_sound_idx = 117;
           doorst->panel_tab_idx = 0;
           if (i < gameadd.trapdoor_conf.door_types_count)
           {
@@ -1330,7 +1333,21 @@ TbBool parse_trapdoor_door_blocks(char *buf, long len, const char *config_textna
             }
           }
           break;
-
+      case 15: // PLACESOUND
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              n = atoi(word_buf);
+              if (n < 0 || n > samples_in_bank - 1)
+              {
+                  CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                      COMMAND_TEXT(cmd_num), block_buf, config_textname);
+              }
+              else
+              {
+                  doorst->place_sound_idx = n;
+              }
+          }
+          break;
       case 0: // comment
           break;
       case -1: // end of buffer

--- a/src/config_trapdoor.h
+++ b/src/config_trapdoor.h
@@ -52,6 +52,7 @@ struct DoorConfigStats {
     long bigsym_sprite_idx;
     long medsym_sprite_idx;
     long pointer_sprite_idx;
+    long place_sound_idx;
     unsigned short slbkind[2];
     long health;
     unsigned short open_speed;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2140,6 +2140,12 @@ static void set_door_configuration_process(struct ScriptContext *context)
                 doorst->open_speed = value;
             }
             break;
+        case 15: // PlaceSound
+            if (door_type < gameadd.trapdoor_conf.door_types_count)
+            {
+                doorst->place_sound_idx = value;
+            }
+            break;
         default:
             WARNMSG("Unsupported Door configuration, variable %d.", context->value->shorts[1]);
             break;

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1255,7 +1255,8 @@ TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
     dungeon->camera_deviate_jump = 192;
     if (is_my_player_number(plyr_idx))
     {
-        play_non_3d_sample(117);
+        struct DoorConfigStats* door_cfg = get_door_model_stats(tngmodel);
+        play_non_3d_sample(door_cfg->place_sound_idx);
     }
     return 1;
 }


### PR DESCRIPTION
Complement to PR #2673 as feedback to @Loobinex feedback that it's strange that doors doesn't have configurable sounds when the traps has them. Basically the same code as the traps