### PR TITLE
Added 'CTA' script location

### DIFF
--- a/src/config_strings.c
+++ b/src/config_strings.c
@@ -133,7 +133,7 @@ TbBool setup_campaign_strings_data(struct GameCampaign *campgn)
   long filelen = LbFileLengthRnc(fname);
   if (filelen <= 0)
   {
-    ERRORLOG("Campaign Strings file does not exist or can't be opened");
+    ERRORLOG("Campaign Strings file %s does not exist or can't be opened", campgn->strings_fname);
     return false;
   }
   campgn->strings_data = (char *)LbMemoryAlloc(filelen + 256);

--- a/src/map_locations.c
+++ b/src/map_locations.c
@@ -79,7 +79,7 @@ TbBool get_coords_at_meta_action(struct Coord3d *pos, PlayerNumber target_plyr_i
     
     SYNCDBG(7,"Starting with loc:%ld", i);
     struct Coord3d *src;
-    struct Coord3d* targetpos = {0};
+    struct Coord3d targetpos = {0};
     PlayerNumber loc_player = i & 0xF;
     if (loc_player == 15) // CURRENT_PLAYER
         loc_player = gameadd.script_current_player;
@@ -95,15 +95,12 @@ TbBool get_coords_at_meta_action(struct Coord3d *pos, PlayerNumber target_plyr_i
         src = &dungeon->last_combat_location;
         break;
     case MML_ACTIVE_CTA:
-        targetpos = malloc(sizeof(struct Coord3d));
-        if (targetpos == NULL) {
-            // Handle memory allocation failure
+        if ((dungeon->cta_stl_x == 0) && (dungeon->cta_stl_y == 0))
             return false;
-        }
-        targetpos->x.val = subtile_coord_center(dungeon->cta_stl_x);
-        targetpos->y.val = subtile_coord_center(dungeon->cta_stl_y);
-        targetpos->z.val = get_floor_height_at(pos);
-        src = targetpos; 
+        targetpos.x.val = subtile_coord_center(dungeon->cta_stl_x);
+        targetpos.y.val = subtile_coord_center(dungeon->cta_stl_y);
+        targetpos.z.val = get_floor_height_at(pos);
+        src = &targetpos; 
         break;
     default:
         return false;
@@ -112,7 +109,6 @@ TbBool get_coords_at_meta_action(struct Coord3d *pos, PlayerNumber target_plyr_i
     pos->x.val = src->x.val + PLAYER_RANDOM(target_plyr_idx, 33) - 16;
     pos->y.val = src->y.val + PLAYER_RANDOM(target_plyr_idx, 33) - 16;
     pos->z.val = src->z.val;
-    free(targetpos);
     return true;
     
 }

--- a/src/map_locations.c
+++ b/src/map_locations.c
@@ -426,16 +426,64 @@ TbBool get_map_location_id_f(const char *locname, TbMapLocation *location, const
             strncpy(player_string, start, min(end - start, sizeof(player_string) - 1));
             player_string[end - start] = '\0';
             i = get_rid(player_desc, player_string);
+            if (i == -1)
+            {
+                *location = MLoc_NONE;
+                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
+                return false;
+            }
         }
         *location = (((unsigned long)MML_RECENT_COMBAT) << 12)
             | ((unsigned long)i << 4)
             | MLoc_METALOCATION;
         return true;
     }
-    else if (strcmp(locname, "CTA") == 0)
+    else if (strncmp(locname, "CTA", strlen("CTA")) == 0)
     {
+        if (strcmp(locname, "CTA") == 0)
+        {
+            if (game.game_kind == GKind_MultiGame)
+            {
+                WARNLOG(" %s (line %lu) : LOCATION = '%s' cannot be used on Multiplayer maps", func_name, ln_num, locname);
+                i = PLAYER0;
+            }
+            else
+            {
+                i = my_player_number;
+            }
+        }
+        else
+        {
+            const char* start = strchr(locname, '[');
+            if (start == NULL) {
+                // Square bracket not found
+                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
+                *location = MLoc_NONE;
+                return false;
+            }
+
+            start++; // Move past '['
+            const char* end = strchr(start, ']');
+            if (end == NULL) {
+                // Closing square bracket not found
+                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
+                *location = MLoc_NONE;
+                return false;
+            }
+
+            // Extract the player number string
+            strncpy(player_string, start, min(end - start, sizeof(player_string) - 1));
+            player_string[end - start] = '\0';
+            i = get_rid(player_desc, player_string);
+            if (i == -1)
+            {
+                *location = MLoc_NONE;
+                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
+                return false;
+            }
+        }
         *location = (((unsigned long)MML_ACTIVE_CTA) << 12)
-            | ((unsigned long)my_player_number << 4)
+            | ((unsigned long)i << 4)
             | MLoc_METALOCATION;
         return true;
     }

--- a/src/map_locations.c
+++ b/src/map_locations.c
@@ -335,6 +335,32 @@ void find_location_pos(long location, PlayerNumber plyr_idx, struct Coord3d *pos
   SYNCDBG(15,"From %s; Location %ld, pos(%ld,%ld)",func_name, location, pos->x.stl.num, pos->y.stl.num);
 }
 
+/**
+ * Returns playernumber included withing brackets from location string from script.
+ * @param locname
+ * @return Playernumber, or -1 on error.
+ */
+PlayerNumber get_player_name_from_location_string(const char* locname)
+{
+    char player_string[COMMAND_WORD_LEN];
+    const char* start = strchr(locname, '[');
+    if (start == NULL) {
+        // Square bracket not found
+        return -1;
+    }
+
+    start++; // Move past '['
+    const char* end = strchr(start, ']');
+    if (end == NULL) {
+        // Closing square bracket not found
+        return -1;
+    }
+
+    // Extract the player number string
+    strncpy(player_string, start, min(end - start, sizeof(player_string) - 1));
+    player_string[end - start] = '\0';
+    return get_rid(player_desc, player_string);
+}
 
 /**
  * Returns location id for 1-param location from script.
@@ -346,7 +372,6 @@ void find_location_pos(long location, PlayerNumber plyr_idx, struct Coord3d *pos
 #define get_map_location_id(locname, location) get_map_location_id_f(locname, location, __func__, text_line_number)
 TbBool get_map_location_id_f(const char *locname, TbMapLocation *location, const char *func_name, long ln_num)
 {
-    char player_string[COMMAND_WORD_LEN];
     // If there's no locname, then coordinates are set directly as (x,y)
     if (locname == NULL || *locname == '\0')
     {
@@ -405,31 +430,11 @@ TbBool get_map_location_id_f(const char *locname, TbMapLocation *location, const
         }
         else
         {
-            const char* start = strchr(locname, '[');
-            if (start == NULL) {
-                // Square bracket not found
-                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
-                *location = MLoc_NONE;
-                return false;
-            }
-
-            start++; // Move past '['
-            const char* end = strchr(start, ']');
-            if (end == NULL) {
-                // Closing square bracket not found
-                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
-                *location = MLoc_NONE;
-                return false;
-            }
-
-            // Extract the player number string
-            strncpy(player_string, start, min(end - start, sizeof(player_string) - 1));
-            player_string[end - start] = '\0';
-            i = get_rid(player_desc, player_string);
+            i = get_player_name_from_location_string(locname);
             if (i == -1)
             {
-                *location = MLoc_NONE;
                 ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
+                *location = MLoc_NONE;
                 return false;
             }
         }
@@ -454,31 +459,11 @@ TbBool get_map_location_id_f(const char *locname, TbMapLocation *location, const
         }
         else
         {
-            const char* start = strchr(locname, '[');
-            if (start == NULL) {
-                // Square bracket not found
-                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
-                *location = MLoc_NONE;
-                return false;
-            }
-
-            start++; // Move past '['
-            const char* end = strchr(start, ']');
-            if (end == NULL) {
-                // Closing square bracket not found
-                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
-                *location = MLoc_NONE;
-                return false;
-            }
-
-            // Extract the player number string
-            strncpy(player_string, start, min(end - start, sizeof(player_string) - 1));
-            player_string[end - start] = '\0';
-            i = get_rid(player_desc, player_string);
+            i = get_player_name_from_location_string(locname);
             if (i == -1)
             {
-                *location = MLoc_NONE;
                 ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
+                *location = MLoc_NONE;
                 return false;
             }
         }

--- a/src/map_locations.h
+++ b/src/map_locations.h
@@ -50,6 +50,7 @@ enum MapLocationTypes {
 enum MetaLocation {
   MML_LAST_EVENT = 1,
   MML_RECENT_COMBAT,
+  MML_ACTIVE_CTA,
 };
 
 /******************************************************************************/


### PR DESCRIPTION
How to use:

```
REM Add a red bile demon to blue's cta.
ADD_CREATURE_TO_LEVEL(PLAYER0,BILE_DEMON,CTA[PLAYER1],1,1,1)
QUICK_OBJECTIVE(1,"See blue casting Call to Arms",CTA[PLAYER1])
```
Is only active when Call to Arms is cast, does not update

Also changed the combat location to have a [player] 

```
REM Add a red bile demon to blue's fighting
ADD_CREATURE_TO_LEVEL(PLAYER0,BILE_DEMON,COMBAT[PLAYER1],1,1,1)
QUICK_OBJECTIVE(1,"See the fighting",COMBAT[PLAYER1])
```
They both work without the [player] bracket, then they will take MY_PLAYER_NUMBER. On Multiplayer games it takes player0 and throws an error message.