### PR TITLE
Perform sanity check after loading game settings

### DIFF
--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -19,14 +19,14 @@
 #include "pre_inc.h"
 #include "config_settings.h"
 #include "globals.h"
-
+#include "sounds.h"
 #include "bflib_basics.h"
 #include "bflib_memory.h"
 #include "bflib_fileio.h"
 #include "bflib_dernc.h"
 #include "bflib_keybrd.h"
 #include "bflib_video.h"
-
+#include "frontmenu_options.h"
 #include "config.h"
 #include "engine_camera.h"
 #include "game_merge.h"
@@ -109,7 +109,7 @@ void setup_default_settings(void)
      6,                         // first_person_move_sensitivity
      256,                       // minimap_zoom
      8192,                      // isometric_view_zoom_level
-     65536,                     // frontview_zoom_level
+     FRONTVIEW_CAMERA_ZOOM_MAX, // frontview_zoom_level
      127,                       // mentor_volume
      CAMERA_TILT_DEFAULT,       // isometric_tilt
     };
@@ -126,6 +126,22 @@ TbBool load_settings(void)
     {
       if (LbFileLoadAt(fname, &settings) == sizeof(struct GameSettings))
       {
+          // sanity checks
+          settings.video_shadows = clamp(settings.video_shadows, 0, 3);
+          settings.view_distance = clamp(settings.view_distance, 0, 3);
+          settings.video_rotate_mode = clamp(settings.video_rotate_mode, 0, 2);
+          settings.video_textures = clamp(settings.video_textures, 0, 1);
+          settings.video_cluedo_mode = clamp(settings.video_cluedo_mode, 0, 1);
+          settings.sound_volume = clamp(settings.sound_volume, 0, FULL_LOUDNESS);
+          settings.redbook_volume = clamp(settings.redbook_volume, 0, FULL_LOUDNESS);
+          settings.gamma_correction = clamp(settings.gamma_correction, 0, GAMMA_LEVELS_COUNT);
+          settings.switching_vidmodes_index = clamp(settings.switching_vidmodes_index, 0, MAX_GAME_VIDMODE_COUNT);
+          settings.first_person_move_sensitivity = clamp(settings.first_person_move_sensitivity, 0, 1000);
+          settings.minimap_zoom = clamp(settings.minimap_zoom, 256, 2048);
+          settings.isometric_view_zoom_level = clamp(settings.isometric_view_zoom_level, CAMERA_ZOOM_MIN, CAMERA_ZOOM_MAX);
+          settings.frontview_zoom_level = clamp(settings.frontview_zoom_level, FRONTVIEW_CAMERA_ZOOM_MIN, FRONTVIEW_CAMERA_ZOOM_MAX);
+          settings.mentor_volume = clamp(settings.mentor_volume, 0, 127);
+          settings.isometric_tilt = clamp(settings.isometric_tilt, CAMERA_TILT_MIN, CAMERA_TILT_MAX);
           return true;
       }
     }

--- a/src/globals.h
+++ b/src/globals.h
@@ -89,6 +89,9 @@ extern "C" {
 #ifndef min
 #define min(a,b) ((a)<(b)?(a):(b))
 #endif
+#ifndef clamp
+#define clamp(v,lo,hi) (max(lo, min(v, hi)))
+#endif
 #endif
 
 // Return values for verification functions


### PR DESCRIPTION
Make sure game settings are somewhat acceptable before using them. If for example minimap_zoom is loaded as zero, players won't be able to zoom out their minimap anymore.