### PR TITLE
Fixed Call to Arms not being used

### DIFF
--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2331,7 +2331,7 @@ static struct Thing *find_creature_for_call_to_arms(struct Computer2 *comp, TbBo
 
         if ( flag_is_set(i->alloc_flags, TAlF_IsInLimbo) )
             continue;
-        if (flag_is_set(i->state_flags, TAlF_IsInMapWho) )
+        if (flag_is_set(i->state_flags, TF1_InCtrldLimbo) )
             continue;
         if ( i->active_state == CrSt_CreatureUnconscious )
             continue;

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2329,7 +2329,9 @@ static struct Thing *find_creature_for_call_to_arms(struct Computer2 *comp, TbBo
     {
         struct CreatureControl *cctrl = creature_control_get_from_thing(i);
 
-        if ( any_flag_is_set(i->alloc_flags, (TAlF_IsInLimbo|TAlF_IsInMapWho)) )
+        if ( flag_is_set(i->alloc_flags, TAlF_IsInLimbo) )
+            continue;
+        if (flag_is_set(i->state_flags, TAlF_IsInMapWho) )
             continue;
         if ( i->active_state == CrSt_CreatureUnconscious )
             continue;


### PR DESCRIPTION
Computer players would often not use call to arms anymore.

Issue was introduced in this commit: https://github.com/dkfans/keeperfx/commit/50005565e2ac00cbdba9e29de16c17f7a94e98e7

This is not the same:
![image](https://github.com/dkfans/keeperfx/assets/13840686/29f77298-f2cf-4a28-a566-23a5a161a088)
