### PR TITLE
Update SDL2 libs to latest version

### DIFF
--- a/libexterns.mk
+++ b/libexterns.mk
@@ -43,7 +43,7 @@ sdl/lib/libSDL2main.a: sdl/$(SDL_PACKAGE)
 	-$(ECHO) 'Extracting package: $<'
 	# Grep is used to remove bogus error messages, return state of tar is also ignored
 	-cd "$(<D)"; \
-	tar --strip-components=2 -zxmUf "$(<F)" SDL2-2.30.6/i686-w64-mingw32/bin SDL2-2.30.6/i686-w64-mingw32/include SDL2-2.30.6/i686-w64-mingw32/lib SDL2-2.30.6/i686-w64-mingw32/share 2>&1 | \
+	tar --strip-components=2 -zxmUf "$(<F)" SDL2-2.30.7/i686-w64-mingw32/bin SDL2-2.30.7/i686-w64-mingw32/include SDL2-2.30.7/i686-w64-mingw32/lib SDL2-2.30.7/i686-w64-mingw32/share 2>&1 | \
 	grep -v '^.*: Archive value .* is out of .* range.*$$'
 	$(CP) sdl/bin/SDL2.dll sdl/for_final_package/
 	-$(ECHO) 'Finished extracting: $<'

--- a/libexterns.mk
+++ b/libexterns.mk
@@ -43,7 +43,7 @@ sdl/lib/libSDL2main.a: sdl/$(SDL_PACKAGE)
 	-$(ECHO) 'Extracting package: $<'
 	# Grep is used to remove bogus error messages, return state of tar is also ignored
 	-cd "$(<D)"; \
-	tar --strip-components=2 -zxmUf "$(<F)" SDL2-2.28.5/i686-w64-mingw32/bin SDL2-2.28.5/i686-w64-mingw32/include SDL2-2.28.5/i686-w64-mingw32/lib SDL2-2.28.5/i686-w64-mingw32/share 2>&1 | \
+	tar --strip-components=2 -zxmUf "$(<F)" SDL2-2.30.6/i686-w64-mingw32/bin SDL2-2.30.6/i686-w64-mingw32/include SDL2-2.30.6/i686-w64-mingw32/lib SDL2-2.30.6/i686-w64-mingw32/share 2>&1 | \
 	grep -v '^.*: Archive value .* is out of .* range.*$$'
 	$(CP) sdl/bin/SDL2.dll sdl/for_final_package/
 	-$(ECHO) 'Finished extracting: $<'

--- a/prebuilds.mk
+++ b/prebuilds.mk
@@ -41,7 +41,7 @@ DKILLCONV_PACKAGE=$(notdir $(DKILLCONV_DOWNLOAD))
 
 # Tools and libraries to be used for the target system
 # Currently, the target is always windows-mingw32
-SDL_DOWNLOAD=https://github.com/libsdl-org/SDL/releases/download/release-2.30.6/SDL2-devel-2.30.6-mingw.tar.gz
+SDL_DOWNLOAD=https://github.com/libsdl-org/SDL/releases/download/release-2.30.7/SDL2-devel-2.30.7-mingw.tar.gz
 #SDL_NET_DOWNLOAD=https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-VC.zip
 SDL_NET_DOWNLOAD=https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-mingw.tar.gz
 #SDL_MIXER_DOWNLOAD=https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.0/SDL2_mixer-devel-2.8.0-VC.zip

--- a/prebuilds.mk
+++ b/prebuilds.mk
@@ -41,7 +41,7 @@ DKILLCONV_PACKAGE=$(notdir $(DKILLCONV_DOWNLOAD))
 
 # Tools and libraries to be used for the target system
 # Currently, the target is always windows-mingw32
-SDL_DOWNLOAD=https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-devel-2.28.5-mingw.tar.gz
+SDL_DOWNLOAD=https://github.com/libsdl-org/SDL/releases/download/release-2.30.6/SDL2-devel-2.30.6-mingw.tar.gz
 #SDL_NET_DOWNLOAD=https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-VC.zip
 SDL_NET_DOWNLOAD=https://github.com/libsdl-org/SDL_net/releases/download/release-2.2.0/SDL2_net-devel-2.2.0-mingw.tar.gz
 #SDL_MIXER_DOWNLOAD=https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.0/SDL2_mixer-devel-2.8.0-VC.zip


### PR DESCRIPTION
- Updated SDL2 from 2.28.5 to 2.30.6
- SDL mixer, net and image are still up-to-date