### PR TITLE
make clear_active_dungeons_stats also loop trough new players

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2665,7 +2665,7 @@ int clear_active_dungeons_stats(void)
 {
   struct Dungeon *dungeon;
   int i;
-  for (i=0; i <= game.hero_player_num; i++)
+  for (i=0; i < PLAYERS_COUNT; i++)
   {
       dungeon = get_dungeon(i);
       if (dungeon_invalid(dungeon))


### PR DESCRIPTION
haven't tested anything about it, but noticed this loop that didn't clear the 3 new extra players