### PR TITLE
Flames on traps

### DIFF
--- a/config/fxdata/objects.cfg
+++ b/config/fxdata/objects.cfg
@@ -48,9 +48,9 @@ FlameAnimationSpeed = 256
 ; The size of the secondary sprite. Assume 300 is a normal size.
 FlameAnimationSize = 0
 ; Position of the secondary sprite compared to the first one. First x,y for possession, then x,y in normal view.
-FlameAnimationOffset = 1 2 0 14
+FlameAnimationOffset = 0 0 0 0
 ; Flame can have a different transparency from main object.
-FlameTransparencyFlags = 3
+FlameTransparencyFlags = 0
 Immobile = 0
 ; Initial state, only used for chickens.
 InitialState = 0

--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -215,7 +215,7 @@ PlaceSound = 0
 TriggerSound = 0
 ; Effect shown upon destruction of the trap if destructible was enabled. Takes the name of the effect or effect element, see 'effects.toml'.
 DestroyedEffect = 0
-; Sprite number for a secondary sprite drawn on top of the first one
+; Sprite number for a secondary sprite drawn on top of the first one. Not shown on depleted traps.
 FlameAnimationID = 0
 ; The speed of the flame animation
 FlameAnimationSpeed = 0

--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -214,6 +214,16 @@ PlaceSound = 0
 TriggerSound = 0
 ; Effect shown upon destruction of the trap if destructible was enabled. Takes the name of the effect or effect element, see 'effects.toml'.
 DestroyedEffect = 0
+; Sprite number for a secondary sprite drawn on top of the first one
+FlameAnimationID = 0
+; The speed of the flame animation
+FlameAnimationSpeed = 0
+; The size of the secondary sprite. Assume 300 is a normal size.
+FlameAnimationSize = 0
+; Position of the secondary sprite compared to the first one. First x,y for possession, then x,y in normal view.
+FlameAnimationOffset = 0 0 0 0
+; Flame can have a different transparency from main object.
+FlameTransparencyFlags = 0
 
 [trap1]
 Name = BOULDER

--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -204,6 +204,7 @@ Unsellable = 0
 LightRadius = 0
 LightIntensity = 0
 LightFlags = 0
+; Makes object transparant in different ways. Range: 0~3, where 3 is both 1 and 2 together.
 TransparencyFlags = 0
 ; Place where a shot fired by the trap originates, relative to trap position.
 ShotOrigin = 0 0 0

--- a/src/config_effects.c
+++ b/src/config_effects.c
@@ -167,7 +167,7 @@ static void load_effectelements(VALUE *value, unsigned short flags)
             CONDITIONAL_ASSIGN_INT(section,"Transparent",      effelcst->transparent);
             CONDITIONAL_ASSIGN_INT(section,"MovementFlags",    effelcst->movement_flags);
             CONDITIONAL_ASSIGN_INT(section,"SizeChange",       effelcst->size_change);
-            CONDITIONAL_ASSIGN_INT(section,"fallAcceleration", effelcst->fall_acceleration);
+            CONDITIONAL_ASSIGN_INT(section,"FallAcceleration", effelcst->fall_acceleration);
             CONDITIONAL_ASSIGN_INT(section,"InertiaFloor",     effelcst->inertia_floor);
             CONDITIONAL_ASSIGN_INT(section,"InertiaAir",       effelcst->inertia_air);
             CONDITIONAL_ASSIGN_INT(section,"SubeffectModel",   effelcst->subeffect_model);

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -765,13 +765,13 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
                     COMMAND_TEXT(cmd_num), block_buf, config_textname);
             }
             break;
-      case 31: // LIGHTFLAGS
+      case 31: // TRANSPARENCY_FLAGS
           if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
           {
               k = atoi(word_buf);
               if (k >= 0)
               {
-                  game.conf.trap_stats[i].light_flag = k;
+                  game.conf.trap_stats[i].transparency_flag = k<<4;
                   n++;
               }
           }

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -108,7 +108,12 @@ const struct NamedCommand trapdoor_trap_commands[] = {
   {"DESTROYEDEFFECT",      42},
   {"INITIALDELAY",         43},
   {"PLACEONSUBTILE",       44},
-  {NULL,                    0},
+  {"FLAMEANIMATIONID",     45},
+  {"FLAMEANIMATIONSPEED",  46},
+  {"FLAMEANIMATIONSIZE",   47},
+  {"FLAMEANIMATIONOFFSET",    48},
+  {"FLAMETRANSPARENCYFLAGS",  49},
+  {NULL,                       0},
 };
 
 const struct NamedCommand door_properties_commands[] = {
@@ -1013,6 +1018,89 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
               if (k >= 0)
               {
                   trapst->place_on_subtile = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), block_buf, config_textname);
+          }
+          break;
+      case 45: // FLAMEANIMATIONID
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  trapst->flame.animation_id = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), block_buf, config_textname);
+          }
+          break;
+      case 46: // FLAMEANIMATIONSPEED
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  trapst->flame.anim_speed = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), block_buf, config_textname);
+          }
+          break;
+      case 47: // FLAMEANIMATIONSIZE
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  trapst->flame.sprite_size = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), block_buf, config_textname);
+          }
+          break;
+      case 48: // FLAMEANIMATIONOFFSET
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  trapst->flame.fp_add_x = k;
+                  trapst->flame.fp_add_y = k;
+                  trapst->flame.td_add_x = k;
+                  trapst->flame.td_add_y = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), block_buf, config_textname);
+          }
+          break;
+      case 49: // FLAMETRANSPARENCYFLAGS
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  trapst->flame.transparency_flags = k << 4;
                   n++;
               }
           }

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -519,8 +519,7 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
       case 16: // ANIMATIONID
           if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)
           {
-            struct ObjectConfigStats obj_tmp;
-            k = get_anim_id(word_buf, &obj_tmp);
+            k = get_anim_id_(word_buf);
             if (k >= 0)
             {
                 game.conf.trap_stats[i].sprite_anim_idx = k;
@@ -1030,7 +1029,7 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
       case 45: // FLAMEANIMATIONID
           if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
           {
-              k = atoi(word_buf);
+              k = get_anim_id_(word_buf);
               if (k >= 0)
               {
                   trapst->flame.animation_id = k;
@@ -1079,16 +1078,28 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
           if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
           {
               k = atoi(word_buf);
-              if (k >= 0)
-              {
-                  trapst->flame.fp_add_x = k;
-                  trapst->flame.fp_add_y = k;
-                  trapst->flame.td_add_x = k;
-                  trapst->flame.td_add_y = k;
-                  n++;
-              }
+              trapst->flame.fp_add_x = k;
+              n++;
           }
-          if (n < 1)
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              trapst->flame.fp_add_y = k;
+              n++;
+          }
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              trapst->flame.td_add_x = k;
+              n++;
+          }
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              trapst->flame.td_add_y = k;
+              n++;
+          }
+          if (n < 4)
           {
               CONFWRNLOG("Incorrect value of \"%s\" parameter in [%s] block of %s file.",
                   COMMAND_TEXT(cmd_num), block_buf, config_textname);

--- a/src/config_trapdoor.h
+++ b/src/config_trapdoor.h
@@ -21,6 +21,7 @@
 
 #include "globals.h"
 #include "bflib_basics.h"
+#include "config_objects.h"
 
 #include "config.h"
 
@@ -87,6 +88,7 @@ struct TrapConfigStats {
     TbBool place_on_bridge;
     TbBool place_on_subtile;
     EffectOrEffElModel destroyed_effect;
+    struct FlameProperties flame;
 };
 
 /**

--- a/src/creature_control.c
+++ b/src/creature_control.c
@@ -155,7 +155,7 @@ struct Thing *create_and_control_creature_as_controller(struct PlayerInfo *playe
     set_selected_creature(player, thing);
     player->view_mode_restore = cam->view_mode;
     thing->alloc_flags |= TAlF_IsControlled;
-    thing->rendering_flags |= TRF_Visible;
+    thing->rendering_flags |= TRF_Invisible;
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->flgfield_2 |= TF2_Spectator;
     cctrl->max_speed = calculate_correct_creature_maxspeed(thing);

--- a/src/creature_control.c
+++ b/src/creature_control.c
@@ -155,7 +155,7 @@ struct Thing *create_and_control_creature_as_controller(struct PlayerInfo *playe
     set_selected_creature(player, thing);
     player->view_mode_restore = cam->view_mode;
     thing->alloc_flags |= TAlF_IsControlled;
-    thing->rendering_flags |= TRF_Unknown01;
+    thing->rendering_flags |= TRF_Visible;
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->flgfield_2 |= TF2_Spectator;
     cctrl->max_speed = calculate_correct_creature_maxspeed(thing);

--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -371,13 +371,13 @@ TbBool update_creature_anim_td(struct Thing *thing, long speed, long td_idx)
 void update_creature_rendering_flags(struct Thing *thing)
 {
     // Clear related flags
-    thing->rendering_flags &= ~TRF_Unknown01;
+    thing->rendering_flags &= ~TRF_Visible;
     thing->rendering_flags &= ~TRF_Transpar_Flags;
     thing->rendering_flags &= ~TRF_AnimateOnce;
     // Now set only those that should be
     if ( (is_thing_directly_controlled_by_player(thing, my_player_number)) || (is_thing_passenger_controlled_by_player(thing, my_player_number)) )
     {
-        thing->rendering_flags |= TRF_Unknown01;
+        thing->rendering_flags |= TRF_Visible;
     }
     if (thing_is_creature(thing))
     {
@@ -395,7 +395,7 @@ void update_creature_rendering_flags(struct Thing *thing)
           thing->rendering_flags |= TRF_Transpar_4;
       } else
       {
-            thing->rendering_flags |= TRF_Unknown01;
+            thing->rendering_flags |= TRF_Visible;
             struct PlayerInfo* player = get_my_player();
             struct Thing* creatng = thing_get(player->influenced_thing_idx);
             if (creatng != thing)
@@ -404,7 +404,7 @@ void update_creature_rendering_flags(struct Thing *thing)
                 {
                     if (creature_can_see_invisible(creatng))
                     {
-                        thing->rendering_flags &= ~TRF_Unknown01;
+                        thing->rendering_flags &= ~TRF_Visible;
                         thing->rendering_flags &= ~TRF_Transpar_Flags;
                         thing->rendering_flags |= TRF_Transpar_4;
                     }
@@ -428,7 +428,7 @@ void update_creature_graphic_anim(struct Thing *thing)
     } else
     if ((thing->active_state == CrSt_CreatureHeroEntering) && (cctrl->countdown_282 >= 0))
     {
-      thing->rendering_flags |= TRF_Unknown01;
+      thing->rendering_flags |= TRF_Visible;
     } else
     if (!creature_affected_by_spell(thing, SplK_Chicken))
     {

--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -371,13 +371,13 @@ TbBool update_creature_anim_td(struct Thing *thing, long speed, long td_idx)
 void update_creature_rendering_flags(struct Thing *thing)
 {
     // Clear related flags
-    thing->rendering_flags &= ~TRF_Visible;
+    thing->rendering_flags &= ~TRF_Invisible;
     thing->rendering_flags &= ~TRF_Transpar_Flags;
     thing->rendering_flags &= ~TRF_AnimateOnce;
     // Now set only those that should be
     if ( (is_thing_directly_controlled_by_player(thing, my_player_number)) || (is_thing_passenger_controlled_by_player(thing, my_player_number)) )
     {
-        thing->rendering_flags |= TRF_Visible;
+        thing->rendering_flags |= TRF_Invisible;
     }
     if (thing_is_creature(thing))
     {
@@ -395,7 +395,7 @@ void update_creature_rendering_flags(struct Thing *thing)
           thing->rendering_flags |= TRF_Transpar_4;
       } else
       {
-            thing->rendering_flags |= TRF_Visible;
+            thing->rendering_flags |= TRF_Invisible;
             struct PlayerInfo* player = get_my_player();
             struct Thing* creatng = thing_get(player->influenced_thing_idx);
             if (creatng != thing)
@@ -404,7 +404,7 @@ void update_creature_rendering_flags(struct Thing *thing)
                 {
                     if (creature_can_see_invisible(creatng))
                     {
-                        thing->rendering_flags &= ~TRF_Visible;
+                        thing->rendering_flags &= ~TRF_Invisible;
                         thing->rendering_flags &= ~TRF_Transpar_Flags;
                         thing->rendering_flags |= TRF_Transpar_4;
                     }
@@ -428,7 +428,7 @@ void update_creature_graphic_anim(struct Thing *thing)
     } else
     if ((thing->active_state == CrSt_CreatureHeroEntering) && (cctrl->countdown_282 >= 0))
     {
-      thing->rendering_flags |= TRF_Visible;
+      thing->rendering_flags |= TRF_Invisible;
     } else
     if (!creature_affected_by_spell(thing, SplK_Chicken))
     {

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -1611,7 +1611,7 @@ short creature_change_from_chicken(struct Thing *creatng)
         cctrl->countdown_282--;
     if (cctrl->countdown_282 > 0)
     { // Changing under way - gradually modify size of the creature
-        creatng->rendering_flags |= TRF_Unknown01;
+        creatng->rendering_flags |= TRF_Visible;
         creatng->size_change |= TSC_ChangeSize;
         struct Thing* efftng = create_effect_element(&creatng->mappos, TngEffElm_Chicken, creatng->owner);
         if (!thing_is_invalid(efftng))
@@ -1625,7 +1625,7 @@ short creature_change_from_chicken(struct Thing *creatng)
         return 0;
     } else
     {
-        creatng->rendering_flags &= ~TRF_Unknown01;
+        creatng->rendering_flags &= ~TRF_Visible;
         cctrl->stateblock_flags &= ~CCSpl_ChickenRel;
         cctrl->spell_flags &= ~CSAfF_Chicken;
         set_creature_size_stuff(creatng);
@@ -1644,7 +1644,7 @@ short creature_change_to_chicken(struct Thing *creatng)
     if (cctrl->countdown_282 > 0)
     {
       creatng->size_change |= TSC_ChangeSize;
-      creatng->rendering_flags |= TRF_Unknown01;
+      creatng->rendering_flags |= TRF_Visible;
       struct Thing* efftng = create_effect_element(&creatng->mappos, TngEffElm_Chicken, creatng->owner);
       if (!thing_is_invalid(efftng))
       {
@@ -1656,7 +1656,7 @@ short creature_change_to_chicken(struct Thing *creatng)
       return 0;
     }
     cctrl->spell_flags |= CSAfF_Chicken;
-    creatng->rendering_flags &= ~TRF_Unknown01;
+    creatng->rendering_flags &= ~TRF_Visible;
     set_creature_size_stuff(creatng);
     creatng->state_flags &= ~TF1_Unkn10;
     creatng->active_state = CrSt_CreaturePretendChickenSetupMove;
@@ -3382,14 +3382,14 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
 void place_thing_in_creature_controlled_limbo(struct Thing *thing)
 {
     remove_thing_from_mapwho(thing);
-    thing->rendering_flags |= TRF_Unknown01;
+    thing->rendering_flags |= TRF_Visible;
     thing->state_flags |= TF1_InCtrldLimbo;
 }
 
 void remove_thing_from_creature_controlled_limbo(struct Thing *thing)
 {
     thing->state_flags &= ~TF1_InCtrldLimbo;
-    thing->rendering_flags &= ~TRF_Unknown01;
+    thing->rendering_flags &= ~TRF_Visible;
     place_thing_in_mapwho(thing);
 }
 

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -1611,7 +1611,7 @@ short creature_change_from_chicken(struct Thing *creatng)
         cctrl->countdown_282--;
     if (cctrl->countdown_282 > 0)
     { // Changing under way - gradually modify size of the creature
-        creatng->rendering_flags |= TRF_Visible;
+        creatng->rendering_flags |= TRF_Invisible;
         creatng->size_change |= TSC_ChangeSize;
         struct Thing* efftng = create_effect_element(&creatng->mappos, TngEffElm_Chicken, creatng->owner);
         if (!thing_is_invalid(efftng))
@@ -1625,7 +1625,7 @@ short creature_change_from_chicken(struct Thing *creatng)
         return 0;
     } else
     {
-        creatng->rendering_flags &= ~TRF_Visible;
+        creatng->rendering_flags &= ~TRF_Invisible;
         cctrl->stateblock_flags &= ~CCSpl_ChickenRel;
         cctrl->spell_flags &= ~CSAfF_Chicken;
         set_creature_size_stuff(creatng);
@@ -1644,7 +1644,7 @@ short creature_change_to_chicken(struct Thing *creatng)
     if (cctrl->countdown_282 > 0)
     {
       creatng->size_change |= TSC_ChangeSize;
-      creatng->rendering_flags |= TRF_Visible;
+      creatng->rendering_flags |= TRF_Invisible;
       struct Thing* efftng = create_effect_element(&creatng->mappos, TngEffElm_Chicken, creatng->owner);
       if (!thing_is_invalid(efftng))
       {
@@ -1656,7 +1656,7 @@ short creature_change_to_chicken(struct Thing *creatng)
       return 0;
     }
     cctrl->spell_flags |= CSAfF_Chicken;
-    creatng->rendering_flags &= ~TRF_Visible;
+    creatng->rendering_flags &= ~TRF_Invisible;
     set_creature_size_stuff(creatng);
     creatng->state_flags &= ~TF1_Unkn10;
     creatng->active_state = CrSt_CreaturePretendChickenSetupMove;
@@ -3382,14 +3382,14 @@ long setup_head_for_empty_treasure_space(struct Thing *thing, struct Room *room)
 void place_thing_in_creature_controlled_limbo(struct Thing *thing)
 {
     remove_thing_from_mapwho(thing);
-    thing->rendering_flags |= TRF_Visible;
+    thing->rendering_flags |= TRF_Invisible;
     thing->state_flags |= TF1_InCtrldLimbo;
 }
 
 void remove_thing_from_creature_controlled_limbo(struct Thing *thing)
 {
     thing->state_flags &= ~TF1_InCtrldLimbo;
-    thing->rendering_flags &= ~TRF_Visible;
+    thing->rendering_flags &= ~TRF_Invisible;
     place_thing_in_mapwho(thing);
 }
 

--- a/src/creature_states_tortr.c
+++ b/src/creature_states_tortr.c
@@ -118,7 +118,7 @@ short cleanup_torturing(struct Thing *creatng)
         struct Thing* thing = thing_get(cctrl->tortured.assigned_torturer);
         if (thing_exists(thing)) {
             thing->torturer.belongs_to = 0;
-            thing->rendering_flags &= ~TRF_Visible;
+            thing->rendering_flags &= ~TRF_Invisible;
         }
         cctrl->tortured.assigned_torturer = 0;
     }
@@ -215,7 +215,7 @@ long process_torture_visuals(struct Thing *creatng, struct Room *room, CreatureJ
             set_creature_instance(creatng, CrInst_TORTURED, 0, 0);
         }
         if (thing_exists(sectng)) {
-            sectng->rendering_flags |= TRF_Visible;
+            sectng->rendering_flags |= TRF_Invisible;
         } else {
             ERRORLOG("No device for torture");
         }

--- a/src/creature_states_tortr.c
+++ b/src/creature_states_tortr.c
@@ -118,7 +118,7 @@ short cleanup_torturing(struct Thing *creatng)
         struct Thing* thing = thing_get(cctrl->tortured.assigned_torturer);
         if (thing_exists(thing)) {
             thing->torturer.belongs_to = 0;
-            thing->rendering_flags &= ~TRF_Unknown01;
+            thing->rendering_flags &= ~TRF_Visible;
         }
         cctrl->tortured.assigned_torturer = 0;
     }
@@ -215,7 +215,7 @@ long process_torture_visuals(struct Thing *creatng, struct Room *room, CreatureJ
             set_creature_instance(creatng, CrInst_TORTURED, 0, 0);
         }
         if (thing_exists(sectng)) {
-            sectng->rendering_flags |= TRF_Unknown01;
+            sectng->rendering_flags |= TRF_Visible;
         } else {
             ERRORLOG("No device for torture");
         }

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -450,7 +450,7 @@ void set_sprite_view_3d(void)
         struct Thing* thing = thing_get(i);
         if (thing_exists(thing))
         {
-            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Unknown01) == 0))
+            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Visible) == 0))
             {
                 int n = straight_iso_td(thing->anim_sprite);
                 if (n >= 0)
@@ -481,7 +481,7 @@ void set_sprite_view_isometric(void)
         struct Thing* thing = thing_get(i);
         if (thing_exists(thing))
         {
-            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Unknown01) == 0))
+            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Visible) == 0))
             {
                 int n = straight_td_iso(thing->anim_sprite);
                 if (n >= 0)

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -450,7 +450,7 @@ void set_sprite_view_3d(void)
         struct Thing* thing = thing_get(i);
         if (thing_exists(thing))
         {
-            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Visible) == 0))
+            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Invisible) == 0))
             {
                 int n = straight_iso_td(thing->anim_sprite);
                 if (n >= 0)
@@ -481,7 +481,7 @@ void set_sprite_view_isometric(void)
         struct Thing* thing = thing_get(i);
         if (thing_exists(thing))
         {
-            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Visible) == 0))
+            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Invisible) == 0))
             {
                 int n = straight_td_iso(thing->anim_sprite);
                 if (n >= 0)

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -5016,7 +5016,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
             if (is_shown || thing->trap.revealed)
             {
                 struct TrapConfigStats* trapst = get_trap_model_stats(thing->model);
-                if (trapst->flame.animation_id != 0)
+                if ((trapst->flame.animation_id != 0) && (thing->trap.num_shots != 0))
                 {
                     flame_on_sprite = true;
                     process_keeper_flame_on_sprite(jspr, angle, size_on_screen);
@@ -8101,7 +8101,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
             {
                 break;
             }
-            if (trapst->flame.animation_id > 0)
+            if ((trapst->flame.animation_id > 0) && (thing->trap.num_shots != 0))
             {
                 process_keeper_flame_on_sprite(jspr, angle, scaled_size);
                 break;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4825,62 +4825,68 @@ static void process_keeper_flame_on_sprite(struct BucketKindJontySprite* jspr, l
     struct PlayerInfo* player = get_my_player();
     struct Thing* thing = jspr->thing;
     struct ObjectConfigStats* objst;
+    struct TrapConfigStats* trapst;
+    struct FlameProperties flame;
     unsigned long nframe;
     long add_x, add_y;
     long scale;
-    if (!thing_is_object(thing))
+    if (thing_is_object(thing))
     {
-        ERRORLOG("Thing %s is not an object.", thing_model_name(thing));
-        return;
-    }
-    objst = get_object_model_stats(thing->model);
-    scale = (objst->flame.sprite_size * base_sprite_size / thing->sprite_size);
-
-    if (player->view_type == PVT_DungeonTop)
+        objst = get_object_model_stats(thing->model);
+        flame = objst->flame;
+    } else
+    if (thing_is_deployed_trap(thing))
     {
-        add_x = (base_sprite_size * objst->flame.td_add_x) >> 5;
-        add_y = (base_sprite_size * objst->flame.td_add_y) >> 5;
+        trapst = get_trap_model_stats(thing->model);
+        flame = trapst->flame;
     }
     else
     {
-        add_x = (base_sprite_size * objst->flame.fp_add_x) >> 5;
-        add_y = (base_sprite_size * objst->flame.fp_add_y) >> 5;
+        ERRORLOG("Thing %s is neither an object nor a flame.", thing_model_name(thing));
+        return;
+    }
+    
+    scale = (flame.sprite_size * base_sprite_size / thing->sprite_size);
+
+    if (player->view_type == PVT_DungeonTop)
+    {
+        add_x = (base_sprite_size * flame.td_add_x) >> 5;
+        add_y = (base_sprite_size * flame.td_add_y) >> 5;
+    }
+    else
+    {
+        add_x = (base_sprite_size * flame.fp_add_x) >> 5;
+        add_y = (base_sprite_size * flame.fp_add_y) >> 5;
     }
 
-    //Object
+    //Object/Trap itself
     lbDisplay.DrawFlags = 0;
     EngineSpriteDrawUsingAlpha = 0;
-    if (objst->transparency_flags == TRF_Transpar_8)
-    {
+    if (flag_is_set(thing->rendering_flags,TRF_Transpar_8))
         lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR8;
-    }
-    else if (objst->transparency_flags == TRF_Transpar_4)
-    {
+    if (flag_is_set(thing->rendering_flags, TRF_Transpar_4))
         lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR4;
-    }
-    else if (objst->transparency_flags == TRF_Transpar_Alpha)
-    {
+    if (flag_is_set(thing->rendering_flags, TRF_Transpar_Alpha))
         EngineSpriteDrawUsingAlpha = 1;
-    }
     process_keeper_sprite(jspr->scr_x, jspr->scr_y, thing->anim_sprite, angle, thing->current_frame, base_sprite_size);
 
     //Flame
     lbDisplay.DrawFlags = 0;
     EngineSpriteDrawUsingAlpha = 0;
-    if (objst->flame.transparency_flags == TRF_Transpar_8)
+    if (flame.transparency_flags == TRF_Transpar_8)
     {
         lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR8;
     }
-    else if (objst->flame.transparency_flags == TRF_Transpar_4)
+    else if (flame.transparency_flags == TRF_Transpar_4)
     {
         lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR4;
     }
-    else if (objst->flame.transparency_flags == TRF_Transpar_Alpha)
+    else if (flame.transparency_flags == TRF_Transpar_Alpha)
     {
         EngineSpriteDrawUsingAlpha = 1;
     }
-    nframe = (thing->index + game.play_gameturn * objst->flame.anim_speed / 256) % keepersprite_frames(objst->flame.animation_id);
-    process_keeper_sprite(jspr->scr_x + add_x, jspr->scr_y + add_y, objst->flame.animation_id, angle, nframe, scale);
+    nframe = (thing->index + game.play_gameturn * flame.anim_speed / 256) % keepersprite_frames(flame.animation_id);
+    process_keeper_sprite(jspr->scr_x + add_x, jspr->scr_y + add_y, flame.animation_id, angle, nframe, scale);
 }
 
 static unsigned short get_thing_shade(struct Thing* thing);
@@ -5001,13 +5007,21 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
             flame_on_sprite = true;
             process_keeper_flame_on_sprite(jspr, angle, size_on_screen);
         }
-        is_shown = ((thing->rendering_flags & TRF_Unknown01) == 0);
     }
     else
     {
         if (thing->class_id == TCls_Trap)
         {
             is_shown = !game.conf.trapdoor_conf.trap_cfgstats[thing->model].hidden;
+            if (is_shown || thing->trap.revealed)
+            {
+                struct TrapConfigStats* trapst = get_trap_model_stats(thing->model);
+                if (trapst->flame.animation_id != 0)
+                {
+                    flame_on_sprite = true;
+                    process_keeper_flame_on_sprite(jspr, angle, size_on_screen);
+                }
+            }
         }
         else
         {
@@ -8082,9 +8096,14 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
             process_keeper_sprite(jspr->scr_x, jspr->scr_y, thing->anim_sprite, angle, thing->current_frame, scaled_size);
             break;
         case TCls_Trap:
-            trapst = &game.conf.trapdoor_conf.trap_cfgstats[thing->model];
+            trapst = get_trap_model_stats(thing->model);
             if ((trapst->hidden == 1) && (player->id_number != thing->owner) && (thing->trap.revealed == 0))
             {
+                break;
+            }
+            if (trapst->flame.animation_id > 0)
+            {
+                process_keeper_flame_on_sprite(jspr, angle, scaled_size);
                 break;
             }
             process_keeper_sprite(jspr->scr_x, jspr->scr_y, thing->anim_sprite, angle, thing->current_frame, scaled_size);

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -5025,7 +5025,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
         }
         else
         {
-            is_shown = ((thing->rendering_flags & TRF_Visible) == 0);
+            is_shown = ((thing->rendering_flags & TRF_Invisible) == 0);
         }
     }
     if (!flame_on_sprite)
@@ -8887,7 +8887,7 @@ static void do_map_who(short tnglist_idx)
         }
         i = thing->next_on_mapblk;
         // Per thing code start
-        if ((thing->rendering_flags & TRF_Visible) == 0)
+        if ((thing->rendering_flags & TRF_Invisible) == 0)
         {
             do_map_who_for_thing(thing);
         }
@@ -8911,7 +8911,7 @@ static void draw_frontview_thing_on_element(struct Thing *thing, struct Map *map
     long cx;
     long cy;
     long cz;
-    if ((thing->rendering_flags & TRF_Visible) != 0)
+    if ((thing->rendering_flags & TRF_Invisible) != 0)
         return;
     switch (thing->draw_class)
     {

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -5001,17 +5001,17 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
             flame_on_sprite = true;
             process_keeper_flame_on_sprite(jspr, angle, size_on_screen);
         }
+        is_shown = ((thing->rendering_flags & TRF_Unknown01) == 0);
+    }
+    else
+    {
+        if (thing->class_id == TCls_Trap)
+        {
+            is_shown = !game.conf.trapdoor_conf.trap_cfgstats[thing->model].hidden;
+        }
         else
         {
-            if (thing->class_id == TCls_Trap)
-            {
-                is_shown = !game.conf.trapdoor_conf.trap_cfgstats[thing->model].hidden;
-            }
-            else
-            {
-                is_shown = ((thing->rendering_flags & TRF_Unknown01) == 0);
-            }
-
+            is_shown = ((thing->rendering_flags & TRF_Unknown01) == 0);
         }
     }
     if (!flame_on_sprite)

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4860,7 +4860,7 @@ static void process_keeper_flame_on_sprite(struct BucketKindJontySprite* jspr, l
     }
 
     //Object/Trap itself
-    lbDisplay.DrawFlags = 0;
+    clear_flag(lbDisplay.DrawFlags, TRF_Transpar_Flags);
     EngineSpriteDrawUsingAlpha = 0;
     if (flag_is_set(thing->rendering_flags,TRF_Transpar_8))
         lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR8;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -5025,7 +5025,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
         }
         else
         {
-            is_shown = ((thing->rendering_flags & TRF_Unknown01) == 0);
+            is_shown = ((thing->rendering_flags & TRF_Visible) == 0);
         }
     }
     if (!flame_on_sprite)
@@ -8887,7 +8887,7 @@ static void do_map_who(short tnglist_idx)
         }
         i = thing->next_on_mapblk;
         // Per thing code start
-        if ((thing->rendering_flags & TRF_Unknown01) == 0)
+        if ((thing->rendering_flags & TRF_Visible) == 0)
         {
             do_map_who_for_thing(thing);
         }
@@ -8911,7 +8911,7 @@ static void draw_frontview_thing_on_element(struct Thing *thing, struct Map *map
     long cx;
     long cy;
     long cz;
-    if ((thing->rendering_flags & TRF_Unknown01) != 0)
+    if ((thing->rendering_flags & TRF_Visible) != 0)
         return;
     switch (thing->draw_class)
     {

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -250,6 +250,11 @@ const struct NamedCommand trap_config_desc[] = {
   {"AttackAnimationID",   40},
   {"DestroyedEffect",     41},
   {"InitialDelay",        42},
+  {"FlameAnimationID",       43},
+  {"FlameAnimationSpeed",    44},
+  {"FlameAnimationSize",     45},
+  {"FlameAnimationOffset",   46},
+  {"FlameTransparencyFlags", 47},
   {NULL,                   0},
 };
 
@@ -1062,6 +1067,13 @@ static void set_trap_configuration_check(const struct ScriptLine* scline)
         }
         value->uarg1 = newvalue;
     }
+    else if (trapvar == 46) //FlameAnimationOffset
+    {
+        value->chars[8] = atoi(scline->tp[2]);
+        value->chars[9] = scline->np[3];
+        value->chars[10] = scline->np[4];
+        value->chars[11] = scline->np[5];
+    }
     else if ((trapvar != 4) && (trapvar != 12) && (trapvar != 39) && (trapvar != 40))  // PointerSprites && AnimationIDs
     {
         if (parameter_is_number(valuestring))
@@ -1862,6 +1874,24 @@ static void set_trap_configuration_process(struct ScriptContext *context)
             break;
         case 42: // InitialDelay
             trapstat->initial_delay = value;
+            break;
+        case 43: // FlameAnimationID
+            trapst->flame.animation_id = value;
+            break;
+        case 44: // FlameAnimationSpeed
+            trapst->flame.anim_speed = value;
+            break;
+        case 45: // FlameAnimationSize
+            trapst->flame.sprite_size = value;
+            break;
+        case 46: // FlameAnimationOffset
+            trapst->flame.fp_add_x = context->value->chars[8];
+            trapst->flame.fp_add_y = context->value->chars[9];
+            trapst->flame.td_add_x = context->value->chars[10];
+            trapst->flame.td_add_y = context->value->chars[11];
+            break;
+        case 47: // FlameTransparencyFlags
+            trapst->flame.transparency_flags = value << 4;
             break;
         default:
             WARNMSG("Unsupported Trap configuration, variable %d.", context->value->shorts[1]);
@@ -6022,7 +6052,7 @@ const struct CommandDesc command_desc[] = {
   {"CHANGE_CREATURE_OWNER",             "PC!AP   ", Cmd_CHANGE_CREATURE_OWNER, NULL, NULL},
   {"SET_GAME_RULE",                     "AN      ", Cmd_SET_GAME_RULE, &set_game_rule_check, &set_game_rule_process},
   {"SET_ROOM_CONFIGURATION",            "AAAa!n! ", Cmd_SET_ROOM_CONFIGURATION, &set_room_configuration_check, &set_room_configuration_process},
-  {"SET_TRAP_CONFIGURATION",            "AAAn!n! ", Cmd_SET_TRAP_CONFIGURATION, &set_trap_configuration_check, &set_trap_configuration_process},
+  {"SET_TRAP_CONFIGURATION",            "AAAn!n!n!", Cmd_SET_TRAP_CONFIGURATION, &set_trap_configuration_check, &set_trap_configuration_process},
   {"SET_DOOR_CONFIGURATION",            "AAAn!   ", Cmd_SET_DOOR_CONFIGURATION, &set_door_configuration_check, &set_door_configuration_process},
   {"SET_OBJECT_CONFIGURATION",          "AAAn!n!n!", Cmd_SET_OBJECT_CONFIGURATION, &set_object_configuration_check, &set_object_configuration_process},
   {"SET_CREATURE_CONFIGURATION",        "CAAaa   ", Cmd_SET_CREATURE_CONFIGURATION, &set_creature_configuration_check, &set_creature_configuration_process},

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1876,7 +1876,8 @@ static void set_trap_configuration_process(struct ScriptContext *context)
             trapstat->initial_delay = value;
             break;
         case 43: // FlameAnimationID
-            trapst->flame.animation_id = value;
+            trapst->flame.animation_id = get_anim_id(context->value->str2, &obj_tmp);
+            refresh_trap_anim(trap_type);
             break;
         case 44: // FlameAnimationSpeed
             trapst->flame.anim_speed = value;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -3253,7 +3253,7 @@ static void set_object_configuration_process(struct ScriptContext *context)
             objst->flame.fp_add_x = context->value->chars[5];
             objst->flame.fp_add_y = context->value->chars[6];
             objst->flame.td_add_x = context->value->chars[7];
-            objst->flame.td_add_x = context->value->chars[8];
+            objst->flame.td_add_y = context->value->chars[8];
             break;
         case 37: // FLAMETRANSPARENCYFLAGS
             objst->flame.transparency_flags = context->value->arg1 << 4;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1820,7 +1820,7 @@ static void set_trap_configuration_process(struct ScriptContext *context)
             trapstat->light_flag = value;
             break;
         case 30: // TransparencyFlags
-            trapstat->transparency_flag = value;
+            trapstat->transparency_flag = value<<4;
             break;
         case 31: // ShotVector
             trapstat->shotvector.x = value;

--- a/src/magic.c
+++ b/src/magic.c
@@ -1425,7 +1425,7 @@ static TbResult magic_use_power_lightning(PowerKind power_kind, PlayerNumber ply
     if (!thing_is_invalid(obtng))
     {
         obtng->lightning.spell_level = splevel;
-        obtng->rendering_flags |= TRF_Unknown01;
+        obtng->rendering_flags |= TRF_Visible;
     }
     i = electricity_affecting_area(&pos, plyr_idx, range, max_damage);
     SYNCDBG(9,"Affected %ld targets within range %ld, damage %ld",i,range,max_damage);
@@ -1503,7 +1503,7 @@ static TbResult magic_use_power_sight(PowerKind power_kind, PlayerNumber plyr_id
         dungeon->sight_casted_splevel = splevel;
         dungeon->sight_casted_thing_idx = thing->index;
         LbMemorySet(dungeon->soe_explored_flags, 0, sizeof(dungeon->soe_explored_flags));
-        thing->rendering_flags |= TRF_Unknown01;
+        thing->rendering_flags |= TRF_Visible;
         thing_play_sample(thing, powerst->select_sound_idx, NORMAL_PITCH, -1, 3, 0, 3, FULL_LOUDNESS);
     }
     return Lb_SUCCESS;

--- a/src/magic.c
+++ b/src/magic.c
@@ -1425,7 +1425,7 @@ static TbResult magic_use_power_lightning(PowerKind power_kind, PlayerNumber ply
     if (!thing_is_invalid(obtng))
     {
         obtng->lightning.spell_level = splevel;
-        obtng->rendering_flags |= TRF_Visible;
+        obtng->rendering_flags |= TRF_Invisible;
     }
     i = electricity_affecting_area(&pos, plyr_idx, range, max_damage);
     SYNCDBG(9,"Affected %ld targets within range %ld, damage %ld",i,range,max_damage);
@@ -1503,7 +1503,7 @@ static TbResult magic_use_power_sight(PowerKind power_kind, PlayerNumber plyr_id
         dungeon->sight_casted_splevel = splevel;
         dungeon->sight_casted_thing_idx = thing->index;
         LbMemorySet(dungeon->soe_explored_flags, 0, sizeof(dungeon->soe_explored_flags));
-        thing->rendering_flags |= TRF_Visible;
+        thing->rendering_flags |= TRF_Invisible;
         thing_play_sample(thing, powerst->select_sound_idx, NORMAL_PITCH, -1, 3, 0, 3, FULL_LOUDNESS);
     }
     return Lb_SUCCESS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2721,7 +2721,7 @@ TbBool valid_cave_in_position(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSub
 long update_cave_in(struct Thing *thing)
 {
     thing->health--;
-    thing->rendering_flags |= TRF_Unknown01;
+    thing->rendering_flags |= TRF_Visible;
     if (thing->health < 1)
     {
         delete_thing_structure(thing, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2721,7 +2721,7 @@ TbBool valid_cave_in_position(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSub
 long update_cave_in(struct Thing *thing)
 {
     thing->health--;
-    thing->rendering_flags |= TRF_Visible;
+    thing->rendering_flags |= TRF_Invisible;
     if (thing->health < 1)
     {
         delete_thing_structure(thing, 0);

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -249,16 +249,16 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
             {
                 set_power_hand_graphic(plyr_idx, HndA_Hover);
                 if (!thing_is_invalid(thing))
-                    thing->rendering_flags |= TRF_Visible;
+                    thing->rendering_flags |= TRF_Invisible;
             } else
             if ((thing->class_id == TCls_Object) && object_is_gold_pile(thing))
             {
                 set_power_hand_graphic(plyr_idx, HndA_HoldGold);
-                thing->rendering_flags &= ~TRF_Visible;
+                thing->rendering_flags &= ~TRF_Invisible;
             } else
             {
                 set_power_hand_graphic(plyr_idx, HndA_Hold);
-                thing->rendering_flags &= ~TRF_Visible;
+                thing->rendering_flags &= ~TRF_Invisible;
             }
         }
     }

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -249,16 +249,16 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
             {
                 set_power_hand_graphic(plyr_idx, HndA_Hover);
                 if (!thing_is_invalid(thing))
-                    thing->rendering_flags |= TRF_Unknown01;
+                    thing->rendering_flags |= TRF_Visible;
             } else
             if ((thing->class_id == TCls_Object) && object_is_gold_pile(thing))
             {
                 set_power_hand_graphic(plyr_idx, HndA_HoldGold);
-                thing->rendering_flags &= ~TRF_Unknown01;
+                thing->rendering_flags &= ~TRF_Visible;
             } else
             {
                 set_power_hand_graphic(plyr_idx, HndA_Hold);
-                thing->rendering_flags &= ~TRF_Unknown01;
+                thing->rendering_flags &= ~TRF_Visible;
             }
         }
     }

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -949,7 +949,7 @@ void leave_creature_as_controller(struct PlayerInfo *player, struct Thing *thing
     clear_selected_thing(player);
     set_player_mode(player, PVT_DungeonTop);
     thing->alloc_flags &= ~TAlF_IsControlled;
-    thing->rendering_flags &= ~TRF_Unknown01;
+    thing->rendering_flags &= ~TRF_Visible;
     player->allocflags &= ~PlaF_Unknown8;
     set_engine_view(player, player->view_mode_restore);
     long i = player->acamera->orient_a;
@@ -994,7 +994,7 @@ void leave_creature_as_passenger(struct PlayerInfo *player, struct Thing *thing)
     return;
   }
   set_player_mode(player, PVT_DungeonTop);
-  thing->rendering_flags &= ~TRF_Unknown01;
+  thing->rendering_flags &= ~TRF_Visible;
   player->allocflags &= ~PlaF_Unknown8;
   set_engine_view(player, player->view_mode_restore);
   long i = player->acamera->orient_a;

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -949,7 +949,7 @@ void leave_creature_as_controller(struct PlayerInfo *player, struct Thing *thing
     clear_selected_thing(player);
     set_player_mode(player, PVT_DungeonTop);
     thing->alloc_flags &= ~TAlF_IsControlled;
-    thing->rendering_flags &= ~TRF_Visible;
+    thing->rendering_flags &= ~TRF_Invisible;
     player->allocflags &= ~PlaF_Unknown8;
     set_engine_view(player, player->view_mode_restore);
     long i = player->acamera->orient_a;
@@ -994,7 +994,7 @@ void leave_creature_as_passenger(struct PlayerInfo *player, struct Thing *thing)
     return;
   }
   set_player_mode(player, PVT_DungeonTop);
-  thing->rendering_flags &= ~TRF_Visible;
+  thing->rendering_flags &= ~TRF_Invisible;
   player->allocflags &= ~PlaF_Unknown8;
   set_engine_view(player, player->view_mode_restore);
   long i = player->acamera->orient_a;

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -502,14 +502,14 @@ long get_thing_in_hand_id(const struct Thing* thing, PlayerNumber plyr_idx)
 void place_thing_in_limbo(struct Thing *thing)
 {
     remove_thing_from_mapwho(thing);
-    thing->rendering_flags |= TRF_Visible;
+    thing->rendering_flags |= TRF_Invisible;
     thing->alloc_flags |= TAlF_IsInLimbo;
 }
 
 void remove_thing_from_limbo(struct Thing *thing)
 {
     thing->alloc_flags &= ~TAlF_IsInLimbo;
-    thing->rendering_flags &= ~TRF_Visible;
+    thing->rendering_flags &= ~TRF_Invisible;
     place_thing_in_mapwho(thing);
 }
 
@@ -612,7 +612,7 @@ void draw_power_hand(void)
     long inputpos_x;
     long inputpos_y;
     picktng = get_first_thing_in_power_hand(player);
-    if ((!thing_is_invalid(picktng)) && ((picktng->rendering_flags & TRF_Visible) == 0))
+    if ((!thing_is_invalid(picktng)) && ((picktng->rendering_flags & TRF_Invisible) == 0))
     {
         SYNCDBG(7,"Holding %s",thing_model_name(picktng));
         switch (picktng->class_id)

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -502,14 +502,14 @@ long get_thing_in_hand_id(const struct Thing* thing, PlayerNumber plyr_idx)
 void place_thing_in_limbo(struct Thing *thing)
 {
     remove_thing_from_mapwho(thing);
-    thing->rendering_flags |= TRF_Unknown01;
+    thing->rendering_flags |= TRF_Visible;
     thing->alloc_flags |= TAlF_IsInLimbo;
 }
 
 void remove_thing_from_limbo(struct Thing *thing)
 {
     thing->alloc_flags &= ~TAlF_IsInLimbo;
-    thing->rendering_flags &= ~TRF_Unknown01;
+    thing->rendering_flags &= ~TRF_Visible;
     place_thing_in_mapwho(thing);
 }
 
@@ -612,7 +612,7 @@ void draw_power_hand(void)
     long inputpos_x;
     long inputpos_y;
     picktng = get_first_thing_in_power_hand(player);
-    if ((!thing_is_invalid(picktng)) && ((picktng->rendering_flags & TRF_Unknown01) == 0))
+    if ((!thing_is_invalid(picktng)) && ((picktng->rendering_flags & TRF_Visible) == 0))
     {
         SYNCDBG(7,"Holding %s",thing_model_name(picktng));
         switch (picktng->class_id)

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -615,7 +615,7 @@ struct Thing *create_ambient_sound(const struct Coord3d *pos, ThingModel model, 
     thing->parent_idx = thing->index;
     memcpy(&thing->mappos,pos,sizeof(struct Coord3d));
     thing->owner = owner;
-    thing->rendering_flags |= TRF_Visible;
+    thing->rendering_flags |= TRF_Invisible;
     add_thing_to_its_class_list(thing);
     return thing;
 }

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -615,7 +615,7 @@ struct Thing *create_ambient_sound(const struct Coord3d *pos, ThingModel model, 
     thing->parent_idx = thing->index;
     memcpy(&thing->mappos,pos,sizeof(struct Coord3d));
     thing->owner = owner;
-    thing->rendering_flags |= TRF_Unknown01;
+    thing->rendering_flags |= TRF_Visible;
     add_thing_to_its_class_list(thing);
     return thing;
 }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -257,7 +257,7 @@ TbBool control_creature_as_controller(struct PlayerInfo *player, struct Thing *t
     if (cam != NULL)
       player->view_mode_restore = cam->view_mode;
     thing->alloc_flags |= TAlF_IsControlled;
-    thing->rendering_flags |= TRF_Visible;
+    thing->rendering_flags |= TRF_Invisible;
     if (!chicken)
     {
         set_start_state(thing);
@@ -311,7 +311,7 @@ TbBool control_creature_as_passenger(struct PlayerInfo *player, struct Thing *th
     if (cam != NULL)
       player->view_mode_restore = cam->view_mode;
     set_player_mode(player, PVT_CreaturePasngr);
-    thing->rendering_flags |= TRF_Visible;
+    thing->rendering_flags |= TRF_Invisible;
     return true;
 }
 
@@ -1241,7 +1241,7 @@ void terminate_thing_spell_effect(struct Thing *thing, SpellKind spkind)
         if (thing->light_id != 0)
         {
             cctrl->spell_flags &= ~CSAfF_Light;
-            if ((thing->rendering_flags & TRF_Visible) != 0)
+            if ((thing->rendering_flags & TRF_Invisible) != 0)
             {
                 light_set_light_intensity(thing->light_id, (light_get_light_intensity(thing->light_id) - 20));
                 struct Light* lgt = &game.lish.lights[thing->light_id];
@@ -6070,7 +6070,7 @@ struct Thing *script_create_creature_at_location(PlayerNumber plyr_idx, ThingMod
             thing->mappos.z.val = get_ceiling_height(&thing->mappos);
             create_effect(&thing->mappos, TngEff_CeilingBreach, thing->owner);
             initialise_thing_state(thing, CrSt_CreatureHeroEntering);
-            thing->rendering_flags |= TRF_Visible;
+            thing->rendering_flags |= TRF_Invisible;
             cctrl->countdown_282 = 24;
         }
     default:

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -257,7 +257,7 @@ TbBool control_creature_as_controller(struct PlayerInfo *player, struct Thing *t
     if (cam != NULL)
       player->view_mode_restore = cam->view_mode;
     thing->alloc_flags |= TAlF_IsControlled;
-    thing->rendering_flags |= TRF_Unknown01;
+    thing->rendering_flags |= TRF_Visible;
     if (!chicken)
     {
         set_start_state(thing);
@@ -311,7 +311,7 @@ TbBool control_creature_as_passenger(struct PlayerInfo *player, struct Thing *th
     if (cam != NULL)
       player->view_mode_restore = cam->view_mode;
     set_player_mode(player, PVT_CreaturePasngr);
-    thing->rendering_flags |= TRF_Unknown01;
+    thing->rendering_flags |= TRF_Visible;
     return true;
 }
 
@@ -1241,7 +1241,7 @@ void terminate_thing_spell_effect(struct Thing *thing, SpellKind spkind)
         if (thing->light_id != 0)
         {
             cctrl->spell_flags &= ~CSAfF_Light;
-            if ((thing->rendering_flags & TRF_Unknown01) != 0)
+            if ((thing->rendering_flags & TRF_Visible) != 0)
             {
                 light_set_light_intensity(thing->light_id, (light_get_light_intensity(thing->light_id) - 20));
                 struct Light* lgt = &game.lish.lights[thing->light_id];
@@ -6070,7 +6070,7 @@ struct Thing *script_create_creature_at_location(PlayerNumber plyr_idx, ThingMod
             thing->mappos.z.val = get_ceiling_height(&thing->mappos);
             create_effect(&thing->mappos, TngEff_CeilingBreach, thing->owner);
             initialise_thing_state(thing, CrSt_CreatureHeroEntering);
-            thing->rendering_flags |= TRF_Unknown01;
+            thing->rendering_flags |= TRF_Visible;
             cctrl->countdown_282 = 24;
         }
     default:

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -61,7 +61,7 @@ enum ThingFlags2 {
 };
 
 enum ThingRenderingFlags {
-    TRF_Visible       = 0x01, // Not Drawn
+    TRF_Invisible       = 0x01, // Not Drawn
     TRF_Unshaded      = 0x02, // Not shaded
 
     TRF_Tint_1        = 0x04, // Tint1 (used to draw enemy creatures when they are blinking to owners color)

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -61,12 +61,12 @@ enum ThingFlags2 {
 };
 
 enum ThingRenderingFlags {
-    TRF_Invisible       = 0x01, // Not Drawn
-    TRF_Unshaded      = 0x02, // Not shaded
+    TRF_Invisible      = 0x01, // Not Drawn
+    TRF_Unshaded       = 0x02, // Not shaded
 
-    TRF_Tint_1        = 0x04, // Tint1 (used to draw enemy creatures when they are blinking to owners color)
-    TRF_Tint_2        = 0x08, // Tint2 (not used?)
-    TRF_Tint_Flags    = 0x0C, // Tint flags
+    TRF_Tint_1         = 0x04, // Tint1 (used to draw enemy creatures when they are blinking to owners color)
+    TRF_Tint_2         = 0x08, // Tint2 (not used?)
+    TRF_Tint_Flags     = 0x0C, // Tint flags
 
     TRF_Transpar_8     = 0x10, // Used on chicken effect when creature is turned to chicken
     TRF_Transpar_4     = 0x20, // Used for Invisible creatures and traps -- more transparent

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -61,7 +61,7 @@ enum ThingFlags2 {
 };
 
 enum ThingRenderingFlags {
-    TRF_Unknown01     = 0x01, /** Not Drawn **/
+    TRF_Visible       = 0x01, // Not Drawn
     TRF_Unshaded      = 0x02, // Not shaded
 
     TRF_Tint_1        = 0x04, // Tint1 (used to draw enemy creatures when they are blinking to owners color)

--- a/src/thing_doors.c
+++ b/src/thing_doors.c
@@ -121,7 +121,7 @@ struct Thing *create_door(struct Coord3d *pos, ThingModel tngmodel, unsigned cha
     doortng->next_on_mapblk = 0;
     doortng->parent_idx = doortng->index;
     doortng->owner = plyr_idx;
-    doortng->rendering_flags |= TRF_Unknown01;
+    doortng->rendering_flags |= TRF_Visible;
     doortng->door.orientation = orient;
     doortng->active_state = DorSt_Closed;
     doortng->creation_turn = game.play_gameturn;

--- a/src/thing_doors.c
+++ b/src/thing_doors.c
@@ -121,7 +121,7 @@ struct Thing *create_door(struct Coord3d *pos, ThingModel tngmodel, unsigned cha
     doortng->next_on_mapblk = 0;
     doortng->parent_idx = doortng->index;
     doortng->owner = plyr_idx;
-    doortng->rendering_flags |= TRF_Visible;
+    doortng->rendering_flags |= TRF_Invisible;
     doortng->door.orientation = orient;
     doortng->active_state = DorSt_Closed;
     doortng->creation_turn = game.play_gameturn;

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -114,7 +114,7 @@ struct Thing *create_effect_element(const struct Coord3d *pos, ThingModel eelmod
         set_flag_value(thing->rendering_flags, TRF_AnimateOnce, eestat->rendering_flag);
     } else
     {
-        set_flag(thing->rendering_flags, TRF_Visible);
+        set_flag(thing->rendering_flags, TRF_Invisible);
     }
 
     thing->fall_acceleration = eestat->fall_acceleration;
@@ -574,7 +574,7 @@ struct Thing *create_effect_generator(struct Coord3d *pos, ThingModel model, uns
     effgentng->mappos = *pos;
     effgentng->creation_turn = game.play_gameturn;
     effgentng->health = -1;
-    effgentng->rendering_flags |= TRF_Visible;
+    effgentng->rendering_flags |= TRF_Invisible;
     add_thing_to_its_class_list(effgentng);
     place_thing_in_mapwho(effgentng);
     return effgentng;
@@ -889,7 +889,7 @@ struct Thing *create_effect(const struct Coord3d *pos, ThingModel effmodel, Play
     thing->fall_acceleration = 0;
     thing->inertia_floor = 0;
     thing->inertia_air = 0;
-    thing->rendering_flags |= TRF_Visible;
+    thing->rendering_flags |= TRF_Invisible;
     thing->health = effcst->start_health;
     thing->shot_effect.hit_type = effcst->effect_hit_type;
     if (effcst->ilght.radius != 0)

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -114,7 +114,7 @@ struct Thing *create_effect_element(const struct Coord3d *pos, ThingModel eelmod
         set_flag_value(thing->rendering_flags, TRF_AnimateOnce, eestat->rendering_flag);
     } else
     {
-        set_flag(thing->rendering_flags, TRF_Unknown01);
+        set_flag(thing->rendering_flags, TRF_Visible);
     }
 
     thing->fall_acceleration = eestat->fall_acceleration;
@@ -574,7 +574,7 @@ struct Thing *create_effect_generator(struct Coord3d *pos, ThingModel model, uns
     effgentng->mappos = *pos;
     effgentng->creation_turn = game.play_gameturn;
     effgentng->health = -1;
-    effgentng->rendering_flags |= TRF_Unknown01;
+    effgentng->rendering_flags |= TRF_Visible;
     add_thing_to_its_class_list(effgentng);
     place_thing_in_mapwho(effgentng);
     return effgentng;
@@ -889,7 +889,7 @@ struct Thing *create_effect(const struct Coord3d *pos, ThingModel effmodel, Play
     thing->fall_acceleration = 0;
     thing->inertia_floor = 0;
     thing->inertia_air = 0;
-    thing->rendering_flags |= TRF_Unknown01;
+    thing->rendering_flags |= TRF_Visible;
     thing->health = effcst->start_health;
     thing->shot_effect.hit_type = effcst->effect_hit_type;
     if (effcst->ilght.radius != 0)

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1471,7 +1471,7 @@ static TngUpdateRet object_update_armour(struct Thing *objtng)
     struct Thing* thing = thing_get(objtng->armor.belongs_to);
     if (thing_is_picked_up(thing))
     {
-        objtng->rendering_flags |= TRF_Visible;
+        objtng->rendering_flags |= TRF_Invisible;
         return 1;
     }
     struct Coord3d pos;
@@ -1513,7 +1513,7 @@ static TngUpdateRet object_update_armour(struct Thing *objtng)
     objtng->veloc_push_add.x.val += cvect.x;
     objtng->veloc_push_add.y.val += cvect.y;
     objtng->veloc_push_add.z.val += cvect.z;
-    objtng->rendering_flags &= ~TRF_Visible;
+    objtng->rendering_flags &= ~TRF_Invisible;
     return 1;
 }
 

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1471,7 +1471,7 @@ static TngUpdateRet object_update_armour(struct Thing *objtng)
     struct Thing* thing = thing_get(objtng->armor.belongs_to);
     if (thing_is_picked_up(thing))
     {
-        objtng->rendering_flags |= TRF_Unknown01;
+        objtng->rendering_flags |= TRF_Visible;
         return 1;
     }
     struct Coord3d pos;
@@ -1513,7 +1513,7 @@ static TngUpdateRet object_update_armour(struct Thing *objtng)
     objtng->veloc_push_add.x.val += cvect.x;
     objtng->veloc_push_add.y.val += cvect.y;
     objtng->veloc_push_add.z.val += cvect.z;
-    objtng->rendering_flags &= ~TRF_Unknown01;
+    objtng->rendering_flags &= ~TRF_Visible;
     return 1;
 }
 

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -1787,7 +1787,7 @@ struct Thing *create_shot(struct Coord3d *pos, ThingModel model, unsigned short 
     set_thing_draw(thing, shotst->sprite_anim_idx, 256, shotst->sprite_size_max, 0, 0, ODC_Default);
     thing->rendering_flags ^= (thing->rendering_flags ^ TRF_Unshaded * shotst->unshaded) & TRF_Unshaded;
     thing->rendering_flags ^= thing->rendering_flags ^ ((thing->rendering_flags ^ TRF_Transpar_8 * shotst->animation_transparency) & (TRF_Transpar_Flags));
-    thing->rendering_flags ^= (thing->rendering_flags ^ shotst->hidden_projectile) & TRF_Visible;
+    thing->rendering_flags ^= (thing->rendering_flags ^ shotst->hidden_projectile) & TRF_Invisible;
     thing->clipbox_size_xy = shotst->size_xy;
     thing->clipbox_size_z = shotst->size_z;
     thing->solid_size_xy = shotst->size_xy;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -1787,7 +1787,7 @@ struct Thing *create_shot(struct Coord3d *pos, ThingModel model, unsigned short 
     set_thing_draw(thing, shotst->sprite_anim_idx, 256, shotst->sprite_size_max, 0, 0, ODC_Default);
     thing->rendering_flags ^= (thing->rendering_flags ^ TRF_Unshaded * shotst->unshaded) & TRF_Unshaded;
     thing->rendering_flags ^= thing->rendering_flags ^ ((thing->rendering_flags ^ TRF_Transpar_8 * shotst->animation_transparency) & (TRF_Transpar_Flags));
-    thing->rendering_flags ^= (thing->rendering_flags ^ shotst->hidden_projectile) & TRF_Unknown01;
+    thing->rendering_flags ^= (thing->rendering_flags ^ shotst->hidden_projectile) & TRF_Visible;
     thing->clipbox_size_xy = shotst->size_xy;
     thing->clipbox_size_z = shotst->size_z;
     thing->solid_size_xy = shotst->size_xy;

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -740,8 +740,8 @@ void process_trap_charge(struct Thing* traptng)
             if ((slb->kind != SlbT_CLAIMED) && (slb->kind != SlbT_PATH)) {
                 traptng->health = -1;
             }
-            traptng->rendering_flags &= TRF_Transpar_Flags;
-            traptng->rendering_flags |= TRF_Transpar_4;
+            clear_flag(traptng->rendering_flags, TRF_Transpar_Flags);
+            set_flag(traptng->rendering_flags, TRF_Transpar_4);
             if (!is_neutral_thing(traptng) && !is_hero_thing(traptng))
             {
                 if (placing_offmap_workshop_item(traptng->owner, TCls_Trap, traptng->model))

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -804,7 +804,10 @@ TbBool rearm_trap(struct Thing *traptng)
     struct ManfctrConfig* mconf = &game.conf.traps_config[traptng->model];
     struct TrapStats* trapstat = &game.conf.trap_stats[traptng->model];
     traptng->trap.num_shots = mconf->shots;
-    traptng->rendering_flags ^= (traptng->rendering_flags ^ (trapstat->transparency_flag << 4)) & (TRF_Transpar_Flags);
+
+    clear_flag(traptng->rendering_flags, TRF_Transpar_Flags);
+    set_flag(traptng->rendering_flags, trapstat->transparency_flag);
+
     return true;
 }
 


### PR DESCRIPTION
```
- Added flame fields on traps, same as on objects
- Depleted traps do not show the flame
- Can be configured with SET_TRAP_CONFIGURATION
- Works with custom sprites
- SET_TRAP_CONFIGURATION has extra field: 
      SET_TRAP_CONFIGURATION([trapname],[property],[value],[second value]*,[third value]*,[forth value]*)

- Fixed a bug introduced recently where all enemy traps are visible in straight view
- Fixed SET_OBJECT_CONFIGURATION not taking 4th param of FlameAnimationOffset
- Fixed bug where already existing TransparencyFlags field in trapdoor.cfg was not functional
- SET_TRAP_CONFIGURATION TransparencyFlags now take the same values as on objects

- Named a rendering flag
- Refactored some transparency flag setting and clearing
```