### PR TITLE
increased LIGHTS_COUNT

### DIFF
--- a/src/light_data.h
+++ b/src/light_data.h
@@ -23,7 +23,7 @@
 #include "bflib_basics.h"
 
 #define LIGHT_MAX_RANGE       256 // Large enough to cover the whole map
-#define LIGHTS_COUNT          400
+#define LIGHTS_COUNT         2048
 #define MINIMUM_LIGHTNESS    8192
 
 #ifdef __cplusplus


### PR DESCRIPTION
For fixing Carbon's map. If this value is too low, then the cursor light won't spawn if the map has too many lights.

These lights on the map don't need to just be manually placed Lights, lots of things create their own light such as Dungeon Hearts and Lava. (this limit can be reached easily)