### PR TITLE
New Script Command: DECREASE_LEVEL

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -4834,6 +4834,7 @@ const struct CommandDesc command_desc[] = {
   {"SET_EFFECT_GENERATOR_CONFIGURATION","AAAnn   ", Cmd_SET_EFFECT_GENERATOR_CONFIGURATION, &set_effectgen_configuration_check, &set_effectgen_configuration_process },
   {"SET_POWER_CONFIGURATION",           "AAAa    ", Cmd_SET_POWER_CONFIGURATION, &set_power_configuration_check, &set_power_configuration_process},
   {"SET_PLAYER_COLOR",                  "PA      ", Cmd_SET_PLAYER_COLOR, &set_player_color_check, &set_player_color_process },
+  {"DECREASE_LEVEL",                    "PN      ", Cmd_DECREASE_LEVEL, NULL, NULL},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script_commands_old.c
+++ b/src/lvl_script_commands_old.c
@@ -1540,6 +1540,22 @@ static void command_creature_entrance_level(long plr_range_id, unsigned char val
   command_add_value(Cmd_CREATURE_ENTRANCE_LEVEL, plr_range_id, val, 0, 0);
 }
 
+static void command_decrease_level(long plr_range_id, long count)
+{
+    if (count < 1)
+    {
+        SCRPTWRNLOG("Invalid count: %d, setting to 1.", count);
+        count = 1;
+    }
+
+    if (count > 9)
+    {
+        SCRPTWRNLOG("Count too high: %d, setting to 9.", count);
+        count = 9;
+    }
+    command_add_value(Cmd_DECREASE_LEVEL, plr_range_id, count, 0, 0);
+}
+
 static void command_randomise_flag(long plr_range_id, const char *flgname, long val)
 {
     long flg_id;
@@ -1901,6 +1917,9 @@ void script_add_command(const struct CommandDesc *cmd_desc, const struct ScriptL
         break;
     case Cmd_CREATURE_ENTRANCE_LEVEL:
         command_creature_entrance_level(scline->np[0], scline->np[1]);
+        break;
+    case Cmd_DECREASE_LEVEL:
+        command_decrease_level(scline->np[0], scline->np[1]);
         break;
     case Cmd_RANDOMISE_FLAG:
         command_randomise_flag(scline->np[0], scline->tp[1], scline->np[2]);

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -178,6 +178,7 @@ enum TbScriptCommands {
     Cmd_SET_EFFECT_GENERATOR_CONFIGURATION = 165,
     Cmd_SET_POWER_CONFIGURATION           = 166,
     Cmd_SET_PLAYER_COLOR                  = 167,
+    Cmd_DECREASE_LEVEL                    = 168,
 };
 
 struct ScriptLine {

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -396,6 +396,16 @@ TbBool script_use_special_locate_hidden_world()
 }
 
 /**
+ * Decreases creatures' levels for player.
+ * @param plyr_idx target player
+ * @param count how many times should the level be decreased
+ */
+void script_decrease_level(PlayerNumber plyr_idx, int count)
+{
+    decrease_level(get_player(plyr_idx), count);
+}
+
+/**
  * Processes given VALUE immediately.
  * This processes given script command. It is used to process VALUEs at start when they have
  * no conditions, or during the gameplay when conditions are met.
@@ -996,6 +1006,12 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
     }
     break;
   }
+  case Cmd_DECREASE_LEVEL:
+      for (i=plr_start; i < plr_end; i++)
+      {
+          script_decrease_level(i, val2);
+      }
+      break;
   case Cmd_RANDOMISE_FLAG:
       for (i=plr_start; i < plr_end; i++)
       {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3963,6 +3963,61 @@ TbBool creature_change_multiple_levels(struct Thing *thing, int count)
     }
 }
 
+void decrease_level(struct PlayerInfo *player, int count)
+{
+    struct CreatureControl *cctrl;
+    struct Thing *thing;
+    struct Dungeon* dungeon = get_dungeon(player->id_number);
+    // Decrease level of normal creatures
+    unsigned long k = 0;
+    int i = dungeon->creatr_list_start;
+    while (i != 0)
+    {
+        thing = thing_get(i);
+        cctrl = creature_control_get_from_thing(thing);
+        if (thing_is_invalid(thing) || creature_control_invalid(cctrl))
+        {
+          ERRORLOG("Jump to invalid creature detected");
+          break;
+        }
+        i = cctrl->players_next_creature_idx;
+        // Thing list loop body
+        if (count != 1) set_creature_level(thing, cctrl->explevel - count);
+        else set_creature_level(thing, cctrl->explevel - 1);
+        // Thing list loop body ends
+        k++;
+        if (k > CREATURES_COUNT)
+        {
+          ERRORLOG("Infinite loop detected when sweeping creatures list");
+          break;
+        }
+    }
+    // Decrease level of special diggers
+    k = 0;
+    i = dungeon->digger_list_start;
+    while (i != 0)
+    {
+        thing = thing_get(i);
+        cctrl = creature_control_get_from_thing(thing);
+        if (thing_is_invalid(thing) || creature_control_invalid(cctrl))
+        {
+          ERRORLOG("Jump to invalid creature detected");
+          break;
+        }
+        i = cctrl->players_next_creature_idx;
+        // Thing list loop body
+        if (count > 1) set_creature_level(thing, cctrl->explevel - count);
+        else set_creature_level(thing, cctrl->explevel - 1);
+        // Thing list loop body ends
+        k++;
+        if (k > CREATURES_COUNT)
+        {
+          ERRORLOG("Infinite loop detected when sweeping creatures list");
+          break;
+        }
+    }
+}
+
 /**
  * Creates creature of random evil kind, and with random experience level.
  * @param x

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -93,6 +93,7 @@ struct Thing *create_owned_special_digger(MapCoord x, MapCoord y, PlayerNumber o
 
 TbBool creature_increase_level(struct Thing *thing);
 TbBool creature_change_multiple_levels(struct Thing *thing, int count);
+void decrease_level(struct PlayerInfo *player, int count);
 void set_creature_level(struct Thing *thing, long nlvl);
 void init_creature_level(struct Thing *thing, long nlev);
 long get_creature_speed(const struct Thing *thing);


### PR DESCRIPTION
A simple script command that decreases all creatures' levels of targeted player.

``DECREASE_LEVEL([player_target],[count])``