### PR TITLE
Show ?-screen when installation is not complete

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1584,11 +1584,6 @@ unsigned char *load_data_file_to_buffer(long *ldsize, short fgroup, const char *
   prepare_file_path_buf(ffullpath, fgroup, fname);
   va_end(arg);
   // Load the file
-  if (file_group_needs_cd(fgroup))
-  {
-    if (!wait_for_cd_to_be_available())
-      return NULL;
-   }
    long fsize = LbFileLengthRnc(ffullpath);
    if (fsize < *ldsize)
    {

--- a/src/engine_arrays.c
+++ b/src/engine_arrays.c
@@ -1121,8 +1121,6 @@ TbBool load_ceiling_table(void)
     TbBool do_next;
     long i;
     long n;
-    // Prepare filename and open the file
-    wait_for_cd_to_be_available();
     fname = prepare_file_path(FGrp_StdData,"ceiling.txt");
     fh = LbFileOpen(fname, Lb_FILE_MODE_READ_ONLY);
     if (fh == -1) {

--- a/src/engine_textures.c
+++ b/src/engine_textures.c
@@ -126,8 +126,6 @@ static TbBool load_one_file(unsigned long tmapidx,char letter, void *dst)
         fname = prepare_file_fmtpath(FGrp_StdData, "tmap%c%03d.dat",letter, tmapidx);
     }
 
-    if (!wait_for_cd_to_be_available())
-        return false;
     if (!LbFileExists(fname))
     {
         WARNMSG("Texture file \"%s\" doesn't exist.",fname);

--- a/src/front_credits.c
+++ b/src/front_credits.c
@@ -58,7 +58,6 @@ int credits_end;
 /******************************************************************************/
 void frontstory_load(void)
 {
-    wait_for_cd_to_be_available();
     frontend_load_data_from_cd();
     if (LbDataLoadAll(frontstory_load_files_640))
     {

--- a/src/front_fmvids.c
+++ b/src/front_fmvids.c
@@ -180,7 +180,6 @@ void demo(void)
         break;
     case DIK_LoadPacket:
         fname = prepare_file_path(FGrp_FxData,demo_item[index].fname);
-        wait_for_cd_to_be_available();
         if ( LbFileExists(fname) )
         {
           strcpy(game.packet_fname, fname);

--- a/src/front_landview.c
+++ b/src/front_landview.c
@@ -889,7 +889,6 @@ TbBool load_map_and_window(LevelNumber lvnum)
     memcpy(frontend_backup_palette, &frontend_palette, PALETTE_SIZE);
     // Now prepare window sprite file name and load the file
     fname = prepare_file_fmtpath(FGrp_LandView,"%s.dat",land_window);
-    wait_for_cd_to_be_available();
     map_window_len = LbFileLoadAt(fname, ptr);
     if (map_window_len < (long)(WINDOW_Y_SIZE*sizeof(long)))
     {
@@ -908,7 +907,6 @@ TbBool load_map_and_window(LevelNumber lvnum)
     map_window_len -= WINDOW_Y_SIZE*sizeof(long);
     // Load palette
     fname = prepare_file_fmtpath(FGrp_LandView,"%s.pal",land_view);
-    wait_for_cd_to_be_available();
     if (LbFileLoadAt(fname, frontend_palette) != PALETTE_SIZE)
     {
         ERRORLOG("Unable to load Land Map palette \"%s.pal\"",land_view);
@@ -955,7 +953,6 @@ TbBool frontnetmap_load(void)
       if (LbNetwork_EnableNewPlayers(0))
         ERRORLOG("Unable to prohibit new players joining exchange");
     }
-    wait_for_cd_to_be_available();
     frontend_load_data_from_cd();
     game.selected_level_number = 0;
     switch (campaign.land_markers)
@@ -1090,7 +1087,6 @@ TbBool frontmap_load(void)
     LbPaletteSet(scratch);
     initialize_description_speech();
     mouse_over_lvnum = SINGLEPLAYER_NOTSTARTED;
-    wait_for_cd_to_be_available();
     frontend_load_data_from_cd();
     switch (campaign.land_markers)
     {

--- a/src/front_simple.h
+++ b/src/front_simple.h
@@ -79,7 +79,7 @@ TbBool show_actv_bitmap_screen(TbClockMSec tmdelay);
 /******************************************************************************/
 
 TbBool display_loading_screen(void);
-TbBool wait_for_cd_to_be_available(void);
+TbBool wait_for_installation_files(void);
 TbBool display_centered_message(long showTime, char *text);
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/front_torture.c
+++ b/src/front_torture.c
@@ -132,7 +132,6 @@ void fronttorture_unload(void)
 
 void fronttorture_load(void)
 {
-    wait_for_cd_to_be_available();
     frontend_load_data_from_cd();
     memcpy(frontend_backup_palette, &frontend_palette, PALETTE_SIZE);
     // Texture blocks memory isn't used here, so reuse it instead of allocating

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -951,7 +951,6 @@ TbResult frontend_load_data(void)
     TbResult ret;
     long len;
     ret = Lb_SUCCESS;
-    wait_for_cd_to_be_available();
     frontend_background = (unsigned char *)game.map;
 #ifdef SPRITE_FORMAT_V2
     fname = prepare_file_fmtpath(FGrp_LoData,"front-%d.raw",64);
@@ -2613,7 +2612,7 @@ char *mdlf_for_cd(struct TbLoadFiles * tb_load_files)
     result = tb_load_files;
     if ( tb_load_files->FName[0] != 42 )
     {
-        sprintf(path_string, "%s/%s", install_info.inst_path, tb_load_files->FName);
+        sprintf(path_string, "%s/%s", install_info.inst_path, tb_load_files->FName); // todo check out
         return path_string;
     }
     return result->FName;
@@ -2714,11 +2713,9 @@ void frontend_shutdown_state(FrontendMenuState pstate)
     {
     case FeSt_INITIAL:
         init_gui();
-        wait_for_cd_to_be_available();
         fname = prepare_file_path(FGrp_LoData,"front.pal");
         if (LbFileLoadAt(fname, frontend_palette) != PALETTE_SIZE)
             ERRORLOG("Unable to load FRONTEND PALETTE");
-        wait_for_cd_to_be_available();
         LbMoveGameCursorToHostCursor(); // set the initial cursor position for the main menu
         update_mouse();
         break;

--- a/src/game_heap.c
+++ b/src/game_heap.c
@@ -72,7 +72,6 @@ TbBool setup_heap_manager(void)
         return false;
     }
     long i;
-    wait_for_cd_to_be_available();
 #ifdef SPRITE_FORMAT_V2
     fname = prepare_file_fmtpath(FGrp_StdData,"thingspr-%d.jty",32);
 #else

--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -372,8 +372,6 @@ TbBool load_game(long slot_num)
     {
         // Use fname only here - it is overwritten by next use of prepare_file_fmtpath()
         char* fname = prepare_file_fmtpath(FGrp_Save, saved_game_filename, slot_num);
-        if (!wait_for_cd_to_be_available())
-          return false;
         fh = LbFileOpen(fname,Lb_FILE_MODE_READ_ONLY);
         if (fh == -1)
         {

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -126,7 +126,6 @@ unsigned char *load_single_map_file_to_buffer(LevelNumber lvnum,const char *fext
 {
   short fgroup = get_level_fgroup(lvnum);
   char* fname = prepare_file_fmtpath(fgroup, "map%05lu.%s", lvnum, fext);
-  wait_for_cd_to_be_available();
   long fsize = LbFileLengthRnc(fname);
   if (fsize < *ldsize)
   {
@@ -1417,7 +1416,6 @@ static TbBool load_level_file(LevelNumber lvnum)
     TbBool new_format = true;
     short fgroup = get_level_fgroup(lvnum);
     char* fname = prepare_file_fmtpath(fgroup, "map%05lu.slb", (unsigned long)lvnum);
-    wait_for_cd_to_be_available();
     if (LbFileExists(fname))
     {
         result = true;


### PR DESCRIPTION
- Removed all checks for the disk availability (since we do not work with cd's)
- Show the 'No CD' screen when it is missing the first 'launcher' screen.
- If you alt-tab and complete installation with the launcher it will actually proceed and continue with booting up the game
- Show a clearer error message when you try to boot up without having completed the keeperfx installation
- Seriously reduced the amount of time the game 'hangs' on the no disk screen
- Added Escape as a possible key to close the screen