### PR TITLE
Information messages do not time out in possession/map view

### DIFF
--- a/src/map_events.c
+++ b/src/map_events.c
@@ -656,7 +656,7 @@ void maintain_my_event_list(struct Dungeon *dungeon)
                 dungeon->event_button_index[i-1] = curr_ev_idx;
                 dungeon->event_button_index[i] = 0;
                 struct Event* event = &game.event[curr_ev_idx];
-                if (((event->flags & EvF_BtnFirstFall) != 0) || event->falling_button)
+                if (!flag_is_set(event->flags,EvF_BtnFirstFall))
                 {
                     if ((i == 1) || ((i >= 2) && dungeon->event_button_index[i-2] != 0))
                     {
@@ -668,7 +668,6 @@ void maintain_my_event_list(struct Dungeon *dungeon)
                         unsigned char prev_ev_idx = dungeon->event_button_index[i - 1];
                         event = &game.event[prev_ev_idx];
                         event->flags &= ~EvF_BtnFirstFall;
-                        event->falling_button = 0;
                     }
                 }
             }

--- a/src/map_events.c
+++ b/src/map_events.c
@@ -747,8 +747,12 @@ void event_process_events(void)
         if ((event->flags & EvF_Exists) == 0) {
             continue;
         }
-        if (event->lifespan_turns > 0) {
-            event->lifespan_turns--;
+        struct PlayerInfo*player = get_player(event->owner);
+        if (player->view_type == PVT_DungeonTop)
+        {
+            if (event->lifespan_turns > 0) {
+                event->lifespan_turns--;
+            }
         }
         if (event->lifespan_turns <= 0)
         {

--- a/src/map_events.h
+++ b/src/map_events.h
@@ -92,7 +92,6 @@ struct Event { // sizeof=0x15
     long target;
     /** Button lifespan, decreased over time. When reaches 0, the button disappears. */
     unsigned long lifespan_turns;
-    unsigned char falling_button; // Old way - make it unused when only EvF_BtnFirstFall is used
 };
 
 struct Bookmark {


### PR DESCRIPTION
Prevents players missing these messages on possession maps.