### PR TITLE
Grow up carry over data and gold

### DIFF
--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -5480,8 +5480,8 @@ void transfer_creature_data_and_gold(struct Thing *oldtng, struct Thing *newtng)
 {
     struct CreatureControl* oldcctrl = creature_control_get_from_thing(oldtng);
     struct CreatureControl* newcctrl = creature_control_get_from_thing(newtng);
+    strcpy(newcctrl->creature_name, oldcctrl->creature_name);
     newcctrl->blood_type = oldcctrl->blood_type;
-    newcctrl->creature_name = oldcctrl->creature_name;
     newcctrl->kills_num = oldcctrl->kills_num;
     newcctrl->joining_age = oldcctrl->joining_age;
     newtng->creature.gold_carried += oldtng->creature.gold_carried;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -5480,13 +5480,24 @@ void transfer_creature_data_and_gold(struct Thing *oldtng, struct Thing *newtng)
 {
     struct CreatureControl* oldcctrl = creature_control_get_from_thing(oldtng);
     struct CreatureControl* newcctrl = creature_control_get_from_thing(newtng);
+    struct CreatureStats* ncrstat = creature_stats_get_from_thing(newtng);
+
     strcpy(newcctrl->creature_name, oldcctrl->creature_name);
     newcctrl->blood_type = oldcctrl->blood_type;
     newcctrl->kills_num = oldcctrl->kills_num;
     newcctrl->joining_age = oldcctrl->joining_age;
     newtng->creation_turn = oldtng->creation_turn;
-    newtng->creature.gold_carried += oldtng->creature.gold_carried;
-    oldtng->creature.gold_carried = 0;
+
+    if (ncrstat->gold_hold >= oldtng->creature.gold_carried)
+    {
+        newtng->creature.gold_carried += oldtng->creature.gold_carried;
+        oldtng->creature.gold_carried = 0;
+    }
+    else
+    {
+        newtng->creature.gold_carried = ncrstat->gold_hold;
+        oldtng->creature.gold_carried -= ncrstat->gold_hold;
+    }
     return;
 }
 

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -5476,6 +5476,19 @@ long get_creature_thing_score(const struct Thing *thing)
     return game.creature_scores[crmodel].value[exp];
 }
 
+void transfer_creature_data_and_gold(struct Thing *oldtng, struct Thing *newtng)
+{
+    struct CreatureControl* oldcctrl = creature_control_get_from_thing(oldtng);
+    struct CreatureControl* newcctrl = creature_control_get_from_thing(newtng);
+    newcctrl->blood_type = oldcctrl->blood_type;
+    newcctrl->creature_name = oldcctrl->creature_name;
+    newcctrl->kills_num = oldcctrl->kills_num;
+    newcctrl->joining_age = oldcctrl->joining_age;
+    newtng->creature.gold_carried += oldtng->creature.gold_carried;
+    oldtng->creature.gold_carried = 0;
+    return;
+}
+
 long update_creature_levels(struct Thing *thing)
 {
     SYNCDBG(18,"Starting");
@@ -5538,6 +5551,7 @@ long update_creature_levels(struct Thing *thing)
         return 0;
     }
     set_creature_level(newtng, crstat->grow_up_level-1);
+    transfer_creature_data_and_gold(thing, newtng);// Transfer the blood type, creature name, kill count, joined age and carried gold to the new creature.
     update_creature_health_to_max(newtng);
     cctrl = creature_control_get_from_thing(thing);
     cctrl->countdown_282 = 50;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -5484,6 +5484,7 @@ void transfer_creature_data_and_gold(struct Thing *oldtng, struct Thing *newtng)
     newcctrl->blood_type = oldcctrl->blood_type;
     newcctrl->kills_num = oldcctrl->kills_num;
     newcctrl->joining_age = oldcctrl->joining_age;
+    newtng->creation_turn = oldtng->creation_turn;
     newtng->creature.gold_carried += oldtng->creature.gold_carried;
     oldtng->creature.gold_carried = 0;
     return;


### PR DESCRIPTION
Currently when a creature grow up it's a whole new creature, it doesn't look good.

This PR makes it so the new creature get to remember its own past, this includes the blood type, creature name, kill count, joined age/creation turn and the carried gold. This will stop the evolving creature to drop its carried gold too, so if you think this should be configurable let me know (some people may dislike the change?)...