### PR TITLE
Fixed a crash when displaying FLOATING_SPIRIT in battle menu

### DIFF
--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -206,6 +206,11 @@ void draw_battle_head(struct Thing *thing, long scr_x, long scr_y, int units_per
     }
     short spr_idx = get_creature_model_graphics(thing->model, CGI_HandSymbol);
     struct TbSprite* spr = &gui_panel_sprites[spr_idx];
+    if (spr->SHeight == 0)
+    {
+        ERRORLOG("drawing invalid battle head for %s", thing_model_name(thing));
+        return;
+    }
     int ps_units_per_px = (50 * units_per_px + spr->SHeight / 2) / spr->SHeight;
     int curscr_x = scr_x - (spr->SWidth * ps_units_per_px / 16) / 2;
     int curscr_y = scr_y - (spr->SHeight * ps_units_per_px / 16) / 2;

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -208,7 +208,7 @@ void draw_battle_head(struct Thing *thing, long scr_x, long scr_y, int units_per
     struct TbSprite* spr = &gui_panel_sprites[spr_idx];
     if (spr->SHeight == 0)
     {
-        ERRORLOG("drawing invalid battle head for %s", thing_model_name(thing));
+        ERRORLOG("Trying to draw non existing icon in battle menu for %s", thing_model_name(thing));
         return;
     }
     int ps_units_per_px = (50 * units_per_px + spr->SHeight / 2) / spr->SHeight;


### PR DESCRIPTION
or any other other unit without an icon configured