### PR TITLE
break infinite chain in render code

### DIFF
--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -8960,6 +8960,8 @@ static void do_map_who(short tnglist_idx)
         if (k > THINGS_COUNT)
         {
             ERRORLOG("Infinite loop detected when sweeping things list");
+            struct Map* mapblk = get_map_block_at(thing->mappos.x.stl.num, thing->mappos.y.stl.num);
+            break_mapwho_infinite_chain(mapblk);
             break;
         }
     }


### PR DESCRIPTION
doesn't address the root cause of #3233 but mitigates some of the slowdown