### PR TITLE
Creatures use buffs when attacking objects or doors

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -526,11 +526,13 @@ long process_creature_self_spell_casting(struct Thing* creatng)
         return 0;
     }
     if (cctrl->combat_flags != 0) {
-        return 0;
+        if ((cctrl->combat_flags & (CmbtF_ObjctFight|CmbtF_DoorFight)) == 0) {
+            return 0;
+        }
     }
 
-    long inst_idx = get_self_spell_casting(creatng);
-    if (inst_idx <= 0) {
+    CrInstance inst_idx = get_self_spell_casting(creatng);
+    if (inst_idx <= CrInst_NULL) {
         return 0;
     }
     set_creature_instance(creatng, inst_idx, creatng->index, 0);

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -3124,7 +3124,7 @@ TbBool creature_look_for_enemy_heart_combat(struct Thing *thing)
         struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
         heartng = thing_get(cctrl->combat.battle_enemy_idx);
         if (thing_is_dungeon_heart(heartng)) {
-            return false;
+            return true;
         }
     }
     heartng = get_enemy_soul_container_creature_can_see(thing);
@@ -3199,7 +3199,7 @@ TbBool creature_look_for_enemy_object_combat(struct Thing* thing)
         struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
         objtng = thing_get(cctrl->combat.battle_enemy_idx);
         if (thing_is_dungeon_heart(objtng)) {
-            return false;
+            return true;
         }
     }
     objtng = check_for_object_to_fight(thing);


### PR DESCRIPTION
Fixes #3445

Because doors are so fragile, it's difficult to test on them, but it should work there, too.