### PR TITLE
Potential fix for crash in trig_render_md10

### DIFF
--- a/src/bflib_crash.c
+++ b/src/bflib_crash.c
@@ -93,7 +93,7 @@ void ctrl_handler(int sig_id)
 {
     signal(sig_id, SIG_DFL);
     LbErrorLog("Failure signal: %s.\n",sigstr(sig_id));
-    LbScreenReset();
+    LbScreenReset(true);
     LbErrorLogClose();
     raise(sig_id);
 }
@@ -307,7 +307,7 @@ static LONG CALLBACK ctrl_handler_w32(LPEXCEPTION_POINTERS info)
             _backtrace(16 , info->ContextRecord);
             SymCleanup(GetCurrentProcess());
     }
-    LbScreenReset();
+    LbScreenReset(true);
     LbErrorLogClose();
     return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/src/bflib_render.c
+++ b/src/bflib_render.c
@@ -55,8 +55,8 @@ void setup_bflib_render(long width, long height)
     {
         free(polyscans);
     }
-    if (height < 4096)
-        height = 4096;
+    if (height < 4320)
+        height = 4320;
     polyscans = malloc(sizeof(struct PolyPoint) * height);
 }
 

--- a/src/bflib_render.c
+++ b/src/bflib_render.c
@@ -51,13 +51,13 @@ void draw_quad(struct PolyPoint *point_a, struct PolyPoint *point_b, struct Poly
 
 void setup_bflib_render()
 {
-    polyscans = malloc(sizeof(struct PolyPoint) * MAX_SUPPORTED_SCREEN_HEIGHT);
-    memset(polyscans, 0, sizeof(struct PolyPoint) * MAX_SUPPORTED_SCREEN_HEIGHT);
+    polyscans = malloc(sizeof(struct PolyPoint) * 4096);
+    memset(polyscans, 0, sizeof(struct PolyPoint) * 4096);
 }
 
 void reset_bflib_render()
 {
-    memset(polyscans, 0, sizeof(struct PolyPoint) * MAX_SUPPORTED_SCREEN_HEIGHT);
+    memset(polyscans, 0, sizeof(struct PolyPoint) * 4096);
 }
 
 void finish_bflib_render()

--- a/src/bflib_render.c
+++ b/src/bflib_render.c
@@ -55,6 +55,8 @@ void setup_bflib_render(long width, long height)
     {
         free(polyscans);
     }
+    if (height < 4096)
+        height = 4096;
     polyscans = malloc(sizeof(struct PolyPoint) * height);
 }
 

--- a/src/bflib_render.c
+++ b/src/bflib_render.c
@@ -49,16 +49,15 @@ void draw_quad(struct PolyPoint *point_a, struct PolyPoint *point_b, struct Poly
     draw_gpoly(point_a, point_b, point_d);
 }
 
-void setup_bflib_render(long width, long height)
+void setup_bflib_render()
 {
-    if (polyscans)
-    {
-        free(polyscans);
-    }
-    if (height < 4320)
-        height = 4320;
-    polyscans = malloc(sizeof(struct PolyPoint) * height);
-    memset(polyscans, 0, sizeof(struct PolyPoint) * height);
+    polyscans = malloc(sizeof(struct PolyPoint) * MAX_SUPPORTED_SCREEN_HEIGHT);
+    memset(polyscans, 0, sizeof(struct PolyPoint) * MAX_SUPPORTED_SCREEN_HEIGHT);
+}
+
+void reset_bflib_render()
+{
+    memset(polyscans, 0, sizeof(struct PolyPoint) * MAX_SUPPORTED_SCREEN_HEIGHT);
 }
 
 void finish_bflib_render()

--- a/src/bflib_render.c
+++ b/src/bflib_render.c
@@ -58,6 +58,7 @@ void setup_bflib_render(long width, long height)
     if (height < 4320)
         height = 4320;
     polyscans = malloc(sizeof(struct PolyPoint) * height);
+    memset(polyscans, 0, sizeof(struct PolyPoint) * height);
 }
 
 void finish_bflib_render()

--- a/src/bflib_render.h
+++ b/src/bflib_render.h
@@ -115,7 +115,8 @@ void gtblock_draw(struct GtBlock *gtb);
 /******************************************************************************/
 void trig(struct PolyPoint *point_a, struct PolyPoint *point_b, struct PolyPoint *point_c);
 /******************************************************************************/
-void setup_bflib_render(long width, long height);
+void setup_bflib_render();
+void reset_bflib_render();
 void finish_bflib_render();
 
 #ifdef __cplusplus

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -603,7 +603,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
         lbDrawSurface = SDL_CreateRGBSurface(0, mdinfo->Width, mdinfo->Height, lbEngineBPP, 0, 0, 0, 0);
         if (lbDrawSurface == NULL) {
             ERRORLOG("Can't create secondary surface for mode %d (%s): %s", (int)mode, mdinfo->Desc, SDL_GetError());
-            LbScreenReset();
+            LbScreenReset(false);
             return Lb_FAIL;
         }
         lbHasSecondSurface = true;
@@ -643,7 +643,7 @@ TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord hei
         }
     }
 
-    setup_bflib_render(lbDisplay.GraphicsScreenWidth, lbDisplay.GraphicsScreenHeight);
+    reset_bflib_render();
     SYNCDBG(8,"Finished");
     return Lb_SUCCESS;
 }
@@ -769,7 +769,7 @@ TbBool LbScreenIsLocked(void)
     return (lbDisplay.WScreen != NULL);
 }
 
-TbResult LbScreenReset(void)
+TbResult LbScreenReset(TbBool exiting_application)
 {
     if (!lbScreenInitialised)
       return Lb_FAIL;
@@ -778,12 +778,16 @@ TbResult LbScreenReset(void)
         SDL_FreeSurface(lbDrawSurface);
     }
     //do not free screen surface, it is freed automatically on SDL_Quit or next call to set video mode
-    finish_bflib_render();
     lbHasSecondSurface = false;
     lbDrawSurface = NULL;
     lbScreenSurface = NULL;
     // Mark as not initialized
     lbScreenInitialised = false;
+    if (exiting_application)
+    {
+        // we get here when we are actually closing the application
+        finish_bflib_render();
+    }
     return Lb_SUCCESS;
 }
 

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -36,8 +36,8 @@ extern "C" {
 
 #define LOWRES_SCREEN_SIZE          320
 
-#define MAX_SUPPORTED_SCREEN_WIDTH  3840
-#define MAX_SUPPORTED_SCREEN_HEIGHT 2160
+#define MAX_SUPPORTED_SCREEN_WIDTH  7680
+#define MAX_SUPPORTED_SCREEN_HEIGHT 4320
 
 /******************************************************************************/
 #pragma pack(1)

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -290,7 +290,7 @@ TbResult LbScreenSetDoubleBuffering(TbBool state);
 TbBool LbScreenIsDoubleBufferred(void);
 TbResult LbScreenSetup(TbScreenMode mode, TbScreenCoord width, TbScreenCoord height,
     unsigned char *palette, short buffers_count, TbBool wscreen_vid);
-TbResult LbScreenReset(void);
+TbResult LbScreenReset(TbBool exiting_application);
 
 TbBool LbScreenIsModeAvailable(TbScreenMode mode, unsigned short display);
 TbScreenMode LbRecogniseVideoModeString(const char *desc);

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -36,8 +36,8 @@ extern "C" {
 
 #define LOWRES_SCREEN_SIZE          320
 
-#define MAX_SUPPORTED_SCREEN_WIDTH  7680
-#define MAX_SUPPORTED_SCREEN_HEIGHT 4320
+#define MAX_SUPPORTED_SCREEN_WIDTH  3840
+#define MAX_SUPPORTED_SCREEN_HEIGHT 2160
 
 /******************************************************************************/
 #pragma pack(1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1127,6 +1127,9 @@ short setup_game(void)
       return 0;
   }
 
+  // Setup polyscans
+  setup_bflib_render();
+
   // View the legal screen
   if (!setup_screen_mode_zero(get_frontend_vidmode()))
   {
@@ -3925,7 +3928,7 @@ short reset_game(void)
 
     LbMouseSuspend();
     LbIKeyboardClose();
-    LbScreenReset();
+    LbScreenReset(false);
     LbDataFreeAll(game_load_files);
     free_gui_strings_data();
     FreeAudio();
@@ -4267,7 +4270,7 @@ int LbBullfrogMain(unsigned short argc, char *argv[])
         game_loop();
     }
     reset_game();
-    LbScreenReset();
+    LbScreenReset(true);
     if ( !retval )
     {
         static const char *msg_text="Setting up game failed.\n";

--- a/src/vidmode.c
+++ b/src/vidmode.c
@@ -654,7 +654,7 @@ TbScreenMode setup_screen_mode(TbScreenMode nmode, TbBool failsafe)
       unload_pointer_file(hi_res);
     }
     if (nmode != old_mode)
-        LbScreenReset();
+        LbScreenReset(false);
     if (MinimalResolutionSetup)
       LbDataFreeAll(hi_res ? front_load_files_minimal_640 : front_load_files_minimal_320);
     else
@@ -829,7 +829,7 @@ TbScreenMode setup_screen_mode_minimal(TbScreenMode nmode)
     if ((!MinimalResolutionSetup && !hi_res) || (MinimalResolutionSetup && hi_res))
       unload_pointer_file(hi_res);
     if ((nmode != old_mode) || (force_video_mode_reset))
-      LbScreenReset();
+      LbScreenReset(false);
     if (hi_res)
     {
       if (MinimalResolutionSetup)


### PR DESCRIPTION
Old log: [keeperfx.log](https://github.com/dkfans/keeperfx/files/13694284/keeperfx.log)
new repeated crash:

```
=== Crash ===
Error: Attempt to read from inaccessible memory address.
[#15]  in   keeperfx.exe : trig_render_md10                         [0x450ba0+0xfb]     (map lookup for 0023:00720c9b, base: 006d0000)
[#14]  in   keeperfx.exe : trig                                     [0x452950+0x338]     (map lookup for 0023:00722c88, base: 006d0000)
[#13]  in   keeperfx.exe : draw_view                                [0x4e6440+0x45e8]     (map lookup for 0023:007baa28, base: 006d0000)
[#12]  in   keeperfx.exe : engine                                   [0x5fa570+0x149]     (map lookup for 0023:008ca6b9, base: 006d0000)
[#11]  in   keeperfx.exe : draw_creature_view                       [0x5c61b0+0x12d]     (map lookup for 0023:008962dd, base: 006d0000)
[#10]  in   keeperfx.exe : redraw_creature_view                     [0x4d67e0+0x508]     (map lookup for 0023:007a6ce8, base: 006d0000)
[#9 ]  in   keeperfx.exe : redraw_display                           [0x4d80f0+0x5ad]     (map lookup for 0023:007a869d, base: 006d0000)
[#8 ]  in   keeperfx.exe : keeper_screen_redraw                     [0x4d8930+0x148]     (map lookup for 0023:007a8a78, base: 006d0000)
[#7 ]  in   keeperfx.exe : gameplay_loop_draw                       [0x5face0+0x3d]     (map lookup for 0023:008cad1d, base: 006d0000)
[#6 ]  in   keeperfx.exe : game_loop                                [0x5fb280+0x346]     (map lookup for 0023:008cb5c6, base: 006d0000) 
[#5 ]  in   keeperfx.exe : LbBullfrogMain                           [0x5fc740+0xfa]     (map lookup for 0023:008cc83a, base: 006d0000)
[#4 ]  in   keeperfx.exe : SDL_main                                 [0x5fca90+0x4a]     (map lookup for 0023:008ccada, base: 006d0000)
[#3 ]  in   keeperfx.exe : -> /sdl/lib/libSDL2main.a(SDL_windows_main.o) [0x603120+0x174]     (map lookup for 0023:008d3294, base: 006d0000)
[#2 ]  in   keeperfx.exe : WinMain@16                               [0x603330+0x5]     (map lookup for 0023:008d3335, base: 006d0000)
[#1 ]  in   keeperfx.exe : -> r/usr/lib/gcc/i686-w64-mingw32/10-win32/../../../../i686-w64-mingw32/lib/../lib/crt2.o [0x401000+0x396]     (map lookup for 0023:006d1396, base: 006d0000)
[#0 ]  in   KERNEL32.DLL : BaseThreadInitThunk                      [0023:75aafcc9+0x19, base 75a90000] (symbol lookup)
```

The suggested fix by @SimTheVoid 
![image](https://github.com/dkfans/keeperfx/assets/13840686/491d21c6-28ea-4bfe-9260-671d4b012fa4)

