### PR TITLE
Prevent CHANGE_SLAB_TYPE from leaving room information on slabs

### DIFF
--- a/src/room_util.c
+++ b/src/room_util.c
@@ -332,6 +332,7 @@ TbBool replace_slab_from_script(MapSlabCoord slb_x, MapSlabCoord slb_y, unsigned
     SYNCDBG(7, "Room on (%d,%d) had %d slabs", (int)slb_x, (int)slb_y, (int)room->slabs_count);
     decrease_room_area(room->owner, 1);
     kill_room_slab_and_contents(room->owner, slb_x, slb_y);
+    remove_slab_from_room_tiles_list(room, slb_x, slb_y);
     if (room->slabs_count <= 1)
     {
         delete_room_flag(room);


### PR DESCRIPTION
If the CHANGE_SLAB_TYPE script command is used to change a room slab into another room slab, it would leave the old room present in the slab information.

Function `do_slab_efficiency_alteration` would do this:
```c
struct SlabAttr* slbattr = get_slab_attrs(slb);
        if (slbattr->category == SlbAtCtg_RoomInterior)
        {
            struct Room* room = slab_room_get(sslb_x, sslb_y);
 ```
 
 And find a room of type NULL, causing several log errors and related issues, possibly also player notifications when the room was destroyed.
 This PR cleans that up.

To reproduce the original issue:
1) Run this map: [map30117.zip](https://github.com/user-attachments/files/16740693/map30117.1.zip)
2) Press `~` to see logging
3) Wait for 140 gameturns to see rooms get replaced
-> Notice a `!` message that says a room is destroyed, with the eye at pos (0,0).

