### PR TITLE
Hand rule to not pick up dropped creatures

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -135,6 +135,8 @@ const struct NamedCommand hand_rule_desc[] = {
   {"WANDERING",             HandRule_Wandering},
   {"WORKING",               HandRule_Working},
   {"FIGHTING",              HandRule_Fighting},
+  {"DROPPED_TIME_HIGHER",   HandRule_DroppedTimeHigher},
+  {"DROPPED_TIME_LOWER",    HandRule_DroppedTimeLower},
   {NULL,                    0},
 };
 

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -1498,6 +1498,18 @@ static TbBool hand_rule_age_higher(struct HandRule *hand_rule, const struct Thin
     return (game.play_gameturn - thing->creation_turn < hand_rule->param) ? !hand_rule->allow : !!hand_rule->allow;
 }
 
+static TbBool hand_rule_dropped_time_lower(struct HandRule* hand_rule, const struct Thing* thing)
+{
+    struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
+    return (((game.play_gameturn - cctrl->dropped_turn) <= hand_rule->param) && (cctrl->dropped_turn != 0)) ? !hand_rule->allow : !!hand_rule->allow;
+}
+
+static TbBool hand_rule_dropped_time_higher(struct HandRule* hand_rule, const struct Thing* thing)
+{
+    struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
+    return ((game.play_gameturn - cctrl->dropped_turn) >= hand_rule->param) ? !hand_rule->allow : !!hand_rule->allow;
+}
+
 static TbBool hand_rule_lvl_lower(struct HandRule *hand_rule, const struct Thing *thing)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
@@ -1554,6 +1566,8 @@ static HandTestFn hand_rule_test_fns[] = {
     hand_rule_wandering,
     hand_rule_working,
     hand_rule_fighting,
+    hand_rule_dropped_time_higher,
+    hand_rule_dropped_time_lower,
 };
 
 TbBool eval_hand_rule_for_thing(struct HandRule *rule, const struct Thing *thing_to_pick)

--- a/src/power_hand.h
+++ b/src/power_hand.h
@@ -97,6 +97,8 @@ enum HandRuleType {
     HandRule_Wandering,
     HandRule_Working,
     HandRule_Fighting,
+    HandRule_DroppedTimeHigher,
+    HandRule_DroppedTimeLower
 };
 
 enum HandRuleAction {


### PR DESCRIPTION
Use it like this:
`SET_HAND_RULE(PLAYER0,ARCHER,RULE1,DENY,DROPPED_TIME_LOWER,60)`

Would stop a unit from being picked up within 3 seconds after it was last dropped from hand