### PR TITLE
no force feed sleep for needless creatures

### DIFF
--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -255,7 +255,7 @@ TbBool parse_creaturemodel_attributes_blocks(long crtr_model,char *buf,long len,
       crstat->defense = 0;
       crstat->luck = 0;
       crstat->sleep_recovery = 1;
-      crstat->toking_recovery = 10;
+      crstat->toking_recovery = 0;
       crstat->hunger_rate = 1;
       crstat->hunger_fill = 1;
       crstat->lair_size = 1;

--- a/src/creature_jobs.c
+++ b/src/creature_jobs.c
@@ -1035,6 +1035,9 @@ TbBool attempt_job_sleep_in_lair_near_pos(struct Thing *creatng, MapSubtlCoord s
         ERRORLOG("No arrive at state for job %s in %s room",creature_job_code_name(new_job),room_code_name(room->kind));
         return false;
     }
+    if(!creature_can_do_healing_sleep(creatng)){
+        return false;
+    }
     cctrl->slap_turns = 0;
     cctrl->max_speed = calculate_correct_creature_maxspeed(creatng);
     if (creature_has_lair_room(creatng) && (room->index == cctrl->lair_room_id))

--- a/src/creature_states_gardn.c
+++ b/src/creature_states_gardn.c
@@ -61,7 +61,7 @@ TbBool creature_able_to_eat(const struct Thing *creatng)
     struct CreatureStats* crstat = creature_stats_get_from_thing(creatng);
     if (creature_stats_invalid(crstat))
         return false;
-    return (crstat->hunger_rate != 0);
+    return ((crstat->hunger_rate > 0) && (crstat->hunger_fill > 0));
 }
 
 TbBool hunger_is_creature_hungry(const struct Thing *creatng)
@@ -206,6 +206,10 @@ short creature_arrived_at_garden(struct Thing *thing)
     {
         WARNLOG("Room %s owned by player %d is invalid for %s index %d",
             room_code_name(room->kind),(int)room->owner,thing_model_name(thing),(int)thing->index);
+        set_start_state(thing);
+        return 0;
+    }
+    if (!creature_able_to_eat(thing)){
         set_start_state(thing);
         return 0;
     }


### PR DESCRIPTION
Prevent creatures with LairSize = 0 or HungerRate = 0 from being forced to build a lair or eat when dropped in the relevant room

Now, dropped creatures require LairSize > 0 and HealRequirement > 0 to build a lair
and dropped creatures require HungerRate > 0 and HungerFill > 0 to eat 
Additionally, the default TokenRecovery value is set to 0 to prevent creatures with LairSize > 0 from accidentally attempting token recovery