### PR TITLE
Feature/battlefield awareness

### DIFF
--- a/config/fxdata/creature.cfg
+++ b/config/fxdata/creature.cfg
@@ -73,12 +73,13 @@ PrimaryTarget = 0
 ; DANGEROUS will be avoided when attacking Doors and Hearts
 ; DESTRUCTIVE is required when attacking Doors and Hearts
 ; SELF_BUFF can be applied to caster.
-; RANGED_BUFF can be applied to another friendly creature.
+; RANGED_BUFF can be applied to another own creature.
 ; REPEAT_TRIGGER allows player to hold down the mouse button to cast
 ; QUICK ranged attacks will be used by units going postal
 ; DISARMING allows instance to be used against traps
 ; DISPLAY_SWIPE Shows the swipe in possession loaded from the creatures PossessSwipeIndex
 ; NEEDS_TARGET Cannot be used in possession without a target to cast it on
+; APPLY_TO_ALLIES Allows RANGED_BUFF to be applied to mutual allied player's creature.
 Properties =
 ; Function used as the instance action, and its parameters
 Function = none 0 0
@@ -967,8 +968,8 @@ SymbolSprites = 786
 Graphics = ATTACK
 RangeMin = MIN
 RangeMax = 5120
-PrimaryTarget = 6
-Properties = RANGED_BUFF SELF_BUFF NEEDS_TARGET
+PrimaryTarget = 2
+Properties = RANGED_BUFF SELF_BUFF NEEDS_TARGET APPLY_TO_ALLIES
 Function = creature_cast_spell SPELL_HEAL 0
 ValidateFunc = validate_source_ranged_heal validate_target_ranged_heal
 SearchTargetsFunc = search_target_ranged_heal

--- a/src/config_creature.c
+++ b/src/config_creature.c
@@ -112,6 +112,7 @@ const struct NamedCommand creaturetype_instance_properties[] = {
   {"DISPLAY_SWIPE",        InstPF_UsesSwipe},
   {"RANGED_BUFF",          InstPF_RangedBuff},
   {"NEEDS_TARGET",         InstPF_NeedsTarget},
+  {"APPLY_TO_ALLIES",      InstPF_ApplyToAllies},
   {NULL,                     0},
   };
 

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -150,6 +150,7 @@ enum InstancePropertiesFlags {
     InstPF_UsesSwipe          = 0x0200,
     InstPF_RangedBuff         = 0x0400,
     InstPF_NeedsTarget        = 0x0800,
+    InstPF_ApplyToAllies      = 0x1000,
 };
 
 enum CreatureDeathKind {

--- a/src/creature_control.c
+++ b/src/creature_control.c
@@ -346,6 +346,66 @@ TbBool creature_can_gain_experience(const struct Thing *thing)
     return true;
 }
 
+/**
+ * @brief Insert one creature with its distance to the creatures_nearby array of the
+ * specified creature(center).
+ * @param center The creature in the center.
+ * @param creature_idx The index of the nearby creature.
+ * @param distance The distance of the above creature.
+ * @return TbBool True if successfully inserted.
+ */
+TbBool insert_nearby_creature(struct Thing *center, ThingIndex creature_idx, long distance)
+{
+    if (thing_is_invalid(center))
+    {
+        ERRORLOG("Invalid thing!");
+        return false;
+    }
+    struct CreatureControl* cctrl = creature_control_get_from_thing(center);
+    if (creature_control_invalid(cctrl))
+    {
+        ERRORLOG("Invalid creature control!");
+        return false;
+    }
+
+    TbBool ok = true;
+    for(int i = 0; i < COUNT_OF(cctrl->creatures_nearby); i++)
+    {
+        if (cctrl->creatures_nearby[i].creature_idx == 0)
+        {
+            // Insert in an empty slot.
+            cctrl->creatures_nearby[i].creature_idx = creature_idx;
+            cctrl->creatures_nearby[i].distance = distance;
+            break;
+        }
+        else if(cctrl->creatures_nearby[i].distance > distance)
+        {
+            // Conduct insertion sort.
+            for (int k = COUNT_OF(cctrl->creatures_nearby) - 1; k >= i; k--)
+            {
+                if(cctrl->creatures_nearby[k].creature_idx != 0)
+                {
+                    if(k == COUNT_OF(cctrl->creatures_nearby) - 1)
+                    {
+                        // This array is full. Cannot add anymore.
+                        ok = false;
+                        break;
+                    }
+                    else
+                    {
+                        cctrl->creatures_nearby[k + 1].creature_idx = cctrl->creatures_nearby[k].creature_idx;
+                        cctrl->creatures_nearby[k + 1].distance = cctrl->creatures_nearby[k].distance;
+                    }
+                }
+            }
+            cctrl->creatures_nearby[i].creature_idx = creature_idx;
+            cctrl->creatures_nearby[i].distance = distance;
+            break;
+        }
+    }
+    return ok;
+}
+
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -34,6 +34,9 @@ extern "C" {
 
 #define CREATURE_TYPES_MAX 128
 #define CREATURE_STATES_MAX 256
+#define CREATURE_TRACKING_MAX (CREATURES_COUNT / 4)
+// 7680 is roughly 10 slabs.
+#define CREATURE_SCAN_RANGE_MAX 7680
 
 #define MAX_SIZEXY            768
 /** Max amount of spells casted at the creature at once. */
@@ -136,6 +139,11 @@ enum ObjectCombatStates {
 struct CastedSpellData {
     unsigned char spkind;
     short duration;
+};
+
+struct CreatureWithDistance {
+  unsigned int distance;
+  ThingIndex creature_idx;
 };
 
 struct CreatureControl {
@@ -414,6 +422,8 @@ unsigned char sound_flag;
     ThingIndex summoner_idx;
     long summon_spl_idx;
     ThingIndex familiar_idx[FAMILIAR_MAX];
+    // Ascending sorted array by the distance.
+    struct CreatureWithDistance creatures_nearby[CREATURE_TRACKING_MAX];
 };
 
 struct CreatureStats { // These stats are not compatible with original DK - they have more fields
@@ -585,6 +595,8 @@ void play_creature_sound_and_create_sound_thing(struct Thing *thing, long snd_id
 struct CreatureSound *get_creature_sound(struct Thing *thing, long snd_idx);
 void reset_creature_eye_lens(struct Thing *thing);
 TbBool creature_can_gain_experience(const struct Thing *thing);
+TbBool insert_nearby_creature(struct Thing *center, ThingIndex creature_idx, long distance);
+
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -148,7 +148,7 @@ struct Dungeon {
     struct Coord3d mappos;
     unsigned char creature_tendencies;
     unsigned char computer_enabled;
-    short creatr_list_start;
+    ThingIndex creatr_list_start;
     short digger_list_start;
     ThingIndex summon_list[MAX_SUMMONS];
     unsigned short num_summon;

--- a/src/globals.h
+++ b/src/globals.h
@@ -65,6 +65,16 @@
 #include <algorithm>
 using std::min;
 using std::max;
+#define COUNT_OF(_Array) (sizeof(_Array) / sizeof(_Array[0]))
+#else
+// C version (from Google's Chromium project)
+// It improves on the array[0] or *array version by using 0[array], which is equivalent to array[0] on plain arrays,
+// but will fail to compile if array happens to be a C++ type that overloads operator[]()
+#define COUNT_OF(_Array) ((sizeof(_Array) / sizeof(0[_Array])) / ((size_t)(!(sizeof(_Array) % sizeof(0[_Array])))))
+#endif
+
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -3448,13 +3448,6 @@ ThingIndex get_human_controlled_creature_target(struct Thing *thing, CrInstance 
             return thing->index;
         }
     }
-    if((inst_inf->instance_property_flags & InstPF_RangedBuff) != 0)
-    {
-        if(inst_inf->primary_target != 5 && inst_inf->primary_target != 6)
-        {
-            ERRORLOG("The instance %d has RANGED_BUFF property but has no valid primary target.", inst_id);
-        }
-    }
 
     struct Thing *i;
     long angle_xy_to;
@@ -3587,7 +3580,6 @@ ThingIndex process_player_use_instance(struct Thing *thing, CrInstance inst_id, 
         if (target_idx == 0)
         {
             // If cannot find a valid target, do not use it and don't consider it used.
-
             // Make a rejection sound
             play_non_3d_sample(119);
             return 0;
@@ -5934,6 +5926,7 @@ TngUpdateRet update_creature(struct Thing *thing)
     {
         cctrl->move_speed = 0;
     }
+    scan_nearby_creature(thing);
     process_spells_affected_by_effect_elements(thing);
     process_landscape_affecting_creature(thing);
     process_disease(thing);
@@ -7040,6 +7033,96 @@ TbBool creature_can_be_queried(struct PlayerInfo *player, struct Thing *creatng)
 TbBool creature_can_be_transferred(const struct Thing* thing)
 {
     return ((get_creature_model_flags(thing) & CMF_NoTransfer) == 0);
+}
+
+/**
+ * @brief Use the specified creature's position as the center, scan nearby area,
+ * collect creatures within CREATURE_SCAN_RANGE_MAX, and record found creatures in the
+ * CreatureControl.creatures_nearby.
+ * @param center The creature being processed.
+ * @return The number of found creatures.
+ */
+int scan_nearby_creature(struct Thing *center)
+{
+    SYNCDBG(11, "Processing %s(%d).", thing_model_name(center), center->index);
+    if (thing_is_invalid(center))
+    {
+        return 0;
+    }
+    struct CreatureControl* cctrl = creature_control_get_from_thing(center);
+    if (creature_control_invalid(cctrl))
+    {
+        ERRORLOG("Invalid creature control");
+        return 0;
+    }
+    memset(&cctrl->creatures_nearby, 0, sizeof(cctrl->creatures_nearby));
+    int k = 0;
+    int count = 1;
+    for(int player_idx = 0; player_idx < PLAYERS_COUNT; player_idx++)
+    {
+        struct Dungeon* dungeon = get_players_num_dungeon(player_idx);
+        ThingIndex creature_idx = dungeon->creatr_list_start;
+
+        while (creature_idx != 0 && count < COUNT_OF(cctrl->creatures_nearby))
+        {
+            struct Thing* current = thing_get(creature_idx);
+            if (thing_is_invalid(current))
+            {
+                ERRORLOG("Invalid creature at index %d", creature_idx);
+                break;
+            }
+            struct CreatureControl* temp_ctrl = creature_control_get_from_thing(current);
+            if (creature_control_invalid(temp_ctrl))
+            {
+                ERRORLOG("Invalid creature control");
+                break;
+            }
+            // Don't use creature_idx anymore until next iteration.
+            creature_idx = temp_ctrl->players_next_creature_idx;
+
+            if(center->index == current->index)
+            {
+                // Skip itself.
+                continue;
+            }
+
+            long dist = get_2d_distance(&center->mappos, &current->mappos);
+            if (dist <= CREATURE_SCAN_RANGE_MAX)
+            {
+                if (!insert_nearby_creature(center, current->index, dist))
+                {
+                    ERRORLOG("Failed to insert nearby creature!");
+                    break;
+                }
+                SYNCDBG(15, "Inserted nearby %s(%d) in distance %d, count: %d",
+                    thing_model_name(current), current->index, dist, count);
+                count++;
+            }
+
+            k++;
+            if (k > CREATURES_COUNT)
+            {
+                ERRORLOG("Infinite loop detected when sweeping creatures list");
+                break;
+            }
+        }
+    }
+
+    #if (BFDEBUG_LEVEL >= 12)
+    SYNCDBG(11, "Debug creatures_nearby...");
+    for(int i = 0; i < COUNT_OF(cctrl->creatures_nearby); i++)
+    {
+        if (cctrl->creatures_nearby[i].creature_idx != 0)
+        {
+            struct Thing* current = thing_get(cctrl->creatures_nearby[i].creature_idx);
+            SYNCDBG(11, "#%d Nearby creature %s(%d) in distaccne %d.", i,
+                thing_model_name(current), cctrl->creatures_nearby[i].creature_idx,
+                cctrl->creatures_nearby[i].distance);
+        }
+    }
+    #endif
+
+    return count;
 }
 
 /******************************************************************************/

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -201,6 +201,7 @@ short get_creature_eye_height(const struct Thing *creatng);
 
 void query_creature(struct PlayerInfo *player, ThingIndex index, TbBool reset, TbBool zoom);
 TbBool creature_can_be_queried(struct PlayerInfo *player, struct Thing *creatng);
+int scan_nearby_creature(struct Thing *thing);
 /******************************************************************************/
 TbBool thing_is_creature(const struct Thing *thing);
 TbBool thing_is_dead_creature(const struct Thing *thing);

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -259,6 +259,7 @@ long switch_owned_objects_on_destoyed_slab_to_neutral(MapSlabCoord slb_x, MapSla
 // Filters to select thing anywhere on map but only of one given class
 struct Thing *get_random_thing_of_class_with_filter(Thing_Maximizer_Filter filter, MaxTngFilterParam param, PlayerNumber plyr_idx);
 struct Thing *get_nth_thing_of_class_with_filter(Thing_Maximizer_Filter filter, MaxTngFilterParam param, long tngindex);
+struct Thing *get_nth_creature_with_filter(Thing_Maximizer_Filter filter, MaxTngFilterParam param, long tngindex);
 long count_things_of_class_with_filter(Thing_Maximizer_Filter filter, MaxTngFilterParam param);
 long do_to_all_things_of_class_and_model(int tngclass, int tngmodel, Thing_Bool_Modifier do_cb);
 // Final routines to select thing anywhere on map but only of one given class


### PR DESCRIPTION
Store nearby creatures in GameControl
    
The current performance of using ranged buffs is not good.
It requires one search for each ranged buff instance. The search
results cannot be retained and cannot benefit future usages.

This change adds scan_nearby_creature(), which runs every turn.
For each creature, it scans nearby area and collects creatures
within CREATURE_SCAN_RANGE_MAX, and records found creatures in the
CreatureControl.creatures_nearby.

This CreatureControl.creatures_nearby is a sorted array by
the distance in ascending order.

It can be used in many places, especially useful for ranged buffs.
It will benefit combat(searching for targets) in the future.

Since the allied creatures are also included, we can extend our
ranged buffs to allies. The new property - APPLY_TO_ALLIES is added.

Type: New Feature