### PR TITLE
Allow the use of the right keys for one-click

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1941,7 +1941,7 @@ int global_frameskipTurn = 0;
 void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rotate_pressed,int speed_pressed)
 {
     // Reserve the scroll wheel for the resurrect and transfer creature specials
-    if ((menu_is_active(GMnu_RESURRECT_CREATURE) || menu_is_active(GMnu_TRANSFER_CREATURE) || (key_modifiers & KMod_SHIFT) || (key_modifiers & KMod_CONTROL)) == 0)
+    if ((menu_is_active(GMnu_RESURRECT_CREATURE) || menu_is_active(GMnu_TRANSFER_CREATURE) || rotate_pressed || speed_pressed) == 0)
     {
         // mouse scroll zoom unaffected by frameskip
         if ((pckt->control_flags & PCtr_MapCoordsValid) != 0)
@@ -1956,7 +1956,7 @@ void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rotate_pre
             }
         }
     }
-    if (menu_is_active(GMnu_BATTLE) && (key_modifiers & KMod_CONTROL))
+    if (menu_is_active(GMnu_BATTLE) && (rotate_pressed))
     {
         if (wheel_scrolled_up)
         {

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -222,7 +222,9 @@ int is_game_key_pressed(long key_id, long *val, TbBool ignore_mods)
       return 0;
     }
   }
-  if ((key_id == Gkey_RotateMod) || (key_id == Gkey_SpeedMod) || (key_id == Gkey_CrtrContrlMod) || (key_id == Gkey_CrtrQueryMod))
+  if ((key_id == Gkey_RotateMod) || (key_id == Gkey_SpeedMod) || (key_id == Gkey_CrtrContrlMod) 
+      || (key_id == Gkey_CrtrQueryMod) || (key_id == Gkey_BestRoomSpace) || (key_id == Gkey_SquareRoomSpace)
+      || (key_id == Gkey_SellTrapOnSubtile))
   {
       i = settings.kbkeys[key_id].code;
       switch (i)

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1075,7 +1075,7 @@ TbBool get_dungeon_control_pausable_action_inputs(void)
           struct Camera* cam = &player->cameras[CamIV_Isometric];
           struct Packet* pckt = get_packet(my_player_number);
           int angle = cam->orient_a;
-          if (lbKeyOn[KC_LCONTROL])
+          if (key_modifiers & KMod_CONTROL)
           {
               if ((angle >= 0 && angle < 256) || angle == 2048)
               {
@@ -1110,7 +1110,7 @@ TbBool get_dungeon_control_pausable_action_inputs(void)
                   angle = 0;
               }
         }
-        else if (lbKeyOn[KC_LSHIFT])
+        else if (key_modifiers & KMod_SHIFT)
         {
             if (angle > 0 && angle <= 256)
             {angle = 2048;}
@@ -1167,11 +1167,11 @@ TbBool get_dungeon_control_pausable_action_inputs(void)
           struct Camera* cam = &player->cameras[CamIV_FrontView];
           struct Packet* pckt = get_packet(my_player_number);
           int angle = cam->orient_a;
-          if (lbKeyOn[KC_LCONTROL])
+          if (key_modifiers & KMod_CONTROL)
           {
               set_packet_control(pckt, PCtr_ViewRotateCW);
         }
-        else if (lbKeyOn[KC_LSHIFT])
+        else if (key_modifiers & KMod_SHIFT)
         {
             set_packet_control(pckt, PCtr_ViewRotateCCW);
         }
@@ -1941,7 +1941,7 @@ int global_frameskipTurn = 0;
 void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rotate_pressed,int speed_pressed)
 {
     // Reserve the scroll wheel for the resurrect and transfer creature specials
-    if ((menu_is_active(GMnu_RESURRECT_CREATURE) || menu_is_active(GMnu_TRANSFER_CREATURE) || lbKeyOn[KC_LSHIFT] || lbKeyOn[KC_LCONTROL]) == 0)
+    if ((menu_is_active(GMnu_RESURRECT_CREATURE) || menu_is_active(GMnu_TRANSFER_CREATURE) || (key_modifiers & KMod_SHIFT) || (key_modifiers & KMod_CONTROL)) == 0)
     {
         // mouse scroll zoom unaffected by frameskip
         if ((pckt->control_flags & PCtr_MapCoordsValid) != 0)
@@ -1956,7 +1956,7 @@ void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rotate_pre
             }
         }
     }
-    if (menu_is_active(GMnu_BATTLE) && lbKeyOn[KC_LCONTROL])
+    if (menu_is_active(GMnu_BATTLE) && (key_modifiers & KMod_CONTROL))
     {
         if (wheel_scrolled_up)
         {

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -865,7 +865,7 @@ void maintain_scroll_up(struct GuiButton *gbtn)
     gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * (scrollwnd->start_y < 0)) & LbBtnF_Enabled;
     if (!check_current_gui_layer(GuiLayer_OneClick))
     {
-        if (wheel_scrolled_up & lbKeyOn[KC_LCONTROL])
+        if (wheel_scrolled_up & (lbKeyOn[KC_LCONTROL] || lbKeyOn[KC_RCONTROL]))
         {
             scrollwnd->action = 1;
         }
@@ -880,7 +880,7 @@ void maintain_scroll_down(struct GuiButton *gbtn)
         * (scrollwnd->window_height - scrollwnd->text_height + 2 < scrollwnd->start_y)) & LbBtnF_Enabled;
     if (!check_current_gui_layer(GuiLayer_OneClick))
     {
-        if (wheel_scrolled_down & lbKeyOn[KC_LCONTROL])
+        if (wheel_scrolled_down & (lbKeyOn[KC_LCONTROL] || lbKeyOn[KC_RCONTROL]))
         {
             scrollwnd->action = 2;
         }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -865,7 +865,7 @@ void maintain_scroll_up(struct GuiButton *gbtn)
     gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * (scrollwnd->start_y < 0)) & LbBtnF_Enabled;
     if (!check_current_gui_layer(GuiLayer_OneClick))
     {
-        if (wheel_scrolled_up & (lbKeyOn[KC_LCONTROL] || lbKeyOn[KC_RCONTROL]))
+        if (wheel_scrolled_up && (is_game_key_pressed(Gkey_RotateMod, NULL, true)))
         {
             scrollwnd->action = 1;
         }
@@ -880,7 +880,7 @@ void maintain_scroll_down(struct GuiButton *gbtn)
         * (scrollwnd->window_height - scrollwnd->text_height + 2 < scrollwnd->start_y)) & LbBtnF_Enabled;
     if (!check_current_gui_layer(GuiLayer_OneClick))
     {
-        if (wheel_scrolled_down & (lbKeyOn[KC_LCONTROL] || lbKeyOn[KC_RCONTROL]))
+        if (wheel_scrolled_down && (is_game_key_pressed(Gkey_RotateMod, NULL, true)))
         {
             scrollwnd->action = 2;
         }

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1796,7 +1796,7 @@ void maintain_activity_up(struct GuiButton *gbtn)
         gbtn->flags |= LbBtnF_Visible;
         gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * (top_of_breed_list > 0)) & LbBtnF_Enabled;
     }
-    if (wheel_scrolled_up & lbKeyOn[KC_LSHIFT])
+    if (wheel_scrolled_up & (lbKeyOn[KC_LSHIFT]|| lbKeyOn[KC_RSHIFT]))
     {
         if (top_of_breed_list > 0)
         {
@@ -1817,7 +1817,7 @@ void maintain_activity_down(struct GuiButton *gbtn)
         gbtn->flags |= LbBtnF_Visible;
         gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * (no_of_breeds_owned - 6 > top_of_breed_list)) & LbBtnF_Enabled;
     }
-    if (wheel_scrolled_down & lbKeyOn[KC_LSHIFT])
+    if (wheel_scrolled_down & (lbKeyOn[KC_LSHIFT] || lbKeyOn[KC_RSHIFT]))
     {
         if (top_of_breed_list + 6 < no_of_breeds_owned)
         {
@@ -1997,7 +1997,7 @@ void maintain_event_button(struct GuiButton *gbtn)
     {
         // Fight icon flashes when there are fights to show
         gbtn->sprite_idx += 2;
-        if(is_game_key_pressed(Gkey_ZoomToFight, &keycode, true) && lbKeyOn[KC_LSHIFT])
+        if(is_game_key_pressed(Gkey_ZoomToFight, &keycode, true) && (key_modifiers & KMod_SHIFT))
         {
             if ((evidx == dungeon->visible_event_idx))
             {

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1796,7 +1796,7 @@ void maintain_activity_up(struct GuiButton *gbtn)
         gbtn->flags |= LbBtnF_Visible;
         gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * (top_of_breed_list > 0)) & LbBtnF_Enabled;
     }
-    if (wheel_scrolled_up & (lbKeyOn[KC_LSHIFT]|| lbKeyOn[KC_RSHIFT]))
+    if (wheel_scrolled_up && (is_game_key_pressed(Gkey_SpeedMod, NULL, true)))
     {
         if (top_of_breed_list > 0)
         {
@@ -1817,7 +1817,7 @@ void maintain_activity_down(struct GuiButton *gbtn)
         gbtn->flags |= LbBtnF_Visible;
         gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * (no_of_breeds_owned - 6 > top_of_breed_list)) & LbBtnF_Enabled;
     }
-    if (wheel_scrolled_down & (lbKeyOn[KC_LSHIFT] || lbKeyOn[KC_RSHIFT]))
+    if (wheel_scrolled_down && (is_game_key_pressed(Gkey_SpeedMod, NULL, true)))
     {
         if (top_of_breed_list + 6 < no_of_breeds_owned)
         {
@@ -1997,7 +1997,7 @@ void maintain_event_button(struct GuiButton *gbtn)
     {
         // Fight icon flashes when there are fights to show
         gbtn->sprite_idx += 2;
-        if(is_game_key_pressed(Gkey_ZoomToFight, &keycode, true) && (key_modifiers & KMod_SHIFT))
+        if(is_game_key_pressed(Gkey_ZoomToFight, &keycode, true) && (is_game_key_pressed(Gkey_SpeedMod, NULL, true)))
         {
             if ((evidx == dungeon->visible_event_idx))
             {


### PR DESCRIPTION
In the define keys menu, the user would press right shift/ctrl/alt to use on the one-click room commands and it would accept it as the general 'shift/control/alt', but then ingame would only accept pressing the left key. Now it accepts either.

Fixes #3415