### PR TITLE
Tooltip time adjustments

### DIFF
--- a/src/bflib_guibtns.h
+++ b/src/bflib_guibtns.h
@@ -167,6 +167,7 @@ struct GuiButton {
        struct GuiMenu *parent_menu;
        unsigned long *content; //TODO FRONTEND change it to GuiVariant
        unsigned short slide_val; // slider value, scaled 0..255
+       short has_shown_before; // GUI tooltips take longer to display the next time you show them
 };
 
 struct GuiMenu {

--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -269,7 +269,7 @@ short setup_land_tooltips(struct Coord3d *pos)
   if (cursor_moved_to_new_subtile(player) || !thing_is_invalid(handthing)) {
       return false;
   }
-  if ( (help_tip_time > 100) || (player->work_state == PSt_CreatrQuery) )
+  if ( (help_tip_time > 50) || (player->work_state == PSt_CreatrQuery) )
   {
       set_gui_tooltip_box_fmt(2,"%s",get_string(slbattr->tooltip_stridx));
   } else
@@ -297,7 +297,7 @@ short setup_room_tooltips(struct Coord3d *pos)
   if (cursor_moved_to_new_subtile(player) || !thing_is_invalid(handthing)) {
       return false;
   }
-  if ( (help_tip_time > 100) || (player->work_state == PSt_CreatrQuery) )
+  if ( (help_tip_time > 50) || (player->work_state == PSt_CreatrQuery) )
   {
     set_gui_tooltip_box_fmt(1,"%s",get_string(stridx));
   } else


### PR DESCRIPTION
Continuing my war on land tooltips. I hate that every screenshot that someone takes of DK has a land tooltip in it. They're way too pushy and non-immersive.

- Increased land tooltips time to 2.5 seconds
- Land tooltips now require you to keep your cursor even more still
- Land tooltips will no longer display if you're hovering a creature (torture chamber was especially annoying)

Unrelated to land:
- GUI button tooltips now take longer to display the second time you see them (2 seconds instead of 0.5 seconds). I think this feels pretty subtle.

By the way, clicking the 'Query' button and hovering over stuff makes the tooltips display instantly. So you always can use that if you want to see fast land tooltips.