### PR TITLE
Fix log warning about "hate" on rules.cfg

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -30,7 +30,7 @@ SpellFlags = 0
 ; The [power] the spell is taking the stats from
 SpellPower = NOPOWER
 ; The creature it summons, the amount of them and the experience level. Negative experience levels are relative to summoning creature.
-SummonCreature = NULL 0 0
+SummonCreature = 0 0 0
 ; Duration of the spell, provided the duration does not come from the linked power
 Duration = 0
 ; Effects or Effect elements (negative numbers) surround the target for the duration of the spell

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -105,11 +105,11 @@ const struct NamedField rules_computer_named_fields[] = {
 
 const struct NamedField rules_creatures_named_fields[] = {
   {"RECOVERYFREQUENCY",         &game.conf.rules.creature.recovery_frequency,    var_type(game.conf.rules.creature.recovery_frequency    ),       0,UCHAR_MAX},
-  {"FIGHTMAXHATE",              &game.conf.rules.creature.fight_max_hate,        var_type(game.conf.rules.creature.fight_max_hate        ),       0,USHRT_MAX},
-  {"FIGHTBORDERLINE",           &game.conf.rules.creature.fight_borderline,      var_type(game.conf.rules.creature.fight_borderline      ),       0,USHRT_MAX},
-  {"FIGHTMAXLOVE",              &game.conf.rules.creature.fight_max_love,        var_type(game.conf.rules.creature.fight_max_love        ),       0,USHRT_MAX},
+  {"FIGHTMAXHATE",              &game.conf.rules.creature.fight_max_hate,        var_type(game.conf.rules.creature.fight_max_hate        ),       SHRT_MIN,SHRT_MAX},
+  {"FIGHTBORDERLINE",           &game.conf.rules.creature.fight_borderline,      var_type(game.conf.rules.creature.fight_borderline      ),       SHRT_MIN,SHRT_MAX},
+  {"FIGHTMAXLOVE",              &game.conf.rules.creature.fight_max_love,        var_type(game.conf.rules.creature.fight_max_love        ),       SHRT_MIN,SHRT_MAX},
   {"BODYREMAINSFOR",            &game.conf.rules.creature.body_remains_for,      var_type(game.conf.rules.creature.body_remains_for      ),       0,USHRT_MAX},
-  {"FIGHTHATEKILLVALUE",        &game.conf.rules.creature.fight_hate_kill_value, var_type(game.conf.rules.creature.fight_hate_kill_value ),       0,USHRT_MAX},
+  {"FIGHTHATEKILLVALUE",        &game.conf.rules.creature.fight_hate_kill_value, var_type(game.conf.rules.creature.fight_hate_kill_value ),       SHRT_MIN,SHRT_MAX},
   {"FLEEZONERADIUS",            &game.conf.rules.creature.flee_zone_radius,      var_type(game.conf.rules.creature.flee_zone_radius      ),       0,ULONG_MAX},
   {"GAMETURNSINFLEE",           &game.conf.rules.creature.game_turns_in_flee,    var_type(game.conf.rules.creature.game_turns_in_flee    ),       0,LONG_MAX},
   {"GAMETURNSUNCONSCIOUS",      &game.conf.rules.creature.game_turns_unconscious,var_type(game.conf.rules.creature.game_turns_unconscious),       0,USHRT_MAX},

--- a/src/config_rules.h
+++ b/src/config_rules.h
@@ -106,11 +106,11 @@ struct ComputerRulesConfig {
 
 struct CreatureRulesConfig {
     unsigned char recovery_frequency;
-    unsigned short fight_max_hate;
-    unsigned short fight_borderline;
-    unsigned short fight_max_love;
+    short fight_max_hate;
+    short fight_borderline;
+    short fight_max_love;
     unsigned short body_remains_for;
-    unsigned short fight_hate_kill_value;
+    short fight_hate_kill_value;
     unsigned long flee_zone_radius;
     GameTurnDelta game_turns_in_flee;
     unsigned short game_turns_unconscious;


### PR DESCRIPTION
```
Warning: assign_conf_command_field(line 68): field 'FIGHTMAXLOVE' smaller then min value '0', was '0'
Warning: assign_conf_command_field(line 70): field 'FIGHTHATEKILLVALUE' smaller then min value '0', was '0'
```

Those warnings were triggered by an incorrect minimum setting in config_rules.c and in config_rules.h the variables were mistakenly defined as unsigned when they should actually be signed, [see the variable hates_player in dungeon_data.h](https://github.com/dkfans/keeperfx/blob/master/src/dungeon_data.h#L213). Since hates_player is a short variable, all rule variables related to it should also be defined as short types, at least from my understanding, let me know if I'm wrong!