### PR TITLE
Lost Levels use classic ruleset

### DIFF
--- a/levels/lostlvls.cfg
+++ b/levels/lostlvls.cfg
@@ -7,9 +7,9 @@ NAME_TEXT_ID = 975
 ; Folders storing level files for the mappack
 LEVELS_LOCATION = levels/lostlvls
 ; If you wish your levels to have customized creatures, you may uncomment this
-;CREATURES_LOCATION = levels/lostlvls_crtr
+CREATURES_LOCATION = levels/classic_crtr
 ; If you wish your levels to have customized rules and other configs, you may uncomment this
-;CONFIGS_LOCATION = levels/lostlvls_cfgs
+CONFIGS_LOCATION = levels/classic_cfgs
 ; High score table parameters (num of entries and file name)
 HIGH_SCORES = 9999 scr_lost.dat
 ; Player number to use for human player in these levels.


### PR DESCRIPTION
It's up to debate but I think "Lost Levels" pack should use classic ruleset?