### PR TITLE
Decupled EVENTS_COUNT

### DIFF
--- a/src/map_events.h
+++ b/src/map_events.h
@@ -28,7 +28,7 @@ extern "C" {
 /******************************************************************************/
 #define EVENT_BUTTONS_COUNT    12
 #define EVENT_KIND_COUNT       36
-#define EVENTS_COUNT          100
+#define EVENTS_COUNT          1000
 #define INVALID_EVENT &game.event[0]
 
 enum EventKinds {


### PR DESCRIPTION
Not sure what the ideal number is, but the current number of 100 is too few for the largest and busiest maps, resulting in events not being triggered.