### PR TITLE
Reworked 'CHECK FOR QUICK ATTACK'

### DIFF
--- a/config/fxdata/keepcompp.cfg
+++ b/config/fxdata/keepcompp.cfg
@@ -425,6 +425,7 @@ Name = CHECK FOR QUICK ATTACK
 Mnemonic = AtckQck1
 Values = 0 690
 Functions = check_for_quick_attack
+; Params = <Percentage of free creatures to attack with>, <Call to Arms duration> , <min creatures>, <use turn>
 Params = 90 3000 7 9500
 
 [check26]

--- a/src/player_compchecks.c
+++ b/src/player_compchecks.c
@@ -692,7 +692,7 @@ struct Room *get_opponent_room(struct Computer2 *comp, PlayerNumber plyr_idx)
     return INVALID_ROOM;
 }
 
-struct Room *get_hated_room_for_quick_attack(struct Computer2 *comp, long min_hate)
+struct Room *get_hated_room_for_quick_attack(struct Computer2 *comp)
 {
     SYNCDBG(8,"Starting for player %d",(int)comp->dungeon->owner);
     struct THate hates[PLAYERS_COUNT];
@@ -703,7 +703,7 @@ struct Room *get_hated_room_for_quick_attack(struct Computer2 *comp, long min_ha
         struct THate* hate = &hates[i];
         if (players_are_enemies(comp->dungeon->owner, hate->plyr_idx))
         {
-            if ((hate->pos_near != NULL) && (hate->amount > min_hate))
+            if (hate->pos_near != NULL)
             {
                 struct Room* room = get_opponent_room(comp, hate->plyr_idx);
                 if (!room_is_invalid(room)) {
@@ -725,8 +725,13 @@ long computer_check_for_quick_attack(struct Computer2 *comp, struct ComputerChec
 {
     SYNCDBG(8,"Starting");
     struct Dungeon* dungeon = comp->dungeon;
-    int creatrs_num = check->param1 * dungeon->num_active_creatrs / 100;
-    if (check->param3 >= creatrs_num) {
+    long attack_percentage = check->param1;
+    long cta_duration = check->param2;
+    long min_creatures_to_attack = check->param3;
+    int max_attack_amount = attack_percentage * dungeon->num_active_creatrs / 100;
+    unsigned long creatures_to_fight_amount;
+
+    if (min_creatures_to_attack >= max_attack_amount) {
         return CTaskRet_Unk4;
     }
     if (!computer_able_to_use_power(comp, PwrK_CALL2ARMS, 1, 3)) {
@@ -735,7 +740,7 @@ long computer_check_for_quick_attack(struct Computer2 *comp, struct ComputerChec
     if ((check_call_to_arms(comp) != 1) || is_there_an_attack_task(comp)) {
         return CTaskRet_Unk4;
     }
-    struct Room* room = get_hated_room_for_quick_attack(comp, check->param3);
+    struct Room* room = get_hated_room_for_quick_attack(comp);
     if (room_is_invalid(room)) {
         return CTaskRet_Unk4;
     }
@@ -744,10 +749,12 @@ long computer_check_for_quick_attack(struct Computer2 *comp, struct ComputerChec
     pos.x.val = subtile_coord_center(room->central_stl_x);
     pos.y.val = subtile_coord_center(room->central_stl_y);
     pos.z.val = subtile_coord(1,0);
-    if (count_creatures_availiable_for_fight(comp, &pos) <= check->param3) {
+    if (creatures_to_fight_amount = count_creatures_availiable_for_fight(comp, &pos) <= min_creatures_to_attack) {
         return CTaskRet_Unk4;
     }
-    if (!create_task_magic_support_call_to_arms(comp, &pos, check->param2, 0, creatrs_num)) {
+    if (creatures_to_fight_amount > max_attack_amount)
+        creatures_to_fight_amount = max_attack_amount;
+    if (!create_task_magic_support_call_to_arms(comp, &pos, cta_duration, 0, creatures_to_fight_amount)) {
         return CTaskRet_Unk4;
     }
     SYNCLOG("Player %d decided to attack %s owned by player %d",(int)dungeon->owner,room_code_name(room->kind),(int)room->owner);

--- a/src/player_compchecks.c
+++ b/src/player_compchecks.c
@@ -749,7 +749,8 @@ long computer_check_for_quick_attack(struct Computer2 *comp, struct ComputerChec
     pos.x.val = subtile_coord_center(room->central_stl_x);
     pos.y.val = subtile_coord_center(room->central_stl_y);
     pos.z.val = subtile_coord(1,0);
-    if (creatures_to_fight_amount = count_creatures_availiable_for_fight(comp, &pos) <= min_creatures_to_attack) {
+    creatures_to_fight_amount = count_creatures_availiable_for_fight(comp, &pos);
+    if (creatures_to_fight_amount <= min_creatures_to_attack) {
         return CTaskRet_Unk4;
     }
     if (creatures_to_fight_amount > max_attack_amount)

--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -435,7 +435,7 @@ long computer_finds_nearest_room_to_gold(struct Computer2 *comp, struct Coord3d 
     return dig_distance;
 }
 
-long count_creatures_availiable_for_fight(struct Computer2 *comp, struct Coord3d *pos)
+unsigned long count_creatures_availiable_for_fight(struct Computer2 *comp, struct Coord3d *pos)
 {
     SYNCDBG(8,"Starting");
     struct Dungeon* dungeon = comp->dungeon;

--- a/src/player_computer.h
+++ b/src/player_computer.h
@@ -671,7 +671,7 @@ const char *computer_task_code_name(int ctask_type);
 TbBool create_task_move_creatures_to_defend(struct Computer2 *comp, struct Coord3d *pos, long creatrs_num, unsigned long evflags);
 TbBool create_task_move_creatures_to_room(struct Computer2 *comp, int room_idx, long creatrs_num);
 TbBool create_task_magic_battle_call_to_arms(struct Computer2 *comp, struct Coord3d *pos, long par2, long creatrs_num);
-TbBool create_task_magic_support_call_to_arms(struct Computer2 *comp, struct Coord3d *pos, long par2, long par3, long creatrs_num);
+TbBool create_task_magic_support_call_to_arms(struct Computer2 *comp, struct Coord3d *pos, long cta_duration, long par3, long repeat_num);
 TbBool create_task_pickup_for_attack(struct Computer2 *comp, struct Coord3d *pos, long par3, long creatrs_num);
 TbBool create_task_sell_traps_and_doors(struct Computer2 *comp, long num_to_sell, GoldAmount gold_up_to, TbBool allow_deployed);
 TbBool create_task_move_gold_to_treasury(struct Computer2 *comp, long num_to_move, long gold_up_to);

--- a/src/player_computer.h
+++ b/src/player_computer.h
@@ -713,7 +713,7 @@ long count_diggers_in_dungeon(const struct Dungeon *dungeon);
 long check_call_to_arms(struct Computer2 *comp);
 long count_creatures_for_defend_pickup(struct Computer2 *comp);
 long count_creatures_for_pickup(struct Computer2 *comp, struct Coord3d *pos, struct Room *room, long a4);
-long count_creatures_availiable_for_fight(struct Computer2 *comp, struct Coord3d *pos);
+unsigned long count_creatures_availiable_for_fight(struct Computer2 *comp, struct Coord3d *pos);
 
 long setup_computer_attack(struct Computer2 *comp, struct ComputerProcess *cproc, struct Coord3d *pos, long victim_plyr_idx);
 


### PR DESCRIPTION
Param3 was used for both 'min creatures' and 'min hate', that conflicts. I do not believe hate is needed there.

Fixes #2680