### PR TITLE
AZERTY keyboard workaround

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -89,3 +89,7 @@ COMMAND_CHAR=!
 ; This allows other applications to communicate with KeeperFX
 API_ENABLED=FALSE
 API_PORT=5599
+
+; Workaround for some keys on an AZERTY keyboard.
+; Only enable this if you have trouble with some keybinds.
+AZERTY_KEYBOARD_WORKAROUND=FALSE

--- a/src/config.c
+++ b/src/config.c
@@ -62,6 +62,7 @@ struct InstallInfo install_info;
 char keeper_runtime_directory[152];
 short api_enabled = false;
 uint16_t api_port = 5599;
+short azerty_keyboard_workaround_enabled = false;
 
 /**
  * Language 3-char abbreviations.
@@ -148,6 +149,7 @@ const struct NamedCommand conf_commands[] = {
   {"COMMAND_CHAR"                  , 32},
   {"API_ENABLED"                   , 33},
   {"API_PORT"                      , 34},
+  {"AZERTY_KEYBOARD_WORKAROUND"    , 35},
   {NULL,                   0},
   };
 
@@ -1336,6 +1338,16 @@ short load_configuration(void)
           } else {
               CONFWRNLOG("Invalid API port '%s' in %s file.",COMMAND_TEXT(cmd_num),config_textname);
           }
+          break;
+      case 35: // AZERTY_KEYBOARD_WORKAROUND
+          i = recognize_conf_parameter(buf, &pos, len, logicval_type);
+          if (i <= 0)
+          {
+            CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
+                          COMMAND_TEXT(cmd_num), config_textname);
+            break;
+          }
+          azerty_keyboard_workaround_enabled = (i == 1);
           break;
       case 0: // comment
           break;

--- a/src/config.h
+++ b/src/config.h
@@ -255,6 +255,7 @@ extern const struct NamedCommand scrshot_type[];
 extern char cmd_char;
 extern short api_enabled;
 extern uint16_t api_port;
+extern short azerty_keyboard_workaround_enabled;
 /******************************************************************************/
 char *prepare_file_path_buf(char *ffullpath,short fgroup,const char *fname);
 char *prepare_file_path(short fgroup,const char *fname);


### PR DESCRIPTION
This is a workaround to make the top row of AZERTY keyboards work.

SDL2 does not generate a keypress event for these keys as they are not considered number keys. This workaround simulates those presses based on the character that has been pressed.

It currently breaks writing those characters in the chat and sends numbers instead. It does however fix all top row keybindings (console, tab switching, spawn creature level, etc)

I'll keep it as a draft until I also fix the keys while writing in chat.

If other people with AZERTY keyboards could test this out that would be great.