### PR TITLE
Keeper powers target keeperless creatures

### DIFF
--- a/src/magic.c
+++ b/src/magic.c
@@ -418,7 +418,8 @@ TbBool can_cast_power_on_thing(PlayerNumber plyr_idx, const struct Thing *thing,
         }
         if ((powerst->can_cast_flags & PwCast_EnemyCrtrs) != 0)
         {
-            if (players_are_enemies(plyr_idx, thing->owner)) {
+            if (!players_creatures_tolerate_each_other(plyr_idx, thing->owner))
+            {
                 return true;
             }
         }


### PR DESCRIPTION
Keeper powers targeting enemy creatures now follow the same rules as creatures do when looking for something to attack. This fixes an issue that yellow creatures on a map without a yellow keeper could not be targeted with a chicken or disease power.

Fixes #3365