### PR TITLE
No longer hardcoded sound for Seek The Enemy job

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -4385,8 +4385,11 @@ short seek_the_enemy(struct Thing *creatng)
             {
               if ((dist < 2304) && (game.play_gameturn-cctrl->countdown_282 < 20))
               {
+                struct CreatureSound* crsound = get_creature_sound(creatng, CrSnd_Fight);
+                unsigned short sound_idx = crsound->index;
+                unsigned char sound_var = crsound->count;
                 set_creature_instance(creatng, CrInst_CELEBRATE_SHORT, 0, 0);
-                thing_play_sample(creatng, 168+UNSYNC_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+                thing_play_sample(creatng, sound_idx+UNSYNC_RANDOM(sound_var), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
                 return 1;
               }
               if (CREATURE_RANDOM(creatng, 4) != 0)

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -4376,6 +4376,7 @@ short seek_the_enemy(struct Thing *creatng)
     TRACE_THING(creatng);
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     struct Thing* enemytng = thing_update_enemy_to_fight_with(creatng);
+    struct CreatureSound* crsound;
     if (!thing_is_invalid(enemytng))
     {
         MapCoordDelta dist = get_chessboard_distance(&enemytng->mappos, &creatng->mappos);
@@ -4383,29 +4384,27 @@ short seek_the_enemy(struct Thing *creatng)
         {
             if (cctrl->instance_id == CrInst_NULL)
             {
-              if ((dist < 2304) && (game.play_gameturn-cctrl->countdown_282 < 20))
-              {
-                struct CreatureSound* crsound = get_creature_sound(creatng, CrSnd_Fight);
-                unsigned short sound_idx = crsound->index;
-                unsigned char sound_var = crsound->count;
-                set_creature_instance(creatng, CrInst_CELEBRATE_SHORT, 0, 0);
-                thing_play_sample(creatng, sound_idx+UNSYNC_RANDOM(sound_var), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
-                return 1;
-              }
-              if (CREATURE_RANDOM(creatng, 4) != 0)
-              {
-                  if (setup_person_move_close_to_position(creatng, enemytng->mappos.x.stl.num, enemytng->mappos.y.stl.num, NavRtF_Default))
-                  {
+                if ((dist < 2304) && (game.play_gameturn-cctrl->countdown_282 < 20))
+                {
+                    crsound = get_creature_sound(creatng, CrSnd_Fight);
+                    thing_play_sample(creatng, crsound->index + UNSYNC_RANDOM(crsound->count), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+                    set_creature_instance(creatng, CrInst_CELEBRATE_SHORT, 0, 0);
+                    return 1;
+                }
+                if (CREATURE_RANDOM(creatng, 4) != 0)
+                {
+                    if (setup_person_move_close_to_position(creatng, enemytng->mappos.x.stl.num, enemytng->mappos.y.stl.num, NavRtF_Default))
+                    {
+                        creatng->continue_state = CrSt_SeekTheEnemy;
+                        cctrl->countdown_282 = game.play_gameturn;
+                        return 1;
+                    }
+                }
+                if (creature_choose_random_destination_on_valid_adjacent_slab(creatng))
+                {
                     creatng->continue_state = CrSt_SeekTheEnemy;
                     cctrl->countdown_282 = game.play_gameturn;
-                    return 1;
-                  }
-              }
-              if (creature_choose_random_destination_on_valid_adjacent_slab(creatng))
-              {
-                  creatng->continue_state = CrSt_SeekTheEnemy;
-                  cctrl->countdown_282 = game.play_gameturn;
-              }
+                }
             }
             return 1;
         }


### PR DESCRIPTION
Currently it only plays hounds fighting sound, this PR allows any creature with the job to use their own fighting sound.

To test it have a creature with SEEK_THE_ENEMY primary job and tunnellers digging around your walls, usually the hound bark at the walls.