### PR TITLE
Fixed winning maps by chasing heroes through gate

### DIFF
--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -150,6 +150,9 @@ unsigned long object_is_pickable_by_hand_for_use(const struct Thing *thing, long
     return false;
 }
 
+/**
+ * @param In a player hand or in limbo (out through hero gate)
+  */
 TbBool thing_is_picked_up(const struct Thing *thing)
 {
     return (((thing->alloc_flags & TAlF_IsInLimbo) != 0) || ((thing->state_flags & TF1_InCtrldLimbo) != 0));
@@ -157,7 +160,7 @@ TbBool thing_is_picked_up(const struct Thing *thing)
 
 TbBool thing_is_picked_up_by_player(const struct Thing *thing, PlayerNumber plyr_idx)
 {
-    if (((thing->alloc_flags & TAlF_IsInLimbo) == 0) && ((thing->state_flags & TF1_InCtrldLimbo) == 0))
+    if ((thing->alloc_flags & TAlF_IsInLimbo) == 0)
         return false;
     if (thing_is_in_power_hand_list(thing, plyr_idx))
         return true;
@@ -171,9 +174,9 @@ TbBool thing_is_picked_up_by_owner(const struct Thing *thing)
 
 TbBool thing_is_picked_up_by_enemy(const struct Thing *thing)
 {
-    if (((thing->alloc_flags & TAlF_IsInLimbo) == 0) && ((thing->state_flags & TF1_InCtrldLimbo) == 0))
+    if ((thing->alloc_flags & TAlF_IsInLimbo) == 0)
         return false;
-    return !thing_is_in_power_hand_list(thing, thing->owner) && !thing_is_in_computer_power_hand_list(thing, thing->owner);
+    return !thing_is_in_power_hand_list(thing, thing->owner) && !thing_is_in_computer_power_hand_list(thing, thing->owner) && ((thing->state_flags & TF1_InCtrldLimbo) == 0);
 }
 
 /**

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -757,7 +757,7 @@ void update_first_person_object_ambience(struct Thing *thing)
              objtng = thing_get(objtng->next_of_class))
         {
             objst = get_object_model_stats(objtng->model);
-            if ((objst->fp_smpl_idx != 0) && !thing_is_in_limbo(objtng))
+            if ((objst->fp_smpl_idx != 0) && !thing_is_picked_up(objtng))
             {
                 new_distance = get_chessboard_distance(&thing->mappos, &objtng->mappos);
                 if (new_distance <= hearing_range)

--- a/src/thing_data.c
+++ b/src/thing_data.c
@@ -226,6 +226,9 @@ TbBool thing_exists(const struct Thing *thing)
     return true;
 }
 
+/**
+ * @param In a player hand, excludes creature controlled limbo like hero gates
+  */
 TbBool thing_is_in_limbo(const struct Thing* thing)
 {
     return (thing->alloc_flags & TAlF_IsInLimbo);

--- a/src/thing_navigate.c
+++ b/src/thing_navigate.c
@@ -269,7 +269,7 @@ struct Thing *find_hero_door_hero_can_navigate_to(struct Thing *herotng)
         }
         i = thing->next_of_class;
         // Per thing code
-        if (object_is_hero_gate(thing) && !thing_is_in_limbo(thing))
+        if (object_is_hero_gate(thing) && !thing_is_picked_up(thing))
         {
             if (creature_can_navigate_to_with_storage(herotng, &thing->mappos, NavRtF_Default)) {
                 return thing;


### PR DESCRIPTION
User reported the game reported he had won level 14 prematurely. This happened because he cast cave-in on the knight, which promptly hid in the hero gate for a second.

This triggered 'IF_CONTROLS' to say the good player controlled no knights, so the map was won.
There is however 2 kinds of limbo:
- Regular limbo (picked up)
- Creature controlled limbo (not on the map for another reason, like hiding in hero gate)

I made sure that IF_CONTROLS only checks regular limbo.