### PR TITLE
Restore magic door resistance to original value

### DIFF
--- a/src/thing_stats.c
+++ b/src/thing_stats.c
@@ -983,7 +983,7 @@ HitPoints calculate_shot_real_damage_to_door(const struct Thing *doortng, const 
         dmg = shotng->shot.damage;
     } else
     {
-        dmg = shotng->shot.damage / 10;
+        dmg = shotng->shot.damage / 8;
         if (dmg < 1)
             dmg = 1;
     }


### PR DESCRIPTION
Would revert this commit:

https://github.com/dkfans/keeperfx/commit/0eb6c985d07f64f9121bf84f92741e467538069d#diff-a8e1351154215ba628dff88df33ab7d49f14f9e722d37cbdcee817941bedb50e