### PR TITLE
Heart Destruction Configurable

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -899,6 +899,8 @@ HitCreatureSound = 137 1
 WithstandHitAgainst = WALL DOOR
 Properties = REBOUND_IMMUNE WIND_IMMUNE NO_STUN HIDDEN_PROJECTILE EXPLODE_FLESH
 UpdateLogic = 4
+EffectModel = EFFECTELEMENT_ELECTRIC_BALL3
+EffectSpacing = 256
 
 [shot17]
 Name = SHOT_SPIKE

--- a/config/fxdata/objects.cfg
+++ b/config/fxdata/objects.cfg
@@ -167,6 +167,17 @@ Persistence = 0
 Immobile = 1
 Properties = EXISTS_ONLY_IN_ROOM BEATING HEART
 UpdateFunction = UPDATE_DUNGEON_HEART
+; Beam effect during destruction.
+EffectBeam = EFFECTELEMENT_ELECTRIC_BALL3
+; Particle effect during destruction.
+EffectParticle = EFFECT_ELECTRIC_BALLS
+; Explosion effect after destruction.
+EffectExplosion1 = EFFECT_EXPLOSION_4
+EffectExplosion2 = EFFECT_WORD_OF_POWER
+; Used to calculate the spacing to draw the beam effect.
+EffectSpacing = 96
+; Sound played along the beam effect during destruction.
+EffectSound = 157
 
 [object6]
 Name = GOLD

--- a/src/config_magic.h
+++ b/src/config_magic.h
@@ -309,9 +309,8 @@ struct ShotConfigStats {
     EffectOrEffElModel effect_id;
     unsigned char fire_logic; // see enum ShotFireLogics
     unsigned char update_logic; // see enum ShotUpdateLogics
-    unsigned char effect_spacing;
+    unsigned short effect_spacing;
     unsigned char effect_amount;
-
 };
 
 typedef unsigned char (*Expand_Check_Func)(void);

--- a/src/config_objects.c
+++ b/src/config_objects.c
@@ -72,6 +72,12 @@ const struct NamedCommand objects_object_commands[] = {
   {"INITIALSTATE",      24},
   {"RANDOMSTARTFRAME",  25},
   {"TRANSPARENCYFLAGS", 26},
+  {"EFFECTBEAM",        27},
+  {"EFFECTPARTICLE",    28},
+  {"EFFECTEXPLOSION1",  29},
+  {"EFFECTEXPLOSION2",  30},
+  {"EFFECTSPACING",     31},
+  {"EFFECTSOUND",       32},
   {NULL,                 0},
   };
 
@@ -656,7 +662,87 @@ TbBool parse_objects_object_blocks(char *buf, long len, const char *config_textn
                         COMMAND_TEXT(cmd_num), block_buf, config_textname);
                 }
                 break;
-            case 0: // comment
+            case 27: // EFFECTBEAM
+                if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+                {
+                    n = effect_or_effect_element_id(word_buf);
+                    objst->effect.beam = n;
+                    n++;
+                }
+                if (n < 0)
+                {
+                    CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                        COMMAND_TEXT(cmd_num), block_buf, config_textname);
+                }
+                break;
+            case 28: // EFFECTPARTICLE
+                if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+                {
+                    n = effect_or_effect_element_id(word_buf);
+                    objst->effect.particle = n;
+                    n++;
+                }
+                if (n < 0)
+                {
+                    CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                        COMMAND_TEXT(cmd_num), block_buf, config_textname);
+                }
+                break;
+            case 29: // EFFECTEXPLOSION1
+                if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+                {
+                    n = effect_or_effect_element_id(word_buf);
+                    objst->effect.explosion1 = n;
+                    n++;
+                }
+                if (n < 0)
+                {
+                    CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                        COMMAND_TEXT(cmd_num), block_buf, config_textname);
+                }
+                break;
+            case 30: // EFFECTEXPLOSION2
+                if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+                {
+                    n = effect_or_effect_element_id(word_buf);
+                    objst->effect.explosion2 = n;
+                    n++;
+                }
+                if (n < 0)
+                {
+                    CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                        COMMAND_TEXT(cmd_num), block_buf, config_textname);
+                }
+                break;
+            case 31: // EFFECTSPACING
+                if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+                {
+                    n = atoi(word_buf);
+                    objst->effect.spacing = n;
+                    n++;
+                }
+                if (n <= 0)
+                {
+                    CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                        COMMAND_TEXT(cmd_num), block_buf, config_textname);
+                }
+                break;
+            case 32: // EFFECTSOUND
+                if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+                {
+                    n = atoi(word_buf);
+                    if ( (!SoundDisabled) && ( (n < 0) || (n > (samples_in_bank - 1)) ) )
+                    {
+                        CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                        COMMAND_TEXT(cmd_num), block_buf, config_textname);
+                    }
+                    else
+                    {
+                        objst->effect.sound = n;
+                    }
+                }
+                break;
+           case 0: // comment
                 break;
             case -1: // end of buffer
                 break;

--- a/src/config_objects.h
+++ b/src/config_objects.h
@@ -59,6 +59,15 @@ enum ObjectModelFlags {
 
 
 /******************************************************************************/
+struct Effects {
+    EffectOrEffElModel beam;
+    EffectOrEffElModel particle;
+    EffectOrEffElModel explosion1;
+    EffectOrEffElModel explosion2;
+    unsigned short spacing;
+    unsigned short sound;
+};
+
 struct ObjectConfigStats {
     char code_name[COMMAND_WORD_LEN];
     unsigned long model_flags;
@@ -86,7 +95,8 @@ struct ObjectConfigStats {
     unsigned char updatefn_idx;
     unsigned char initial_state;
     unsigned char random_start_frame;
-    unsigned char transparancy_flags;  // Lower 2 bits are transparency flags
+    unsigned char transparancy_flags;  // Lower 2 bits are transparency flags.
+    struct Effects effect;
 };
 
 struct ObjectsConfig {

--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -21,6 +21,7 @@
 #include "thing_list.h"
 #include "player_computer.h"
 #include "thing_effects.h"
+#include "thing_objects.h"
 #include "room_data.h"
 #include "room_library.h"
 #include "room_workshop.h"
@@ -45,12 +46,13 @@ extern "C" {
 static void powerful_magic_breaking_sparks(struct Thing* breaktng)
 {
     struct Coord3d pos;
+    struct ObjectConfigStats* objst = get_object_model_stats(breaktng->model);
     pos.x.val = subtile_coord_center(breaktng->mappos.x.stl.num + GAME_RANDOM(11) - 5);
     pos.y.val = subtile_coord_center(breaktng->mappos.y.stl.num + GAME_RANDOM(11) - 5);
     pos.z.val = get_floor_height_at(&pos);
-    draw_lightning(&breaktng->mappos, &pos, 96, -TngEffElm_ElectricBall3);
-    if (!S3DEmitterIsPlayingSample(breaktng->snd_emitter_id, 157, 0)) {
-        thing_play_sample(breaktng, 157, NORMAL_PITCH, -1, 3, 1, 6, FULL_LOUDNESS);
+    draw_lightning(&breaktng->mappos, &pos, objst->effect.spacing, objst->effect.beam);
+    if (!S3DEmitterIsPlayingSample(breaktng->snd_emitter_id, objst->effect.sound, 0)) {
+        thing_play_sample(breaktng, objst->effect.sound, NORMAL_PITCH, -1, 3, 1, 6, FULL_LOUDNESS);
     }
 }
 
@@ -79,11 +81,10 @@ void process_dungeon_destroy(struct Thing* heartng)
 {
     if (heartng->owner == game.neutral_player_num)
         return;
-
     long plyr_idx = heartng->owner;
     struct Dungeon* dungeon = get_dungeon(plyr_idx);
     struct Thing* soultng = thing_get(dungeon->free_soul_idx);
-
+    struct ObjectConfigStats* objst = get_object_model_stats(heartng->model);
     if (dungeon->heart_destroy_state == 0)
     {
         return;
@@ -92,9 +93,7 @@ void process_dungeon_destroy(struct Thing* heartng)
     {
         return;
     }
-
     TbBool no_backup = !(dungeon->backup_heart_idx > 0);
-
     powerful_magic_breaking_sparks(heartng);
     const struct Coord3d* central_pos;
     central_pos = &heartng->mappos;
@@ -144,12 +143,11 @@ void process_dungeon_destroy(struct Thing* heartng)
                 delete_thing_structure(soultng, 0);
             }
         }
-
         dungeon->heart_destroy_turn++;
         if (dungeon->heart_destroy_turn < 32)
         {
             if (GAME_RANDOM(96) < (dungeon->heart_destroy_turn << 6) / 32 + 32) {
-                create_effect(central_pos, TngEff_HearthCollapse, plyr_idx);
+                create_effect(central_pos, objst->effect.particle, plyr_idx);
             }
         }
         else
@@ -162,7 +160,7 @@ void process_dungeon_destroy(struct Thing* heartng)
         dungeon->heart_destroy_turn++;
         if (dungeon->heart_destroy_turn < 32)
         {
-            create_effect(central_pos, TngEff_HearthCollapse, plyr_idx);
+            create_effect(central_pos, objst->effect.particle, plyr_idx);
         }
         else
         { // Got to next phase
@@ -191,10 +189,10 @@ void process_dungeon_destroy(struct Thing* heartng)
         // Final phase - destroy the heart, both pedestal room and container thing
     {
         struct Thing* efftng;
-        efftng = create_effect(central_pos, TngEff_Explosion4, plyr_idx);
+        efftng = create_effect(central_pos, objst->effect.explosion1, plyr_idx);
         if (!thing_is_invalid(efftng))
             efftng->shot_effect.hit_type = THit_HeartOnlyNotOwn;
-        efftng = create_effect(central_pos, TngEff_WoPExplosion, plyr_idx);
+        efftng = create_effect(central_pos, objst->effect.explosion2, plyr_idx);
         if (!thing_is_invalid(efftng))
             efftng->shot_effect.hit_type = THit_HeartOnlyNotOwn;
         destroy_dungeon_heart_room(plyr_idx, heartng);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2972,6 +2972,24 @@ static void set_object_configuration_process(struct ScriptContext *context)
         case 26: // TRANSPARENCYFLAGS
             objst->transparancy_flags = context->value->arg2;
             break;
+        case 27: // EFFECTBEAM
+            objst->effect.beam = context->value->arg2;
+            break;
+        case 28: // EFFECTPARTICLE
+            objst->effect.particle = context->value->arg2;
+            break;
+        case 29: // EFFECTEXPLOSION1
+            objst->effect.explosion1 = context->value->arg2;
+            break;
+        case 30: // EFFECTEXPLOSION2
+            objst->effect.explosion2 = context->value->arg2;
+            break;
+        case 31: // EFFECTSPACING
+            objst->effect.spacing = context->value->arg2;
+            break;
+        case 32: // EFFECTSOUND
+            objst->effect.sound = context->value->arg2;
+            break;
         default:
             WARNMSG("Unsupported Object configuration, variable %d.", context->value->arg1);
             break;

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -383,8 +383,8 @@ void draw_god_lightning(struct Thing *shotng)
         locpos.x.val = (shotng->mappos.x.val + (LbSinL(i + cam->orient_a) >> (LbFPMath_TrigmBits - 10))) + 128;
         locpos.y.val = (shotng->mappos.y.val - (LbCosL(i + cam->orient_a) >> (LbFPMath_TrigmBits - 10))) + 128;
         locpos.z.val = shotng->mappos.z.val + subtile_coord(12,0);
-        struct ShotConfigStats* shotst = get_shot_model_stats(ShM_GodLightBall);
-        draw_lightning(&locpos, &shotng->mappos, 256, shotst->effect_id);
+        struct ShotConfigStats* shotst = get_shot_model_stats(ShM_GodLightning);
+        draw_lightning(&locpos, &shotng->mappos, shotst->effect_spacing, shotst->effect_id);
     }
 }
 


### PR DESCRIPTION
Adds the following for ``SOUL_CONTAINER`` on objects.cfg:

```
; Beam effect during destruction.
EffectBeam = EFFECTELEMENT_ELECTRIC_BALL3
; Particle effect during destruction.
EffectParticle = EFFECT_ELECTRIC_BALLS
; Explosion effect after destruction.
EffectExplosion1 = EFFECT_EXPLOSION_4
EffectExplosion2 = EFFECT_WORD_OF_POWER
; Used to calculate the spacing to draw the beam effect.
EffectSpacing = 96
; Sound played along the beam effect during destruction.
EffectSound = 157
```

The effects during destruction of a Dungeon Heart is no longer hardcoded and can be configured with those fields.

Allows to configure differents effects for custom Dungeon Heart aswell.