### PR TITLE
Restore some instance behaviors that got changed when validate functions were introduced

### DIFF
--- a/config/fxdata/creature.cfg
+++ b/config/fxdata/creature.cfg
@@ -359,7 +359,7 @@ PrimaryTarget = 3
 Properties = SELF_BUFF
 Function = creature_cast_spell SPELL_INVISIBILITY 0
 ValidateSourceFunc = validate_source_generic 0 0
-ValidateTargetFunc = validate_target_benefits_from_defensive 0 0
+ValidateTargetFunc = validate_target_non_idle 0 0
 
 [instance14]
 Name = TELEPORT
@@ -395,7 +395,7 @@ PrimaryTarget = 3
 Properties = SELF_BUFF
 Function = creature_cast_spell SPELL_SPEED 0
 ValidateSourceFunc = validate_source_generic 0 0
-ValidateTargetFunc = validate_target_generic 0 0
+ValidateTargetFunc = validate_target_non_idle 0 0
 
 [instance16]
 Name = SLOW

--- a/levels/classic_cfgs/creature.cfg
+++ b/levels/classic_cfgs/creature.cfg
@@ -14,6 +14,10 @@ FPResetTime = 2
 Name = NAVIGATING_MISSILE
 FPResetTime = 2
 
+[instance22]
+Name = WIND
+ValidateTargetFunc = validate_target_takes_gas_damage 0 0
+
 [instance26]
 Name = GRENADE
 ResetTime = 60

--- a/levels/legacy_cfgs/creature.cfg
+++ b/levels/legacy_cfgs/creature.cfg
@@ -32,6 +32,7 @@ FPActionTime = 1
 [instance22]
 Name = WIND
 ResetTime = 1200
+ValidateTargetFunc = validate_target_takes_gas_damage 0 0
 
 [instance23]
 Name = LIGHT

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -1344,7 +1344,6 @@ TbBool validate_target_non_idle(struct Thing* source, struct Thing* target, CrIn
     }
     struct InstanceInfo* inst_inf = creature_instance_info_get(inst_idx);
     SpellKind spl_idx = inst_inf->func_params[0];
-    struct SpellConfig* spconf = get_spell_config(spl_idx);
     long state_type = get_creature_state_type(target);
     if ((state_type != CrStTyp_Idle) && !creature_affected_by_spell(target, spl_idx))
     {

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -1515,9 +1515,8 @@ TbBool validate_target_benefits_from_higher_altitude
         return false;
     }
     long state_type = get_creature_state_type(target);
-    if (state_type != CrStTyp_Idle ||
-        // Water or lava. Flying on water is beneficial because the target can go on a Guard Post.
-        subtile_is_liquid(target->mappos.x.stl.num, target->mappos.y.stl.num))
+    //Flyin in water has no advantage, since creatures will not fly over guardposts anyway.
+    if ((state_type != CrStTyp_Idle) || terrain_toxic_for_creature_at_position(source, coord_subtile(source->mappos.x.val), coord_subtile(source->mappos.y.val)))
     {
         return true;
     }

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -1322,6 +1322,33 @@ TbBool validate_target_generic
     return true;
 }
 
+
+/**
+ * @brief Check if the given creature can be the target of the specified spell by checking if it is non-idle.
+ * @param source The source creature
+ * @param target The target creature
+ * @param inst_idx The spell instance index
+ * @param param1 Optional 1st parameter.
+ * @param param2 Optional 2nd parameter.
+ * @return TbBool True if the creature can be, false if otherwise.
+ */
+TbBool validate_target_non_idle(struct Thing* source, struct Thing* target, CrInstance inst_idx, int32_t param1,int32_t param2)
+{
+    if (!validate_target_generic(source, target, inst_idx, param1, param2))
+    {
+        return false;
+    }
+    struct InstanceInfo* inst_inf = creature_instance_info_get(inst_idx);
+    SpellKind spl_idx = inst_inf->func_params[0];
+    struct SpellConfig* spconf = get_spell_config(spl_idx);
+    long state_type = get_creature_state_type(target);
+    if ((state_type != CrStTyp_Idle) && !creature_affected_by_spell(target, spl_idx))
+    {
+        return true;
+    }
+    return false;
+}
+
 /**
  * @brief Check if the given creature can be the target of the specified spell when the creature
  * is in prison/torture room.

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -124,6 +124,8 @@ const struct NamedCommand creature_instances_validate_func_type[] = {
     {"validate_target_benefits_from_higher_altitude",           8},
     {"validate_target_benefits_from_offensive",                 9},
     {"validate_target_benefits_from_wind",                      10},
+    {"validate_target_non_idle",                                11},
+    {"validate_target_takes_gas_damage",                        12},
     {NULL, 0},
 };
 
@@ -139,6 +141,8 @@ Creature_Validate_Func creature_instances_validate_func_list[] = {
     validate_target_benefits_from_higher_altitude,
     validate_target_benefits_from_offensive,
     validate_target_benefits_from_wind,
+    validate_target_non_idle,
+    validate_target_takes_gas_damage,
     NULL,
 };
 
@@ -1599,6 +1603,34 @@ TbBool validate_target_benefits_from_wind
         return true;
     }
 
+    return false;
+}
+
+
+/**
+ * @brief The classic condition to determine if wind is used.
+ *
+ * @param source The source creature
+ * @param target The target creature
+ * @param inst_idx  The spell instance index
+ * @param param1 Optional 1st parameter.
+ * @param param2 Optional 2nd parameter.
+ * @return TbBool True if the creature can, false if otherwise.
+ */
+TbBool validate_target_takes_gas_damage(struct Thing* source, struct Thing* target, CrInstance inst_idx, int32_t param1, int32_t param2)
+{
+    // Note that we don't need to call validate_target_generic or validate_target_basic because
+    // Wind isn't SELF_BUFF. It doesn't require a target, the target parameter is just the source.
+    struct CreatureControl* cctrl = creature_control_get_from_thing(target);
+    if (creature_control_invalid(cctrl))
+    {
+        ERRORLOG("Invalid creature control");
+        return false;
+    }
+    if ((cctrl->spell_flags & CSAfF_PoisonCloud) != 0)
+    {
+        return true;
+    }
     return false;
 }
 

--- a/src/creature_instances.h
+++ b/src/creature_instances.h
@@ -176,6 +176,8 @@ TbBool validate_target_benefits_from_higher_altitude(struct Thing *source, struc
 TbBool validate_target_benefits_from_offensive(struct Thing *source, struct Thing *target, CrInstance inst_idx, int32_t param1, int32_t param2);
 TbBool validate_target_benefits_from_wind(struct Thing *source, struct Thing *target, CrInstance inst_idx, int32_t param1, int32_t param2);
 TbBool validate_target_benefits_from_healing(struct Thing *source, struct Thing *target, CrInstance inst_idx, int32_t param1, int32_t param2);
+TbBool validate_target_non_idle(struct Thing* source, struct Thing* target, CrInstance inst_idx, int32_t param1, int32_t param2);
+TbBool validate_target_takes_gas_damage(struct Thing* source, struct Thing* target, CrInstance inst_idx, int32_t param1, int32_t param2);
 
 TbBool search_target_generic(struct Thing *source, CrInstance inst_idx, ThingIndex **targets, uint16_t *found_count, int32_t param1, int32_t param2);
 TbBool search_target_ranged_heal(struct Thing *source, CrInstance inst_idx, ThingIndex **targets, uint16_t *found_count, int32_t param1, int32_t param2);


### PR DESCRIPTION
- Speed only cast when heroes non-idle
- Invisibility also cast outside of combat
- Flight no longer cast when idle in water
- Wind on classic/legacy no longer used when facing several melee attackers