### PR TITLE
PlaceTrapsOnSubtiles now a trap property instead of a game rule

### DIFF
--- a/config/fxdata/rules.cfg
+++ b/config/fxdata/rules.cfg
@@ -38,8 +38,6 @@ HeroDoorWaitTime = 200
 RoomSellGoldBackPercent = 50
 DoorSellValuePercent = 100
 TrapSellValuePercent = 100
-; Traps can be placed on subtiles, allowing you to place up to 9 traps per tiles, enable with 1 or disable with 0.
-PlaceTrapsOnSubtiles = 0
 ; Torturing a creature changes the salary for its kind, value is a percentage, 100 for no change.
 TorturePayday = 50
 ; Torturing a creature changes the cost of training for its kind, value is a percentage, 100 for no change.

--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -185,8 +185,10 @@ Destructible = 0
 Unstable = 0
 ; Will there be an event message when the trap is triggered.
 TriggerAlarm = 0
-; If set to 1 allow the trap to be placed on bridge.
+; If set to 1 allows the trap to be placed on bridges.
 PlaceOnBridge = 0
+; If set to 1 allows the trap to be placed anywhere on a slab. This results in up to 9 traps per tile.
+PlaceOnSubtile = 0
 ; The hitpoints of the object.
 Health = 0
 Unshaded = 0

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -80,7 +80,6 @@ const struct NamedField rules_game_named_fields[] = {
   {"ROOMSELLGOLDBACKPERCENT",    &game.conf.rules.game.room_sale_percent,          var_type(game.conf.rules.game.room_sale_percent         ),       0,LONG_MAX},
   {"DOORSELLVALUEPERCENT",       &game.conf.rules.game.door_sale_percent,          var_type(game.conf.rules.game.door_sale_percent         ),       0,LONG_MAX},
   {"TRAPSELLVALUEPERCENT",       &game.conf.rules.game.trap_sale_percent,          var_type(game.conf.rules.game.trap_sale_percent         ),       0,LONG_MAX},
-  {"PLACETRAPSONSUBTILES",       &game.conf.rules.game.place_traps_on_subtiles,    var_type(game.conf.rules.game.place_traps_on_subtiles   ),       0,       1},
   {"BAGGOLDHOLD",                &game.conf.rules.game.bag_gold_hold,              var_type(game.conf.rules.game.bag_gold_hold             ),LONG_MIN,LONG_MAX},
   {"ALLIESSHAREVISION",          &game.conf.rules.game.allies_share_vision,        var_type(game.conf.rules.game.allies_share_vision       ),       0,       1},
   {"ALLIESSHAREDROP",            &game.conf.rules.game.allies_share_drop,          var_type(game.conf.rules.game.allies_share_drop         ),       0,       1},
@@ -282,7 +281,6 @@ static void set_defaults()
     game.conf.rules.game.trap_sale_percent = 100;
     game.conf.rules.game.gem_effectiveness = 17;
     game.conf.rules.game.pay_day_speed = 100;
-    game.conf.rules.game.place_traps_on_subtiles = false;
     game.conf.rules.game.gold_per_hoard = 2000;
     game.conf.rules.game.torture_payday = 50;
     game.conf.rules.game.torture_training_cost = 100;

--- a/src/config_rules.h
+++ b/src/config_rules.h
@@ -90,7 +90,6 @@ struct GameRulesConfig {
     long room_sale_percent;
     long trap_sale_percent;
     unsigned long pay_day_speed;
-    TbBool place_traps_on_subtiles;
     TbBool allies_share_vision;
     TbBool allies_share_drop;
     TbBool allies_share_cta;

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -113,6 +113,7 @@ const struct NamedCommand trapdoor_trap_commands[] = {
   {"ATTACKANIMATIONID",    41},
   {"DESTROYEDEFFECT",      42},
   {"INITIALDELAY",         43},
+  {"PLACEONSUBTILE",       44},
   {NULL,                    0},
 };
 
@@ -282,13 +283,14 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
           trapst->place_sound_idx = 117; 
           trapst->trigger_sound_idx = 176;
           trapst->panel_tab_idx = 0;
-          trapst->hidden = 0;
+          trapst->hidden = false;
           trapst->slappable = 0;
           trapst->destructible = 0;
           trapst->unstable = 0;
-          trapst->unsellable = 0;
-          trapst->notify = 0;
-          trapst->placeonbridge = 0;
+          trapst->unsellable = false;
+          trapst->notify = false;
+          trapst->placeonbridge = false;
+          trapst->placeonsubtile = false;
           // Default destroyed_effect is TngEffElm_Blast2.
           trapst->destroyed_effect = -39;
 
@@ -1094,6 +1096,22 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
               if (k >= 0)
               {
                   game.conf.trap_stats[i].initial_delay = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), block_buf, config_textname);
+          }
+          break;
+      case 44: // PLACEONSUBTILE
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  trapst->placeonsubtile = k;
                   n++;
               }
           }

--- a/src/config_trapdoor.h
+++ b/src/config_trapdoor.h
@@ -78,13 +78,14 @@ struct TrapConfigStats {
     long pointer_sprite_idx;
     short place_sound_idx;
     short trigger_sound_idx;
-    short hidden;
+    TbBool hidden;
     short slappable;
     short destructible;
     short unstable;
-    short notify;
-    short unsellable;
-    short placeonbridge;
+    TbBool notify;
+    TbBool unsellable;
+    TbBool placeonbridge;
+    TbBool placeonsubtile;
     EffectOrEffElModel destroyed_effect;
 };
 

--- a/src/cursor_tag.c
+++ b/src/cursor_tag.c
@@ -160,26 +160,22 @@ TbBool tag_cursor_blocks_place_door(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
     if (floor_height_z == 1)
     {
         Orientation = find_door_angle(stl_x, stl_y, plyr_idx);
-        if (game.conf.rules.game.place_traps_on_subtiles)
+        switch(Orientation)
         {
-            switch(Orientation)
+            case 0:
             {
-                case 0:
-                {
-                    Check = (!slab_middle_row_has_trap_on(slb_x, slb_y) );
-                    break;
-                }
-                case 1:
-                {
-                    Check = (!slab_middle_column_has_trap_on(slb_x, slb_y) );
-                    break;
-                }
+                Check = (!slab_middle_row_has_trap_on(slb_x, slb_y) );
+                break;
+            }
+            case 1:
+            {
+                Check = (!slab_middle_column_has_trap_on(slb_x, slb_y) );
+                break;
             }
         }
         if ( ( (slabmap_owner(slb) == plyr_idx) && (slb->kind == SlbT_CLAIMED) )
-            && (Orientation != -1)
-            && ( ( (game.conf.rules.game.place_traps_on_subtiles) ? (Check) : (!slab_has_trap_on(slb_x, slb_y) ) ) && (!slab_has_door_thing_on(slb_x, slb_y) ) )
-            )
+            && (Orientation != -1) && ( Check ) 
+            && (!slab_has_door_thing_on(slb_x, slb_y)) )
         {
             allowed = true;
         }

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1591,9 +1591,10 @@ static void new_trap_type_check(const struct ScriptLine* scline)
     trapst->slappable = 0;
     trapst->destructible = 0;
     trapst->unstable = 0;
-    trapst->unsellable = 0;
-    trapst->notify = 0;
-    trapst->placeonbridge = 0;
+    trapst->unsellable = false;
+    trapst->notify = false;
+    trapst->placeonbridge = false;
+    trapst->placeonsubtile = false;
     trapst->place_sound_idx = 117; 
     trapst->trigger_sound_idx = 176;
     trapst->destroyed_effect = -39;

--- a/src/magic.c
+++ b/src/magic.c
@@ -291,7 +291,7 @@ TbBool can_cast_power_on_thing(PlayerNumber plyr_idx, const struct Thing *thing,
             if (thing->owner == plyr_idx) {
                 struct TrapConfigStats *trapst;
                 trapst = &game.conf.trapdoor_conf.trap_cfgstats[thing->model];
-                if ((trapst->slappable == 1) && trap_is_active(thing)) {
+                if ((trapst->slappable > 0) && trap_is_active(thing)) {
                     return true;
                 }
             }

--- a/src/magic.c
+++ b/src/magic.c
@@ -291,7 +291,7 @@ TbBool can_cast_power_on_thing(PlayerNumber plyr_idx, const struct Thing *thing,
             if (thing->owner == plyr_idx) {
                 struct TrapConfigStats *trapst;
                 trapst = &game.conf.trapdoor_conf.trap_cfgstats[thing->model];
-                if ((trapst->slappable > 0) && trap_is_active(thing)) {
+                if ((trapst->slappable == 1) && trap_is_active(thing)) {
                     return true;
                 }
             }

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -630,7 +630,8 @@ TbBool process_dungeon_control_packet_dungeon_place_trap(long plyr_idx)
         }
         return false;
     }
-    player->full_slab_cursor = ((player->chosen_trap_kind == TngTrp_Boulder) || (!game.conf.rules.game.place_traps_on_subtiles));
+    struct TrapConfigStats *trapst = get_trap_model_stats(player->chosen_trap_kind);
+    player->full_slab_cursor = (trapst->placeonsubtile == false);
     long i = tag_cursor_blocks_place_trap(player->id_number, stl_x, stl_y, player->full_slab_cursor, player->chosen_trap_kind);
     if ((pckt->control_flags & PCtr_LBtnClick) == 0)
     {

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1193,15 +1193,16 @@ TbBool player_place_trap_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
         WARNLOG("Player %d tried to build %s but has none to place",(int)plyr_idx,trap_code_name(tngmodel));
         return false;
     }
+    struct TrapConfigStats* trap_cfg = get_trap_model_stats(tngmodel);
     struct Coord3d pos;
     struct PlayerInfo* player = get_player(plyr_idx);
-    if ((player->chosen_trap_kind == TngTrp_Boulder) || (!game.conf.rules.game.place_traps_on_subtiles))
+    if (trap_cfg->placeonsubtile)
     {
-        set_coords_to_slab_center(&pos,subtile_slab(stl_x),subtile_slab(stl_y));
+        set_coords_to_subtile_center(&pos, stl_x, stl_y, 1);
     }
     else
     {
-        set_coords_to_subtile_center(&pos,stl_x,stl_y,1);
+        set_coords_to_slab_center(&pos, subtile_slab(stl_x), subtile_slab(stl_y));
     }
     delete_room_slabbed_objects(get_slab_number(subtile_slab(stl_x),subtile_slab(stl_y)));
     struct Thing* traptng = create_trap(&pos, tngmodel, plyr_idx);
@@ -1221,7 +1222,6 @@ TbBool player_place_trap_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
     dungeon->camera_deviate_jump = 192;
     if (is_my_player_number(plyr_idx))
     {
-        struct TrapConfigStats* trap_cfg = get_trap_model_stats(tngmodel);    
         play_non_3d_sample(trap_cfg->place_sound_idx);
     }
     return true;

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -252,7 +252,7 @@ long pinstfe_hand_whip(struct PlayerInfo *player, long *n)
       break;
   case TCls_Trap:
       trapst = &game.conf.trapdoor_conf.trap_cfgstats[thing->model];
-      if ((trapst->slappable > 0) && trap_is_active(thing))
+      if ((trapst->slappable == 1) && trap_is_active(thing))
       {
           external_activate_trap_shot_at_angle(thing, player->acamera->orient_a, thing_get(player->hand_thing_idx));
       }

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -252,7 +252,7 @@ long pinstfe_hand_whip(struct PlayerInfo *player, long *n)
       break;
   case TCls_Trap:
       trapst = &game.conf.trapdoor_conf.trap_cfgstats[thing->model];
-      if ((trapst->slappable == 1) && trap_is_active(thing))
+      if ((trapst->slappable > 0) && trap_is_active(thing))
       {
           external_activate_trap_shot_at_angle(thing, player->acamera->orient_a, thing_get(player->hand_thing_idx));
       }

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -72,7 +72,7 @@ TbBool trap_is_slappable(const struct Thing *thing, PlayerNumber plyr_idx)
     if (thing->owner == plyr_idx)
     {
         trapst = &game.conf.trapdoor_conf.trap_cfgstats[thing->model];
-        return (trapst->slappable > 0) && trap_is_active(thing);
+        return (trapst->slappable == 1) && trap_is_active(thing);
     }
     return false;
 }

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -72,7 +72,7 @@ TbBool trap_is_slappable(const struct Thing *thing, PlayerNumber plyr_idx)
     if (thing->owner == plyr_idx)
     {
         trapst = &game.conf.trapdoor_conf.trap_cfgstats[thing->model];
-        return (trapst->slappable == 1) && trap_is_active(thing);
+        return (trapst->slappable > 0) && trap_is_active(thing);
     }
     return false;
 }

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -572,7 +572,7 @@ void activate_trap(struct Thing *traptng, struct Thing *creatng)
     traptng->trap.revealed = 1;
     const struct TrapStats *trapstat = &game.conf.trap_stats[traptng->model];
     struct TrapConfigStats *trapst = &game.conf.trapdoor_conf.trap_cfgstats[traptng->model];
-    if (trapst->notify == 1)
+    if (trapst->notify == true)
     {
         event_create_event(traptng->mappos.x.val, traptng->mappos.y.val, EvKind_AlarmTriggered, traptng->owner, 0);
     }
@@ -1077,6 +1077,8 @@ TbBool can_place_trap_on(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoo
     struct PlayerInfo* player = get_player(plyr_idx);
     TbBool HasTrap = true;
     TbBool HasDoor = true;
+    struct TrapConfigStats* trap_cfg = get_trap_model_stats(trpkind);
+
     if (!subtile_revealed(stl_x, stl_y, plyr_idx)) {
         return false;
     }
@@ -1088,14 +1090,9 @@ TbBool can_place_trap_on(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoo
     }
     if ((slabmap_owner(slb) == plyr_idx) && (((slb->kind == SlbT_BRIDGE) && (trap_on_bridge(trpkind))) || (slb->kind == SlbT_CLAIMED) || (slab_is_door(slb_x, slb_y))))
     {
-        if ((!game.conf.rules.game.place_traps_on_subtiles))
+        if (trap_cfg->placeonsubtile == false)
         {
                 HasTrap = slab_has_trap_on(slb_x, slb_y);
-                HasDoor = slab_is_door(slb_x, slb_y);
-        }
-        else if ( (game.conf.rules.game.place_traps_on_subtiles) && (player->chosen_trap_kind == TngTrp_Boulder) ) 
-        {
-                HasTrap = subtile_has_trap_on(slab_subtile_center(slb_x), slab_subtile_center(slb_y));
                 HasDoor = slab_is_door(slb_x, slb_y);
         }
         else


### PR DESCRIPTION
This allows for much more flexibility for mapmakers. A possibility where say, mines can be stacked 9 per slab, but lightning traps cannot.
Also removed the need for a hardcoded boulder.