### PR TITLE
Nerfed poison gas to be similar to original game

### DIFF
--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -1365,7 +1365,7 @@ TbBool poison_cloud_affecting_thing(struct Thing *tngsrc, struct Thing *tngdst, 
             case AAffT_GasDamage:
                 if (max_damage > 0) {
                     HitPoints damage;
-                    damage = get_radially_decaying_value(max_damage,3*max_dist/4,max_dist/4,distance)+1;
+                    damage = get_radially_decaying_value(max_damage,max_dist/4, 3*max_dist/4,distance)+1;
                     SYNCDBG(7,"Causing %d damage to %s at distance %d",(int)damage,thing_model_name(tngdst),(int)distance);
                     apply_damage_to_thing_and_display_health(tngdst, damage, damage_type, tngsrc->owner);
                 }


### PR DESCRIPTION
It seems bile demons in groups did a lot less damage in the original game compared to now, starting with this commit from 0.4.5: https://github.com/dkfans/keeperfx/commit/ef8653a1c134790ef41cfa08a7907c4bfb529b75

Original game:
![image](https://github.com/dkfans/keeperfx/assets/13840686/fce00437-4290-4f1a-ad71-471471f4080d)

KeeperFX:
![image](https://github.com/dkfans/keeperfx/assets/13840686/c275ad3a-9ffb-428a-b620-de934d445c3b)

KeeperFX with this PR:
![image](https://github.com/dkfans/keeperfx/assets/13840686/7514f568-f4b5-4ab7-9ccb-d4c3ba93c190)

Based on this fight:
![image](https://github.com/dkfans/keeperfx/assets/13840686/053d0884-a73a-4a68-85e3-e710f486f3bb)
