### PR TITLE
External sound filenames only cleared when exiting a game

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3920,6 +3920,7 @@ void game_loop(void)
       StopMusicPlayer();
       free_custom_music();
       free_sound_chunks();
+      memset(&game.loaded_sound,0,DISKPATH_SIZE * EXTERNAL_SOUNDS_COUNT);
       turn_off_all_menus();
       delete_all_structures();
       clear_mapwho();

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -843,7 +843,6 @@ void free_sound_chunks()
         {
             Mix_FreeChunk(Ext_Sounds[i]);
             Ext_Sounds[i] = NULL;
-            memset(game.loaded_sound[i],0,DISKPATH_SIZE);
         }
     }
     game.sounds_count = 0;


### PR DESCRIPTION
Fixes #2985