### PR TITLE
Tunnels displaying correctly in low walls mode

### DIFF
--- a/src/bflib_coroutine.c
+++ b/src/bflib_coroutine.c
@@ -5,7 +5,7 @@
  *     "Improvised coroutine-like functions"
  * @par Purpose:
  *     Implementation
- * @author   KeeperFF Team
+ * @author   KeeperFX Team
  * @date     01 Nov 2020
  * @par  Copying and copyrights:
  *     This program is free software; you can redistribute it and/or modify

--- a/src/bflib_coroutine.c
+++ b/src/bflib_coroutine.c
@@ -5,7 +5,7 @@
  *     "Improvised coroutine-like functions"
  * @par Purpose:
  *     Implementation
- * @author   KeeperFX Team
+ * @author   KeeperFF Team
  * @date     01 Nov 2020
  * @par  Copying and copyrights:
  *     This program is free software; you can redistribute it and/or modify

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1171,7 +1171,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
 
-            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1180,7 +1180,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
 
-            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }
@@ -1246,7 +1246,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
-            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1254,7 +1254,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
-            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1116,10 +1116,10 @@ static void fill_in_points_perspective(struct Camera *cam, long bstl_x, long bst
     }
 }
 
-TbBool has_cube(struct Column *col) 
+TbBool has_cube_higher_up(struct Column *col) 
 {
-    for (int i = 3; i < COLUMN_STACK_HEIGHT-1; i++) {
-        if (col->cubes[i] > 0) {
+    for (int i = 3; i < COLUMN_STACK_HEIGHT; i++) {
+        if (col->cubes[i] != 0) {
             return true;
         }
     }
@@ -1171,7 +1171,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
 
-            if (has_cube(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1180,7 +1180,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
 
-            if (has_cube(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }
@@ -1246,7 +1246,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
-            if (has_cube(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1254,7 +1254,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
-            if (has_cube(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1116,7 +1116,7 @@ static void fill_in_points_perspective(struct Camera *cam, long bstl_x, long bst
     }
 }
 
-TbBool has_cube(const struct Column *col) 
+TbBool has_cube(struct Column *col) 
 {
     for (int i = 3; i < COLUMN_STACK_HEIGHT; i++) {
         if (col->cubes[i] > 0) {

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -470,7 +470,7 @@ struct EngineCoord object_origin;
 short mx;
 short my;
 short mz;
-unsigned char temp_cluedo_mode; // This is true(1) if the "short wall" have been enabled in the graphics options
+unsigned char temp_cluedo_mode; // This is true(1) if "low walls/"short wall" has been enabled in the graphics options
 struct Thing *thing_being_displayed;
 
 TbSpriteData *keepsprite[KEEPSPRITE_LENGTH];

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1116,7 +1116,7 @@ static void fill_in_points_perspective(struct Camera *cam, long bstl_x, long bst
     }
 }
 
-bool has_cube(const struct Column *col) 
+TbBool has_cube(const struct Column *col) 
 {
     for (int i = 3; i < COLUMN_STACK_HEIGHT; i++) {
         if (col->cubes[i] > 0) {
@@ -1171,7 +1171,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
 
-            if (has_cubes(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1180,7 +1180,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
 
-            if (has_cubes(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }
@@ -1246,7 +1246,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
-            if (has_cubes(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1254,7 +1254,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
-            if (has_cubes(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1171,7 +1171,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
 
-            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1180,7 +1180,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
 
-            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0)) {
                 mask_yp &= 3;
             }
         }
@@ -1246,7 +1246,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
-            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1254,7 +1254,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
-            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cube_higher_up(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0)) {
                 mask_yp &= 3;
             }
         }

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1116,6 +1116,16 @@ static void fill_in_points_perspective(struct Camera *cam, long bstl_x, long bst
     }
 }
 
+bool has_cube(const struct Column *col) 
+{
+    for (int i = 3; i < COLUMN_STACK_HEIGHT; i++) {
+        if (col->cubes[i] > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, struct MinMax *mm)
 {
     if ((bstl_y < 0) || (bstl_y > gameadd.map_subtiles_y-1)) {
@@ -1151,16 +1161,6 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
     struct Column *col;
     unsigned long pfulmask_or;
     unsigned long pfulmask_and;
-    bool has_cube(const struct Column *col) {
-    for (int i = 3; i < COLUMN_STACK_HEIGHT; i++) {
-        if (col->cubes[i] > 0) {
-            return true;
-        }
-    }
-    return false;
-    }
-
-    
     {
         unsigned long mask_cur;
         unsigned long mask_yp;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1160,7 +1160,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
-            if ((mask_cur >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & 0xE) == 0)) {
+            if ((mask_cur >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1168,7 +1168,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
-            if ((mask_yp >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & 0xE) == 0)) {
+            if ((mask_yp >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }
@@ -1234,7 +1234,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
-            if ((mask_cur >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & 0xE) == 0)) {
+            if ((mask_cur >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1242,7 +1242,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
-            if ((mask_yp >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & 0xE) == 0)) {
+            if ((mask_yp >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }
@@ -4467,7 +4467,7 @@ static void do_a_plane_of_engine_columns_cluedo(long stl_x, long stl_y, long pla
             solidmsk_cur = solidmsk_cur_raw;
             if (solidmsk_cur >= (1<<3))
             {
-                if (((cur_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((cur_colmn->bitfields & 0xE) == 0)) {
+                if (((cur_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((cur_colmn->bitfields & CLF_CEILING_MASK) == 0)) {
                     solidmsk_cur &= 3;
                 }
             }
@@ -4480,7 +4480,7 @@ static void do_a_plane_of_engine_columns_cluedo(long stl_x, long stl_y, long pla
             solidmsk_back = colmn->solidmask;
             if (solidmsk_back >= (1<<3))
             {
-                if (((sib_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((colmn->bitfields & 0xE) == 0)) {
+                if (((sib_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((colmn->bitfields & CLF_CEILING_MASK) == 0)) {
                     solidmsk_back &= 3;
                 }
             }
@@ -4492,7 +4492,7 @@ static void do_a_plane_of_engine_columns_cluedo(long stl_x, long stl_y, long pla
             solidmsk_front = colmn->solidmask;
             if (solidmsk_front >= (1<<3))
             {
-                if (((sib_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((colmn->bitfields & 0xE) == 0)) {
+                if (((sib_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((colmn->bitfields & CLF_CEILING_MASK) == 0)) {
                     solidmsk_front &= 3;
                 }
             }
@@ -4504,7 +4504,7 @@ static void do_a_plane_of_engine_columns_cluedo(long stl_x, long stl_y, long pla
             solidmsk_left = colmn->solidmask;
             if (solidmsk_left >= (1<<3))
             {
-                if (((sib_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((colmn->bitfields & 0xE) == 0)) {
+                if (((sib_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((colmn->bitfields & CLF_CEILING_MASK) == 0)) {
                     solidmsk_left &= 3;
                 }
             }
@@ -4516,7 +4516,7 @@ static void do_a_plane_of_engine_columns_cluedo(long stl_x, long stl_y, long pla
             solidmsk_right = colmn->solidmask;
             if (solidmsk_right >= (1<<3))
             {
-                if (((sib_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((colmn->bitfields & 0xE) == 0)) {
+                if (((sib_mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((colmn->bitfields & CLF_CEILING_MASK) == 0)) {
                     solidmsk_right &= 3;
                 }
             }

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1118,7 +1118,7 @@ static void fill_in_points_perspective(struct Camera *cam, long bstl_x, long bst
 
 TbBool has_cube(struct Column *col) 
 {
-    for (int i = 3; i < COLUMN_STACK_HEIGHT; i++) {
+    for (int i = 3; i < COLUMN_STACK_HEIGHT-1; i++) {
         if (col->cubes[i] > 0) {
             return true;
         }

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -1151,6 +1151,16 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
     struct Column *col;
     unsigned long pfulmask_or;
     unsigned long pfulmask_and;
+    bool has_cube(const struct Column *col) {
+    for (int i = 3; i < COLUMN_STACK_HEIGHT; i++) {
+        if (col->cubes[i] > 0) {
+            return true;
+        }
+    }
+    return false;
+    }
+
+    
     {
         unsigned long mask_cur;
         unsigned long mask_yp;
@@ -1160,7 +1170,8 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
-            if ((mask_cur >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+
+            if (has_cubes(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1168,7 +1179,8 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
-            if ((mask_yp >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+
+            if (has_cubes(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }
@@ -1234,7 +1246,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_cur = col->solidmask;
-            if ((mask_cur >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cubes(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_cur &= 3;
             }
         }
@@ -1242,7 +1254,7 @@ static void fill_in_points_cluedo(struct Camera *cam, long bstl_x, long bstl_y, 
         if (map_block_revealed(mapblk, my_player_number)) {
             col = get_map_column(mapblk);
             mask_yp = col->solidmask;
-            if ((mask_yp >= 8) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
+            if (has_cubes(col) && ((mapblk->flags & (SlbAtFlg_IsDoor|SlbAtFlg_IsRoom)) == 0) && ((col->bitfields & CLF_CEILING_MASK) == 0)) {
                 mask_yp &= 3;
             }
         }

--- a/src/engine_render.h
+++ b/src/engine_render.h
@@ -146,7 +146,7 @@ void update_engine_settings(struct PlayerInfo *player);
 void draw_view(struct Camera *cam, unsigned char a2);
 void draw_frontview_engine(struct Camera *cam);
 
-TbBool has_cube(const struct Column *col);
+TbBool has_cube(struct Column *col);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/engine_render.h
+++ b/src/engine_render.h
@@ -145,6 +145,8 @@ void draw_map_volume_box(long cor1_x, long cor1_y, long cor2_x, long cor2_y, lon
 void update_engine_settings(struct PlayerInfo *player);
 void draw_view(struct Camera *cam, unsigned char a2);
 void draw_frontview_engine(struct Camera *cam);
+
+TbBool has_cube(const struct Column *col);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -2,7 +2,7 @@
 // Free implementation of Bullfrog's Dungeon Keeper strategy game.
 /******************************************************************************/
 /** @file lvl_filesdk1.c
- *     Level files reading routines fore standard DK1 levels.
+ *     Level files reading routines for standard DK1 levels.
  * @par Purpose:
  *     Allows reading level files in DK1 format.
  * @par Comment:

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -246,20 +246,17 @@ void make_solidmask(struct Column *col)
 
 unsigned short find_column_height(struct Column *col)
 {
-  unsigned short h, highest;
+  unsigned short h;
   h = 0;
-  highest = 0; // Want to find height even if column has holes in
   if (col->solidmask == 0)
-    return highest;
-  while (h < COLUMN_STACK_HEIGHT)
+    return h;
+  while (col->cubes[h] > 0)
   {
-    if (col->cubes[h]>0)
-    {
-        highest = h;
-    }
     h++;
+    if (h >= COLUMN_STACK_HEIGHT)
+      return COLUMN_STACK_HEIGHT;
   }
-  return highest;
+  return h;
 }
 
 /**

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -63,16 +63,22 @@ TbBool column_invalid(const struct Column *colmn)
 }
 
 /**
- * Returns amount of filled subtiles at bottom of given column.
+ * These commands retrieve and set how much of the column intersects with the standard floor and ceiling
+ * 
+ * 
+ */
+
+/**
+ * Returns amount of filled subtiles at bottom of given column (how many make up the floor).
  * @param col The column which filled height should be returned.
  */
 long get_column_floor_filled_subtiles(const struct Column *col)
 {
-    return (col->bitfields & CLF_FLOOR_MASK) >> 4;
+    return (col->bitfields & CLF_FLOOR_MASK) >> 4; // Returns standard floor level or lower
 }
 
 /**
- * Returns amount of filled subtiles at bottom of column at given map block.
+ * Returns amount of filled subtiles at bottom of column at given map block (how many make up the floor).
  * @param mapblk The map block for which column height should be returned.
  */
 long get_map_floor_filled_subtiles(const struct Map *mapblk)
@@ -81,11 +87,11 @@ long get_map_floor_filled_subtiles(const struct Map *mapblk)
     col = get_map_column(mapblk);
     if (column_invalid(col))
         return 0;
-    return (col->bitfields & CLF_FLOOR_MASK) >> 4;
+    return (col->bitfields & CLF_FLOOR_MASK) >> 4; // Returns standard floor level or lower
 }
 
 /**
- * Returns amount of filled subtiles at bottom of column at given coords.
+ * Returns amount of filled subtiles at bottom of column at given coords (how many make up the floor).
  * @param stl_x Subtile for which column height should be returned, X coord.
  * @param stl_y Subtile for which column height should be returned, Y coord.
  */
@@ -95,22 +101,22 @@ long get_floor_filled_subtiles_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
     col = get_column_at(stl_x, stl_y);
     if (column_invalid(col))
         return 0;
-    return (col->bitfields & CLF_FLOOR_MASK) >> 4;
+    return (col->bitfields & CLF_FLOOR_MASK) >> 4; // Returns standard floor level or lower
 }
 
 /**
- * Sets amount of filled subtiles at bottom of given column.
+ * Sets amount of filled subtiles at bottom of given column (how many make up the floor).
  * @param col The column which filled height should be set.
  * @param n Amount of subtiles.
  */
 void set_column_floor_filled_subtiles(struct Column *col, MapSubtlCoord n)
 {
-    col->bitfields &= ~CLF_FLOOR_MASK;
-    col->bitfields |= (n<<4) & CLF_FLOOR_MASK;
+    col->bitfields &= ~CLF_FLOOR_MASK; 
+    col->bitfields |= (n<<4) & CLF_FLOOR_MASK; // sets standard floor level or lower
 }
 
 /**
- * Sets amount of filled subtiles at bottom of a column at given map block.
+ * Sets amount of filled subtiles at bottom of a column at given map block (how many make up the floor).
  * @param mapblk The map block for which filled height should be set.
  * @param n Amount of subtiles.
  */
@@ -121,20 +127,20 @@ void set_map_floor_filled_subtiles(struct Map *mapblk, MapSubtlCoord n)
     if (column_invalid(col))
         return;
     col->bitfields &= ~CLF_FLOOR_MASK;
-    col->bitfields |= (n<<4) & CLF_FLOOR_MASK;
+    col->bitfields |= (n<<4) & CLF_FLOOR_MASK; // sets standard floor level or lower
 }
 
 /**
- * Returns amount of filled subtiles at top of given column.
+ * Returns amount of filled subtiles at top of given column (how many make up the ceiling).
  * @param col The column which filled height should be returned.
  */
 long get_column_ceiling_filled_subtiles(const struct Column *col)
 {
-    return (col->bitfields & CLF_CEILING_MASK) >> 1;
+    return (col->bitfields & CLF_CEILING_MASK) >> 1; // Returns ceiling length or lower if column is shorter
 }
 
 /**
- * Returns amount of filled subtiles at top of column at given map block.
+ * Returns amount of filled subtiles at top of column at given map block (how many make up the ceiling).
  * @param mapblk The map block for which column height should be returned.
  */
 long get_map_ceiling_filled_subtiles(const struct Map *mapblk)
@@ -240,17 +246,20 @@ void make_solidmask(struct Column *col)
 
 unsigned short find_column_height(struct Column *col)
 {
-  unsigned short h;
+  unsigned short h, highest;
   h = 0;
+  highest = 0; // Want to find height even if column has holes in
   if (col->solidmask == 0)
-    return h;
-  while (col->cubes[h] > 0)
+    return highest;
+  while (h < COLUMN_STACK_HEIGHT)
   {
+    if (col->cubes[h]>0)
+    {
+        highest = h;
+    }
     h++;
-    if (h >= COLUMN_STACK_HEIGHT)
-      return COLUMN_STACK_HEIGHT;
   }
-  return h;
+  return highest;
 }
 
 /**
@@ -443,36 +452,36 @@ void init_columns(void)
             mskbit = 1;
             col->solidmask = 0;
             int n;
-            for (n=0; n < COLUMN_STACK_HEIGHT; n++)
+            for (n=0; n < COLUMN_STACK_HEIGHT; n++) 
             {
                 if (col->cubes[n] != 0) {
-                    col->solidmask |= mskbit;
+                    col->solidmask |= mskbit; //set nth bit to 1 if the cube is nonempty
                 }
                 mskbit *= 2;
             }
-            if (col->solidmask)
+            if (col->solidmask) // if column contains any cubes
             {
                 for (n=0; n < COLUMN_STACK_HEIGHT; n++)
                 {
                     if (col->cubes[n] == 0) {
-                        break;
+                        break; // set the number of solid cubes from the floor
                     }
                 }
             } else
             {
                 n = 0;
             }
-            set_column_floor_filled_subtiles(col, n);
-            n = get_column_floor_filled_subtiles(col);
+            set_column_floor_filled_subtiles(col, n); 
+            n = get_column_floor_filled_subtiles(col); // adjusts n against floor level
             for (;n < COLUMN_STACK_HEIGHT; n++)
             {
                 if (col->cubes[n] != 0) {
-                  break;
+                  break; // get first nonempty cube above floor
                 }
             }
             if (n >= COLUMN_STACK_HEIGHT)
             {
-                col->bitfields &= ~CLF_CEILING_MASK;
+                col->bitfields &= ~CLF_CEILING_MASK; // zero out any that are in ceiling
             } else
             {
                 mskbit = 0;

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -354,7 +354,7 @@ long create_column(struct Column *col)
 {
     long result;
     struct Column *dst;
-    unsigned char v6;
+    unsigned char floor_level;
     unsigned char top_of_floor;
 
     // Find an empty column
@@ -376,12 +376,12 @@ long create_column(struct Column *col)
     make_solidmask(dst);
 
     // Find lowest cube
-    for (v6 = 0; v6 < COLUMN_STACK_HEIGHT;v6++)
+    for (floor_level = 0; floor_level < COLUMN_STACK_HEIGHT;floor_level++)
     {
-        if ( dst->cubes[v6] == 0)
+        if ( dst->cubes[floor_level] == 0) // first empty cube from bottom
             break;
     }
-    top_of_floor = v6;
+    top_of_floor = floor_level;
     // set lowest cube info
     dst->bitfields &= ~CLF_FLOOR_MASK;
     dst->bitfields |= (top_of_floor << 4);
@@ -396,7 +396,7 @@ long create_column(struct Column *col)
         unsigned char ceiling = top_of_floor;
         for (; ceiling < COLUMN_STACK_HEIGHT; ceiling++)
         {
-            if (dst->cubes[ceiling])
+            if (dst->cubes[ceiling]) // first solid cube above that
                 break;
         }
 
@@ -406,14 +406,14 @@ long create_column(struct Column *col)
         }
         else
         {
-            unsigned short *v13 = &dst->cubes[7];
+            unsigned short *ceiling_cube_id = &dst->cubes[7];
             unsigned char v12 = 0;
             // Counting ceiling height
             for (int i = 0; i < COLUMN_STACK_HEIGHT-1; i++)
             {
-                if (*v13)
+                if (*ceiling_cube_id)
                     dst->bitfields ^= (v12 ^ dst->bitfields) & CLF_CEILING_MASK;
-                --v13;
+                --ceiling_cube_id;
                 v12 += 2;
             }
         }

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -240,17 +240,20 @@ void make_solidmask(struct Column *col)
 
 unsigned short find_column_height(struct Column *col)
 {
-  unsigned short h;
+  unsigned short h, highest;
   h = 0;
+  highest = 0; // Want to find height even if column has holes in
   if (col->solidmask == 0)
-    return h;
-  while (col->cubes[h] > 0)
+    return highest;
+  while (h < COLUMN_STACK_HEIGHT)
   {
+    if (col->cubes[h]>0)
+    {
+        highest = h;
+    }
     h++;
-    if (h >= COLUMN_STACK_HEIGHT)
-      return COLUMN_STACK_HEIGHT;
   }
-  return h;
+  return highest;
 }
 
 /**

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -68,7 +68,7 @@ TbBool column_invalid(const struct Column *colmn)
  */
 long get_column_floor_filled_subtiles(const struct Column *col)
 {
-    return (col->bitfields & 0xF0) >> 4;
+    return (col->bitfields & CLF_FLOOR_MASK) >> 4;
 }
 
 /**
@@ -81,7 +81,7 @@ long get_map_floor_filled_subtiles(const struct Map *mapblk)
     col = get_map_column(mapblk);
     if (column_invalid(col))
         return 0;
-    return (col->bitfields & 0xF0) >> 4;
+    return (col->bitfields & CLF_FLOOR_MASK) >> 4;
 }
 
 /**
@@ -95,7 +95,7 @@ long get_floor_filled_subtiles_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
     col = get_column_at(stl_x, stl_y);
     if (column_invalid(col))
         return 0;
-    return (col->bitfields & 0xF0) >> 4;
+    return (col->bitfields & CLF_FLOOR_MASK) >> 4;
 }
 
 /**
@@ -105,8 +105,8 @@ long get_floor_filled_subtiles_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
  */
 void set_column_floor_filled_subtiles(struct Column *col, MapSubtlCoord n)
 {
-    col->bitfields &= ~0xF0;
-    col->bitfields |= (n<<4) & 0xF0;
+    col->bitfields &= ~CLF_FLOOR_MASK;
+    col->bitfields |= (n<<4) & CLF_FLOOR_MASK;
 }
 
 /**
@@ -120,8 +120,8 @@ void set_map_floor_filled_subtiles(struct Map *mapblk, MapSubtlCoord n)
     col = get_map_column(mapblk);
     if (column_invalid(col))
         return;
-    col->bitfields &= ~0xF0;
-    col->bitfields |= (n<<4) & 0xF0;
+    col->bitfields &= ~CLF_FLOOR_MASK;
+    col->bitfields |= (n<<4) & CLF_FLOOR_MASK;
 }
 
 /**
@@ -475,14 +475,14 @@ void init_columns(void)
             }
             if (n >= COLUMN_STACK_HEIGHT)
             {
-                col->bitfields &= ~0x0E;
+                col->bitfields &= ~CLF_CEILING_MASK;
             } else
             {
                 mskbit = 0;
                 for (n=COLUMN_STACK_HEIGHT-1; n > 0; n--)
                 {
                     if (col->cubes[n] != 0) {
-                        col->bitfields ^= (mskbit ^ col->bitfields) & 0xE;
+                        col->bitfields ^= (mskbit ^ col->bitfields) & CLF_CEILING_MASK;
                     }
                     mskbit += 2;
                 }

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -240,20 +240,17 @@ void make_solidmask(struct Column *col)
 
 unsigned short find_column_height(struct Column *col)
 {
-  unsigned short h, highest;
+  unsigned short h;
   h = 0;
-  highest = 0; // Want to find height even if column has holes in
   if (col->solidmask == 0)
-    return highest;
-  while (h < COLUMN_STACK_HEIGHT)
+    return h;
+  while (col->cubes[h] > 0)
   {
-    if (col->cubes[h]>0)
-    {
-        highest = h;
-    }
     h++;
+    if (h >= COLUMN_STACK_HEIGHT)
+      return COLUMN_STACK_HEIGHT;
   }
-  return highest;
+  return h;
 }
 
 /**


### PR DESCRIPTION
See https://discord.com/channels/480505152806191114/648319840288768000/1305891716133421127

Tunnels (i.e. columns with empty cubes inside but solid cubes above) don't display properly in low walls mode. I want to make them display correctly in low walls mode so they don't look weird and potential spoil secrets.

<img src="https://github.com/user-attachments/assets/523fbd00-a664-4ea3-a175-15234db2b4ca" width="200">
<img src="https://github.com/user-attachments/assets/f3c5b002-255b-487a-8afb-1bef6ac43f0c" width="200"><br><br>


<img src="https://github.com/user-attachments/assets/5f1dd540-9dd5-478e-87dd-dc62bcd6aa0f" width="200"><img src="https://github.com/user-attachments/assets/18cbc2c8-3d9c-49fd-b551-cc65882dff00" width="200">

The aim is (for a standard 5-high column) to put the top of cube 5 onto cube 2, and display cubes 1 and 2.

![image](https://github.com/user-attachments/assets/d57535d3-cbea-4c7f-ba48-c07df0777cce)
![image](https://github.com/user-attachments/assets/bc10ce84-1936-4bd4-a653-16329ebd2212)

I've tried to find code for low walls mode but I just can't seem to find it. Wall height seems to be `video_cluedo_mode`, but I can't find any code, just toggles.

The only thing that seemed to help is [find_column_height](https://github.com/dkfans/keeperfx/blob/7dc4019bc0f6ea299b5bcdb1e99c8e5818890e91/src/map_columns.c#L241), which seems to treat the height as "how many solid blocks are there connected to the floor?", so for a cave with a hole in like in the pictures, it treats the height as 1 or 0. Maybe that's why it's not working - it's reading the height of these examples as 0 or 1. I'm going to see if this works, and if not hope someone can point me in the right direction.