### PR TITLE
Less sticky slab tooltips

### DIFF
--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -44,6 +44,7 @@
 #include "game_legacy.h"
 #include "keeperfx.hpp"
 #include "post_inc.h"
+#include <math.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -122,6 +123,12 @@ static inline void clear_gui_tooltip_button(void)
 {
     tool_tip_time = 0;
     tool_tip_box.gbutton = NULL;
+}
+
+TbBool cursor_moved_to_new_slab(struct PlayerInfo *player)
+{
+    struct PlayerInfoAdd* playeradd = get_playeradd(player->id_number);
+    return (floor(playeradd->cursor_subtile_x/3) != floor(playeradd->previous_cursor_subtile_x/3) || floor(playeradd->cursor_subtile_y/3) != floor(playeradd->previous_cursor_subtile_y/3));
 }
 
 TbBool setup_trap_tooltips(struct Coord3d *pos)
@@ -254,7 +261,10 @@ short setup_land_tooltips(struct Coord3d *pos)
     return false;
   update_gui_tooltip_target((void *)skind);
   struct PlayerInfo* player = get_my_player();
-  if ( (help_tip_time > 20) || (player->work_state == PSt_CreatrQuery) )
+  if (cursor_moved_to_new_slab(player)) {
+      return false;
+  }
+  if ( (help_tip_time > 30) || (player->work_state == PSt_CreatrQuery) )
   {
       set_gui_tooltip_box_fmt(2,"%s",get_string(slbattr->tooltip_stridx));
   } else
@@ -278,7 +288,10 @@ short setup_room_tooltips(struct Coord3d *pos)
     return false;
   update_gui_tooltip_target(room);
   struct PlayerInfo* player = get_my_player();
-  if ( (help_tip_time > 20) || (player->work_state == PSt_CreatrQuery) )
+  if (cursor_moved_to_new_slab(player)) {
+      return false;
+  }
+  if ( (help_tip_time > 30) || (player->work_state == PSt_CreatrQuery) )
   {
     set_gui_tooltip_box_fmt(1,"%s",get_string(stridx));
   } else


### PR DESCRIPTION
When you move your cursor to a new slab position, the tooltip timer now resets.

The generally expected behaviour of tooltips (in operating systems and software) is that you keep your mouse cursor still. However DK allowed you to move your cursor across multiple slabs of the same type while the tooltip annoyingly wouldn't disappear.

I also increased this particular tooltip's time by 50% (30 turns instead of 20). Tooltips have a lot of arbitrary appearance times (some are 10 turns, some are 20), so I don't believe I'm stepping out of bounds by increasing the most annoying one to 30.