### PR TITLE
Script command ADD_TO_PLAYER_MODIFIER

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5111,11 +5111,144 @@ static void set_player_modifier_process(struct ScriptContext* context)
                     break;
                 case 8: // ScavengingCost
                     SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.scavenging_cost, mdfrval);
-                       dungeon->modifier.scavenging_cost = mdfrval;
+                    dungeon->modifier.scavenging_cost = mdfrval;
                 break;
                 case 9: // Loyalty
                     SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.loyalty, mdfrval);
                     dungeon->modifier.loyalty = mdfrval;
+                    break;
+                default:
+                    WARNMSG("Unsupported Player Modifier, command %d.", mdfrdesc);
+                    break;
+            }
+        } else
+        {
+            SCRPTERRLOG("Can't manipulate Player Modifier '%s', player %d has no dungeon.", mdfrname, (int)plyr_idx);
+            break;
+        }
+    }
+}
+
+static void add_to_player_modifier_check(const struct ScriptLine* scline)
+{
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
+    short mdfrdesc = get_id(modifier_desc, scline->tp[1]);
+    short mdfrval = scline->np[2];
+    const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
+    if (mdfrdesc == -1)
+    {
+        SCRPTERRLOG("Unknown Player Modifier '%s'.", mdfrname);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
+    value->shorts[0] = mdfrdesc;
+    value->shorts[1] = mdfrval;
+    PROCESS_SCRIPT_VALUE(scline->command);
+}
+
+static void add_to_player_modifier_process(struct ScriptContext* context)
+{
+    struct Dungeon* dungeon;
+    short mdfrdesc = context->value->shorts[0];
+    short mdfrval = context->value->shorts[1];
+    short mdfradd;
+    const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
+    for (int plyr_idx = context->plr_start; plyr_idx < context->plr_end; plyr_idx++)
+    {
+        if (plyr_idx != game.neutral_player_num)
+        {
+            dungeon = get_dungeon(plyr_idx);
+            switch (mdfrdesc)
+            {
+                case 1: // Health
+                    mdfradd = dungeon->modifier.health;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.health = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
+                    break;
+                case 2: // Strength
+                    mdfradd = dungeon->modifier.strength;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.strength = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
+                    break;
+                case 3: // Armour
+                    mdfradd = dungeon->modifier.armour;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.armour = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
+                    break;
+                case 4: // SpellDamage
+                    mdfradd = dungeon->modifier.spell_damage;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.spell_damage = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
+                    break;
+                case 5: // Speed
+                    mdfradd = dungeon->modifier.speed;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.speed = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
+                    break;
+                case 6: // Salary
+                    mdfradd = dungeon->modifier.pay;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.pay = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
+                    break;
+                case 7: // TrainingCost
+                    mdfradd = dungeon->modifier.training_cost;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.training_cost = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
+                    break;
+                case 8: // ScavengingCost
+                    mdfradd = dungeon->modifier.scavenging_cost;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.scavenging_cost = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
+                break;
+                case 9: // Loyalty
+                    mdfradd = dungeon->modifier.loyalty;
+                    mdfradd = mdfradd + mdfrval;
+                    if (mdfradd >= 0) {
+                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
+                        dungeon->modifier.loyalty = mdfradd;
+                    } else {
+                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                    }
                     break;
                 default:
                     WARNMSG("Unsupported Player Modifier, command %d.", mdfrdesc);
@@ -5351,6 +5484,7 @@ const struct CommandDesc command_desc[] = {
   {"MAKE_UNSAFE",                       "P       ", Cmd_MAKE_UNSAFE, NULL, NULL},
   {"SET_INCREASE_ON_EXPERIENCE",        "AN      ", Cmd_SET_INCREASE_ON_EXPERIENCE, &set_increase_on_experience_check, &set_increase_on_experience_process},
   {"SET_PLAYER_MODIFIER",               "PAN     ", Cmd_SET_PLAYER_MODIFIER, &set_player_modifier_check, &set_player_modifier_process},
+  {"ADD_TO_PLAYER_MODIFIER",            "PAN     ", Cmd_ADD_TO_PLAYER_MODIFIER, &add_to_player_modifier_check, &add_to_player_modifier_process},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5063,6 +5063,12 @@ static void set_player_modifier_check(const struct ScriptLine* scline)
         DEALLOCATE_SCRIPT_VALUE
         return;
     }
+    if (scline->np[0] == game.neutral_player_num)
+    {
+        SCRPTERRLOG("Can't manipulate Player Modifier '%s', player %d has no dungeon.", mdfrname, scline->np[0]);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
     value->shorts[0] = mdfrdesc;
     value->shorts[1] = mdfrval;
     PROCESS_SCRIPT_VALUE(scline->command);
@@ -5076,55 +5082,48 @@ static void set_player_modifier_process(struct ScriptContext* context)
     const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
     for (int plyr_idx = context->plr_start; plyr_idx < context->plr_end; plyr_idx++)
     {
-        if (plyr_idx != game.neutral_player_num)
+        dungeon = get_dungeon(plyr_idx);
+        switch (mdfrdesc)
         {
-            dungeon = get_dungeon(plyr_idx);
-            switch (mdfrdesc)
-            {
-                case 1: // Health
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.health, mdfrval);
-                    dungeon->modifier.health = mdfrval;
-                    break;
-                case 2: // Strength
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.strength, mdfrval);
-                    dungeon->modifier.strength = mdfrval;
-                    break;
-                case 3: // Armour
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.armour, mdfrval);
-                    dungeon->modifier.armour = mdfrval;
-                    break;
-                case 4: // SpellDamage
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.spell_damage, mdfrval);
-                    dungeon->modifier.spell_damage = mdfrval;
-                    break;
-                case 5: // Speed
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.speed, mdfrval);
-                    dungeon->modifier.speed = mdfrval;
-                    break;
-                case 6: // Salary
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.pay, mdfrval);
-                    dungeon->modifier.pay = mdfrval;
-                    break;
-                case 7: // TrainingCost
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.training_cost, mdfrval);
-                    dungeon->modifier.training_cost = mdfrval;
-                    break;
-                case 8: // ScavengingCost
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.scavenging_cost, mdfrval);
-                    dungeon->modifier.scavenging_cost = mdfrval;
+            case 1: // Health
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.health, mdfrval);
+                dungeon->modifier.health = mdfrval;
                 break;
-                case 9: // Loyalty
-                    SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.loyalty, mdfrval);
-                    dungeon->modifier.loyalty = mdfrval;
-                    break;
-                default:
-                    WARNMSG("Unsupported Player Modifier, command %d.", mdfrdesc);
-                    break;
-            }
-        } else
-        {
-            SCRPTERRLOG("Can't manipulate Player Modifier '%s', player %d has no dungeon.", mdfrname, (int)plyr_idx);
-            break;
+            case 2: // Strength
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.strength, mdfrval);
+                dungeon->modifier.strength = mdfrval;
+                break;
+            case 3: // Armour
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.armour, mdfrval);
+                dungeon->modifier.armour = mdfrval;
+                break;
+            case 4: // SpellDamage
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.spell_damage, mdfrval);
+                dungeon->modifier.spell_damage = mdfrval;
+                break;
+            case 5: // Speed
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.speed, mdfrval);
+                dungeon->modifier.speed = mdfrval;
+                break;
+            case 6: // Salary
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.pay, mdfrval);
+                dungeon->modifier.pay = mdfrval;
+                break;
+            case 7: // TrainingCost
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.training_cost, mdfrval);
+                dungeon->modifier.training_cost = mdfrval;
+                break;
+            case 8: // ScavengingCost
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.scavenging_cost, mdfrval);
+                dungeon->modifier.scavenging_cost = mdfrval;
+                break;
+            case 9: // Loyalty
+                SCRIPTDBG(7,"Changing Player Modifier '%s' of player %d from %d to %d.", mdfrname, (int)plyr_idx, dungeon->modifier.loyalty, mdfrval);
+                dungeon->modifier.loyalty = mdfrval;
+                break;
+            default:
+                WARNMSG("Unsupported Player Modifier, command %d.", mdfrdesc);
+                break;
         }
     }
 }
@@ -5137,6 +5136,12 @@ static void add_to_player_modifier_check(const struct ScriptLine* scline)
     if (mdfrdesc == -1)
     {
         SCRPTERRLOG("Unknown Player Modifier '%s'.", scline->tp[1]);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
+    if (scline->np[0] == game.neutral_player_num)
+    {
+        SCRPTERRLOG("Can't manipulate Player Modifier '%s', player %d has no dungeon.", mdfrname, scline->np[0]);
         DEALLOCATE_SCRIPT_VALUE
         return;
     }
@@ -5154,100 +5159,93 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
     const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
     for (int plyr_idx = context->plr_start; plyr_idx < context->plr_end; plyr_idx++)
     {
-        if (plyr_idx != game.neutral_player_num)
+        dungeon = get_dungeon(plyr_idx);
+        switch (mdfrdesc)
         {
-            dungeon = get_dungeon(plyr_idx);
-            switch (mdfrdesc)
-            {
-                case 1: // Health
-                    mdfradd = dungeon->modifier.health + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.health = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.health);
-                    }
-                    break;
-                case 2: // Strength
-                    mdfradd = dungeon->modifier.strength + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.strength = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.strength);
-                    }
-                    break;
-                case 3: // Armour
-                    mdfradd = dungeon->modifier.armour + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.armour = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.armour);
-                    }
-                    break;
-                case 4: // SpellDamage
-                    mdfradd = dungeon->modifier.spell_damage + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.spell_damage = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.spell_damage);
-                    }
-                    break;
-                case 5: // Speed
-                    mdfradd = dungeon->modifier.speed + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.speed = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.speed);
-                    }
-                    break;
-                case 6: // Salary
-                    mdfradd = dungeon->modifier.pay + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.pay = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.pay);
-                    }
-                    break;
-                case 7: // TrainingCost
-                    mdfradd = dungeon->modifier.training_cost + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.training_cost = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.training_cost);
-                    }
-                    break;
-                case 8: // ScavengingCost
-                    mdfradd = dungeon->modifier.scavenging_cost + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.scavenging_cost = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.scavenging_cost);
-                    }
+            case 1: // Health
+                mdfradd = dungeon->modifier.health + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.health = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.health);
+                }
                 break;
-                case 9: // Loyalty
-                    mdfradd = dungeon->modifier.loyalty + mdfrval;
-                    if (mdfradd >= 0) {
-                        SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
-                        dungeon->modifier.loyalty = mdfradd;
-                    } else {
-                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.loyalty);
-                    }
-                    break;
-                default:
-                    WARNMSG("Unsupported Player Modifier, command %d.", mdfrdesc);
-                    break;
-            }
-        } else
-        {
-            SCRPTERRLOG("Can't manipulate Player Modifier '%s', player %d has no dungeon.", mdfrname, (int)plyr_idx);
-            break;
+            case 2: // Strength
+                mdfradd = dungeon->modifier.strength + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.strength = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.strength);
+                }
+                break;
+            case 3: // Armour
+                mdfradd = dungeon->modifier.armour + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.armour = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.armour);
+                }
+                break;
+            case 4: // SpellDamage
+                mdfradd = dungeon->modifier.spell_damage + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.spell_damage = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.spell_damage);
+                }
+                break;
+            case 5: // Speed
+                mdfradd = dungeon->modifier.speed + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.speed = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.speed);
+                }
+                break;
+            case 6: // Salary
+                mdfradd = dungeon->modifier.pay + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.pay = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.pay);
+                }
+                break;
+            case 7: // TrainingCost
+                mdfradd = dungeon->modifier.training_cost + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.training_cost = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.training_cost);
+                }
+                break;
+            case 8: // ScavengingCost
+                mdfradd = dungeon->modifier.scavenging_cost + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.scavenging_cost = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.scavenging_cost);
+                }
+                break;
+            case 9: // Loyalty
+                mdfradd = dungeon->modifier.loyalty + mdfrval;
+                if (mdfradd >= 0) {
+                    SCRIPTDBG(7,"Adding %d to Player %d Modifier '%s'.", mdfrval, (int)plyr_idx, mdfrname);
+                    dungeon->modifier.loyalty = mdfradd;
+                } else {
+                    SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.loyalty);
+                }
+                break;
+            default:
+                WARNMSG("Unsupported Player Modifier, command %d.", mdfrdesc);
+                break;
         }
     }
 }

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5134,7 +5134,6 @@ static void add_to_player_modifier_check(const struct ScriptLine* scline)
     ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
     short mdfrdesc = get_id(modifier_desc, scline->tp[1]);
     short mdfrval = scline->np[2];
-    const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
     if (mdfrdesc == -1)
     {
         SCRPTERRLOG("Unknown Player Modifier '%s'.", scline->tp[1]);
@@ -5167,7 +5166,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.health = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.health);
                     }
                     break;
                 case 2: // Strength
@@ -5177,7 +5176,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.strength = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.strength);
                     }
                     break;
                 case 3: // Armour
@@ -5187,7 +5186,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.armour = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.armour);
                     }
                     break;
                 case 4: // SpellDamage
@@ -5197,7 +5196,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.spell_damage = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.spell_damage);
                     }
                     break;
                 case 5: // Speed
@@ -5207,7 +5206,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.speed = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.speed);
                     }
                     break;
                 case 6: // Salary
@@ -5217,7 +5216,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.pay = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.pay);
                     }
                     break;
                 case 7: // TrainingCost
@@ -5227,7 +5226,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.training_cost = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.training_cost);
                     }
                     break;
                 case 8: // ScavengingCost
@@ -5237,7 +5236,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.scavenging_cost = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.scavenging_cost);
                     }
                 break;
                 case 9: // Loyalty
@@ -5247,7 +5246,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.loyalty = mdfradd;
                     } else {
-                        SCRPTERRLOG("Unable to add %d to Player Modifier of player %d: final value of '%s' cannot be negative.", mdfrval, (int)plyr_idx, mdfrname);
+                        SCRPTERRLOG("Player %d Modifier '%s' may not be negative. Tried to add %d to value %d", (int)plyr_idx, mdfrname, mdfrval, dungeon->modifier.loyalty);
                     }
                     break;
                 default:

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5160,8 +5160,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
             switch (mdfrdesc)
             {
                 case 1: // Health
-                    mdfradd = dungeon->modifier.health;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.health + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.health = mdfradd;
@@ -5170,8 +5169,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                     }
                     break;
                 case 2: // Strength
-                    mdfradd = dungeon->modifier.strength;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.strength + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.strength = mdfradd;
@@ -5180,8 +5178,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                     }
                     break;
                 case 3: // Armour
-                    mdfradd = dungeon->modifier.armour;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.armour + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.armour = mdfradd;
@@ -5190,8 +5187,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                     }
                     break;
                 case 4: // SpellDamage
-                    mdfradd = dungeon->modifier.spell_damage;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.spell_damage + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.spell_damage = mdfradd;
@@ -5200,8 +5196,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                     }
                     break;
                 case 5: // Speed
-                    mdfradd = dungeon->modifier.speed;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.speed + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.speed = mdfradd;
@@ -5210,8 +5205,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                     }
                     break;
                 case 6: // Salary
-                    mdfradd = dungeon->modifier.pay;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.pay + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.pay = mdfradd;
@@ -5220,8 +5214,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                     }
                     break;
                 case 7: // TrainingCost
-                    mdfradd = dungeon->modifier.training_cost;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.training_cost + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.training_cost = mdfradd;
@@ -5230,8 +5223,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                     }
                     break;
                 case 8: // ScavengingCost
-                    mdfradd = dungeon->modifier.scavenging_cost;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.scavenging_cost + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.scavenging_cost = mdfradd;
@@ -5240,8 +5232,7 @@ static void add_to_player_modifier_process(struct ScriptContext* context)
                     }
                 break;
                 case 9: // Loyalty
-                    mdfradd = dungeon->modifier.loyalty;
-                    mdfradd = mdfradd + mdfrval;
+                    mdfradd = dungeon->modifier.loyalty + mdfrval;
                     if (mdfradd >= 0) {
                         SCRIPTDBG(7,"Adding %d to Player Modifier '%s' of player %d.", mdfrval, mdfrname, (int)plyr_idx);
                         dungeon->modifier.loyalty = mdfradd;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5133,6 +5133,7 @@ static void add_to_player_modifier_check(const struct ScriptLine* scline)
     ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
     short mdfrdesc = get_id(modifier_desc, scline->tp[1]);
     short mdfrval = scline->np[2];
+    const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
     if (mdfrdesc == -1)
     {
         SCRPTERRLOG("Unknown Player Modifier '%s'.", scline->tp[1]);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5079,7 +5079,9 @@ static void set_player_modifier_process(struct ScriptContext* context)
     struct Dungeon* dungeon;
     short mdfrdesc = context->value->shorts[0];
     short mdfrval = context->value->shorts[1];
-    const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
+    #if (BFDEBUG_LEVEL > 0)
+        const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
+    #endif
     for (int plyr_idx = context->plr_start; plyr_idx < context->plr_end; plyr_idx++)
     {
         dungeon = get_dungeon(plyr_idx);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5053,7 +5053,7 @@ static void set_player_modifier_check(const struct ScriptLine* scline)
     const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
     if (mdfrdesc == -1)
     {
-        SCRPTERRLOG("Unknown Player Modifier '%s'.", mdfrname);
+        SCRPTERRLOG("Unknown Player Modifier '%s'.", scline->tp[1]);
         DEALLOCATE_SCRIPT_VALUE
         return;
     }
@@ -5137,7 +5137,7 @@ static void add_to_player_modifier_check(const struct ScriptLine* scline)
     const char *mdfrname = get_conf_parameter_text(modifier_desc,mdfrdesc);
     if (mdfrdesc == -1)
     {
-        SCRPTERRLOG("Unknown Player Modifier '%s'.", mdfrname);
+        SCRPTERRLOG("Unknown Player Modifier '%s'.", scline->tp[1]);
         DEALLOCATE_SCRIPT_VALUE
         return;
     }

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -182,6 +182,7 @@ enum TbScriptCommands {
     Cmd_LEVEL_UP_PLAYERS_CREATURES         = 169,
     Cmd_SET_INCREASE_ON_EXPERIENCE         = 170,
     Cmd_SET_PLAYER_MODIFIER                = 171,
+    Cmd_ADD_TO_PLAYER_MODIFIER             = 172,
 };
 
 struct ScriptLine {


### PR DESCRIPTION
Following the recent implementation of ``SET_PLAYER_MODIFIER`` this second command aims to add more flexibility for scripting, like ``ADD_TO_FLAG`` it adds value to choosen modifier. Accepts ``ALL_PLAYERS`` and negatives numbers.