### PR TITLE
RANDOMISE_FLAG can use current flag value as max

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5229,7 +5229,7 @@ const struct CommandDesc command_desc[] = {
   {"SET_HEART_HEALTH",                  "PN      ", Cmd_SET_HEART_HEALTH, &set_heart_health_check, &set_heart_health_process},
   {"ADD_HEART_HEALTH",                  "PNn     ", Cmd_ADD_HEART_HEALTH, &add_heart_health_check, &add_heart_health_process},
   {"CREATURE_ENTRANCE_LEVEL",           "PN      ", Cmd_CREATURE_ENTRANCE_LEVEL, NULL, NULL},
-  {"RANDOMISE_FLAG",                    "PAN     ", Cmd_RANDOMISE_FLAG, NULL, NULL},
+  {"RANDOMISE_FLAG",                    "PAn     ", Cmd_RANDOMISE_FLAG, NULL, NULL},
   {"COMPUTE_FLAG",                      "PAAPAN  ", Cmd_COMPUTE_FLAG, NULL, NULL},
   {"DISPLAY_TIMER",                     "PAn     ", Cmd_DISPLAY_TIMER, &display_timer_check, &display_timer_process},
   {"ADD_TO_TIMER",                      "PAN     ", Cmd_ADD_TO_TIMER, &add_to_timer_check, &add_to_timer_process},

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5230,7 +5230,7 @@ const struct CommandDesc command_desc[] = {
   {"ADD_HEART_HEALTH",                  "PNn     ", Cmd_ADD_HEART_HEALTH, &add_heart_health_check, &add_heart_health_process},
   {"CREATURE_ENTRANCE_LEVEL",           "PN      ", Cmd_CREATURE_ENTRANCE_LEVEL, NULL, NULL},
   {"RANDOMISE_FLAG",                    "PAn     ", Cmd_RANDOMISE_FLAG, NULL, NULL},
-  {"COMPUTE_FLAG",                      "PAAPAN  ", Cmd_COMPUTE_FLAG, NULL, NULL},
+  {"COMPUTE_FLAG",                      "PAAPAn  ", Cmd_COMPUTE_FLAG, NULL, NULL},
   {"DISPLAY_TIMER",                     "PAn     ", Cmd_DISPLAY_TIMER, &display_timer_check, &display_timer_process},
   {"ADD_TO_TIMER",                      "PAN     ", Cmd_ADD_TO_TIMER, &add_to_timer_check, &add_to_timer_process},
   {"ADD_BONUS_TIME",                    "N       ", Cmd_ADD_BONUS_TIME, &add_bonus_time_check, &add_bonus_time_process},

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -1022,7 +1022,15 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
   case Cmd_RANDOMISE_FLAG:
       for (i=plr_start; i < plr_end; i++)
       {
-          set_variable(i, val4, val2, GAME_RANDOM(val3) + 1);
+          if (val3 == 0)
+          {
+              long current_flag_val = get_condition_value(i, val4, val2);
+              set_variable(i, val4, val2, GAME_RANDOM(current_flag_val) + 1);
+          }
+          else
+          {
+              set_variable(i, val4, val2, GAME_RANDOM(val3) + 1);
+          }
       }
       break;
   case Cmd_COMPUTE_FLAG:


### PR DESCRIPTION
- Made final param of RANDOMISE_FLAG optional
- If final value of RANDOMISE_FLAG is not given or set to 0, it uses the current value as the max.
- Made final param of COMPUTE_FLAG optional

Example:

```
REM Kill a random amount of the players dragons, but keep at least 2 alive.
SET_FLAG(PLAYER0,FLAG2,2)
COMPUTE_FLAG(PLAYER0,FLAG3,SET,PLAYER0,DRAGON)
RANDOMISE_FLAG(PLAYER0,FLAG3)
COMPUTE_FLAG(PLAYER0,FLAG3,DECREASE,PLAYER0,FLAG2)
IF(PLAYER0,FLAG3 > 1)
	NEXT_COMMAND_REUSABLE
	KILL_CREATURE(PLAYER0,DRAGON,ANYWHERE,1)
	NEXT_COMMAND_REUSABLE
	ADD_TO_FLAG(PLAYER0,FLAG3,-1)
ENDIF
```