### PR TITLE
Fix MAGIC_OVERCHARGE_LEVELS?

### DIFF
--- a/src/config_magic.h
+++ b/src/config_magic.h
@@ -30,11 +30,11 @@ extern "C" {
 #endif
 
 /******************************************************************************/
-#define MAGIC_ITEMS_MAX        2000
+#define MAGIC_ITEMS_MAX         2000
 #define SPELL_MAX_LEVEL         9
 #define POWER_MAX_LEVEL         8
-#define MAGIC_OVERCHARGE_LEVELS (SPELL_MAX_LEVEL+1)
-#define POWER_TYPES_MAX      2000
+#define MAGIC_OVERCHARGE_LEVELS (POWER_MAX_LEVEL+1)
+#define POWER_TYPES_MAX         2000
 
 enum SpellKinds {
     SplK_None = 0,


### PR DESCRIPTION
Maybe I'm wrong but I think ``MAGIC_OVERCHARGE_LEVELS`` isn't correctly defined in config_magic.h with the recents changes.

Close this PR if i'm wrong.