### PR TITLE
Fixed year 2038 crash

### DIFF
--- a/src/bflib_basics.c
+++ b/src/bflib_basics.c
@@ -441,36 +441,44 @@ int LbLog(struct TbLog *log, const char *fmt_str, va_list arg)
       if ((log->flags & LbLog_TimeInHeader) != 0)
       {
         struct TbTime curr_time;
-        LbTime(&curr_time);
-        fprintf(file, "  @ %02d:%02d:%02d",
-            curr_time.Hour,curr_time.Minute,curr_time.Second);
+        if (LbTime(&curr_time) == Lb_SUCCESS)
+        {
+            fprintf(file, "  @ %02u:%02u:%02u",
+                curr_time.Hour,curr_time.Minute,curr_time.Second);
+        }
         at_used = 1;
       }
       if ((log->flags & LbLog_DateInHeader) != 0)
       {
         struct TbDate curr_date;
-        LbDate(&curr_date);
-        const char *sep;
-        if ( at_used )
-          sep = " ";
-        else
-          sep = "  @ ";
-        fprintf(file," %s%02d-%02d-%d",sep,curr_date.Day,curr_date.Month,curr_date.Year);
+        if (LbDate(&curr_date) == Lb_SUCCESS)
+        {
+            const char *sep;
+            if ( at_used )
+              sep = " ";
+            else
+              sep = "  @ ";
+            fprintf(file," %s%02u-%02u-%u",sep,curr_date.Day,curr_date.Month,curr_date.Year);
+        }
       }
       fprintf(file, "\n\n");
     }
     if ((log->flags & LbLog_DateInLines) != 0)
     {
         struct TbDate curr_date;
-        LbDate(&curr_date);
-        fprintf(file,"%02d-%02d-%d ",curr_date.Day,curr_date.Month,curr_date.Year);
+        if (LbDate(&curr_date) == Lb_SUCCESS)
+        {
+            fprintf(file,"%02u-%02u-%u ",curr_date.Day,curr_date.Month,curr_date.Year);
+        }
     }
     if ((log->flags & LbLog_TimeInLines) != 0)
     {
         struct TbTime curr_time;
-        LbTime(&curr_time);
-        fprintf(file, "%02d:%02d:%02d ",
-            curr_time.Hour,curr_time.Minute,curr_time.Second);
+        if (LbTime(&curr_time) == Lb_SUCCESS)
+        {
+            fprintf(file, "%02u:%02u:%02u ",
+                curr_time.Hour,curr_time.Minute,curr_time.Second);
+        }
     }
   if (log->prefix[0] != '\0') {
       fputs(log->prefix, file);

--- a/src/bflib_basics.c
+++ b/src/bflib_basics.c
@@ -445,8 +445,8 @@ int LbLog(struct TbLog *log, const char *fmt_str, va_list arg)
         {
             fprintf(file, "  @ %02u:%02u:%02u",
                 curr_time.Hour,curr_time.Minute,curr_time.Second);
+            at_used = 1;
         }
-        at_used = 1;
       }
       if ((log->flags & LbLog_DateInHeader) != 0)
       {

--- a/src/bflib_basics.h
+++ b/src/bflib_basics.h
@@ -17,9 +17,6 @@
  *     (at your option) any later version.
  */
 /******************************************************************************/
-#define _FILE_OFFSET_BITS 64
-#define _TIME_BITS 64
-
 #ifndef BFLIB_BASICS_H
 #define BFLIB_BASICS_H
 

--- a/src/bflib_basics.h
+++ b/src/bflib_basics.h
@@ -17,6 +17,9 @@
  *     (at your option) any later version.
  */
 /******************************************************************************/
+#define _FILE_OFFSET_BITS 64
+#define _TIME_BITS 64
+
 #ifndef BFLIB_BASICS_H
 #define BFLIB_BASICS_H
 

--- a/src/bflib_datetm.cpp
+++ b/src/bflib_datetm.cpp
@@ -197,20 +197,24 @@ TbResult LbDateTime(struct TbDate *curr_date, struct TbTime *curr_time)
 
 TbResult LbDateTimeDecode(const time_t *datetime,struct TbDate *curr_date,struct TbTime *curr_time)
 {
-  struct tm *ltime=localtime(datetime);
-  if (curr_date!=NULL)
+  struct tm *ltime = localtime(datetime);
+  if (ltime == NULL)
   {
-    curr_date->Day=ltime->tm_mday;
-    curr_date->Month=ltime->tm_mon+1;
-    curr_date->Year=1900+ltime->tm_year;
-    curr_date->DayOfWeek=ltime->tm_wday;
+      return Lb_FAIL;
   }
-  if (curr_time!=NULL)
+  if (curr_date != NULL)
   {
-    curr_time->Hour=ltime->tm_hour;
-    curr_time->Minute=ltime->tm_min;
-    curr_time->Second=ltime->tm_sec;
-    curr_time->HSecond=0;
+    curr_date->Day = ltime->tm_mday;
+    curr_date->Month = ltime->tm_mon+1;
+    curr_date->Year = 1900+ltime->tm_year;
+    curr_date->DayOfWeek = ltime->tm_wday;
+  }
+  if (curr_time != NULL)
+  {
+    curr_time->Hour = ltime->tm_hour;
+    curr_time->Minute = ltime->tm_min;
+    curr_time->Second = ltime->tm_sec;
+    curr_time->HSecond = 0;
   }
   return Lb_SUCCESS;
 }


### PR DESCRIPTION
Fixes #3379

The problem is now that the log doesn't record the date it was created, but that is infinitely preferable to the game crashing before it's even loaded.