### PR TITLE
Raised maximum amount of external sounds from 7 to 32

### DIFF
--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -316,7 +316,7 @@ void gui_set_sound_volume(struct GuiButton *gbtn)
     save_settings();
     SetSoundMasterVolume(settings.sound_volume);
     SetMusicMasterVolume(settings.sound_volume);
-    for (int i = 0; i < EXTERNAL_SOUNDS_COUNT; i++)
+    for (int i = 0; i <= EXTERNAL_SOUNDS_COUNT; i++)
     {
         if (Ext_Sounds[i] != NULL)
         {

--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -269,7 +269,7 @@ unsigned int packet_file_pos;
     int manufactr_spridx;
     int manufactr_tooltip;
     char loaded_track[MUSIC_TRACKS_COUNT][DISKPATH_SIZE];
-    char loaded_sound[EXTERNAL_SOUNDS_COUNT][DISKPATH_SIZE];
+    char loaded_sound[EXTERNAL_SOUNDS_COUNT+1][DISKPATH_SIZE];
     unsigned char sounds_count;
     struct Configs conf;
 };

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -42,7 +42,7 @@ extern "C" {
 
 #define SENSIBLE_GOLD 99999999
 
-#define EXTERNAL_SOUNDS_COUNT 8
+#define EXTERNAL_SOUNDS_COUNT 32
 
 enum ScriptOperator {
     SOpr_SET = 1,

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -4206,7 +4206,7 @@ static void play_message_check(const struct ScriptLine *scline)
                 return;
             }
         }
-        if (game.sounds_count >= (EXTERNAL_SOUNDS_COUNT - 1))
+        if (game.sounds_count >= (EXTERNAL_SOUNDS_COUNT))
         {
             ERRORLOG("All external sounds slots are used.");
             return;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -4208,7 +4208,7 @@ static void play_message_check(const struct ScriptLine *scline)
         }
         if (game.sounds_count >= (EXTERNAL_SOUNDS_COUNT))
         {
-            ERRORLOG("All external sounds slots are used.");
+            SCRPTERRLOG("All external sounds slots are used.");
             return;
         }
         unsigned char slot = game.sounds_count + 1;

--- a/src/lvl_script_commands.h
+++ b/src/lvl_script_commands.h
@@ -45,7 +45,7 @@ extern const struct NamedCommand gui_button_group_desc[];
 extern const struct NamedCommand campaign_flag_desc[];
 extern const struct NamedCommand script_operator_desc[];
 
-extern Mix_Chunk* Ext_Sounds[EXTERNAL_SOUNDS_COUNT];
+extern Mix_Chunk* Ext_Sounds[EXTERNAL_SOUNDS_COUNT+1];
 
 #ifdef __cplusplus
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3920,7 +3920,7 @@ void game_loop(void)
       StopMusicPlayer();
       free_custom_music();
       free_sound_chunks();
-      memset(&game.loaded_sound,0,DISKPATH_SIZE * EXTERNAL_SOUNDS_COUNT);
+      memset(&game.loaded_sound,0,DISKPATH_SIZE * EXTERNAL_SOUNDS_COUNT+1);
       turn_off_all_menus();
       delete_all_structures();
       clear_mapwho();

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -651,7 +651,7 @@ void sound_reinit_after_load(void)
     ambient_sound_stop();
     init_messages();
     free_sound_chunks();
-    for (unsigned int sample = 0; sample < EXTERNAL_SOUNDS_COUNT; sample++)
+    for (unsigned int sample = 0; sample <= EXTERNAL_SOUNDS_COUNT; sample++)
     {
         char *sound = &game.loaded_sound[sample][0];
         if (sound[0] != '\0')
@@ -837,7 +837,7 @@ void ShutDownSDLAudio()
 void free_sound_chunks()
 {
     Mix_HaltChannel(-1);
-    for (int i = 0; i < EXTERNAL_SOUNDS_COUNT; i++)
+    for (int i = 0; i <= EXTERNAL_SOUNDS_COUNT; i++)
     {
         if (Ext_Sounds[i] != NULL)
         {


### PR DESCRIPTION
To test use these files:
[audio-numbers.zip](https://github.com/dkfans/keeperfx/files/14103502/audio-numbers.zip)

And add this script to a map:
```
IF(PLAYER0,GAME_TURN > 0)
	PLAY_MESSAGE(PLAYER0,SPEECH,"1.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"2.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"3.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"4.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"5.wav")
ENDIF
IF(PLAYER0,GAME_TURN > 100)
	PLAY_MESSAGE(PLAYER0,SPEECH,"6.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"7.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"8.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"9.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"10.wav")
ENDIF
IF(PLAYER0,GAME_TURN > 200)
	PLAY_MESSAGE(PLAYER0,SPEECH,"11.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"12.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"13.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"14.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"15.wav")
ENDIF
IF(PLAYER0,GAME_TURN > 350)
	PLAY_MESSAGE(PLAYER0,SPEECH,"16.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"17.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"18.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"19.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"20.wav")
ENDIF
IF(PLAYER0,GAME_TURN > 500)
	PLAY_MESSAGE(PLAYER0,SPEECH,"21.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"22.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"23.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"24.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"25.wav")
ENDIF
IF(PLAYER0,GAME_TURN > 650)
	PLAY_MESSAGE(PLAYER0,SPEECH,"26.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"27.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"28.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"29.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"30.wav")
ENDIF
IF(PLAYER0,GAME_TURN > 800)
	PLAY_MESSAGE(PLAYER0,SPEECH,"31.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"32.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"33.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"34.wav")
	PLAY_MESSAGE(PLAYER0,SPEECH,"35.wav")
ENDIF
```
