### PR TITLE
Fix Release mode in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,11 @@ target_compile_definitions(keeperfx_hvlog PUBLIC BFDEBUG_LEVEL=10)
 target_sources(keeperfx_hvlog PRIVATE "res/keeperfx_stdres.rc")
 
 message(STATUS "We are using ${CMAKE_CXX_COMPILER_ID}")
+
+# The default bfd linker in MinGW is extremely slow. LLVM linker (LLD) is much much faster.
+set_property(TARGET keeperfx PROPERTY LINKER_TYPE LLD)
+set_property(TARGET keeperfx_hvlog PROPERTY LINKER_TYPE LLD)
+
 set(WARNFLAGS -Wall -W -Wshadow -Wno-sign-compare -Wno-unused-parameter -Wno-strict-aliasing -Wno-unknown-pragmas)
 set(GNU_COMPILER_FLAG -march=x86-64 -fno-omit-frame-pointer -fmessage-length=0)
 set(GNU_LINK_FLAG -mwindows -Wl,--enable-auto-import)
@@ -65,21 +70,20 @@ target_compile_options(keeperfx PRIVATE ${WARNFLAGS} ${GNU_COMPILER_FLAG})
 target_compile_options(keeperfx_hvlog PRIVATE ${WARNFLAGS} ${GNU_COMPILER_FLAG})
 target_link_options(keeperfx PRIVATE ${GNU_LINK_FLAG} -Wl,-Map,keeperfx.map)
 target_link_options(keeperfx_hvlog PRIVATE ${GNU_LINK_FLAG} -Wl,-Map,keeperfx_hvlog.map)
-target_link_libraries (keeperfx PUBLIC -static gcc stdc++ winpthread -dynamic)
-target_link_libraries (keeperfx_hvlog PUBLIC -static gcc stdc++ winpthread -dynamic)
-
-# Go into submodules.
-add_subdirectory(deps)
-add_subdirectory(tools)
+target_link_libraries (keeperfx PUBLIC -static stdc++ winpthread -dynamic)
+target_link_libraries (keeperfx_hvlog PUBLIC -static stdc++ winpthread -dynamic)
 
 # System libraries.
 target_link_libraries(keeperfx PRIVATE imagehlp dbghelp)
 target_link_libraries(keeperfx_hvlog PRIVATE imagehlp dbghelp)
 
+# Go into submodules.
+add_subdirectory(deps)
+add_subdirectory(tools)
+
 # External libraries.
 target_link_libraries(keeperfx
     PRIVATE
-    $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
     $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>)
 target_link_libraries(keeperfx
     PRIVATE $<IF:$<TARGET_EXISTS:SDL2_mixer::SDL2_mixer>,SDL2_mixer::SDL2_mixer,SDL2_mixer::SDL2_mixer-static>)
@@ -90,7 +94,6 @@ target_link_libraries(keeperfx
 
 target_link_libraries(keeperfx_hvlog
     PRIVATE
-    $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
     $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>)
 target_link_libraries(keeperfx_hvlog
     PRIVATE $<IF:$<TARGET_EXISTS:SDL2_mixer::SDL2_mixer>,SDL2_mixer::SDL2_mixer,SDL2_mixer::SDL2_mixer-static>)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,8 +35,7 @@
             "displayName": "Config Release",
             "hidden": true,
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
         },
 
@@ -128,6 +127,7 @@
             "name": "Base",
             "hidden": true,
             "jobs": 8,
+            "verbose": true,
             "configurePreset": "Debug"
         },
 
@@ -141,8 +141,7 @@
             "name": "HeavyLog",
             "hidden": true,
             "inherits": "Base",
-            "targets": "keeperfx_hvlog",
-            "verbose": true
+            "targets": "keeperfx_hvlog"
         },
 
         {
@@ -202,7 +201,7 @@
         },
         {
             "name": "Release-MinGW32-Standard",
-            "displayName": "Debug MinGW32 Standard",
+            "displayName": "Release MinGW32 Standard",
             "inherits": "StandardLog",
             "configurePreset": "x86-MinGW32-Release"
         },


### PR DESCRIPTION
* Use LLD as linker

The default bfd linker in MinGW is extremely slow. The final linking seems to run forever.
On the other hand, LLVM linker (LLD) can complete in 1 second. Someone said we shouldn't link gcc if we use LLD, so I remove the linking of gcc.

* Remove INTERPROCEDURAL_OPTIMIZATION because it causes linking error on _WinMain().

* Remove linking of SDL2Main because we have WinMain in main.cpp.

* Enable verbose for standard build.

* Fix wrong display name of Release-MinGW32-Standard.

Type: Bug Fix
Change-Id: I0322fc7b4d851515e07732e18040e30893b98060