### PR TITLE
Fixed -1 amount of creatures to pool

### DIFF
--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -1527,8 +1527,6 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                     return true;
                 }
                 game.pool.crtr_kind[crmodel] += atoi(pr3str);
-                if (game.pool.crtr_kind[crmodel] < 0)
-                    game.pool.crtr_kind[crmodel] = 0;
                 return true;
             }
         }
@@ -1547,8 +1545,6 @@ TbBool cmd_exec(PlayerNumber plyr_idx, char *msg)
                     return true;
                 }
                 game.pool.crtr_kind[crmodel] -= atoi(pr3str);
-                if (game.pool.crtr_kind[crmodel] < 0)
-                    game.pool.crtr_kind[crmodel] = 0;
                 return true;
             }
         }

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -242,7 +242,7 @@ void clear_creature_pool(void);
 void reset_creature_max_levels(void);
 void reset_script_timers_and_flags(void);
 void reset_hand_rules(void);
-void add_creature_to_pool(long kind, long amount, unsigned long a3);
+void add_creature_to_pool(long kind, long amount);
 void draw_texture(long a1, long a2, long a3, long a4, long a5, long a6, long a7);
 
 short zoom_to_next_annoyed_creature(void);

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -510,7 +510,7 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
       }
       break;
   case Cmd_ADD_CREATURE_TO_POOL:
-      add_creature_to_pool(val2, val3, 0);
+      add_creature_to_pool(val2, val3);
       break;
   case Cmd_TUTORIAL_FLASH_BUTTON:
       gui_set_button_flashing(val2, val3);

--- a/src/room_entrance.c
+++ b/src/room_entrance.c
@@ -251,12 +251,13 @@ TbBool creature_will_generate_for_dungeon(const struct Dungeon * dungeon, ThingM
 
 TbBool remove_creature_from_generate_pool(ThingModel crmodel)
 {
-    if (game.pool.crtr_kind[crmodel] <= 0) {
-        WARNLOG("Could not remove creature %s from the creature pool",creature_code_name(crmodel));
-        return false;
+    if (game.pool.crtr_kind[crmodel] > LONG_MIN)
+    {
+        game.pool.crtr_kind[crmodel]--;
+        return true;
     }
-    game.pool.crtr_kind[crmodel]--;
-    return true;
+    WARNLOG("Could not remove creature %s from the creature pool", creature_code_name(crmodel));
+    return false;
 }
 
 static int calculate_creature_to_generate_for_dungeon(const struct Dungeon * dungeon)
@@ -432,16 +433,21 @@ TbBool update_creature_pool_state(void)
     return true;
 }
 
-void add_creature_to_pool(ThingModel kind, long amount, unsigned long a3)
+void add_creature_to_pool(ThingModel kind, long amount)
 {
     long prev_amount;
     kind %= game.conf.crtr_conf.model_count;
-    prev_amount = game.pool.crtr_kind[kind];
-    if ((a3 == 0) || (prev_amount != -1))
+    
+    if (amount > 0 && game.pool.crtr_kind[kind] > LONG_MAX - amount)
     {
-        if ((amount != -1) && (amount != 0) && (prev_amount != -1))
-            game.pool.crtr_kind[kind] = prev_amount + amount;
-        else
-            game.pool.crtr_kind[kind] = amount;
+        game.pool.crtr_kind[kind] = LONG_MAX;
+    }
+    else if (amount < 0 && game.pool.crtr_kind[kind] < LONG_MIN - amount)
+    {
+        game.pool.crtr_kind[kind] = LONG_MIN;
+    }
+    else
+    {
+        game.pool.crtr_kind[kind] += amount;
     }
 }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2744,31 +2744,31 @@ struct Thing* cause_creature_death(struct Thing *thing, CrDeathFlags flags)
     if ((flags & CrDed_NoEffects) != 0)
     {
         if ((game.flags_cd & MFlg_DeadBackToPool) != 0)
-            add_creature_to_pool(crmodel, 1, 1);
+            add_creature_to_pool(crmodel, 1);
         delete_thing_structure(thing, 0);
     } else
     if (!creature_model_bleeds(thing->model))
     {
         // Non-bleeding creatures have no flesh explosion effects
         if ((game.flags_cd & MFlg_DeadBackToPool) != 0)
-            add_creature_to_pool(crmodel, 1, 1);
+            add_creature_to_pool(crmodel, 1);
         return creature_death_as_nature_intended(thing);
     } else
     if (creature_affected_by_spell(thing, SplK_Freeze))
     {
         if ((game.flags_cd & MFlg_DeadBackToPool) != 0)
-            add_creature_to_pool(crmodel, 1, 1);
+            add_creature_to_pool(crmodel, 1);
         return thing_death_ice_explosion(thing);
     } else
     if ( (shot_model_makes_flesh_explosion(cctrl->shot_model)) || (cctrl->timebomb_death) )
     {
         if ((game.flags_cd & MFlg_DeadBackToPool) != 0)
-            add_creature_to_pool(crmodel, 1, 1);
+            add_creature_to_pool(crmodel, 1);
         return thing_death_flesh_explosion(thing);
     } else
     {
         if ((game.flags_cd & MFlg_DeadBackToPool) != 0)
-            add_creature_to_pool(crmodel, 1, 1);
+            add_creature_to_pool(crmodel, 1);
         return creature_death_as_nature_intended(thing);
     }
     return INVALID_THING;


### PR DESCRIPTION
Recently I made it possible to add a negative amount of creatures to a pool, but it would break down at '-1' amount added.

This PR makes '-1' possible, completely simplifies the function, and makes it possible to get to negatives with the console commands too.