### PR TITLE
Fix Flame Breath Crash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -651,6 +651,8 @@ void draw_flame_breath(struct Coord3d *pos1, struct Coord3d *pos2, long delta_st
   int delta_x;
   int delta_y;
   int delta_z;
+  if (delta_step <= 0)
+      delta_step = 1;
   if (dist_x >= 0)
   {
       delta_x = delta_step;


### PR DESCRIPTION
Prevent dividing by zero, don't know if that's a good fix tho, I just did the same thing that was done for lightning.