### PR TITLE
Quadruple THINGS_COUNT

### DIFF
--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -29,8 +29,8 @@ extern "C" {
 #endif
 
 /******************************************************************************/
-#define THING_CLASSES_COUNT    14
-#define THINGS_COUNT         8192
+#define THING_CLASSES_COUNT     14
+#define THINGS_COUNT         32767
 
 enum ThingClassIndex {
     TCls_Empty        =  0,


### PR DESCRIPTION
From 8192 to 32767.

I assume it's a short?

Why this PR?

Support for big maps 170x170 which are 4 times bigger than a standard sized map.