### PR TITLE
Add strings for new spells and door

### DIFF
--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -5791,8 +5791,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "密集的金属矿层：为你的小鬼提供丰富的财富。"
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "反弹术"
 
 #: guitext:1054

--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -5793,7 +5793,7 @@ msgstr "密集的金属矿层：为你的小鬼提供丰富的财富。"
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "反弹术"
 
 #: guitext:1054

--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -5864,7 +5864,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "净化：治愈生物身上所有负面效果。"
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -5808,7 +5808,7 @@ msgstr "缓慢术"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "飞行术"
 
 #: guitext:1057

--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -5808,7 +5808,7 @@ msgstr "缓慢术"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "飞行术"
 
 #: guitext:1057

--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -1624,10 +1624,9 @@ msgid "Group: Not used"
 msgstr "集结术: 未使用"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature invisible to all enemies. Unless they possess a subnatural "
-"Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr "隐身术: 对你的一个怪物使用，使其对敌人隐身。除非拥有超常视力的敌人才能看破隐身。"
 
 #: guitext:240

--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -3740,18 +3740,18 @@ msgstr "无上权威: 强迫你的怪物服从你的每一个命令。左键选�
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
-msgstr "速度术: 提高你的怪物的速度。左键选择。[18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
+msgstr "速度术: 提高你的怪物的速度。"
 
 #: guitext:655
 msgctxt "Keeper spell description"
-msgid "Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
-msgstr "保护术: 保护怪物免受攻击。左键选择。[18.11]"
+msgid "Protect Monster: Shields your creatures from attack."
+msgstr "保护术: 保护怪物免受攻击。"
 
 #: guitext:656
 msgctxt "Keeper spell description"
-msgid "Conceal Monster: Makes your creatures invisible to the enemy. LMB select. [18.7]"
-msgstr "隐身术: 使敌人看不见你的怪物。左键选择。[18.7]"
+msgid "Conceal Monster: Makes your creatures invisible to the enemy."
+msgstr "隐身术: 使敌人看不见你的怪物。"
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -5855,3 +5855,48 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6667,7 +6667,7 @@ msgstr "缓慢术"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "飞行术"
 
 #: guitext:1057

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -4439,21 +4439,20 @@ msgstr "强あ术: 强迫你的怪物服从你的每一个命令。按滑鼠左�
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
-msgstr "加速术: 提高怪物的速度。按滑鼠左键选择。[18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
+msgstr "加速术: 提高怪物的速度。"
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
-msgstr "保护术: 保护你的怪物不受攻击。按滑鼠左键选择。[18.11]"
+"Protect Monster: Shields your creatures from attack."
+msgstr "保护术: 保护你的怪物不受攻击。"
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
-msgstr "隐形术: 让敌人看不见你的怪物。按滑鼠左键选择。[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
+msgstr "隐形术: 让敌人看不见你的怪物。"
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6667,7 +6667,7 @@ msgstr "缓慢术"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "飞行术"
 
 #: guitext:1057

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6473,117 +6473,117 @@ msgid "Moo4"
 msgstr ""s
 
 #: guitext:1011
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - Original Campaign"
 msgstr ""
 
 #: guitext:1012
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Assmist Isle"
 msgstr ""
 
 #: guitext:1013
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1014
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Burdened Imps' Level Pack"
 msgstr ""
 
 #: guitext:1015
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Conquest of the Arctic"
 msgstr ""
 
 #: guitext:1016
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "The Destiny of Ninja"
 msgstr ""
 
 #: guitext:1017
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's  6-level campaign"
 msgstr ""
 
 #: guitext:1018
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 10-level campaign"
 msgstr ""
 
 #: guitext:1019
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 25-level campaign"
 msgstr ""
 
 #: guitext:1020
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Evil Keeper campaign"
 msgstr ""
 
 #: guitext:1021
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Grinics' KReign campaign"
 msgstr ""
 
 #: guitext:1022
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Japanese DKMaps8 pack"
 msgstr ""
 
 #: guitext:1023
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "KDK Levels"
 msgstr ""
 
 #: guitext:1024
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Good Campaign"
 msgstr ""
 
 #: guitext:1025
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Lord Vexer campaign"
 msgstr ""
 
 #: guitext:1026
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Nikolai's Castles campaign"
 msgstr ""
 
 #: guitext:1027
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - NG+"
 msgstr ""
 
 #: guitext:1028
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1029
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Undead Keeper campaign"
 msgstr ""
 
 #: guitext:1030
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Quest for the Hero campaign"
 msgstr ""
 
 #: guitext:1031
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Revenge of the Lord"
 msgstr ""
 
 #: guitext:1032
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Twin Keepers Campaign"
 msgstr ""
 
 #: guitext:1033
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
 msgstr ""
 

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6723,7 +6723,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "净化：治愈生物身上所有负面效果。
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6716,3 +6716,48 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6723,7 +6723,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr "净化：治愈生物身上所有负面效果。
+msgstr "净化：治愈生物身上所有负面效果。"
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6650,8 +6650,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "密集的金属矿层：为你的小鬼提供丰富的财富。"
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "反弹术"
 
 #: guitext:1054

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6652,7 +6652,7 @@ msgstr "密集的金属矿层：为你的小鬼提供丰富的财富。"
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "反弹术"
 
 #: guitext:1054

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -2061,9 +2061,7 @@ msgstr "集结术: 未使用"
 #: guitext:239
 #, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr "隐形术: [26.12]"
 
 #: guitext:240

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -2199,10 +2199,10 @@ msgid "Group: Not used"
 msgstr "Skupina: Nepoužito"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
 msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr "Neviditelnost:"
 
 #: guitext:240

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -6726,117 +6726,117 @@ msgid "Moo4"
 msgstr ""
 
 #: guitext:1011
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - Original Campaign"
 msgstr ""
 
 #: guitext:1012
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Assmist Isle"
 msgstr ""
 
 #: guitext:1013
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1014
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Burdened Imps' Level Pack"
 msgstr ""
 
 #: guitext:1015
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Conquest of the Arctic"
 msgstr ""
 
 #: guitext:1016
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "The Destiny of Ninja"
 msgstr ""
 
 #: guitext:1017
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's  6-level campaign"
 msgstr ""
 
 #: guitext:1018
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 10-level campaign"
 msgstr ""
 
 #: guitext:1019
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 25-level campaign"
 msgstr ""
 
 #: guitext:1020
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Evil Keeper campaign"
 msgstr ""
 
 #: guitext:1021
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Grinics' KReign campaign"
 msgstr ""
 
 #: guitext:1022
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Japanese DKMaps8 pack"
 msgstr ""
 
 #: guitext:1023
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "KDK Levels"
 msgstr ""
 
 #: guitext:1024
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Good Campaign"
 msgstr ""
 
 #: guitext:1025
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Lord Vexer campaign"
 msgstr ""
 
 #: guitext:1026
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Nikolai's Castles campaign"
 msgstr ""
 
 #: guitext:1027
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - NG+"
 msgstr ""
 
 #: guitext:1028
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1029
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Undead Keeper campaign"
 msgstr ""
 
 #: guitext:1030
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Quest for the Hero campaign"
 msgstr ""
 
 #: guitext:1031
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Revenge of the Lord"
 msgstr ""
 
 #: guitext:1032
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Twin Keepers Campaign"
 msgstr ""
 
 #: guitext:1033
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
 msgstr ""
 

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -6976,7 +6976,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Čištění: Vyléčí všechny negativní účinky postihující bytost."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -6920,7 +6920,7 @@ msgstr "Zpomaleni"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Letani"
 
 #: guitext:1057

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -6968,3 +6968,48 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -4595,25 +4595,23 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"Urychlit obludu: Zvysi rychlost tvych vybranych oblud. Vyber kouzla se "
-"provadi LTM. [18.4]"
+"Urychlit obludu: Zvysi rychlost tvych vybranych oblud."
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+"Protect Monster: Shields your creatures from attack."
 msgstr ""
-"Ochránit obludu: Ochrání tvé příšeny před útokem. LTM pro zvolení. [18.11]"
+"Ochránit obludu: Ochrání tvé příšeny před útokem."
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"Skryj obludu: Zneviditelní tvé obludy pro nepřátele. LTM pro volbu. [18.7]"
+"Skryj obludu: Zneviditelní tvé obludy pro nepřátele."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -6905,7 +6905,7 @@ msgstr "Hustý zlatý základ: Obsahuje mnoho bohatství, které mohou tví Skř
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "Odražení"
 
 #: guitext:1054

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -6920,7 +6920,7 @@ msgstr "Zpomaleni"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Letani"
 
 #: guitext:1057

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -6903,8 +6903,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Hustý zlatý základ: Obsahuje mnoho bohatství, které mohou tví Skřeti těžit."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Odražení"
 
 #: guitext:1054

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -2272,7 +2272,7 @@ msgstr "Krachtterm: [26.23]"
 #: guitext:248
 msgctxt "Creature spell"
 msgid "Heal: When this is cast, the creature is massively healed."
-msgstr "Genezing: Deze spreuk zorgt voor veel extra gezondheid."
+msgstr "Genezing: Deze spreuk geneest je wezen voor een aanzienlijk deel."
 
 #: guitext:249
 #, fuzzy
@@ -6910,10 +6910,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Dichte Goudader: Bevat veel rijkdom voor je Dondersteentjes om te delven."
 
 #: guitext:1053
-#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
-msgstr "Magisch Schild: Stuurt projectielen afgevuurd op dit Wezen terug naar de aanvaller."
+msgid "Magic Shield"
+msgstr "Magisch Schild"
 
 #: guitext:1054
 msgctxt "Keeper spell name"
@@ -6978,7 +6977,7 @@ msgstr "Kantel Reset"
 #: guitext:1066
 msgctxt "Creature spell"
 msgid "Heal Monster: The target creature is massively healed."
-msgstr "Genees Monster: Maak het tdoelwit extra gezond"
+msgstr "Genees Monster: Geneest het doelwit voor een aanzienlijk deel."
 
 #: guitext:1067
 msgctxt "Creature spell"

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -6988,7 +6988,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Zuiveren: Geneest alle negatieve effecten die op het wezen zijn toegebracht."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -4619,27 +4619,23 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"Monsterversneller: Verhoogt de snelheid van je slaafjes. LMK: selecteren. "
-"[18.4]"
+"Monsterversneller: Verhoogt de snelheid van je slaafjes."
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+"Protect Monster: Shields your creatures from attack."
 msgstr ""
-"Monsterbescherming: Beschermt je wezens tegen aanvallen. LMK: selecteren. "
-"[18.11]"
+"Monsterbescherming: Beschermt je wezens tegen aanvallen."
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"Onzichtbaar: Maakt je wezens onzichtbaar voor de vijand. LMK: selecteren. "
-"[18.7]"
+"Onzichtbaar: Maakt je wezens onzichtbaar voor de vijand."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -6932,7 +6932,7 @@ msgstr "Vertragen"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Vliegen"
 
 #: guitext:1057

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -2206,12 +2206,9 @@ msgid "Group: Not used"
 msgstr "Groep: Niet gebruikt"
 
 #: guitext:239
-#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
-msgstr "Onzichtbaar: [26.12]"
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
+msgstr "Onzichtbaar: Zorgt ervoor dat het wezen niet meer door vijanden gezien wordt, tenzij ze bovennatuurlijk zicht hebben."
 
 #: guitext:240
 #, fuzzy

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -286,7 +286,6 @@ msgstr ""
 
 #. Level Cosyton information soon after start
 #: guitext:22
-#, fuzzy
 msgctxt "In-game message"
 msgid ""
 "When Imps have no other orders, they run around reinforcing your dungeon. "
@@ -2231,15 +2230,14 @@ msgctxt "Creature spell"
 msgid ""
 "Illumination: Brings light onto darkness, allowing the creature to see but "
 "also be seen by others."
-msgstr "Verlichting: Niet gebruikt"
+msgstr "Verlichting"
 
 #: guitext:243
-#, fuzzy
 msgctxt "Creature spell"
 msgid ""
 "Flight: Causes the creature to take off from the ground and attack creatures "
 "from the air."
-msgstr "Vliegen: [26.7]"
+msgstr "Vliegen: Zorgt dat het wezen van de grond komt en vanuit de lucht kan aanvallen."
 
 #: guitext:244
 #, fuzzy
@@ -2272,12 +2270,9 @@ msgid ""
 msgstr "Krachtterm: [26.23]"
 
 #: guitext:248
-#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Heal: When this is cast, the creature is massively healed. Also, any nearby "
-"creatures are healed by a quarter."
-msgstr "Genezing: [26.11]"
+msgid "Heal: When this is cast, the creature is massively healed."
+msgstr "Genezing: Deze spreuk zorgt voor veel extra gezondheid."
 
 #: guitext:249
 #, fuzzy
@@ -6983,7 +6978,7 @@ msgstr "Kantel Reset"
 #: guitext:1066
 msgctxt "Creature spell"
 msgid "Heal Monster: The target creature is massively healed."
-msgstr ""
+"msgstr "Genees Monster: Maak het tdoelwit extra gezond"
 
 #: guitext:1067
 msgctxt "Creature spell"
@@ -6993,22 +6988,22 @@ msgstr "Zuiveren: Geneest alle negatieve effecten die op het wezen zijn toegebra
 #: guitext:1068
 msgctxt "Creature spell"
 msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
-msgstr ""
+msgstr "Zuiver Monster: Geneest alle negatieve effecten die op het doelwit zijn toegebracht."
 
 #: guitext:1069
 msgctxt "Keeper spell description"
 msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
-msgstr ""
+msgstr "Terugkaats-schild: Stuurt projectielen afgevuurd op het doelwit terug naar de aanvaller."
 
 #: guitext:1070
 msgctxt "Keeper spell description"
 msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
-msgstr ""
+msgstr "Opstijgen: Zorgt dat het doelwit van de grond komt en vanuit de lucht kan aanvallen."
 
 #: guitext:1071
 msgctxt "Keeper spell description"
 msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
-msgstr ""
+"msgstr "Helderziendheid: Laat het wezen onzichtbare vijanden zien."
 
 #: guitext:1072 guitext:1073 guitext:1074 guitext:1075
 msgctxt "Unused"
@@ -7018,9 +7013,9 @@ msgstr ""
 #: guitext:1076
 msgctxt "Door name"
 msgid "Midas Door"
-msgstr ""
+msgstr "Deur van Midas"
 
 #: guitext:1077
 msgctxt "Door description"
 msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
-msgstr ""
+msgstr "Deur van Midas: Vreet goud van de eigenaar om onverwoestbaar te blijven. RMK: inzoomen."

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -6928,7 +6928,7 @@ msgstr "Vertragen"
 #: guitext:1056
 msgctxt "Keeper spell name"
 msgid "Levitate"
-msgstr "Vliegen"
+msgstr "Opstijgen"
 
 #: guitext:1057
 msgctxt "Keeper spell name"
@@ -6978,7 +6978,7 @@ msgstr "Kantel Reset"
 #: guitext:1066
 msgctxt "Creature spell"
 msgid "Heal Monster: The target creature is massively healed."
-"msgstr "Genees Monster: Maak het tdoelwit extra gezond"
+msgstr "Genees Monster: Maak het tdoelwit extra gezond"
 
 #: guitext:1067
 msgctxt "Creature spell"
@@ -7003,7 +7003,7 @@ msgstr "Opstijgen: Zorgt dat het doelwit van de grond komt en vanuit de lucht ka
 #: guitext:1071
 msgctxt "Keeper spell description"
 msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
-"msgstr "Helderziendheid: Laat het wezen onzichtbare vijanden zien."
+msgstr "Helderziendheid: Laat het wezen onzichtbare vijanden zien."
 
 #: guitext:1072 guitext:1073 guitext:1074 guitext:1075
 msgctxt "Unused"

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -6932,7 +6932,7 @@ msgstr "Vertragen"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Vliegen"
 
 #: guitext:1057

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -6985,3 +6985,48 @@ msgstr "Kantel Omlaag"
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr "Kantel Reset"
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -6733,117 +6733,117 @@ msgid "Moo4"
 msgstr ""
 
 #: guitext:1011
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - Original Campaign"
 msgstr "Dungeon Keeper - Originele Campagne"
 
 #: guitext:1012
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Assmist Isle"
 msgstr ""
 
 #: guitext:1013
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1014
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Burdened Imps' Level Pack"
 msgstr ""
 
 #: guitext:1015
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Conquest of the Arctic"
 msgstr ""
 
 #: guitext:1016
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "The Destiny of Ninja"
 msgstr "The Legende van de Ninja"
 
 #: guitext:1017
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's  6-level campaign"
 msgstr "DzjeeAr's campagne met  6 levels"
 
 #: guitext:1018
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 10-level campaign"
 msgstr "DzjeeAr's campagne met 10 levels"
 
 #: guitext:1019
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 25-level campaign"
 msgstr "DzjeeAr's campagne met 25 levels"
 
 #: guitext:1020
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Evil Keeper campaign"
 msgstr ""
 
 #: guitext:1021
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Grinics' KReign campaign"
 msgstr ""
 
 #: guitext:1022
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Japanese DKMaps8 pack"
 msgstr ""
 
 #: guitext:1023
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "KDK Levels"
 msgstr ""
 
 #: guitext:1024
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Good Campaign"
 msgstr "Helden Campagne"
 
 #: guitext:1025
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Lord Vexer campaign"
 msgstr ""
 
 #: guitext:1026
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Nikolai's Castles campaign"
 msgstr "Nikolais Kasteel"
 
 #: guitext:1027
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - NG+"
 msgstr ""
 
 #: guitext:1028
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1029
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Undead Keeper campaign"
 msgstr ""
 
 #: guitext:1030
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Quest for the Hero campaign"
 msgstr ""
 
 #: guitext:1031
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Revenge of the Lord"
 msgstr ""
 
 #: guitext:1032
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Twin Keepers Campaign"
 msgstr ""
 
 #: guitext:1033
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
 msgstr ""
 

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -2143,7 +2143,7 @@ msgstr "Bliksem: [26.13]"
 #, fuzzy
 msgctxt "Creature spell"
 msgid "Rebound: Causes any spell fired at you to bounce back at the attacker."
-msgstr "Terugkaatsen: [26.18]"
+msgstr "Terugkaatsen: Stuurt projectielen terug naar de aanvaller."
 
 #: guitext:231
 #, fuzzy
@@ -6915,9 +6915,10 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Dichte Goudader: Bevat veel rijkdom voor je Dondersteentjes om te delven."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
-msgstr "Terugkaatsen"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr "Magisch Schild: Stuurt projectielen afgevuurd op dit Wezen terug naar de aanvaller."
 
 #: guitext:1054
 msgctxt "Keeper spell name"

--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -1472,7 +1472,7 @@ msgstr ""
 
 #: guitext:239
 msgctxt "Creature spell"
-msgid "Invisibility: Cast on one of your minions, it makes the host creature invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr ""
 
 #: guitext:240
@@ -3560,17 +3560,17 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
 
 #: guitext:655
 msgctxt "Keeper spell description"
-msgid "Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+msgid "Protect Monster: Shields your creatures from attack. LBM select."
 msgstr ""
 
 #: guitext:656
 msgctxt "Keeper spell description"
-msgid "Conceal Monster: Makes your creatures invisible to the enemy. LMB select. [18.7]"
+msgid "Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
 
 #: guitext:657
@@ -5565,7 +5565,7 @@ msgstr ""
 
 #: guitext:1053
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr ""
 
 #: guitext:1054
@@ -5580,7 +5580,7 @@ msgstr ""
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr ""
 
 #: guitext:1057
@@ -5590,7 +5590,7 @@ msgstr ""
 
 #: guitext:1058
 msgctxt "Keeper spell name"
-msgid "Sight"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
 msgstr ""
 
 #: guitext:1059
@@ -5626,4 +5626,24 @@ msgstr ""
 #: guitext:1065
 msgctxt "Game controls"
 msgid "Reset Tilt"
+msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067 guitext:1068 guitext:1069 guitext:1070
+msgctxt "Unused"
+msgid "Moo7"
+msgstr ""
+
+#: guitext:1071
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1072
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
 msgstr ""

--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -5633,31 +5633,41 @@ msgid "Heal Monster: The target creature is massively healed."
 msgstr ""
 
 #: guitext:1067
-msgctxt "Keeper spell description"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
 msgstr ""
 
 #: guitext:1068
-msgctxt "Keeper spell description"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
 msgstr ""
 
 #: guitext:1069
 msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
 msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
 msgstr ""
 
-#: guitext:1070 guitext:1071 guitext:1072 guitext:1073 guitext:1074
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
 msgctxt "Unused"
-msgid "Moo7"
+msgid "Moo8"
 msgstr ""
 
-#: guitext:1075
+#: guitext:1076
 msgctxt "Door name"
 msgid "Midas Door"
 msgstr ""
 
-#: guitext:1076
+#: guitext:1077
 msgctxt "Door description"
 msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
 msgstr ""

--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -3538,9 +3538,8 @@ msgstr ""
 
 #: guitext:650
 msgctxt "Keeper spell description"
-msgid ""
-"Call To Arms: Calls creatures in range to any destination. LMB Select. Cast in range of creatures to gather, cast again for destination. RMB zoom. LMB Cancel. "
-"[18.6]"
+msgid "Call To Arms: Calls creatures in range to any destination. LMB Select. Cast in range of creatures to gather, cast again for destination."
+"RMB zoom. LMB Cancel. [18.6]"
 msgstr ""
 
 #: guitext:651
@@ -5565,7 +5564,7 @@ msgstr ""
 
 #: guitext:1053
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr ""
 
 #: guitext:1054
@@ -5580,7 +5579,7 @@ msgstr ""
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr ""
 
 #: guitext:1057
@@ -5590,7 +5589,7 @@ msgstr ""
 
 #: guitext:1058
 msgctxt "Keeper spell name"
-msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgid "Sight"
 msgstr ""
 
 #: guitext:1059
@@ -5633,17 +5632,32 @@ msgctxt "Creature spell"
 msgid "Heal Monster: The target creature is massively healed."
 msgstr ""
 
-#: guitext:1067 guitext:1068 guitext:1069 guitext:1070
+#: guitext:1067
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1070 guitext:1071 guitext:1072 guitext:1073 guitext:1074
 msgctxt "Unused"
 msgid "Moo7"
 msgstr ""
 
-#: guitext:1071
+#: guitext:1075
 msgctxt "Door name"
 msgid "Midas Door"
 msgstr ""
 
-#: guitext:1072
+#: guitext:1076
 msgctxt "Door description"
 msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
 msgstr ""

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -7152,7 +7152,7 @@ msgstr "Veine d'or dense : Contient beaucoup de richesses que vos Lutins peuvent
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "Rebond"
 
 #: guitext:1054

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -7150,8 +7150,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Veine d'or dense : Contient beaucoup de richesses que vos Lutins peuvent extraire."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Rebond"
 
 #: guitext:1054

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -7167,7 +7167,7 @@ msgstr "Lenteur"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Lévitation"
 
 #: guitext:1057

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -7167,7 +7167,7 @@ msgstr "Lenteur"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Lévitation"
 
 #: guitext:1057

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -2238,14 +2238,13 @@ msgid "Group: Not used"
 msgstr "Contrôle de groupe : Non utilisé"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr ""
 "Invisibilité : Lancé sur un de vos larbins, il rend la créature hôte "
 "invisible pour tous les ennemis. A moins qu'ils ne possèdent une vue "
-"médiocre[26.12]"
+"médiocre."
 
 #: guitext:240
 msgctxt "Creature spell"

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -6973,117 +6973,117 @@ msgid "Moo4"
 msgstr ""
 
 #: guitext:1011
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - Original Campaign"
 msgstr "Dungeon Keeper - Campagne Originale"
 
 #: guitext:1012
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Assmist Isle"
 msgstr ""
 
 #: guitext:1013
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1014
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Burdened Imps' Level Pack"
 msgstr ""
 
 #: guitext:1015
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Conquest of the Arctic"
 msgstr ""
 
 #: guitext:1016
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "The Destiny of Ninja"
 msgstr ""
 
 #: guitext:1017
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's  6-level campaign"
 msgstr ""
 
 #: guitext:1018
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 10-level campaign"
 msgstr ""
 
 #: guitext:1019
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 25-level campaign"
 msgstr ""
 
 #: guitext:1020
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Evil Keeper campaign"
 msgstr ""
 
 #: guitext:1021
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Grinics' KReign campaign"
 msgstr ""
 
 #: guitext:1022
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Japanese DKMaps8 pack"
 msgstr ""
 
 #: guitext:1023
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "KDK Levels"
 msgstr ""
 
 #: guitext:1024
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Good Campaign"
 msgstr ""
 
 #: guitext:1025
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Lord Vexer campaign"
 msgstr ""
 
 #: guitext:1026
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Nikolai's Castles campaign"
 msgstr ""
 
 #: guitext:1027
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - NG+"
 msgstr ""
 
 #: guitext:1028
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1029
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Undead Keeper campaign"
 msgstr ""
 
 #: guitext:1030
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Quest for the Hero campaign"
 msgstr ""
 
 #: guitext:1031
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Revenge of the Lord"
 msgstr ""
 
 #: guitext:1032
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Twin Keepers Campaign"
 msgstr ""
 
 #: guitext:1033
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
 msgstr ""
 

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -4725,26 +4725,22 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"Accélérateur de monstre : Augmente la vitesse de vos monstres. Sélectionnez "
-"avec le bouton gauche de la souris. [18.4]"
+"Accélérateur de monstre : Augmente la vitesse de vos monstres."
 
 #: guitext:655
 msgctxt "Keeper spell description"
-msgid "Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+msgid "Protect Monster: Shields your creatures from attack."
 msgstr ""
-"Protection : Protège avec efficacité vos créatures de toute attaque. "
-"Sélectionnez avec le bouton gauche de la souris. [18.11]"
+"Protection : Protège avec efficacité vos créatures de toute attaque."
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"Invisibilité : Vos créatures sont invisibles pour l'ennemi. Sélectionnez avec "
-"le bouton gauche de la souris. [18.7]"
+"Invisibilité : Vos créatures sont invisibles pour l'ennemi."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -7218,3 +7218,48 @@ msgstr "Incliner Bas"
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr "Réinitialiser"
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -7223,7 +7223,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Purifier : Guérit tous les effets négatifs infligés à la créature."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -2238,13 +2238,9 @@ msgid "Group: Not used"
 msgstr "Contrôle de groupe : Non utilisé"
 
 #: guitext:239
-#, fuzzy
 msgctxt "Creature spell"
 msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
-msgstr ""
-"Invisibilité : Lancé sur un de vos larbins, il rend la créature hôte "
-"invisible pour tous les ennemis. A moins qu'ils ne possèdent une vue "
-"médiocre."
+msgstr "La créature ciblée devient invisible pour tous les ennemis. À moins qu’ils ne possèdent une vision surnaturelle."
 
 #: guitext:240
 msgctxt "Creature spell"
@@ -7153,7 +7149,7 @@ msgstr "Veine d'or dense : Contient beaucoup de richesses que vos Lutins peuvent
 #, fuzzy
 msgctxt "Keeper spell name"
 msgid "Magic Shield"
-msgstr "Rebond"
+msgstr "Bouclier Magique"
 
 #: guitext:1054
 msgctxt "Keeper spell name"
@@ -7218,44 +7214,44 @@ msgstr "Réinitialiser"
 #: guitext:1066
 msgctxt "Creature spell"
 msgid "Heal Monster: The target creature is massively healed."
-msgstr ""
+msgstr "Guérison : La créature ciblée est massivement soignée."
 
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr "Purifier : Guérit tous les effets négatifs infligés à la créature."
+msgstr "Purifier : Guérit de tous les effets négatifs infligés à la créature."
 
 #: guitext:1068
 msgctxt "Creature spell"
 msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
-msgstr ""
+msgstr "Purifier : Guérit de tous les effets négatifs infligés à la créature ciblée."
 
 #: guitext:1069
 msgctxt "Keeper spell description"
 msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
-msgstr ""
+msgstr "Bouclier Magique : Fait rebondir les projectiles lancés sur la cible sur l'attaquant."
 
 #: guitext:1070
 msgctxt "Keeper spell description"
 msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
-msgstr ""
+msgstr "Lévitation : Permet à la créature ciblée de flotter afin d'attaquer depuis les airs ou de traverser la lave indemne."
 
 #: guitext:1071
 msgctxt "Keeper spell description"
 msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
-msgstr ""
+msgstr "Vision : Permet à la créature ciblée d'augmenter temporairement sa vision pour débusquer l'invisible."
 
 #: guitext:1072 guitext:1073 guitext:1074 guitext:1075
 msgctxt "Unused"
 msgid "Moo8"
-msgstr ""
+msgstr "Moooooooooo!"
 
 #: guitext:1076
 msgctxt "Door name"
 msgid "Midas Door"
-msgstr ""
+msgstr "Porte de Midas"
 
 #: guitext:1077
 msgctxt "Door description"
 msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
-msgstr ""
+msgstr "Porte de Midas: Cette porte est indestructible tant que son propriétaire a suffisament d'or. CDS voir."

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7060,8 +7060,8 @@ msgstr "Dichte Goldader: Enthält viel Reichtum, den Eure Imps abbauen können."
 
 #: guitext:1053
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
-msgstr "Abprall: Fliegende Geschossen werden auf den ursprünglichen Beschwörer zurückgeworfen."
+msgid "Magic Shield"
+msgstr "Abprall"
 
 #: guitext:1054
 msgctxt "Keeper spell name"
@@ -7141,7 +7141,7 @@ msgstr "Kuriert alle Statuseffekte von Verbündeten."
 #: guitext:1069
 msgctxt "Keeper spell description"
 msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
-msgstr ""
+msgstr "Abprall: Fliegende Geschossen werden auf den ursprünglichen Beschwörer zurückgeworfen."
 
 #: guitext:1070
 msgctxt "Keeper spell description"

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7131,7 +7131,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Reinigen: Heilt alle negativen Effekte, die der Kreatur zugefügt wurden."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7059,8 +7059,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Dichte Goldader: Enthält viel Reichtum, den Eure Imps abbauen können."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Abprall"
 
 #: guitext:1054

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7161,9 +7161,9 @@ msgstr ""
 #: guitext:1076
 msgctxt "Door name"
 msgid "Midas Door"
-msgstr "Magische Tür"
+msgstr "Habgierige Tür"
 
 #: guitext:1077
 msgctxt "Door description"
 msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
-msgstr "Magische Tür: Diese Tür verbraucht Gold um unzerstörbar zu werden."
+msgstr "Habgierige Tür: Diese Tür verbraucht Gold um unzerstörbar zu werden."

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7111,17 +7111,17 @@ msgstr "Mauern schwächen: Zerstört die Befestigungen der feindlichen Mauern."
 #: guitext:1063
 msgctxt "Game controls"
 msgid "Tilt Up"
-msgstr "Neigen Hoch"
+msgstr "Neigung erhöhen"
 
 #: guitext:1064
 msgctxt "Game controls"
 msgid "Tilt Down"
-msgstr "Neigen Runter"
+msgstr "Neigung senken"
 
 #: guitext:1065
 msgctxt "Game controls"
 msgid "Reset Tilt"
-msgstr "Neigung Zurück"
+msgstr "Neigung zurücksetzen"
 
 #: guitext:1066
 msgctxt "Creature spell"
@@ -7136,7 +7136,7 @@ msgstr "Reinigen: Heilt alle negativen Effekte, die der Kreatur zugefügt wurden
 #: guitext:1068
 msgctxt "Creature spell"
 msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
-msgstr "Kuriert alle Statuseffekte von Verbündeten."
+msgstr "Monster reinigen: Kuriert alle Statuseffekte von Verbündeten."
 
 #: guitext:1069
 msgctxt "Keeper spell description"

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7059,7 +7059,6 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Dichte Goldader: Enthält viel Reichtum, den Eure Imps abbauen können."
 
 #: guitext:1053
-#, fuzzy
 msgctxt "Keeper spell name"
 msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Abprall: Fliegende Geschossen werden auf den ursprünglichen Beschwörer zurückgeworfen."
@@ -7123,6 +7122,7 @@ msgstr "Neigen Runter"
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr "Neigung Zurück"
+
 #: guitext:1066
 msgctxt "Creature spell"
 msgid "Heal Monster: The target creature is massively healed."

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -4657,18 +4657,16 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"Monster beschleunigen: Macht Euren Monstern Beine. Mit der linken Maustaste "
-"wählen. [18.4]"
+"Monster beschleunigen: Macht Euren Monstern Beine."
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+"Protect Monster: Shields your creatures from attack."
 msgstr ""
-"Schutzschild: Bewahrt Eure Kreaturen vor Schaden. Mit der linken Maustaste wählen. "
-"[18.11]"
+"Schutzschild: Bewahrt Eure Kreaturen vor Schaden."
 
 #: guitext:656
 msgctxt "Keeper spell description"
@@ -4676,8 +4674,7 @@ msgid ""
 "Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
 "[18.7]"
 msgstr ""
-"Monster verbergen: Macht Eure Kreatur für den Gegner unsichtbar. Mit der "
-"linken Maustaste wählen. [18.7]"
+"Monster verbergen: Macht Eure Kreatur für den Gegner unsichtbar."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7062,7 +7062,7 @@ msgstr "Dichte Goldader: Enthält viel Reichtum, den Eure Imps abbauen können."
 #, fuzzy
 msgctxt "Keeper spell name"
 msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
-msgstr "Abprall"
+msgstr "Abprall: Fliegende Geschossen werden auf den ursprünglichen Beschwörer zurückgeworfen."
 
 #: guitext:1054
 msgctxt "Keeper spell name"
@@ -7126,7 +7126,7 @@ msgstr "Neigung Zurück"
 #: guitext:1066
 msgctxt "Creature spell"
 msgid "Heal Monster: The target creature is massively healed."
-msgstr ""
+msgstr "Monster heilen: ein Zauberspruch um andere Verbündete zu heilen"
 
 #: guitext:1067
 msgctxt "Creature spell"
@@ -7136,7 +7136,7 @@ msgstr "Reinigen: Heilt alle negativen Effekte, die der Kreatur zugefügt wurden
 #: guitext:1068
 msgctxt "Creature spell"
 msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
-msgstr ""
+msgstr "Kuriert alle Statuseffekte von Verbündeten."
 
 #: guitext:1069
 msgctxt "Keeper spell description"
@@ -7146,12 +7146,12 @@ msgstr ""
 #: guitext:1070
 msgctxt "Keeper spell description"
 msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
-msgstr ""
+msgstr "Fliegen: Lässt Kreaturen schweben."
 
 #: guitext:1071
 msgctxt "Keeper spell description"
 msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
-msgstr ""
+msgstr "Böser Blick: lässt eure Kreaturen andere unsichtbare Kreaturen sehen."
 
 #: guitext:1072 guitext:1073 guitext:1074 guitext:1075
 msgctxt "Unused"
@@ -7161,9 +7161,9 @@ msgstr ""
 #: guitext:1076
 msgctxt "Door name"
 msgid "Midas Door"
-msgstr ""
+msgstr "Magische Tür"
 
 #: guitext:1077
 msgctxt "Door description"
 msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
-msgstr ""
+msgstr "Magische Tür: Diese Tür verbraucht Gold um unzerstörbar zu werden."

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7076,7 +7076,7 @@ msgstr "Verlangsamen"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Flug"
 
 #: guitext:1057

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7076,7 +7076,7 @@ msgstr "Verlangsamen"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Flug"
 
 #: guitext:1057

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7126,3 +7126,47 @@ msgstr "Neigen Runter"
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr "Neigung Zurück"
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -2268,11 +2268,10 @@ msgid "Group: Not used"
 msgstr "Gruppe: Ungebraucht"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
-msgstr "Tarnung: Auf eine Eurer Kreaturen angewendet, wird diese für alle Feinde unsichtbar, ausser gegen Feinde mit aktivierter Sicht.[26.12]"
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
+msgstr "Tarnung: Auf eine Eurer Kreaturen angewendet, wird diese für alle Feinde unsichtbar, ausser gegen Feinde mit aktivierter Sicht."
 
 #: guitext:240
 msgctxt "Creature spell"

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -7007,7 +7007,7 @@ msgstr "Vena d'oro densa: Contiene molta ricchezza che i tuoi Folletti possono e
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "Rimbalzo"
 
 #: guitext:1054

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -6287,8 +6287,7 @@ msgstr ""
 #: guitext:920
 msgctxt "In-game message"
 msgid "Decimate this outpost and send fear into the heart of the Avatar."
-msgstr ""
-"Fai una strage nell'avamposto nemico e incuti il terrore nel cuore dell'Avatar."
+msgstr "Fai una strage nell'avamposto nemico e incuti il terrore nel cuore dell'Avatar."
 
 #. DD Level Belial objective after AP reached
 #: guitext:921
@@ -6501,7 +6500,6 @@ msgid "Your Imp cannot reach a room to drag something into"
 msgstr "Un tuo Imp non può raggiungere una stanza per portarci qualcosa"
 
 #: guitext:948
-#, fuzzy
 msgctxt "Game event description"
 msgid "Storage room unreachable: LMB toggle. RMB delete."
 msgstr "Deposito irraggiungibile. TSM: attiva - disattiva. TDM: cancella."
@@ -6531,7 +6529,6 @@ msgid "Research Skill: unused."
 msgstr "Capacità di ricerca: non utilizzato."
 
 #: guitext:953
-#, fuzzy
 msgctxt "In-game interface description"
 msgid ""
 "Manufacture Skill: How fast the creature works in Workshop. The higher the "
@@ -6541,7 +6538,6 @@ msgstr ""
 "è il livello di abilità e migliore è la prestazione della creatura."
 
 #: guitext:954
-#, fuzzy
 msgctxt "In-game interface description"
 msgid ""
 "Training Skill: How fast the creature works on training. The higher the "
@@ -6551,7 +6547,6 @@ msgstr ""
 "livello di abilità e migliore è la prestazione della creatura."
 
 #: guitext:955
-#, fuzzy
 msgctxt "In-game interface description"
 msgid ""
 "Scavenge Skill: How fast the creature works on scavenging. The higher the "
@@ -6594,7 +6589,6 @@ msgid "Hand Of Evil"
 msgstr "Mano del male"
 
 #: guitext:961
-#, fuzzy
 msgctxt "Keeper spell name"
 msgid "Slap"
 msgstr "Schiaffi"
@@ -6609,7 +6603,6 @@ msgstr ""
 "Basta non tenerle per sempre o possono diventare irritati."
 
 #: guitext:963
-#, fuzzy
 msgctxt "Keeper spell description"
 msgid ""
 "Slap: Makes your creatures work harder, for some time. Your creatures take "
@@ -6826,13 +6819,11 @@ msgid "Display Resolution: Switch to the next configured display resolution. LMB
 msgstr "Risoluzione display: passa alla successiva risoluzione display configurata. LMB toggle. RMB visualizza la risoluzione corrente."
 
 #: guitext:1008
-#, fuzzy
 msgctxt "In-game interface item"
 msgid "Voice"
 msgstr "Voce"
 
 #: guitext:1009
-#, fuzzy
 msgctxt "In-game interface item"
 msgid "Ambience"
 msgstr "Ambiente"
@@ -7021,7 +7012,6 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Vena d'oro densa: Contiene molta ricchezza che i tuoi Folletti possono estrarre."
 
 #: guitext:1053
-#, fuzzy
 msgctxt "Keeper spell name"
 msgid "Magic Shield"
 msgstr "Rimbalzo"
@@ -7128,5 +7118,5 @@ msgstr "Porta di Mida"
 
 #: guitext:1077
 msgctxt "Door description"
-msgid "Porta di Mida: Questa porta consuma oro del suo proprietario per rimanere indistruttibile. RMB zoom."
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
 msgstr "Porta di Mida: Questa porta consuma oro del suo proprietario per rimanere indistruttibile. RMB zoom."

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -7005,8 +7005,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Vena d'oro densa: Contiene molta ricchezza che i tuoi Folletti possono estrarre."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Rimbalzo"
 
 #: guitext:1054

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -4682,27 +4682,23 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"Velocizza Creatura: Aumenta la velocità delle tue creature. TSM: seleziona. "
-"[18.4]"
+"Velocizza Creatura: Aumenta la velocità delle tue creature."
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+"Protect Monster: Shields your creatures from attack."
 msgstr ""
-"Proteggi Creatura: Ripara le tue creature da un attacco. TSM: seleziona. "
-"[18.11]"
+"Proteggi Creatura: Ripara le tue creature da un attacco."
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"Nascondi Creatura: Rende le tue creature invisibili agli occhi del nemico. "
-"TSM: seleziona. [18.7]"
+"Nascondi Creatura: Rende le tue creature invisibili agli occhi del nemico."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -7074,3 +7074,49 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -7078,7 +7078,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Purifica: Cura tutti gli effetti negativi inflitti alla creatura."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -7022,7 +7022,7 @@ msgstr "Rallentamento"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Volo"
 
 #: guitext:1057

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -2231,9 +2231,7 @@ msgstr "Gruppo: Non usato"
 #: guitext:239
 #, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr "Invisibilità: [26.12]"
 
 #: guitext:240
@@ -7074,7 +7072,6 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
-
 
 #: guitext:1066
 msgctxt "Creature spell"

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -6288,7 +6288,7 @@ msgstr ""
 msgctxt "In-game message"
 msgid "Decimate this outpost and send fear into the heart of the Avatar."
 msgstr ""
-"Mena strage nell'avamposto nemico e incuti il terrore nel cuore dell'Avatar."
+"Fai una strage nell'avamposto nemico e incuti il terrore nel cuore dell'Avatar."
 
 #. DD Level Belial objective after AP reached
 #: guitext:921
@@ -6472,39 +6472,39 @@ msgstr ""
 #, fuzzy
 msgctxt "Menu interface item"
 msgid "Land selection"
-msgstr ""
+msgstr "Selezione terra"
 
 #: guitext:943
 msgctxt "Menu interface item"
 msgid "Campaigns"
-msgstr "Campaigns"
+msgstr "Campaigne"
 
 #: guitext:944
 msgctxt "Menu interface item"
 msgid "Add computer"
-msgstr "Add computer"
+msgstr "Aggiungi computer"
 
 #: guitext:945
 msgctxt "Game event name"
 msgid "Your creature cannot reach the room it needs"
-msgstr ""
+msgstr "Una tua creatura non può raggiungere la stanza di cui ha bisogno"
 
 #: guitext:946
 #, fuzzy
 msgctxt "Game event description"
 msgid "Work room unreachable: LMB toggle. RMB delete."
-msgstr "Work room unreachable. TSM: attiva - disattiva. TDM: cancella."
+msgstr "La stanza di lavoro non è raggiungibile. TSM: attiva - disattiva. TDM: cancella."
 
 #: guitext:947
 msgctxt "Game event name"
 msgid "Your Imp cannot reach a room to drag something into"
-msgstr ""
+msgstr "Un tuo Imp non può raggiungere una stanza per portarci qualcosa"
 
 #: guitext:948
 #, fuzzy
 msgctxt "Game event description"
 msgid "Storage room unreachable: LMB toggle. RMB delete."
-msgstr "Storage room unreachable. TSM: attiva - disattiva. TDM: cancella."
+msgstr "Deposito irraggiungibile. TSM: attiva - disattiva. TDM: cancella."
 
 #: guitext:949
 msgctxt "In-game interface description"
@@ -6512,21 +6512,23 @@ msgid ""
 "Armour: Part of the damage which won't affect creature health. The higher "
 "the number, the larger part of damage is discarded."
 msgstr ""
+"Armatura: Parte del danno che non influisce sulla salute della creatura. Più alto "
+"è il valore e maggiore è il danno evitato."
 
 #: guitext:950
 msgctxt "In-game interface description"
 msgid "Speed: How fast the creature moves and perform its dungeon tasks."
-msgstr ""
+msgstr "Velocità: Quanto velocemente la creatura si muove ed esegue i suoi compiti di dungeon."
 
 #: guitext:951
 msgctxt "In-game interface description"
 msgid "Loyalty: How resistant the creature is against scavenging by the enemy."
-msgstr ""
+msgstr "Lealtà: Quanto è resistente la creatura contro lo scavenging da parte del nemico."
 
 #: guitext:952
 msgctxt "In-game interface description"
 msgid "Research Skill: unused."
-msgstr ""
+msgstr "Capacità di ricerca: non utilizzato."
 
 #: guitext:953
 #, fuzzy
@@ -6535,7 +6537,8 @@ msgid ""
 "Manufacture Skill: How fast the creature works in Workshop. The higher the "
 "Skill level, the better the creature's performance."
 msgstr ""
-"Abilità: L'abilità della creatura nell'eseguire i suoi compiti. [23.14]"
+"Abilità: Quanto velocemente la creatura lavora su Workshop. Più alto "
+"è il livello di abilità e migliore è la prestazione della creatura."
 
 #: guitext:954
 #, fuzzy
@@ -6544,7 +6547,8 @@ msgid ""
 "Training Skill: How fast the creature works on training. The higher the "
 "Skill level, the better the creature's performance."
 msgstr ""
-"Abilità: L'abilità della creatura nell'eseguire i suoi compiti. [23.14]"
+"Abilità: Quanto velocemente la creatura lavora sull'allenamento. Più alto è il "
+"livello di abilità e migliore è la prestazione della creatura."
 
 #: guitext:955
 #, fuzzy
@@ -6553,17 +6557,18 @@ msgid ""
 "Scavenge Skill: How fast the creature works on scavenging. The higher the "
 "Skill level, the better the creature's performance."
 msgstr ""
-"Abilità: L'abilità della creatura nell'eseguire i suoi compiti. [23.14]"
+"Abilità: Quanto velocemente la creatura lavora su Scavenging. Più alto "
+"è il livello di abilità e migliore è la prestazione della creatura."
 
 #: guitext:956
 msgctxt "In-game interface description"
 msgid "Training Cost: Gold used for training the creature."
-msgstr ""
+msgstr "Costo addestramento: Oro usato per addestrare la creatura."
 
 #: guitext:957
 msgctxt "In-game interface description"
 msgid "Scavenge Cost: Gold used for scavenging by the creature."
-msgstr ""
+msgstr "Costo di Scavenge: Oro usato per la scavenging dalla creatura."
 
 #: guitext:958
 msgctxt "In-game interface description"
@@ -6571,6 +6576,8 @@ msgid ""
 "Best Damage: How much harm can be made by the strongest attack the creature "
 "has."
 msgstr ""
+"Miglior danno: Quanto danno può essere fatto dal più forte attacco che"
+"la creatura ha."
 
 #: guitext:959
 msgctxt "In-game interface description"
@@ -6578,11 +6585,13 @@ msgid ""
 "Weight: Mass of the creature. Some people say overweight can lead to heart "
 "attack."
 msgstr ""
+"Peso: Peso della creatura. Alcune persone dicono che il sovrappeso può portare ad"
+"attacchi di cuore."
 
 #: guitext:960
 msgctxt "Keeper spell name"
 msgid "Hand Of Evil"
-msgstr ""
+msgstr "Mano del male"
 
 #: guitext:961
 #, fuzzy
@@ -6596,6 +6605,8 @@ msgid ""
 "Hand Of Evil: Ability to pick up your creatures and hold them in your hand. "
 "Just don't hold them forever or they may get irritated."
 msgstr ""
+"Mano del male: Capacità di raccogliere le tue creature e tenerle in mano. "
+"Basta non tenerle per sempre o possono diventare irritati."
 
 #: guitext:963
 #, fuzzy
@@ -6612,18 +6623,22 @@ msgctxt "Keeper spell description"
 msgid "Slap: Makes your creatures work harder, for some time. "
 "Your creatures take some damage from each slap they receive."
 msgstr ""
+"Schiaffo: Fa lavorare di più le tue creature, per un po' di tempo. "
+"Le tue creature subiscono danni da ogni schiaffo che ricevono."
 
 #: guitext:965
 msgctxt "In-game interface description"
 msgid ""
 "Health: How much health points the creature has left to lose."
 msgstr ""
+"Salute: quanti punti di vita ha perso la creatura."
 
 #: guitext:966
 msgctxt "In-game interface description"
 msgid ""
 "Health: The maximum amount of health points for this creature."
 msgstr ""
+"Salute: la quantità massima di punti salute per questa creatura."
 
 #: guitext:967
 msgctxt "Menu interface item"
@@ -6678,112 +6693,112 @@ msgstr ""
 #: guitext:981
 msgctxt "Trap names"
 msgid "Special Trap"
-msgstr ""
+msgstr "Trappola Speciale"
 
 #: guitext:982
 msgctxt "Trap names"
 msgid "Freeze Trap"
-msgstr ""
+msgstr "Trappola Congelante"
 
 #: guitext:983
 msgctxt "Trap names"
 msgid "Fear Trap"
-msgstr ""
+msgstr "Trappola Paura"
 
 #: guitext:984
 msgctxt "Trap names"
 msgid "Sentry Trap"
-msgstr ""
+msgstr "Trappola Sentinella"
 
 #: guitext:985
 msgctxt "Trap names"
 msgid "Mimic Trap"
-msgstr ""
+msgstr "Trappola Mimic"
 
 #: guitext:986
 msgctxt "Trap names"
 msgid "Spawn Trap"
-msgstr ""
+msgstr "Trappola Generatrice"
 
 #: guitext:987
 msgctxt "Trap names"
 msgid "Wind Trap"
-msgstr ""
+msgstr "Trappola Vento"
 
 #: guitext:988
 msgctxt "Trap names"
 msgid "Spitfire Trap"
-msgstr ""
+msgstr "Trappola Sputafuoco"
 
 #: guitext:989
 msgctxt "Trap names"
 msgid "Chicken Trap"
-msgstr ""
+msgstr "Trappola Pollo"
 
 #: guitext:990
 msgctxt "Trap names"
 msgid "Disease Trap"
-msgstr ""
+msgstr "Trappola Malattia"
 
 #: guitext:991
 msgctxt "Trap names"
 msgid "Power Trap"
-msgstr ""
+msgstr "Trappola di Potere"
 
 #: guitext:992
 msgctxt "Trap names"
 msgid "Switch"
-msgstr ""
+msgstr "Interruttore"
 
 #: guitext:993
 msgctxt "Trap names"
 msgid "Hidden Switch"
-msgstr ""
+msgstr "interruttore nascosto"
 
 #: guitext:994
 msgctxt "Door name"
 msgid "Special Door"
-msgstr ""
+msgstr "Posta speciale"
 
 #: guitext:995
 msgctxt "Door name"
 msgid "Hidden Door"
-msgstr ""
+msgstr "Porta Nascosta"
 
 #: guitext:996
 msgctxt "Mouse"
 msgid "Scroll Wheel Up"
-msgstr ""
+msgstr "Scorri rotella su"
 
 #: guitext:997
 msgctxt "Mouse"
 msgid "Scroll Wheel Down"
-msgstr ""
+msgstr "Scorri rotella giù"
 
 #: guitext:998
 msgctxt "Mouse"
 msgid "Mouse Button"
-msgstr ""
+msgstr "Tasto Mouse"
 
 #: guitext:999
 msgctxt "Game controls"
 msgid "Build Square Room"
-msgstr ""
+msgstr "Costruisci una stanza quadrata"
 
 #: guitext:1000
 msgctxt "Game controls"
 msgid "Detect Room"
-msgstr ""
+msgstr "Rilevare la stanza"
 
 #: guitext:1001
 msgctxt "Game controls"
 msgid "Increase Room Size"
-msgstr ""
+msgstr "Aumenta dimansione stanza"
 
 #: guitext:1002
 msgctxt "Game controls"
 msgid "Decrease Room Size"
-msgstr ""
+msgstr "Riduce dimensione stanza"
 
 #: guitext:1003
 msgctxt "Game controls"
@@ -6793,34 +6808,34 @@ msgstr ""
 #: guitext:1004
 msgctxt "Game controls"
 msgid "Snap Camera"
-msgstr ""
+msgstr "Snap Camera"
 
 #: guitext:1005
 msgctxt "Dungeon special decription"
 msgid "Mysterious Box: There's no telling what this will do."
-msgstr ""
+msgstr "Scatola misteriosa: non si sa cosa farà."
 
 #: guitext:1006
 msgctxt "Network game message"
 msgid "Joined player has different map version from host."
-msgstr ""
+msgstr "Il giocatore unito alla partita ha versione  della mappa differente."
 
 #: guitext:1007
 msgctxt "In-game interface description"
 msgid "Display Resolution: Switch to the next configured display resolution. LMB toggle. RMB display current resolution."
-msgstr ""
+msgstr "Risoluzione display: passa alla successiva risoluzione display configurata. LMB toggle. RMB visualizza la risoluzione corrente."
 
 #: guitext:1008
 #, fuzzy
 msgctxt "In-game interface item"
 msgid "Voice"
-msgstr ""
+msgstr "Voce"
 
 #: guitext:1009
 #, fuzzy
 msgctxt "In-game interface item"
 msgid "Ambience"
-msgstr ""
+msgstr "Ambiente"
 
 #: guitext:1010
 msgctxt "Unused"
@@ -6940,7 +6955,7 @@ msgstr ""
 #: guitext:1033
 msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
-msgstr ""
+msgstr "Campagna Keeper non morto"
 
 #: guitext:1034 guitext:1035
 msgctxt "Unused"
@@ -6950,19 +6965,20 @@ msgstr ""
 #: guitext:1036
 msgctxt "Trap names"
 msgid "Demolition Trap"
-msgstr ""
+msgstr "Trappola Demolizione"
 
 #: guitext:1037
 msgctxt "Trap description"
 msgid ""
 "Demolition Trap: An explosive with unrivaled destructive power."
 msgstr ""
+"Trappola Demolizione: un esplosivo con potere distruttivo senza pari."
 
 #: guitext:1038
 msgctxt "Trap description"
 msgid ""
 "Sentry Trap: Stands guard and shoots at enemies in sight."
-msgstr ""
+msgstr "Trappola sentinella: Si erge a guardia e spara ai nemici in vista."
 
 #: guitext:1039 guitext:1040
 msgctxt "Unused"
@@ -7058,47 +7074,47 @@ msgstr "Indebolire Mura: Distrugge le fortificazioni delle mura nemiche"
 #: guitext:1063
 msgctxt "Game controls"
 msgid "Tilt Up"
-msgstr ""
+msgstr "Inclina su"
 
 #: guitext:1064
 msgctxt "Game controls"
 msgid "Tilt Down"
-msgstr ""
+msgstr "Inclina giù"
 
 #: guitext:1065
 msgctxt "Game controls"
 msgid "Reset Tilt"
-msgstr ""
+msgstr "Reset Inclinazione"
 
 #: guitext:1066
 msgctxt "Creature spell"
 msgid "Heal Monster: The target creature is massively healed."
-msgstr ""
+msgstr "Super Guarigione: la creatura bersaglio riceve una super cura."
 
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr "Purifica: Cura tutti gli effetti negativi inflitti alla creatura."
+msgstr "Purifica: Purifica la creatura da tutti gli effetti negativi."
 
 #: guitext:1068
 msgctxt "Creature spell"
 msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
-msgstr ""
+msgstr "Purifica il mostro: cura tutti gli effetti negativi inflitti alla creatura bersaglio."
 
 #: guitext:1069
 msgctxt "Keeper spell description"
 msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
-msgstr ""
+msgstr "Scudo Magico: fa rimbalzare gli incantesimi lanciati sul bersaglio contro l'attaccante."
 
 #: guitext:1070
 msgctxt "Keeper spell description"
 msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
-msgstr ""
+msgstr "Levitazione: Fa fluttuare in aria la creatura bersaglio in modo che possa attaccare le creature dall'aria o attraversare la lava incolume."
 
 #: guitext:1071
 msgctxt "Keeper spell description"
 msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
-msgstr ""
+msgstr "Vista: Permette alla creatura bersaglio di aumentare temporaneamente la sua consapevolezza e notare l'invisibile."
 
 #: guitext:1072 guitext:1073 guitext:1074 guitext:1075
 msgctxt "Unused"
@@ -7108,9 +7124,9 @@ msgstr ""
 #: guitext:1076
 msgctxt "Door name"
 msgid "Midas Door"
-msgstr ""
+msgstr "Porta di Mida"
 
 #: guitext:1077
 msgctxt "Door description"
-msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
-msgstr ""
+msgid "Porta di Mida: Questa porta consuma oro del suo proprietario per rimanere indistruttibile. RMB zoom."
+msgstr "Porta di Mida: Questa porta consuma oro del suo proprietario per rimanere indistruttibile. RMB zoom."

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -7022,7 +7022,7 @@ msgstr "Rallentamento"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Volo"
 
 #: guitext:1057

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -6828,117 +6828,117 @@ msgid "Moo4"
 msgstr ""
 
 #: guitext:1011
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - Original Campaign"
 msgstr "Dungeon Keeper - Campagna Originale"
 
 #: guitext:1012
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Assmist Isle"
 msgstr ""
 
 #: guitext:1013
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1014
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Burdened Imps' Level Pack"
 msgstr ""
 
 #: guitext:1015
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Conquest of the Arctic"
 msgstr ""
 
 #: guitext:1016
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "The Destiny of Ninja"
 msgstr ""
 
 #: guitext:1017
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's  6-level campaign"
 msgstr ""
 
 #: guitext:1018
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 10-level campaign"
 msgstr ""
 
 #: guitext:1019
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 25-level campaign"
 msgstr ""
 
 #: guitext:1020
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Evil Keeper campaign"
 msgstr ""
 
 #: guitext:1021
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Grinics' KReign campaign"
 msgstr ""
 
 #: guitext:1022
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Japanese DKMaps8 pack"
 msgstr ""
 
 #: guitext:1023
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "KDK Levels"
 msgstr ""
 
 #: guitext:1024
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Good Campaign"
 msgstr ""
 
 #: guitext:1025
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Lord Vexer campaign"
 msgstr ""
 
 #: guitext:1026
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Nikolai's Castles campaign"
 msgstr ""
 
 #: guitext:1027
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - NG+"
 msgstr ""
 
 #: guitext:1028
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1029
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Undead Keeper campaign"
 msgstr ""
 
 #: guitext:1030
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Quest for the Hero campaign"
 msgstr ""
 
 #: guitext:1031
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Revenge of the Lord"
 msgstr ""
 
 #: guitext:1032
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Twin Keepers Campaign"
 msgstr ""
 
 #: guitext:1033
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
 msgstr ""
 

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6803,7 +6803,7 @@ msgstr "密な金の層：あなたのインプが採掘するための多くの
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "反射"
 
 #: guitext:1054

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6818,7 +6818,7 @@ msgstr "減速"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "飛行"
 
 #: guitext:1057

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6801,8 +6801,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "濃い金鉱： 手下インプが採掘する莫大な富。"
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "反射"
 
 #: guitext:1054

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6818,7 +6818,7 @@ msgstr "減速"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "飛行"
 
 #: guitext:1057

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6624,117 +6624,117 @@ msgid "Moo4"
 msgstr ""
 
 #: guitext:1011
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - Original Campaign"
 msgstr "ダンジョンキーパーの原キャンペーン"
 
 #: guitext:1012
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Assmist Isle"
 msgstr "アッスミスト島"
 
 #: guitext:1013
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Ancient Keeper campaign"
 msgstr "エンシェント・キーパー・キャンペーン"
 
 #: guitext:1014
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Burdened Imps' Level Pack"
 msgstr "Burdened Impのレベルパック"
 
 #: guitext:1015
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Conquest of the Arctic"
 msgstr "北極圏の征服"
 
 #: guitext:1016
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "The Destiny of Ninja"
 msgstr "忍者の運命"
 
 #: guitext:1017
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's  6-level campaign"
 msgstr "DzjeeArの６面レベルキャンペーン"
 
 #: guitext:1018
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 10-level campaign"
 msgstr "DzjeeArの１０面レベルキャンペーン"
 
 #: guitext:1019
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 25-level campaign"
 msgstr "DzjeeArの２５面レベルキャンペーン"
 
 #: guitext:1020
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Evil Keeper campaign"
 msgstr "邪悪なキーパー・キャンペーン"
 
 #: guitext:1021
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Grinics' KReign campaign"
 msgstr "GrinicのKReignキャンペーン"
 
 #: guitext:1022
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Japanese DKMaps8 pack"
 msgstr "日本製DKMap8パック"
 
 #: guitext:1023
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "KDK Levels"
 msgstr "KDKレベル"
 
 #: guitext:1024
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Good Campaign"
 msgstr "勇者キャンペーン"
 
 #: guitext:1025
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Lord Vexer campaign"
 msgstr "ヴェクサー卿キャンペーン"
 
 #: guitext:1026
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Nikolai's Castles campaign"
 msgstr "ニコライの城キャンペーン"
 
 #: guitext:1027
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - NG+"
 msgstr "増強された原キャンペーン"
 
 #: guitext:1028
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Ancient Keeper campaign"
 msgstr "エンシェント・キーパー後キャンペーン"
 
 #: guitext:1029
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Undead Keeper campaign"
 msgstr "アンデッド・キーパー後キャンペーン"
 
 #: guitext:1030
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Quest for the Hero campaign"
 msgstr "勇者の探求キャンペーン"
 
 #: guitext:1031
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Revenge of the Lord"
 msgstr "主君の復讐"
 
 #: guitext:1032
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Twin Keepers Campaign"
 msgstr "ツイン・キーパーズ・キャンペーン"
 
 #: guitext:1033
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
 msgstr "アンデッド・キーパー・キャンペーン"
 

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6866,3 +6866,48 @@ msgstr "下へ指向"
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr "傾きをリセット"
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6874,7 +6874,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr "クレンズ：クリーチャーに与えられたすべての負の効果を治療します。
+msgstr "クレンズ：クリーチャーに与えられたすべての負の効果を治療します。"
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -2127,11 +2127,10 @@ msgid "Group: Not used"
 msgstr "グループ化: 未使用だ。"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
-msgstr "透明化: 敵が超自然的な視力を持っていない限り、クリーチャーが彼らから見えなく成る。[26.12]"
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
+msgstr "透明化: 敵が超自然的な視力を持っていない限り、クリーチャーが彼らから見えなく成る。"
 
 #: guitext:240
 msgctxt "Creature spell"

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -6798,7 +6798,7 @@ msgstr "基盤岩： 誰の所有でもない岩石の地面。それを占領�
 #: guitext:1052
 msgctxt "Slab description"
 msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
-msgstr "濃い金鉱： 手下インプが採掘する莫大な富。"
+msgstr "密な金の層：あなたのインプが採掘するための多くの富を保持しています。"
 
 #: guitext:1053
 #, fuzzy
@@ -6874,7 +6874,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "クレンズ：クリーチャーに与えられたすべての負の効果を治療します。
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -4525,22 +4525,21 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
-msgstr "加速: 手下クリーチャーのスピードを速める。左クリックで選択。 [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
+msgstr "加速: 手下クリーチャーのスピードを速める。"
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
-msgstr "防御: 手下クリーチャーを攻撃から守る。左クリックで選択。 [18.11]"
+"Protect Monster: Shields your creatures from attack."
+msgstr "防御: 手下クリーチャーを攻撃から守る。"
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"透明化: 手下クリーチャーを敵から見えなくする。左クリックで選択。 [18.7]"
+"透明化: 手下クリーチャーを敵から見えなくする。"
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -7008,3 +7008,48 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -6942,7 +6942,7 @@ msgstr "높은 금맥: 당신의 임프가 추출할 수 있는 많은 부를 �
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "반사"
 
 #: guitext:1054

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -4609,27 +4609,23 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"몬스터 가속 : 몬스터의 속도가 빨라집니다. 왼쪽 마우스 단추로 선택합니다. "
-"[18.4]"
+"몬스터 가속 : 몬스터의 속도가 빨라집니다."
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+"Protect Monster: Shields your creatures from attack."
 msgstr ""
-"몬스터 보호 : 여러분의 피조물을 공격으로부터 보호합니다. 왼쪽 마우스 단추로 "
-"선택합니다. [18.11]"
+"몬스터 보호 : 여러분의 피조물을 공격으로부터 보호합니다."
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"몬스터 은닉: 적에게 당신의 생명체를 보이지 않게 만듭니다. 왼쪽 마우스 단추로 "
-"선택합니다. [18.7]"
+"몬스터 은닉: 적에게 당신의 생명체를 보이지 않게 만듭니다."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -6957,7 +6957,7 @@ msgstr "느려림"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "비행"
 
 #: guitext:1057

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -6957,7 +6957,7 @@ msgstr "느려림"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "비행"
 
 #: guitext:1057

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -2175,10 +2175,9 @@ msgid "Group: Not used"
 msgstr "그룹 : 사용 안함"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr ""
 "투명화: 여러분의 하수인들 중 하나에 던져지면, 모든 적에게 해당 피조물이 보이"
 "지 않게 됩니다. 특이 시야가 없는 한 말이죠."

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -7013,7 +7013,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "정화: 생물에게 가해진 모든 부정적인 효과를 치료합니다."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -6940,8 +6940,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "높은 금맥: 당신의 임프가 추출할 수 있는 많은 부를 보유하고 있습니다."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "반사"
 
 #: guitext:1054

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -5750,7 +5750,7 @@ msgstr "Vena auri densa: Multae opes continet ut diabolulli tui eas fodiant."
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "Resilientia"
 
 #: guitext:1054

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -5748,8 +5748,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Vena auri densa: Multae opes continet ut diabolulli tui eas fodiant."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Resilientia"
 
 #: guitext:1054

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -5810,3 +5810,48 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -1617,8 +1617,9 @@ msgid "Group: Not used"
 msgstr "Glomerare: Non usum"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid "Invisibility: Cast on one of your minions, it makes the host creature invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr "Invisibilitas: Creatura tua iacitur, ea invisibilis ad omnes inimicos fit. Nisi Visum subnaturalem possident."
 
 #: guitext:240

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -3716,18 +3716,18 @@ msgstr "Oboedientia: Obliga creaturas tuas oboedire unumquidque mandatum tuum. B
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
-msgstr "Creaturam Accelerare: Celeritatem creaturarum tuarum auget. BSM delige. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
+msgstr "Creaturam Accelerare: Celeritatem creaturarum tuarum auget."
 
 #: guitext:655
 msgctxt "Keeper spell description"
-msgid "Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
-msgstr "Creaturam Protegere: Creaturas tuas protegit ab aggresione. BSM delige. [18.11]"
+msgid "Protect Monster: Shields your creatures from attack."
+msgstr "Creaturam Protegere: Creaturas tuas protegit ab aggresione."
 
 #: guitext:656
 msgctxt "Keeper spell description"
-msgid "Conceal Monster: Makes your creatures invisible to the enemy. LMB select. [18.7]"
-msgstr "Creaturam Occulere: Creaturae tuae invisibiles ad inimicum fiunt. BSM delige. [18.7]"
+msgid "Conceal Monster: Makes your creatures invisible to the enemy."
+msgstr "Creaturam Occulere: Creaturae tuae invisibiles ad inimicum fiunt."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -5765,7 +5765,7 @@ msgstr "Lentitudo"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Volatus"
 
 #: guitext:1057

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -5765,7 +5765,7 @@ msgstr "Lentitudo"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Volatus"
 
 #: guitext:1057

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -6841,117 +6841,117 @@ msgid "Moo4"
 msgstr ""
 
 #: guitext:1011
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - Original Campaign"
 msgstr ""
 
 #: guitext:1012
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Assmist Isle"
 msgstr ""
 
 #: guitext:1013
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1014
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Burdened Imps' Level Pack"
 msgstr ""
 
 #: guitext:1015
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Conquest of the Arctic"
 msgstr ""
 
 #: guitext:1016
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "The Destiny of Ninja"
 msgstr ""
 
 #: guitext:1017
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's  6-level campaign"
 msgstr ""
 
 #: guitext:1018
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 10-level campaign"
 msgstr ""
 
 #: guitext:1019
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 25-level campaign"
 msgstr ""
 
 #: guitext:1020
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Evil Keeper campaign"
 msgstr ""
 
 #: guitext:1021
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Grinics' KReign campaign"
 msgstr ""
 
 #: guitext:1022
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Japanese DKMaps8 pack"
 msgstr ""
 
 #: guitext:1023
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "KDK Levels"
 msgstr ""
 
 #: guitext:1024
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Good Campaign"
 msgstr ""
 
 #: guitext:1025
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Lord Vexer campaign"
 msgstr ""
 
 #: guitext:1026
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Nikolai's Castles campaign"
 msgstr ""
 
 #: guitext:1027
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - NG+"
 msgstr ""
 
 #: guitext:1028
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1029
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Undead Keeper campaign"
 msgstr ""
 
 #: guitext:1030
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Quest for the Hero campaign"
 msgstr ""
 
 #: guitext:1031
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Revenge of the Lord"
 msgstr ""
 
 #: guitext:1032
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Twin Keepers Campaign"
 msgstr ""
 
 #: guitext:1033
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
 msgstr ""
 

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -4706,26 +4706,23 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"Przyspieszacz potwora: Zwiększa szybkość działania Twoich stworów. LPM "
-"uaktywnia. [18.4]"
+"Przyspieszacz potwora: Zwiększa szybkość działania Twoich stworów."
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+"Protect Monster: Shields your creatures from attack."
 msgstr ""
-"Ochrona potwora: Osłania Twoje stwory przed atakiem. LPM uaktywnia. [18.11]"
+"Ochrona potwora: Osłania Twoje stwory przed atakiem."
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"Ukrycie potwora: Czyni Twoje stwory niewidzialnymi dla wroga. LPM uaktywnia. "
-"[18.7]"
+"Ukrycie potwora: Czyni Twoje stwory niewidzialnymi dla wroga."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -7085,3 +7085,48 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -7091,7 +7091,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Oczyszczenie: Leczy wszystkie negatywne efekty zadane stworzeniu."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -7018,8 +7018,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Gęste żyłki złota: Zawiera dużo bogactwa do wydobycia przez twoje Chochliki."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Odbicie"
 
 #: guitext:1054

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -7035,7 +7035,7 @@ msgstr "Spowolnienie"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Lot"
 
 #: guitext:1057

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -7020,7 +7020,7 @@ msgstr "Gęste żyłki złota: Zawiera dużo bogactwa do wydobycia przez twoje C
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "Odbicie"
 
 #: guitext:1054

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -7035,7 +7035,7 @@ msgstr "Spowolnienie"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Lot"
 
 #: guitext:1057

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -2260,10 +2260,9 @@ msgid "Group: Not used"
 msgstr "Grupowanie: nie używane"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr ""
 "Niewidzialność: Rzucona na twojego podopiecznego sprawia, że jest "
 "niewidzialny dla wszystkich wrogów. Chyba, że posiadają zaklęcie "

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -2279,10 +2279,9 @@ msgid "Group: Not used"
 msgstr "Объединение: Не используется"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature "
-"invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr ""
 "Hевидимость: Создание, на котором было применено это заклинание, становится "
 "невидимым для всех врагов. Если, конечно, у них нет сверхъестественного "

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -7087,8 +7087,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Плотная золотая жила: Содержит много богатства для добычи ваших бесов."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Отражение"
 
 #: guitext:1054

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -4739,24 +4739,22 @@ msgstr ""
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"Ускорить чудище: Увеличивает скорость Ваших созданий. ЛКМ - выбор. [18.4]"
+"Ускорить чудище: Увеличивает скорость Ваших созданий."
 
 #: guitext:655
 msgctxt "Keeper spell description"
 msgid ""
-"Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
-msgstr "Защищать чудище: Защищает Ваших созданий от атак. ЛКМ - выбор. [18.11]"
+"Protect Monster: Shields your creatures from attack."
+msgstr "Защищать чудище: Защищает Ваших созданий от атак."
 
 #: guitext:656
 msgctxt "Keeper spell description"
 msgid ""
-"Conceal Monster: Makes your creatures invisible to the enemy. LMB select. "
-"[18.7]"
+"Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"Скрыть чудище: Делает Ваших созданий невидимыми для врага. ЛКМ - выбор. "
-"[18.7]"
+"Скрыть чудище: Делает Ваших созданий невидимыми для врага. "
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -7160,7 +7160,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Очищение: Излечивает все негативные эффекты, наложенные на существо."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -6910,117 +6910,117 @@ msgid "Moo4"
 msgstr ""
 
 #: guitext:1011
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - Original Campaign"
 msgstr ""
 
 #: guitext:1012
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Assmist Isle"
 msgstr ""
 
 #: guitext:1013
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1014
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Burdened Imps' Level Pack"
 msgstr ""
 
 #: guitext:1015
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Conquest of the Arctic"
 msgstr ""
 
 #: guitext:1016
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "The Destiny of Ninja"
 msgstr ""
 
 #: guitext:1017
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's  6-level campaign"
 msgstr ""
 
 #: guitext:1018
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 10-level campaign"
 msgstr ""
 
 #: guitext:1019
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "DzjeeAr's 25-level campaign"
 msgstr ""
 
 #: guitext:1020
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Evil Keeper campaign"
 msgstr ""
 
 #: guitext:1021
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Grinics' KReign campaign"
 msgstr ""
 
 #: guitext:1022
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Japanese DKMaps8 pack"
 msgstr ""
 
 #: guitext:1023
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "KDK Levels"
 msgstr ""
 
 #: guitext:1024
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Good Campaign"
 msgstr ""
 
 #: guitext:1025
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Lord Vexer campaign"
 msgstr ""
 
 #: guitext:1026
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Nikolai's Castles campaign"
 msgstr ""
 
 #: guitext:1027
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Dungeon Keeper - NG+"
 msgstr ""
 
 #: guitext:1028
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Ancient Keeper campaign"
 msgstr ""
 
 #: guitext:1029
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Post Undead Keeper campaign"
 msgstr ""
 
 #: guitext:1030
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Quest for the Hero campaign"
 msgstr ""
 
 #: guitext:1031
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Revenge of the Lord"
 msgstr ""
 
 #: guitext:1032
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Twin Keepers Campaign"
 msgstr ""
 
 #: guitext:1033
-msgctxt "Menu interface item""
+msgctxt "Menu interface item"
 msgid "Undead Keeper campaign"
 msgstr ""
 

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -7104,7 +7104,7 @@ msgstr "Замедление"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Полет"
 
 #: guitext:1057

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -7089,7 +7089,7 @@ msgstr "Плотная золотая жила: Содержит много бо
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "Отражение"
 
 #: guitext:1054

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -7104,7 +7104,7 @@ msgstr "Замедление"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Полет"
 
 #: guitext:1057

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -7153,3 +7153,48 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -6074,8 +6074,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Veta de oro densa: Contiene mucha riqueza para que tus Duendes la extraigan."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Rebote"
 
 #: guitext:1054

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -6139,3 +6139,48 @@ msgstr "Inclinar Abajo"
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr "Reiniciar Inclinación"
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -1756,8 +1756,9 @@ msgid "Group: Not used"
 msgstr "Grupo: Sin usar"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid "Invisibility: Cast on one of your minions, it makes the host creature invisible to all enemies. Unless they possess a subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr ""
 "Invisibilidad: Lanzado en uno de tus esbirros, convierte a la criatura anfitrión invisible a todos los enemigos. A menos que estos posean una "
 "vista sobrenatural."

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -6091,7 +6091,7 @@ msgstr "Lentitud"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Vuelo"
 
 #: guitext:1057

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -6091,7 +6091,7 @@ msgstr "Lentitud"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Vuelo"
 
 #: guitext:1057

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -3971,24 +3971,21 @@ msgstr "Debe obedecer: Obliga a tus criaturas a obedecer cada una de tus órdene
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
 msgstr ""
-"Acelerar: Incrementa la velocidad de tus criaturas.  Selecciónalo con BIR y pulsa BIR sobre la criatura que deseas aumentarle la velocidad, "
-"mantén pulsado BIR para aumentar el poder del hechizo, antes de ser lanzado."
+"Acelerar: Incrementa la velocidad de tus criaturas."
 
 #: guitext:655
 msgctxt "Keeper spell description"
-msgid "Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
+msgid "Protect Monster: Shields your creatures from attack."
 msgstr ""
-"Proteger: Aumenta la protección a tus criaturas. Selecciónalo con BIR y pulsa BIR sobre la criatura que deseas aumentarle la protección, mantén "
-"pulsado BIR para aumentar el poder del hechizo, antes de ser lanzado."
+"Proteger: Aumenta la protección a tus criaturas."
 
 #: guitext:656
 msgctxt "Keeper spell description"
-msgid "Conceal Monster: Makes your creatures invisible to the enemy. LMB select. [18.7]"
+msgid "Conceal Monster: Makes your creatures invisible to the enemy."
 msgstr ""
-"Ocultar: Hace a tus criaturas invisibles para el enemigo. Selecciónalo con BIR y pulsa BIR sobre la criatura que deseas que sea invisible, "
-"mantén pulsado BIR para aumentar el poder del hechizo, antes de ser lanzado."
+"Ocultar: Hace a tus criaturas invisibles para el enemigo."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -6076,7 +6076,7 @@ msgstr "Veta de oro densa: Contiene mucha riqueza para que tus Duendes la extrai
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "Rebote"
 
 #: guitext:1054

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -6147,7 +6147,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Purificar: Cura todos los efectos negativos infligidos a la criatura."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -6142,3 +6142,48 @@ msgstr ""
 msgctxt "Game controls"
 msgid "Reset Tilt"
 msgstr ""
+
+#: guitext:1066
+msgctxt "Creature spell"
+msgid "Heal Monster: The target creature is massively healed."
+msgstr ""
+
+#: guitext:1067
+msgctxt "Creature spell"
+msgid "Cleanse: Cures all negative effects inflicted on the creature."
+msgstr ""
+
+#: guitext:1068
+msgctxt "Creature spell"
+msgid "Cleanse Monster: Cures all negative effects inflicted on target creature."
+msgstr ""
+
+#: guitext:1069
+msgctxt "Keeper spell description"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgstr ""
+
+#: guitext:1070
+msgctxt "Keeper spell description"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgstr ""
+
+#: guitext:1071
+msgctxt "Keeper spell description"
+msgid "Sight: Allows the target creature to temporarily increase its awareness and notice the invisible."
+msgstr ""
+
+#: guitext:1072 guitext:1073 guitext:1074 guitext:1075
+msgctxt "Unused"
+msgid "Moo8"
+msgstr ""
+
+#: guitext:1076
+msgctxt "Door name"
+msgid "Midas Door"
+msgstr ""
+
+#: guitext:1077
+msgctxt "Door description"
+msgid "Midas Door: This door consumes gold from the owner to stay completely indestructible. RMB zoom."
+msgstr ""

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -6080,7 +6080,7 @@ msgstr "Tät guldåder: Innehåller mycket rikedom för dina Smådjävlar att ut
 #: guitext:1053
 #, fuzzy
 msgctxt "Keeper spell name"
-msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
+msgid "Magic Shield"
 msgstr "Retur"
 
 #: guitext:1054

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -6095,7 +6095,7 @@ msgstr "Långsam"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Flight"
+msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
 msgstr "Sväva"
 
 #: guitext:1057

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -6151,7 +6151,7 @@ msgstr ""
 #: guitext:1067
 msgctxt "Creature spell"
 msgid "Cleanse: Cures all negative effects inflicted on the creature."
-msgstr ""
+msgstr "Rengöring: Botar alla negativa effekter som påverkar varelsen."
 
 #: guitext:1068
 msgctxt "Creature spell"

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -3963,18 +3963,18 @@ msgstr "Tvingad lydnad: Tvingar dina varelser att lyda alla dina kommandon. VMK 
 
 #: guitext:654
 msgctxt "Keeper spell description"
-msgid "Speed Monster: Increases the speed of your monsters. LMB select. [18.4]"
-msgstr "Hastighet: Ökar hastigheten på dina monster. VMK väljer. [18.4]"
+msgid "Speed Monster: Increases the speed of your monsters."
+msgstr "Hastighet: Ökar hastigheten på dina monster."
 
 #: guitext:655
 msgctxt "Keeper spell description"
-msgid "Protect Monster: Shields your creatures from attack. LBM select. [18.11]"
-msgstr "Skydda monster: Skyddar dina varelser från attacker. VMK väljer. [18.11]"
+msgid "Protect Monster: Shields your creatures from attack."
+msgstr "Skydda monster: Skyddar dina varelser från attacker."
 
 #: guitext:656
 msgctxt "Keeper spell description"
-msgid "Conceal Monster: Makes your creatures invisible to the enemy. LMB select. [18.7]"
-msgstr "Dölj monster: Gör dina varelser osynliga för fienden. VMK väljer. [18.7]"
+msgid "Conceal Monster: Makes your creatures invisible to the enemy."
+msgstr "Dölj monster: Gör dina varelser osynliga för fienden."
 
 #: guitext:657
 msgctxt "Keeper spell description"

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -1823,10 +1823,9 @@ msgid "Group: Not used"
 msgstr "Grupp: Används inte"
 
 #: guitext:239
+#, fuzzy
 msgctxt "Creature spell"
-msgid ""
-"Invisibility: Cast on one of your minions, it makes the host creature invisible to all enemies. Unless they possess a "
-"subnatural Sight."
+msgid "Invisibility: Makes the creature invisible to all enemies. Unless they possess a subnatural Sight."
 msgstr ""
 "Osynlighet: Förtrolla en av dina varelser och gör den osynlig till alla fiender - såvida de inte har en övernaturlig syn. "
 

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -6095,7 +6095,7 @@ msgstr "Långsam"
 
 #: guitext:1056
 msgctxt "Keeper spell name"
-msgid "Levitate: Causes the target creature to take off from the ground and attack creatures from the air or cross lava unharmed."
+msgid "Levitate"
 msgstr "Sväva"
 
 #: guitext:1057

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -6078,8 +6078,9 @@ msgid "Dense Gold Seam: Holds a lot of wealth for your Imps to extract. "
 msgstr "Tät guldåder: Innehåller mycket rikedom för dina Smådjävlar att utvinna."
 
 #: guitext:1053
+#, fuzzy
 msgctxt "Keeper spell name"
-msgid "Rebound"
+msgid "Magic Shield: Causes spells fired at the target to bounce back at the attacker."
 msgstr "Retur"
 
 #: guitext:1054

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -28,7 +28,7 @@ extern "C" {
 /******************************************************************************/
 #define STRINGS_MAX       2000
 #define DK_STRINGS_MAX     941
-#define GUI_STRINGS_COUNT 1066
+#define GUI_STRINGS_COUNT 1078
 
 struct GameCampaign;
 


### PR DESCRIPTION
Changes:
239 - Bad string for a SELF_BUFF, so fixed
654 - the 'Monster' part means you target another. Removed LMB so it can be used for a RANGED SPEED creature spell buff
655 - the 'Monster' part means you target another. Removed LMB so it can be used for a RANGED PROTECT creature spell buff 
656 - the 'Monster' part means you target another. Removed LMB so it can be used for a RANGED INVISIBILITY creature spell buff 
1053/1056 - Gave it a different name so it is distinct from flight SELF_BUFF.
1066 - Quite similar to 'heal' keeper power, but added 'Monster' to match other spell/power names with monster in it to target others. This instead of changing the keeper power to HEAL MONSTER too.
1067/1068 - cleanse creature spell which is hopefully a creature spell soon
1069/1070/1071 - Descriptions for the recent Keeper powers, that can also be used for Creature Ranged Buffs
1072~1075 - placeholders for future powers/spells
1076 - new midas door name
1077 - the full tooltip for the midas door