### PR TITLE
Fix a potential issue with detonating shot damage calculation

### DIFF
--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -122,7 +122,7 @@ TbBool detonate_shot(struct Thing *shotng, TbBool destroy)
         }
         else
         {
-            damage = compute_creature_attack_spell_damage(shotst->area_damage, crstat->luck, cctrl->explevel, shotng);
+            damage = compute_creature_attack_spell_damage(shotst->area_damage, crstat->luck, cctrl->explevel, castng);
         }
         HitTargetFlags hit_targets = hit_type_to_hit_targets(shotst->area_hit_type);
         explosion_affecting_area(shotng, &shotng->mappos, dist, damage, shotst->area_blow, hit_targets, shotst->damage_type);


### PR DESCRIPTION
Currently in [thing_shots.c#L125](https://github.com/dkfans/keeperfx/edit/master/src/thing_shots.c#L125) ``compute_creature_attack_spell_damage`` use shotng as argument, this is incorrect: shotng may not share the same index as castng, it is an issue for StrengthBased shots with AreaDamage.