### PR TITLE
Making test action flow easier to understand

### DIFF
--- a/src/ftests/README.md
+++ b/src/ftests/README.md
@@ -65,10 +65,10 @@ They also skip the trademark/cutscene by default for super fast launch.
         - `ftest_append_action( ftest_template_action001__spawn_warlock,            100, NULL );`
         - `ftest_append_action( ftest_template_action002__drop_chicken_on_warlock,  100, NULL );`
     - actions are executed:
-        - **sequentially**: `action002` will not execute until the previous action `returns true`
+        - **sequentially**: `action002` will not execute until the previous action returns `FTRs_Go_To_Next_Action`
         - **after the `game turn delay`**: provided to `ftest_append_action(<test_action>, <game_turn_delay>)`
         
-         this means if an action always `returns false` it will never finish and the `test will run forever`
+         this means if an action always returns `FTRs_Repeat_Current_Action` it will never finish and the `test will run forever`
      
 5. Add your test to the test list [ftest_list.c](./ftest_list.c)
     - add the include for your tests header file
@@ -112,7 +112,7 @@ They also skip the trademark/cutscene by default for super fast launch.
 2. Init function is called for the current active test, which creates a list of actions to perform accordingly.
     - NOTE: You can also call one-time logic here, like altering the map before the test actions are executed.
 3. The game loop will call each action in the list after the desired GameTurn delay.
-    - actions are counted as completed when they `return true`, if they `return false`, the action will be executed again next game turn.
+    - actions are counted as completed when they return `FTRs_Go_To_Next_Action`, if they return `FTRs_Repeat_Current_Action`, the action will be executed again next game turn.
     - by default, if a test fails, the next test will be ran, unless you use the `-exitonfailedtest` flag.
     - (optional) when using the `-exitonfailedtest` flag if there is a failure at any stage (you decide this with your test, using the [FTEST_FAIL_TEST](./ftest.h#L24) macro) the test exits immediately, closing the program.
         - exit code 0 == `test success`
@@ -120,6 +120,7 @@ They also skip the trademark/cutscene by default for super fast launch.
         - optionally view the keeperfx.log to view details on why the test failed
             - example failure message: `FTest: [20] ftest_template_action001__spawn_imp: Failed to level up imp`
             - the above message tells us that at game turn 20, the test failed at function `ftest_template_action001__spawn_imp` because `Failed to level up imp`
+    - (optional) when using the `-includelongtests` flag, extra tests from `long_running_tests_list` will be included in the test search.
 
 
 Seeds are overriden when using the functional tests. This means tests should perform the same every time for random events.

--- a/src/ftests/ftest.h
+++ b/src/ftests/ftest.h
@@ -56,11 +56,17 @@ struct FTestActionArgs
     void* data;
 };
 
+typedef enum FTestActionResult
+{
+    FTRs_Repeat_Current_Action = 0,
+    FTRs_Go_To_Next_Action = 1
+} FTestActionResult;
+
 /**
  * @brief Function Test Action Func -
  * Your test will be comprised of these actions, append them inside your init func using ftest_append_action
  */
-typedef TbBool (*FTest_Action_Func)(struct FTestActionArgs* const args);
+typedef FTestActionResult (*FTest_Action_Func)(struct FTestActionArgs* const args);
 
 typedef enum FTestFrameworkState
 {

--- a/src/ftests/tests/ftest_bug_ai_bridge.c
+++ b/src/ftests/tests/ftest_bug_ai_bridge.c
@@ -59,9 +59,9 @@ struct ftest_bug_ai_bridge__variables ftest_bug_ai_bridge__vars = {
 };
 
 // forward declarations - tests
-TbBool ftest_bug_ai_bridge_action001__setup_map(struct FTestActionArgs* const args);
-TbBool ftest_bug_ai_bridge_action002__end_test(struct FTestActionArgs* const args);
-TbBool ftest_bug_ai_bridge_action003__delayed_screenshot(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_ai_bridge_action001__setup_map(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_ai_bridge_action002__end_test(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_ai_bridge_action003__delayed_screenshot(struct FTestActionArgs* const args);
 
 TbBool ftest_bug_ai_bridge_init()
 {
@@ -72,7 +72,7 @@ TbBool ftest_bug_ai_bridge_init()
     return true;
 }
 
-TbBool ftest_bug_ai_bridge_action001__setup_map(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_ai_bridge_action001__setup_map(struct FTestActionArgs* const args)
 {
     struct ftest_bug_ai_bridge__variables* const vars = args->data;
 
@@ -88,13 +88,13 @@ TbBool ftest_bug_ai_bridge_action001__setup_map(struct FTestActionArgs* const ar
         if(map_block_invalid(mapblk))
         {
             FTEST_FAIL_TEST("Invalid map block at subtile (%ld,%ld)", stl_x, stl_y)
-            return true;
+            return FTRs_Go_To_Next_Action;
         }
         struct Thing* thing = thing_get(get_mapwho_thing_index(mapblk));
         if (thing_is_invalid(thing) || !thing_is_creature(thing))
         {
             FTEST_FAIL_TEST("Failed to find creature to nerf at subtile (%ld,%ld)", stl_x, stl_y);
-            return true;
+            return FTRs_Go_To_Next_Action;
         }
         
         FTESTLOG("Nerfing Creature %s at (%ld,%ld) to 'level 1' and '1 health'", creature_code_name(thing->model), stl_x, stl_y);
@@ -117,7 +117,7 @@ TbBool ftest_bug_ai_bridge_action001__setup_map(struct FTestActionArgs* const ar
     // dig tiles to portal
     ftest_util_replace_slabs(20, 14, 21, 14, SlbT_CLAIMED, PLAYER0);
     
-    return true; //proceed to next test action
+    return FTRs_Go_To_Next_Action; //proceed to next test action
 }
 
 void ftest_bug_ai_bridge__report_stats_and_increment_seed()
@@ -138,7 +138,7 @@ void ftest_bug_ai_bridge__report_stats_and_increment_seed()
     }
 }
 
-TbBool ftest_bug_ai_bridge_action002__end_test(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_ai_bridge_action002__end_test(struct FTestActionArgs* const args)
 {
     struct ftest_bug_ai_bridge__variables* const vars = args->data;
 
@@ -157,7 +157,7 @@ TbBool ftest_bug_ai_bridge_action002__end_test(struct FTestActionArgs* const arg
             if(slabmap_block_invalid(slb))
             {
                 FTEST_FAIL_TEST("Invalid slab found at (%d,%d)", slb_x, slb_y);
-                return true;
+                return FTRs_Go_To_Next_Action;
             }
 
             if(slb->kind == SlbT_BRIDGE)
@@ -176,7 +176,7 @@ TbBool ftest_bug_ai_bridge_action002__end_test(struct FTestActionArgs* const arg
         vars->take_screenshot = true;
         game.frame_skip = 0;
         ftest_bug_ai_bridge__report_stats_and_increment_seed();
-        return true; // exit test
+        return FTRs_Go_To_Next_Action; // exit test
     }
 
     if(game.play_gameturn >= vars->end_test_after_n_turns)
@@ -185,13 +185,13 @@ TbBool ftest_bug_ai_bridge_action002__end_test(struct FTestActionArgs* const arg
         ++vars->test_runs_without_bridges;
         FTESTLOG("Reached GameTurn limit %ld, exiting test.",  vars->end_test_after_n_turns);
         ftest_bug_ai_bridge__report_stats_and_increment_seed();
-        return true; // exit test
+        return FTRs_Go_To_Next_Action; // exit test
     }
 
-    return false; // repeat current action
+    return FTRs_Repeat_Current_Action; // repeat current action
 }
 
-TbBool ftest_bug_ai_bridge_action003__delayed_screenshot(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_ai_bridge_action003__delayed_screenshot(struct FTestActionArgs* const args)
 {
     struct ftest_bug_ai_bridge__variables* const vars = args->data;
 
@@ -201,7 +201,7 @@ TbBool ftest_bug_ai_bridge_action003__delayed_screenshot(struct FTestActionArgs*
     {
         if(game.play_gameturn < args->actual_started_at_game_turn + screenshot_turn_delay) // wait until we are supposed to take the screenshot
         {
-            return false;
+            return FTRs_Repeat_Current_Action;
         }
         
         struct FTestConfig* current_test_config = ftest_get_current_test_config();
@@ -211,7 +211,7 @@ TbBool ftest_bug_ai_bridge_action003__delayed_screenshot(struct FTestActionArgs*
         vars->take_screenshot = false;
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
 #endif

--- a/src/ftests/tests/ftest_bug_imp_goldseam_dig.c
+++ b/src/ftests/tests/ftest_bug_imp_goldseam_dig.c
@@ -28,22 +28,20 @@ struct ftest_bug_imp_goldseam_dig__variables ftest_bug_imp_goldseam_dig__vars = 
 };
 
 // forward declarations - tests
-TbBool ftest_bug_imp_goldseam_dig_action001__map_setup(struct FTestActionArgs* const args);
-//TbBool ftest_bug_imp_goldseam_dig_action002__spawn_imp(struct FTestActionArgs* const args);
-TbBool ftest_bug_imp_goldseam_dig_action003__send_imp_to_dig(struct FTestActionArgs* const args);
-TbBool ftest_bug_imp_goldseam_dig_action004__end_test(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_imp_goldseam_dig_action001__map_setup(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_imp_goldseam_dig_action002__send_imp_to_dig(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_imp_goldseam_dig_action003__end_test(struct FTestActionArgs* const args);
 
 TbBool ftest_bug_imp_goldseam_dig_init()
 {
     ftest_append_action(ftest_bug_imp_goldseam_dig_action001__map_setup,        10,     NULL);
-    //ftest_append_action(ftest_bug_imp_goldseam_dig_action002__spawn_imp,        20,     NULL);
-    ftest_append_action(ftest_bug_imp_goldseam_dig_action003__send_imp_to_dig,  30,     NULL);
-    ftest_append_action(ftest_bug_imp_goldseam_dig_action004__end_test,         400,    NULL);
+    ftest_append_action(ftest_bug_imp_goldseam_dig_action002__send_imp_to_dig,  30,     NULL);
+    ftest_append_action(ftest_bug_imp_goldseam_dig_action003__end_test,         400,    NULL);
 
     return true;
 }
 
-TbBool ftest_bug_imp_goldseam_dig_action001__map_setup(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_imp_goldseam_dig_action001__map_setup(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     struct ftest_bug_imp_goldseam_dig__variables* const vars = &ftest_bug_imp_goldseam_dig__vars;
@@ -55,51 +53,21 @@ TbBool ftest_bug_imp_goldseam_dig_action001__map_setup(struct FTestActionArgs* c
     if(dungeon_invalid(dungeon))
     {
         FTEST_FAIL_TEST("Failed to find dungeon");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
     take_money_from_dungeon(PLAYER0, dungeon->total_money_owned, false);
 
     // place gold room to left of dungeon heart
     ftest_util_replace_slabs(36, 42, 38, 44, SlbT_TREASURE, PLAYER0);
 
-    // // spawn gold
-    // ftest_util_replace_slabs(6, 1, 7, 5, SlbT_PATH, PLAYER_NEUTRAL);
-    // ftest_util_replace_slabs(6, 1, 7, 5, SlbT_GOLD, PLAYER_NEUTRAL);
-
     // store/broadcast the gold stored in a single tile
     vars->game_gold_amount = game.conf.rules.game.gold_per_gold_block;
     message_add_fmt(PLAYER0, "Game gold per gold block: %ld", vars->game_gold_amount);
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
-// TbBool ftest_bug_imp_goldseam_dig_action002__spawn_imp(struct FTestActionArgs* const args)
-// {
-//     // to make the test variable names shorter, use a pointer!
-//     //struct ftest_bug_imp_goldseam_dig__variables* const vars = &ftest_bug_imp_goldseam_dig__vars;
-
-//     // create an imp
-//     struct Coord3d impPos;
-//     set_coords_to_slab_center(&impPos, 1, 1);
-    
-//     struct Thing* ftest_template_target_imp = create_owned_special_digger(impPos.x.val, impPos.y.val, PLAYER0);
-//     if(thing_is_invalid(ftest_template_target_imp))
-//     {
-//         FTEST_FAIL_TEST("Failed to create imp");
-//         return true;
-//     }
-
-//     // level up the imp to 10 for faster digging
-//     if(!creature_change_multiple_levels(ftest_template_target_imp, 9))
-//     {
-//         FTEST_FAIL_TEST("Failed to level up imp");
-//         return true;
-//     }
-
-//     return true; //proceed to next test action
-// }
-
-TbBool ftest_bug_imp_goldseam_dig_action003__send_imp_to_dig(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_imp_goldseam_dig_action002__send_imp_to_dig(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     //struct ftest_bug_imp_goldseam_dig__variables* const vars = &ftest_bug_imp_goldseam_dig__vars;
@@ -112,7 +80,7 @@ TbBool ftest_bug_imp_goldseam_dig_action003__send_imp_to_dig(struct FTestActionA
     if(slabmap_block_invalid(slabMapBlock))
     {
         FTEST_FAIL_TEST("Failed to find gold slabmap block");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     // store/report the blocks health to user
@@ -125,13 +93,13 @@ TbBool ftest_bug_imp_goldseam_dig_action003__send_imp_to_dig(struct FTestActionA
     if (markForDigResult != Lb_OK && markForDigResult != Lb_SUCCESS)
     {
         FTEST_FAIL_TEST("Failed to mark the gold block for digging");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
-    return true; //proceed to next test action
+    return FTRs_Go_To_Next_Action; //proceed to next test action
 }
 
-TbBool ftest_bug_imp_goldseam_dig_action004__end_test(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_imp_goldseam_dig_action003__end_test(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     struct ftest_bug_imp_goldseam_dig__variables* const vars = &ftest_bug_imp_goldseam_dig__vars;
@@ -141,7 +109,7 @@ TbBool ftest_bug_imp_goldseam_dig_action004__end_test(struct FTestActionArgs* co
     if(dungeon_invalid(dungeon))
     {
         FTEST_FAIL_TEST("Failed to find dungeon");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
     
     // report total gold
@@ -149,10 +117,10 @@ TbBool ftest_bug_imp_goldseam_dig_action004__end_test(struct FTestActionArgs* co
     if(dungeon->total_money_owned != vars->game_gold_amount)
     {
         FTEST_FAIL_TEST("Goldseams have %ld gold, but imp returned %d gold!", vars->game_gold_amount, dungeon->total_money_owned);
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
 #endif

--- a/src/ftests/tests/ftest_bug_imp_goldseam_dig.c
+++ b/src/ftests/tests/ftest_bug_imp_goldseam_dig.c
@@ -67,7 +67,7 @@ TbBool ftest_bug_imp_goldseam_dig_action001__map_setup(struct FTestActionArgs* c
     // ftest_util_replace_slabs(6, 1, 7, 5, SlbT_GOLD, PLAYER_NEUTRAL);
 
     // store/broadcast the gold stored in a single tile
-    vars->game_gold_amount = game.gold_per_gold_block;
+    vars->game_gold_amount = game.conf.rules.game.gold_per_gold_block;
     message_add_fmt(PLAYER0, "Game gold per gold block: %ld", vars->game_gold_amount);
 
     return true;

--- a/src/ftests/tests/ftest_bug_imp_tp_job_attack_door.c
+++ b/src/ftests/tests/ftest_bug_imp_tp_job_attack_door.c
@@ -85,9 +85,9 @@ struct ftest_bug_imp_tp_job_attack_door__variables ftest_bug_imp_tp_job_attack_d
 };
 
 // forward declarations - tests
-TbBool ftest_bug_imp_tp_job_attack_door_action001__setup_map(struct FTestActionArgs* const args);
-TbBool ftest_bug_imp_tp_job_attack_door_action002__spawn_crippled_hero(struct FTestActionArgs* const args);
-TbBool ftest_bug_imp_tp_job_attack_door_action003__end_test(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_imp_tp_job_attack_door_action001__setup_map(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_imp_tp_job_attack_door_action002__spawn_crippled_hero(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_imp_tp_job_attack_door_action003__end_test(struct FTestActionArgs* const args);
 
 TbBool ftest_tmp_delete_me(struct FTestActionArgs* const args);
 
@@ -122,7 +122,7 @@ TbBool ftest_bug_imp_tp_attack_door__deadbody_init()
     return true;
 }
 
-TbBool ftest_bug_imp_tp_job_attack_door_action001__setup_map(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_imp_tp_job_attack_door_action001__setup_map(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     struct ftest_bug_imp_tp_job_attack_door__variables* const vars = &ftest_bug_imp_tp_job_attack_door__vars;
@@ -131,21 +131,21 @@ TbBool ftest_bug_imp_tp_job_attack_door_action001__setup_map(struct FTestActionA
     if (!thing_exists(heartng))
     {
         FTEST_FAIL_TEST("No dungeon heart found for player %d", vars->HUMAN_PLAYER);
-        return false;
+        return FTRs_Go_To_Next_Action;
     }
 
     struct Dungeon* dungeon = get_dungeon(vars->HUMAN_PLAYER);
     if(dungeon_invalid(dungeon))
     {
         FTEST_FAIL_TEST("Dungeon for player %d not valid", vars->HUMAN_PLAYER);
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     struct PlayerInfo* player = get_player(dungeon->owner);
     if(player_invalid(player))
     {
         FTEST_FAIL_TEST("Player %d not found", vars->HUMAN_PLAYER);
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     ftest_util_reveal_map(vars->HUMAN_PLAYER); // we might want to see the entire map for testing purposes
@@ -180,7 +180,7 @@ TbBool ftest_bug_imp_tp_job_attack_door_action001__setup_map(struct FTestActionA
         if(thing_is_invalid(vars->new_imp))
         {
             FTEST_FAIL_TEST("Failed to create imp");
-            return true;
+            return FTRs_Go_To_Next_Action;
         }
         // // example code for leveling creatures manually (not using dungeon special)
         // dungeon = get_dungeon(vars->new_imp->owner);
@@ -213,7 +213,7 @@ TbBool ftest_bug_imp_tp_job_attack_door_action001__setup_map(struct FTestActionA
     if (thing_is_invalid(vars->door))
     {
         FTEST_FAIL_TEST("Failed to find door at (%d,%d), this should never happen! Was the map changed!?", vars->slb_x_door, vars->slb_y_door);
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
     
     // lower door health to speed up test
@@ -226,13 +226,13 @@ TbBool ftest_bug_imp_tp_job_attack_door_action001__setup_map(struct FTestActionA
     if (!set_creature_tendencies(player, CrTend_Imprison, true))
     {
         FTEST_FAIL_TEST("Failed to set imprison true for player %d", vars->HUMAN_PLAYER);
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
-TbBool ftest_bug_imp_tp_job_attack_door_action002__spawn_crippled_hero(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_imp_tp_job_attack_door_action002__spawn_crippled_hero(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     struct ftest_bug_imp_tp_job_attack_door__variables* const vars = &ftest_bug_imp_tp_job_attack_door__vars;
@@ -247,7 +247,7 @@ TbBool ftest_bug_imp_tp_job_attack_door_action002__spawn_crippled_hero(struct FT
     if(thing_is_invalid(new_hero))
     {
         FTEST_FAIL_TEST("Failed to create hero");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     // move camera to hero
@@ -261,14 +261,14 @@ TbBool ftest_bug_imp_tp_job_attack_door_action002__spawn_crippled_hero(struct FT
         if(new_hero->health != 1)
         {
             FTEST_FAIL_TEST("Failed to cripple hero");
-            return true;
+            return FTRs_Go_To_Next_Action;
         }
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
-TbBool ftest_bug_imp_tp_job_attack_door_action003__end_test(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_imp_tp_job_attack_door_action003__end_test(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     struct ftest_bug_imp_tp_job_attack_door__variables* const vars = &ftest_bug_imp_tp_job_attack_door__vars;
@@ -280,16 +280,16 @@ TbBool ftest_bug_imp_tp_job_attack_door_action003__end_test(struct FTestActionAr
     if (thing_is_invalid(door))
     {
         FTEST_FAIL_TEST("Failed to find door at (%d,%d), imps destroyed door!", vars->slb_x_door, vars->slb_y_door);
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     if(door != vars->door)
     {
         FTEST_FAIL_TEST("Found different door... what?!");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
 #endif

--- a/src/ftests/tests/ftest_bug_invisible_units_cant_select.c
+++ b/src/ftests/tests/ftest_bug_invisible_units_cant_select.c
@@ -81,11 +81,11 @@ struct ftest_util_action__create_and_fill_torture_room__variables ftest_bug_invi
 };
 
 // forward declarations - tests
-TbBool ftest_bug_invisible_units_cant_select_action001__spawn_unit(struct FTestActionArgs* const args);
-TbBool ftest_bug_invisible_units_cant_select_action002__pickup_unit(struct FTestActionArgs* const args);
-TbBool ftest_bug_invisible_units_cant_select_action003__drop_unit(struct FTestActionArgs* const args);
-TbBool ftest_bug_invisible_units_cant_select_action004__kill_unit(struct FTestActionArgs* const args);
-TbBool ftest_bug_invisible_units_cant_select_action005__restart_actions(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_invisible_units_cant_select_action001__spawn_unit(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_invisible_units_cant_select_action002__pickup_unit(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_invisible_units_cant_select_action003__drop_unit(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_invisible_units_cant_select_action004__kill_unit(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_invisible_units_cant_select_action005__restart_actions(struct FTestActionArgs* const args);
 
 
 TbBool ftest_bug_invisible_units_cant_select_init()
@@ -122,12 +122,12 @@ TbBool ftest_bug_invisible_units_cant_select_init()
 
     //ftest_append_action(ftest_bug_invisible_units_cant_select_action005__restart_actions, 0, NULL);
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
 
 
-TbBool ftest_bug_invisible_units_cant_select_action001__spawn_unit(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_invisible_units_cant_select_action001__spawn_unit(struct FTestActionArgs* const args)
 {
     struct ftest_bug_invisible_units_cant_select__variables* const vars = args->data;
 
@@ -148,7 +148,7 @@ TbBool ftest_bug_invisible_units_cant_select_action001__spawn_unit(struct FTestA
     if(thing_is_invalid(vars->unit))
     {
         FTEST_FAIL_TEST("Failed to create random creature");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     //center cursor/camera on unit pos (using slight offset for better results)
@@ -158,10 +158,10 @@ TbBool ftest_bug_invisible_units_cant_select_action001__spawn_unit(struct FTestA
     vars->unit_spawned_at_turn = game.play_gameturn;
     vars->is_unit_spawned = true;
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
-TbBool ftest_bug_invisible_units_cant_select_action002__pickup_unit(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_invisible_units_cant_select_action002__pickup_unit(struct FTestActionArgs* const args)
 {
     struct ftest_bug_invisible_units_cant_select__variables* const vars = args->data;
 
@@ -188,7 +188,7 @@ TbBool ftest_bug_invisible_units_cant_select_action002__pickup_unit(struct FTest
         if(pickup_result != Lb_SUCCESS)
         {
             FTEST_FAIL_TEST("Cannot pick up %s index %d", thing_model_name(vars->unit), (int)vars->unit->index);
-            return true;
+            return FTRs_Go_To_Next_Action;
         }
 
         vars->unit_grabbed_at_turn = game.play_gameturn;
@@ -196,17 +196,17 @@ TbBool ftest_bug_invisible_units_cant_select_action002__pickup_unit(struct FTest
         return true;
     }
 
-    return false;
+    return FTRs_Repeat_Current_Action;
 }
 
-TbBool ftest_bug_invisible_units_cant_select_action003__drop_unit(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_invisible_units_cant_select_action003__drop_unit(struct FTestActionArgs* const args)
 {
     struct ftest_bug_invisible_units_cant_select__variables* const vars = args->data;
 
     if(!vars->is_unit_in_hand)
     {
         FTEST_FAIL_TEST("There is no unit in hand to drop!");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     // try to drop creature
@@ -215,6 +215,7 @@ TbBool ftest_bug_invisible_units_cant_select_action003__drop_unit(struct FTestAc
     if(!dump_first_held_thing_on_map(PLAYER0, dropPos.x.stl.num, dropPos.y.stl.num, 1))
     {
         FTEST_FAIL_TEST("Cannot drop %s index %d", thing_model_name(vars->unit), (int)vars->unit->index);
+        return FTRs_Go_To_Next_Action;
     }
     else
     {
@@ -222,10 +223,10 @@ TbBool ftest_bug_invisible_units_cant_select_action003__drop_unit(struct FTestAc
         vars->unit_dropped_at_turn = game.play_gameturn;
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
-TbBool ftest_bug_invisible_units_cant_select_action004__kill_unit(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_invisible_units_cant_select_action004__kill_unit(struct FTestActionArgs* const args)
 {
     struct ftest_bug_invisible_units_cant_select__variables* const vars = args->data;
 
@@ -239,15 +240,14 @@ TbBool ftest_bug_invisible_units_cant_select_action004__kill_unit(struct FTestAc
     vars->unit_grabbed_at_turn = ULONG_MAX;
     vars->unit_dropped_at_turn = ULONG_MAX;
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
-TbBool ftest_bug_invisible_units_cant_select_action005__restart_actions(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_invisible_units_cant_select_action005__restart_actions(struct FTestActionArgs* const args)
 {
     ftest_restart_actions();
 
-    //return false;
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
 #endif

--- a/src/ftests/tests/ftest_bug_pathing_pillar_circling.c
+++ b/src/ftests/tests/ftest_bug_pathing_pillar_circling.c
@@ -59,7 +59,7 @@ struct ftest_bug_pathing_pillar_circling__variables ftest_bug_pathing_pillar_cir
 
 
 // forward declarations - tests
-TbBool ftest_bug_pathing_pillar_circling_action001__tunneler_dig_towards_pillar_test(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_pathing_pillar_circling_action001__tunneler_dig_towards_pillar_test(struct FTestActionArgs* const args);
 
 TbBool ftest_bug_pathing_pillar_circling_init()
 {
@@ -75,7 +75,7 @@ TbBool ftest_bug_pathing_pillar_circling_init()
 /**
  * @brief This action will be a sub-test, it will setup the situation of a single tunneler digging towards you, and replicate getting stuck on a pillar (portal?)
  */
-TbBool ftest_bug_pathing_pillar_circling_action001__tunneler_dig_towards_pillar_test(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_pathing_pillar_circling_action001__tunneler_dig_towards_pillar_test(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     // in this case we are grabbing the data from the argument, allowing different action setups!
@@ -104,11 +104,11 @@ TbBool ftest_bug_pathing_pillar_circling_action001__tunneler_dig_towards_pillar_
         if(thing_is_invalid(vars->tunneler))
         {
             FTEST_FAIL_TEST("Failed to create tunneler");
-            return true;
+            return FTRs_Go_To_Next_Action;
         }
 
         vars->is_tunneler_setup = true;
-        return false;
+        return FTRs_Repeat_Current_Action;
     }
 
     // snap camera to tunneler
@@ -117,7 +117,7 @@ TbBool ftest_bug_pathing_pillar_circling_action001__tunneler_dig_towards_pillar_
     // delay for a while so we can watch what's going on
     if(game.play_gameturn < args->actual_started_at_game_turn + 1000)
     {
-        return false;
+        return FTRs_Repeat_Current_Action;
     }
 
     // todo - insert check stage here to verify if tunneler made it past the column or not
@@ -127,7 +127,7 @@ TbBool ftest_bug_pathing_pillar_circling_action001__tunneler_dig_towards_pillar_
     if(thing_is_invalid(vars->tunneler))
     {
         FTEST_FAIL_TEST("Expected tunneler but it didn't exist?");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
     else
     {
@@ -135,11 +135,11 @@ TbBool ftest_bug_pathing_pillar_circling_action001__tunneler_dig_towards_pillar_
         if(thing_is_invalid(vars->tunneler))
         {
             FTEST_FAIL_TEST("Failed to cleanup tunneler on map");
-            return true;
+            return FTRs_Go_To_Next_Action;
         }
     }
 
-    return true; //proceed to next test action
+    return FTRs_Go_To_Next_Action; //proceed to next test action
 }
 
 

--- a/src/ftests/tests/ftest_bug_pathing_stair_treasury.c
+++ b/src/ftests/tests/ftest_bug_pathing_stair_treasury.c
@@ -43,9 +43,9 @@ struct ftest_bug_pathing_stair_treasury__variables ftest_bug_pathing_stair_treas
 
 
 // forward declarations - tests
-TbBool ftest_bug_pathing_stair_treasury_action001__map_setup(struct FTestActionArgs* const args);
-TbBool ftest_bug_pathing_stair_treasury_action002__second_dig_imps_stuck(struct FTestActionArgs* const args);
-TbBool ftest_bug_pathing_stair_treasury_action003__check_imps_stuck(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_pathing_stair_treasury_action001__map_setup(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_pathing_stair_treasury_action002__second_dig_imps_stuck(struct FTestActionArgs* const args);
+FTestActionResult ftest_bug_pathing_stair_treasury_action003__check_imps_stuck(struct FTestActionArgs* const args);
 
 TbBool ftest_bug_pathing_stair_treasury_init()
 {
@@ -61,7 +61,7 @@ TbBool ftest_bug_pathing_stair_treasury_init()
 /**
  * @brief This action will be a sub-test, it will setup the situation of a single tunneler digging towards you, and replicate getting stuck on a pillar (portal?)
  */
-TbBool ftest_bug_pathing_stair_treasury_action001__map_setup(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_pathing_stair_treasury_action001__map_setup(struct FTestActionArgs* const args)
 {
     struct ftest_bug_pathing_stair_treasury__variables* const vars = args->data;
 
@@ -87,16 +87,16 @@ TbBool ftest_bug_pathing_stair_treasury_action001__map_setup(struct FTestActionA
     if (markForDigResult != Lb_OK && markForDigResult != Lb_SUCCESS)
     {
         FTEST_FAIL_TEST("Failed to mark the gold block for digging");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     // focus camera on dig site
     ftest_util_move_camera_to_slab(stair_x+1, stair_y-1, PLAYER0);
 
-    return true; //proceed to next test action
+    return FTRs_Go_To_Next_Action; //proceed to next test action
 }
 
-TbBool ftest_bug_pathing_stair_treasury_action002__second_dig_imps_stuck(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_pathing_stair_treasury_action002__second_dig_imps_stuck(struct FTestActionArgs* const args)
 {
     struct ftest_bug_pathing_stair_treasury__variables* const vars = args->data;
 
@@ -105,16 +105,16 @@ TbBool ftest_bug_pathing_stair_treasury_action002__second_dig_imps_stuck(struct 
     if (markForDigResult != Lb_OK && markForDigResult != Lb_SUCCESS)
     {
         FTEST_FAIL_TEST("Failed to mark the block for digging");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     // focus camera on dig site
     ftest_util_move_camera_to_slab(vars->slb_x_second_dig_action, vars->slb_y_second_dig_action, PLAYER0);
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
-TbBool ftest_bug_pathing_stair_treasury_action003__check_imps_stuck(struct FTestActionArgs* const args)
+FTestActionResult ftest_bug_pathing_stair_treasury_action003__check_imps_stuck(struct FTestActionArgs* const args)
 {
     struct ftest_bug_pathing_stair_treasury__variables* const vars = args->data;
 
@@ -124,17 +124,17 @@ TbBool ftest_bug_pathing_stair_treasury_action003__check_imps_stuck(struct FTest
     // allow camera to sit for a moment so we can view the imps behaviour
     if(game.play_gameturn < args->actual_started_at_game_turn + 100)
     {
-        return false;
+        return FTRs_Repeat_Current_Action;
     }
 
     // if the second block isn't reached/dug then the imps are stuck in the stairs...
     if(ftest_util_do_any_slabs_match(vars->slb_x_second_dig_action, vars->slb_y_second_dig_action, vars->slb_x_second_dig_action, vars->slb_y_second_dig_action, SlbT_WALLWWOMAN))
     {
         FTEST_FAIL_TEST("Imps failed to dig second site, they are stuck in the treasury stairs!");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
 #endif

--- a/src/ftests/tests/ftest_template.c
+++ b/src/ftests/tests/ftest_template.c
@@ -37,9 +37,9 @@ struct ftest_template__variables ftest_template__vars = {
 };
 
 // forward declarations - tests
-TbBool ftest_template_action001__spawn_imp(struct FTestActionArgs* const args);
-TbBool ftest_template_action002__slap_imp_to_death(struct FTestActionArgs* const args);
-TbBool ftest_template_action003__end_test(struct FTestActionArgs* const args);
+FTestActionResult ftest_template_action001__spawn_imp(struct FTestActionArgs* const args);
+FTestActionResult ftest_template_action002__slap_imp_to_death(struct FTestActionArgs* const args);
+FTestActionResult ftest_template_action003__end_test(struct FTestActionArgs* const args);
 
 TbBool ftest_template_init()
 {
@@ -53,7 +53,7 @@ TbBool ftest_template_init()
     return true;
 }
 
-TbBool ftest_template_action001__spawn_imp(struct FTestActionArgs* const args)
+FTestActionResult ftest_template_action001__spawn_imp(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     // in this case we are grabbing the data from the argument, allowing different action setups!
@@ -77,22 +77,22 @@ TbBool ftest_template_action001__spawn_imp(struct FTestActionArgs* const args)
     if(thing_is_invalid(vars->target_imp))
     {
         FTEST_FAIL_TEST("Failed to create imp");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     // level up the imp a couple times for fun
     if(!creature_change_multiple_levels(vars->target_imp, 2))
     {
         FTEST_FAIL_TEST("Failed to level up imp");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
     ftest_util_move_camera_to_slab(vars->slb_x_spawn_imp, vars->slb_y_spawn_imp, PLAYER0);
 
-    return true; //proceed to next test action
+    return FTRs_Go_To_Next_Action; //proceed to next test action
 }
 
-TbBool ftest_template_action002__slap_imp_to_death(struct FTestActionArgs* const args)
+FTestActionResult ftest_template_action002__slap_imp_to_death(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     // in this case we are grabbing the data from the argument, allowing different action setups!
@@ -101,13 +101,13 @@ TbBool ftest_template_action002__slap_imp_to_death(struct FTestActionArgs* const
     // delay the test for a bit as an example
     if(game.play_gameturn < 100)
     {
-        return false;
+        return FTRs_Repeat_Current_Action;
     }
 
     // delay the test after each slap
     if(game.play_gameturn < vars->turn_delay_counter)
     {
-        return false;
+        return FTRs_Repeat_Current_Action;
     }
 
     ftest_util_move_camera_to_thing(vars->target_imp, PLAYER0);
@@ -118,19 +118,19 @@ TbBool ftest_template_action002__slap_imp_to_death(struct FTestActionArgs* const
         message_add_fmt(PLAYER0, "Slap %d", ++vars->slap_counter);
 
         vars->turn_delay_counter = game.play_gameturn + 20;
-        return false;
+        return FTRs_Repeat_Current_Action;
     }
 
     if (vars->target_imp->health <= 0)
     {
         message_add_fmt(PLAYER0, "Oops...");
-        return true;
+        return FTRs_Go_To_Next_Action;
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
-TbBool ftest_template_action003__end_test(struct FTestActionArgs* const args)
+FTestActionResult ftest_template_action003__end_test(struct FTestActionArgs* const args)
 {
     // to make the test variable names shorter, use a pointer!
     // in this case we are grabbing the data from the argument, allowing different action setups!
@@ -139,9 +139,10 @@ TbBool ftest_template_action003__end_test(struct FTestActionArgs* const args)
     if(vars->slap_counter != 26)
     {
         FTEST_FAIL_TEST("Expected 26 slaps for level 3 imp, only counted %d", vars->slap_counter);
+        return FTRs_Go_To_Next_Action;
     }
 
-    return true;
+    return FTRs_Go_To_Next_Action;
 }
 
 #endif


### PR DESCRIPTION
- Added enum `FTestActionResult` to make action flow easier to understand.
Now test actions should return FTestActionResult, either (`FTRs_Repeat_Current_Action` or `FTRs_Go_To_Next_Action`) instead of the old way (`true` or `false`).
Old tests that still use `true`/`false` will work, but will generate compiler warnings because action functions should return FTestActionResult
- Updated README.md
- fixed goldseam test, now uses `game.conf.rules.game.gold_per_gold_block` - Introduced in 49a8821db2a5d015b4a653ba7f9e14ef2486fb00
