### PR TITLE
Added VIEW_TYPE script variable

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -417,6 +417,7 @@ const struct NamedCommand variable_desc[] = {
     {"BONUS_TIME",                  SVar_BONUS_TIME},
     {"CREATURES_TRANSFERRED",       SVar_CREATURES_TRANSFERRED},
     {"ACTIVE_BATTLES",              SVar_ACTIVE_BATTLES},
+    {"VIEW_TYPE",                   SVar_VIEW_TYPE},
     {NULL,                           0},
 };
 

--- a/src/lvl_script_conditions.c
+++ b/src/lvl_script_conditions.c
@@ -44,6 +44,7 @@ long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, unsigned 
     SYNCDBG(10,"Checking condition %d for player %d",(int)valtype,(int)plyr_idx);
     struct Dungeon* dungeon;
     struct Thing* thing;
+    struct PlayerInfo* player;
     switch (valtype)
     {
     case SVar_MONEY:
@@ -225,7 +226,7 @@ long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, unsigned 
         return dungeon->num_active_diggers - count_player_diggers_not_counting_to_total(plyr_idx);
     case SVar_ALL_DUNGEONS_DESTROYED:
     {
-        struct PlayerInfo* player = get_player(plyr_idx);
+        player = get_player(plyr_idx);
         return all_dungeons_destroyed(player);
     }
     case SVar_DOOR_NUM:
@@ -283,11 +284,14 @@ long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, unsigned 
         return dungeon->creatures_transferred;
     case SVar_ALLIED_PLAYER:
     {
-        struct PlayerInfo* player = get_player(plyr_idx);
+        player = get_player(plyr_idx);
         return player_allied_with(player, validx);
     }
     case SVar_ACTIVE_BATTLES:
         return count_active_battles(plyr_idx);
+    case SVar_VIEW_TYPE:
+        player = get_player(plyr_idx);
+        return player->view_type;
     default:
         break;
     };

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -279,6 +279,7 @@ enum ScriptVariables {
   SVar_CREATURES_TRANSFERRED           = 77,
   SVar_ALLIED_PLAYER                   = 78,
   SVar_ACTIVE_BATTLES                  = 79,
+  SVar_VIEW_TYPE                       = 80,
  };
 
 


### PR DESCRIPTION
Allows players to query where the player is looking. Example:

```
IF(PLAYER0,GAME_TURN>=60)
	IF(PLAYER0,VIEW_TYPE == 1)
		ZOOM_TO_LOCATION(PLAYER0,PLAYER1)
	ENDIF
ENDIF
```