### PR TITLE
Health, Speed and LairObject updated when stat changes

### DIFF
--- a/src/config_creature.c
+++ b/src/config_creature.c
@@ -207,7 +207,6 @@ struct NamedCommand attackpref_desc[INSTANCE_TYPES_MAX];
 ThingModel breed_activities[CREATURE_TYPES_MAX];
 /******************************************************************************/
 extern const struct NamedCommand creature_job_player_assign_func_type[];
-extern Creature_Job_Player_Check_Func creature_job_player_check_func_list[];
 extern const struct NamedCommand creature_job_player_check_func_type[];
 extern Creature_Job_Player_Assign_Func creature_job_player_assign_func_list[];
 extern const struct NamedCommand creature_job_coords_check_func_type[];

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -268,6 +268,7 @@ extern const struct NamedCommand creatmodel_attraction_commands[];
 extern const struct NamedCommand creatmodel_sounds_commands[];
 extern const struct NamedCommand creatmodel_sprite_commands[];
 extern const struct NamedCommand creature_graphics_desc[];
+extern Creature_Job_Player_Check_Func creature_job_player_check_func_list[];
 /******************************************************************************/
 struct CreatureStats *creature_stats_get(ThingModel crstat_idx);
 struct CreatureStats *creature_stats_get_from_thing(const struct Thing *thing);

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -1615,8 +1615,8 @@ TbBool parse_creaturemodel_appearance_blocks(long crtr_model,char *buf,long len,
                 if (k > 0)
                 {
                     crstat->natural_death_kind = k;
-                    n++;
                 }
+                n++;
             }
             if (n < 1)
             {
@@ -1691,8 +1691,8 @@ TbBool parse_creaturemodel_appearance_blocks(long crtr_model,char *buf,long len,
                 if (k > 0)
                 {
                     crstat->status_offset = k;
-                    n++;
                 }
+                n++;
             }
             if (n < 1)
             {

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -2644,6 +2644,12 @@ TbBool swap_creature(ThingModel ncrt_id, ThingModel crtr_id)
         return false;
     }
     do_creature_swap(ncrt_id, crtr_id);
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        do_to_players_all_creatures_of_model(plyr_idx, crtr_id, update_relative_creature_health);
+        update_speed_of_player_creatures_of_model(plyr_idx, crtr_id);
+    }
+
     return true;
 }
 

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -2643,11 +2643,19 @@ TbBool swap_creature(ThingModel ncrt_id, ThingModel crtr_id)
         ERRORLOG("Creature index %d is invalid", ncrt_id);
         return false;
     }
+    struct CreatureStats* crstat = creature_stats_get(crtr_id);
+    ThingModel oldlair = crstat->lair_object;
     do_creature_swap(ncrt_id, crtr_id);
+    struct CreatureStats* ncrstat = creature_stats_get(crtr_id);
+    ThingModel newlair = ncrstat->lair_object;
     for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
     {
         do_to_players_all_creatures_of_model(plyr_idx, crtr_id, update_relative_creature_health);
         update_speed_of_player_creatures_of_model(plyr_idx, crtr_id);
+        if (oldlair != newlair)
+        {
+            do_to_players_all_creatures_of_model(plyr_idx, crtr_id, remove_creature_lair);
+        }
     }
 
     return true;

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -39,6 +39,7 @@
 #include "creature_control.h"
 #include "creature_graphics.h"
 #include "creature_states.h"
+#include "creature_states_mood.h"
 #include "player_data.h"
 #include "custom_sprites.h"
 #include "lvl_script_lib.h"
@@ -2656,6 +2657,7 @@ TbBool swap_creature(ThingModel ncrt_id, ThingModel crtr_id)
         {
             do_to_players_all_creatures_of_model(plyr_idx, crtr_id, remove_creature_lair);
         }
+        do_to_players_all_creatures_of_model(plyr_idx, crtr_id, process_job_stress_and_going_postal);
     }
 
     return true;

--- a/src/creature_states_mood.c
+++ b/src/creature_states_mood.c
@@ -589,6 +589,18 @@ TbBool process_job_stress_and_going_postal(struct Thing *creatng)
         state_cleanup_in_room(creatng);
         return true;
     }
+
+    struct CreatureJobConfig* jobcfg = get_config_for_job(cctrl->job_assigned);
+    if (!creature_job_player_check_func_list[jobcfg->func_plyr_check_idx] == NULL)
+    {
+        if (!creature_job_player_check_func_list[jobcfg->func_plyr_check_idx](creatng, creatng->owner, cctrl->job_assigned))
+        {
+            SYNCDBG(13, "Creature %s index %d owner %d can no longer do job %s; check callback failed", thing_model_name(creatng), (int)creatng->index, (int)creatng->owner, creature_job_code_name(cctrl->job_assigned));
+            state_cleanup_in_room(creatng);
+            return true;
+        }
+    }
+
     return false;
 }
 

--- a/src/creature_states_mood.c
+++ b/src/creature_states_mood.c
@@ -591,7 +591,7 @@ TbBool process_job_stress_and_going_postal(struct Thing *creatng)
     }
 
     struct CreatureJobConfig* jobcfg = get_config_for_job(cctrl->job_assigned);
-    if (!creature_job_player_check_func_list[jobcfg->func_plyr_check_idx] == NULL)
+    if (creature_job_player_check_func_list[jobcfg->func_plyr_check_idx] != NULL)
     {
         if (!creature_job_player_check_func_list[jobcfg->func_plyr_check_idx](creatng, creatng->owner, cctrl->job_assigned))
         {

--- a/src/creature_states_scavn.c
+++ b/src/creature_states_scavn.c
@@ -571,6 +571,7 @@ CrStateRet scavengering(struct Thing *creatng)
         set_start_state(creatng);
         return CrStRet_ResetFail;
     }
+
     if (process_scavenge_function(creatng))
     {
         return CrStRet_Modified;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2981,6 +2981,10 @@ static void set_creature_configuration_process(struct ScriptContext* context)
             break;
         case 2: // HEALTH
             crstat->health = value;
+            for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+            {
+                do_to_players_all_creatures_of_model(plyr_idx, creatid, update_relative_creature_health);
+            }
             break;
         case 3: // HEALREQUIREMENT
             crstat->heal_requirement = value;
@@ -3026,6 +3030,10 @@ static void set_creature_configuration_process(struct ScriptContext* context)
             break;
         case 17: // BASESPEED
             crstat->base_speed = value;
+            for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+            {
+                update_speed_of_player_creatures_of_model(plyr_idx, creatid);
+            }
             break;
         case 18: // GOLDHOLD
             crstat->gold_hold = value;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2980,10 +2980,13 @@ static void set_creature_configuration_process(struct ScriptContext* context)
             CONFWRNLOG("Attribute (%d) not supported", creature_variable);
             break;
         case 2: // HEALTH
-            crstat->health = value;
-            for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+            if (crstat->health != value)
             {
-                do_to_players_all_creatures_of_model(plyr_idx, creatid, update_relative_creature_health);
+                crstat->health = value;
+                for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+                {
+                    do_to_players_all_creatures_of_model(plyr_idx, creatid, update_relative_creature_health);
+                }
             }
             break;
         case 3: // HEALREQUIREMENT
@@ -3029,10 +3032,13 @@ static void set_creature_configuration_process(struct ScriptContext* context)
             crstat->hurt_by_lava = value;
             break;
         case 17: // BASESPEED
-            crstat->base_speed = value;
-            for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+            if (crstat->base_speed != value)
             {
-                update_speed_of_player_creatures_of_model(plyr_idx, creatid);
+                crstat->base_speed = value;
+                for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+                {
+                    update_speed_of_player_creatures_of_model(plyr_idx, creatid);
+                }
             }
             break;
         case 18: // GOLDHOLD
@@ -3081,7 +3087,14 @@ static void set_creature_configuration_process(struct ScriptContext* context)
             crstat->footstep_pitch = value;
             break;
         case 34: // LAIROBJECT
-            crstat->lair_object = value;
+            if (crstat->lair_object != value)
+            {
+                for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+                {
+                    do_to_players_all_creatures_of_model(plyr_idx, creatid, remove_creature_lair);
+                }
+                crstat->lair_object = value;
+            }
             break;
         case 0: // comment
             break;

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -3628,6 +3628,11 @@ struct Thing *smallest_gold_pile_at_xy(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
   return chosen_thing;
 }
 
+/**
+ * Re-computes speed of a creature and uses it.
+ * @param thing
+ * @return
+ */
 TbBool update_creature_speed(struct Thing *thing)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);

--- a/src/thing_stats.c
+++ b/src/thing_stats.c
@@ -845,12 +845,27 @@ long compute_value_8bpercentage(long base_val, short npercent)
  * @param thing
  * @return
  */
-TbBool update_creature_health_to_max(struct Thing *thing)
+TbBool update_creature_health_to_max(struct Thing * creatng)
 {
-    struct CreatureStats* crstat = creature_stats_get_from_thing(thing);
-    struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-    cctrl->max_health = compute_creature_max_health(crstat->health,cctrl->explevel,thing->owner);
-    thing->health = cctrl->max_health;
+    struct CreatureStats* crstat = creature_stats_get_from_thing(creatng);
+    struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
+    cctrl->max_health = compute_creature_max_health(crstat->health,cctrl->explevel, creatng->owner);
+    creatng->health = cctrl->max_health;
+    return true;
+}
+
+/**
+ * Re-computes new max health of a creature and updates the health value to stay relative to the old max.
+ * @param thing
+ * @return
+ */
+TbBool update_relative_creature_health(struct Thing* creatng)
+{
+    int health_permil = get_creature_health_permil(creatng);
+    struct CreatureStats* crstat = creature_stats_get_from_thing(creatng);
+    struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
+    cctrl->max_health = compute_creature_max_health(crstat->health, cctrl->explevel, creatng->owner);
+    creatng->health = cctrl->max_health * health_permil / 1000;
     return true;
 }
 

--- a/src/thing_stats.h
+++ b/src/thing_stats.h
@@ -121,8 +121,9 @@ HitPoints calculate_shot_real_damage_to_door(const struct Thing *doortng, const 
 long get_radially_decaying_value(long magnitude,long decay_start,long decay_length,long distance);
 long get_radially_growing_value(long magnitude, long decay_start, long decay_length, long distance, long acceleration);
 
-TbBool update_creature_health_to_max(struct Thing *thing);
-TbBool set_creature_health_to_max_with_heal_effect(struct Thing* thing);
+TbBool update_creature_health_to_max(struct Thing *creatng);
+TbBool update_relative_creature_health(struct Thing *creatng);
+TbBool set_creature_health_to_max_with_heal_effect(struct Thing *thing);
 TbBool apply_health_to_thing(struct Thing *thing, HitPoints amount);
 void apply_health_to_thing_and_display_health(struct Thing *thing, HitPoints amount);
 HitPoints apply_damage_to_thing(struct Thing *thing, HitPoints dmg, DamageType damage_type, PlayerNumber dealing_plyr_idx);


### PR DESCRIPTION
Creature stats may change after SET_CREATURE_CONFIGURATION or after SWAP_CREATURE

In case of health, speed and lair totems, the updated creature stat did not update the value of individual creatures. Now for speed and health they do, and lairs get removed causing them to remake a lair.

If you swap out a creature that keeps a lair model, the lair is not destroyed.