### PR TITLE
Maps can have their own string files

### DIFF
--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -726,6 +726,10 @@ short parse_campaign_strings_blocks(struct GameCampaign *campgn,char *buf,long l
   {
       // Finding command number in this line
       int cmd_num = recognize_conf_command(buf, &pos, len, lang_type);
+      if (n == 0)
+      {
+          campgn->default_language = (cmd_num >= 0) ? cmd_num : 0;
+      }
       // Now store the config item in correct place
       if (cmd_num == -3) break; // if next block starts
       if (cmd_num <= 0)

--- a/src/config_campaigns.h
+++ b/src/config_campaigns.h
@@ -116,6 +116,7 @@ struct GameCampaign {
   // Human player color
   short human_player;
   TbBool assignCpuKeepers;
+  unsigned char default_language;
 };
 
 struct HighScore {

--- a/src/config_strings.c
+++ b/src/config_strings.c
@@ -37,6 +37,7 @@ extern "C" {
 /******************************************************************************/
 char *gui_strings_data;
 char *gui_strings[GUI_STRINGS_COUNT];
+TbBool reload_campaign_strings;
 /******************************************************************************/
 TbBool reset_strings(char **strings, int max)
 {
@@ -151,7 +152,11 @@ TbBool setup_campaign_strings_data(struct GameCampaign *campgn)
   // Resetting all values to empty strings
   reset_strings(campgn->strings, STRINGS_MAX);
   // Analyzing strings data and filling correct values
-  short result = create_strings_list(campgn->strings, campgn->strings_data, strings_data_end, STRINGS_MAX);
+  TbBool result = create_strings_list(campgn->strings, campgn->strings_data, strings_data_end, STRINGS_MAX);
+  if (result)
+  {
+    reload_campaign_strings = false;
+  }
   SYNCDBG(19,"Finished");
   return result;
 }

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -483,11 +483,14 @@ enum CampaignStrings {
 };
 
 /******************************************************************************/
+extern TbBool reload_campaign_strings;
+/******************************************************************************/
 TbBool setup_gui_strings_data(void);
 TbBool free_gui_strings_data(void);
 TbBool reset_strings(char **strings, int max);
 const char * get_string(TextStringId stridx);
 TbBool setup_campaign_strings_data(struct GameCampaign *campgn);
+TbBool create_strings_list(char **strings,char *strings_data,char *strings_data_end, int max);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "config_campaigns.h"
 #include "config_slabsets.h"
+#include "config_strings.h"
 #include "config_terrain.h"
 #include "light_data.h"
 #include "map_ceiling.h"
@@ -1378,9 +1379,46 @@ static void load_ext_slabs(LevelNumber lvnum)
     memcpy(&gameadd.slab_ext_data_initial,&gameadd.slab_ext_data, sizeof(gameadd.slab_ext_data));
 }
 
+static void load_map_string_data(struct GameCampaign *campgn, LevelNumber lvnum, short fgroup)
+{
+    if (campgn->strings_data == NULL)
+    {
+        return;
+    }
+    char* fname = prepare_file_fmtpath(fgroup, "map%05lu.%s", (unsigned long)lvnum, get_language_lwrstr(install_info.lang_id));
+    if (!LbFileExists(fname))
+    {
+        SYNCMSG("Map string file %s doesn't exist.", fname);
+        char buf[2048];
+        memcpy(&buf, fname, 2048);
+        fname = prepare_file_fmtpath(fgroup, "map%05lu.%s", (unsigned long)lvnum, get_language_lwrstr(campgn->default_language));
+        if (strcasecmp(fname, buf) == 0)
+        {
+            return;
+        }
+        if (!LbFileExists(fname))
+        {
+            SYNCMSG("Map string file %s doesn't exist.", fname);
+            return;
+        }
+    }
+    long filelen = LbFileLengthRnc(fname);
+    char* strings_data_end = campgn->strings_data + filelen + 255;
+    long loaded_size = LbFileLoadAt(fname, campgn->strings_data);
+    if (loaded_size > 0)
+    {
+        TbBool result = create_strings_list(campgn->strings, campgn->strings_data, strings_data_end, STRINGS_MAX);
+        if (result)
+        {
+            SYNCLOG("Loaded strings from %s", fname);
+            reload_campaign_strings = true;
+        }
+    }
+}
+
 static TbBool load_level_file(LevelNumber lvnum)
 {
-    short result;
+    TbBool result;
     TbBool new_format = true;
     short fgroup = get_level_fgroup(lvnum);
     char* fname = prepare_file_fmtpath(fgroup, "map%05lu.slb", (unsigned long)lvnum);
@@ -1388,6 +1426,12 @@ static TbBool load_level_file(LevelNumber lvnum)
     if (LbFileExists(fname))
     {
         result = true;
+        struct GameCampaign *campgn = &campaign;
+        if (reload_campaign_strings)
+        {
+            setup_campaign_strings_data(campgn);
+        }
+        load_map_string_data(campgn, lvnum, fgroup);
         load_map_data_file(lvnum);
         load_map_flag_file(lvnum);
         load_column_file(lvnum);


### PR DESCRIPTION
Implements #3124

The language is the extension (e.g.map00250.eng, map00250.fre, map00250.jpn, etc). Slots override the campaign/map pack-wide slots, so these files should only use the slots that are map-specific. If there is no string file for the current language, the campaign/map pack's default language is selected.