### PR TITLE
Improve debugging experience of CMake

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -100,7 +100,7 @@
             },
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "intelliSenseMode": "windows-gcc-x86"
+                    "intelliSenseMode": "windows-clang-x86"
                 }
             }
         },

--- a/launch.vs.json
+++ b/launch.vs.json
@@ -1,0 +1,70 @@
+{
+  "version": "0.2.1",
+  "defaults": {},
+    "configurations": [
+        {
+            "type": "cppdbg",
+            "project": "CMakeLists.txt",
+            "projectTarget": "keeperfx.exe",
+            "name": "keeperfx.exe (gdb)",
+            "currentDir": "E:\\Games\\keeperfx_1_2_0_complete",
+            "cwd": "E:\\Games\\keeperfx_1_2_0_complete",
+            "args": [
+                "-level",
+                "00001",
+                "-campaign",
+                "personal",
+                "-nointro",
+                "-alex"
+            ],
+            "program": "${debugInfo.target}",
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\msys64\\mingw32\\bin\\gdb.exe",
+            "externalConsole": true,
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "type": "cppdbg",
+            "project": "CMakeLists.txt",
+            "projectTarget": "keeperfx_hvlog.exe",
+            "name": "keeperfx_hvlog.exe (gdb)",
+            "currentDir": "E:\\Games\\keeperfx_1_2_0_complete",
+            "cwd": "E:\\Games\\keeperfx_1_2_0_complete",
+            "args": [
+                "-level",
+                "00001",
+                "-campaign",
+                "personal",
+                "-nointro",
+                "-alex"
+            ],
+            "program": "${debugInfo.target}",
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\msys64\\mingw32\\bin\\gdb.exe",
+            "externalConsole": true,
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
* It seems that "intelliSenseMode" should be windows-clang-x86.
* Modify the setupCommands of gdb to make the variables more readable in the debugger window. Without "enable-pretty-printing", they are almost not comprehensible.

The launch.vs.json can be put in the root or .vs folder. Both locations are okay.
Developer should change "currentDir" and "cwd" to the actual game folder. The "miDebuggerPath" might need to be changed, too.

Type: Bug Fix