### PR TITLE
Ranged buff skips instances that are not available to creature

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -590,12 +590,18 @@ TbBool process_creature_self_spell_casting(struct Thing* creatng)
 CrInstance process_creature_ranged_buff_spell_casting(struct Thing* creatng)
 {
     TRACE_THING(creatng);
+    const struct InstanceInfo* inst_inf;
+    struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     SYNCDBG(8,"Processing %s(%d), act.st: %s, con.st: %s", thing_model_name(creatng), creatng->index,
         creature_state_code_name(creatng->active_state), creature_state_code_name(creatng->continue_state));
     CrInstance i = CrInst_NULL + 1;
     for(; i < game.conf.crtr_conf.instances_count; i++ )
     {
-        const struct InstanceInfo* inst_inf = creature_instance_info_get(i);
+        if (cctrl->instance_available[i] == false)
+        {
+            continue;
+        }
+        inst_inf = creature_instance_info_get(i);
         if(creature_instance_info_invalid(inst_inf) || (inst_inf->instance_property_flags & InstPF_RangedBuff) == 0)
         {
             continue;


### PR DESCRIPTION
Hopefully fixes this crash that sometimes happens even though I have no active ranged-buff spells:

```
Sync: [400] creature_explore_dungeon: The creature FLY owned by player 0 can't navigate to subtile (22,178) for exploring
=== Crash ===
Error: Attempt of integer division by zero.
[#15] keeperfx.exe : search_target_ranged_heal            [0x48b970+0xbd]     map lookup for: 0023:0014ba2d, base: 000c0000
[#14] keeperfx.exe : process_creature_ranged_buff_spell_casting [0x48d7d0+0xfc]     map lookup for: 0023:0014d8cc, base: 000c0000
[#13] keeperfx.exe : update_creature                      [0x5c5cc0+0x528]     map lookup for: 0023:002861e8, base: 000c0000
```