### PR TITLE
Added a NeverBlock shot property and set it on shot arrow

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -418,6 +418,7 @@ WithstandHitAgainst =
 ; WIND_IMMUNE - Shot can not be blown away.
 ; EXPLODE_FLESH - Creatures killed by the shot are blown to bits.
 ; PENETRATING - Shot passes through creature to hit those behind. Set DestroyOnHit to 0.
+; NEVER_BLOCK - For STRENGTH_BASED shots, has them ignore Defence and Dexterity to aways hit.
 Properties = 
 ; Logic used when firing the shot.
 ; 0 Default.
@@ -846,7 +847,7 @@ HitWaterEffect = 19
 HitWaterSound = 36 1
 BleedingEffect = EFFECT_BLOOD_HIT
 FrozenEffect = EFFECT_HIT_FROZEN_UNIT
-Properties = STRENGTH_BASED
+Properties = STRENGTH_BASED NEVER_BLOCK
 
 [shot15]
 Name = SHOT_BOULDER

--- a/src/config_magic.c
+++ b/src/config_magic.c
@@ -202,6 +202,7 @@ const struct NamedCommand shotmodel_properties_commands[] = {
   {"DISARMING",           18},
   {"BLOCKS_REBIRTH",      19},
   {"PENETRATING",         20},
+  {"NEVER_BLOCK",         21},
   {NULL,                   0},
   };
 
@@ -1122,6 +1123,10 @@ TbBool parse_magic_shot_blocks(char *buf, long len, const char *config_textname,
                 break;
             case 20: // Penetrating
                 shotst->model_flags |= ShMF_Penetrating;
+                n++;
+                break;
+            case 21: // NeverBlock
+                shotst->model_flags |= ShMF_NeverBlock;
                 n++;
                 break;
             default:

--- a/src/config_magic.h
+++ b/src/config_magic.h
@@ -141,6 +141,7 @@ enum ShotModelFlags {
     ShMF_Exploding      = 0x2000,
     ShMF_BlocksRebirth  = 0x4000,
     ShMF_Penetrating    = 0x8000,
+    ShMF_NeverBlock     = 0x10000,
 };
 
 enum PowerCanCastFlags {

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -860,8 +860,11 @@ static TbBool shot_hit_object_at(struct Thing *shotng, struct Thing *target, str
     return damage_done > 0;
 }
 
-long get_damage_of_melee_shot(struct Thing *shotng, const struct Thing *target)
+long get_damage_of_melee_shot(struct Thing *shotng, const struct Thing *target, TbBool NeverBlock)
 {
+    if (NeverBlock)
+        return shotng->shot.damage;
+
     const struct CreatureStats* tgcrstat = creature_stats_get_from_thing(target);
     const struct CreatureControl* tgcctrl = creature_control_get_from_thing(target);
     long crdefense = compute_creature_max_defense(tgcrstat->defense, tgcctrl->explevel);
@@ -995,7 +998,7 @@ long melee_shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, stru
     if (shotng->parent_idx != shotng->index)
         shooter = thing_get(shotng->parent_idx);
     struct CreatureControl* tgcctrl = creature_control_get_from_thing(trgtng);
-    long damage = get_damage_of_melee_shot(shotng, trgtng);
+    long damage = get_damage_of_melee_shot(shotng, trgtng, flag_is_set(shotst->model_flags, ShMF_NeverBlock));
     if (damage > 0)
     {
       if (shotst->hit_creature.sndsample_idx > 0)
@@ -1150,7 +1153,7 @@ long shot_hit_creature_at(struct Thing *shotng, struct Thing *trgtng, struct Coo
         }
         return 1;
     }
-    if ((shotst->model_flags & ShMF_StrengthBased) != 0)
+    if (flag_is_set(shotst->model_flags,ShMF_StrengthBased))
     {
         return melee_shot_hit_creature_at(shotng, trgtng, pos);
     }

--- a/src/thing_shots.h
+++ b/src/thing_shots.h
@@ -98,7 +98,7 @@ struct Thing *create_shot(struct Coord3d *pos, ThingModel model, unsigned short 
 TngUpdateRet update_shot(struct Thing *thing);
 TbBool thing_is_shot(const struct Thing *thing);
 
-long get_damage_of_melee_shot(struct Thing *shotng, const struct Thing *target);
+long get_damage_of_melee_shot(struct Thing *shotng, const struct Thing *target, TbBool NeverBlock);
 long project_damage_of_melee_shot(long shot_dexterity, long shot_damage, const struct Thing *target);
 void create_relevant_effect_for_shot_hitting_thing(struct Thing *shotng, struct Thing *target);
 


### PR DESCRIPTION
In the past arrows were not strength based so would never miss. This last part is now restored.