### PR TITLE
Implemented PLACE_DOOR script command

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -30,6 +30,7 @@
 #include "creature_states.h"
 #include "creature_states_mood.h"
 #include "creature_states_pray.h"
+#include "cursor_tag.h"
 #include "custom_sprites.h"
 #include "dungeon_data.h"
 #include "frontmenu_ingame_map.h"
@@ -486,6 +487,12 @@ const struct NamedCommand fill_desc[] = {
 const struct NamedCommand set_door_desc[] = {
   {"LOCKED", 1},
   {"UNLOCKED", 2},
+  {NULL, 0}
+};
+
+const struct NamedCommand is_free_desc[] = {
+  {"PAID", 0},
+  {"FREE", 1},
   {NULL, 0}
 };
 
@@ -2665,6 +2672,91 @@ static void set_door_process(struct ScriptContext* context)
         case 2:
             unlock_door(doortng);
             break;
+        }
+    }
+}
+
+static void place_door_check(const struct ScriptLine* scline)
+{
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
+    const char* doorname = scline->tp[1];
+    short door_id = get_id(door_desc, doorname);
+    
+    if (door_id == -1)
+    {
+        SCRPTERRLOG("Unknown door, '%s'", doorname);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
+
+    if (slab_coords_invalid(scline->np[2], scline->np[3]))
+    {
+        SCRPTERRLOG("Invalid slab coordinates: %ld, %ld", scline->np[2], scline->np[3]);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
+
+    short locked = get_id(set_door_desc, scline->tp[4]);
+    if (locked == -1)
+    {
+        SCRPTERRLOG("Door locked state %s not recognized", scline->tp[4]);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
+
+    short free;
+    if (parameter_is_number(scline->tp[5]))
+    {
+        free = atoi(scline->tp[5]);
+    }
+    else
+    {
+        free = get_id(is_free_desc, scline->tp[5]);
+    }
+    if ((free < 0) || (free > 1))
+    {
+        SCRPTERRLOG("Place Door free state '%s' not recognized", scline->tp[5]);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
+
+    value->shorts[1] = door_id;
+    value->shorts[2] = scline->np[2];
+    value->shorts[3] = scline->np[3];
+    value->shorts[4] = (locked == 1);
+    value->shorts[5] = free;
+    PROCESS_SCRIPT_VALUE(scline->command);
+}
+
+static void place_door_process(struct ScriptContext* context)
+{
+    ThingModel doorkind = context->value->shorts[1];
+    MapSubtlCoord stl_x = slab_subtile(context->value->shorts[2], 0);
+    MapSubtlCoord stl_y = slab_subtile(context->value->shorts[3], 0);
+    TbBool locked = context->value->shorts[4];
+    TbBool free = context->value->shorts[5];
+    TbBool success;
+
+    for (int plyridx = context->plr_start; plyridx < context->plr_end; plyridx++)
+    {
+        if (tag_cursor_blocks_place_door(plyridx, stl_x, stl_y))
+        {
+            if (!free)
+            {
+                if (!is_door_placeable(plyridx, doorkind))
+                {
+                    continue;
+                }
+            }
+            success = player_place_door_without_check_at(stl_x, stl_y, plyridx, doorkind);
+            if (success & locked)
+            {
+                struct Thing* doortng = get_door_for_position(stl_x, stl_y);
+                if (!thing_is_invalid(doortng))
+                {
+                    lock_door(doortng);
+                }
+            }
         }
     }
 }
@@ -7304,6 +7396,7 @@ const struct CommandDesc command_desc[] = {
   {"HEART_LOST_QUICK_OBJECTIVE",        "NAl     ", Cmd_HEART_LOST_QUICK_OBJECTIVE, &heart_lost_quick_objective_check, &heart_lost_quick_objective_process},
   {"HEART_LOST_OBJECTIVE",              "Nl      ", Cmd_HEART_LOST_OBJECTIVE, &heart_lost_objective_check, &heart_lost_objective_process},
   {"SET_DOOR",                          "ANN     ", Cmd_SET_DOOR, &set_door_check, &set_door_process},
+  {"PLACE_DOOR",                        "PANNAA  ", Cmd_PLACE_DOOR, &place_door_check, &place_door_process},
   {"ZOOM_TO_LOCATION",                  "PL      ", Cmd_MOVE_PLAYER_CAMERA_TO, &player_zoom_to_check, &player_zoom_to_process},
   {"SET_CREATURE_INSTANCE",             "CNAN    ", Cmd_SET_CREATURE_INSTANCE, &set_creature_instance_check, &set_creature_instance_process},
   {"SET_HAND_RULE",                     "PC!Aaaa ", Cmd_SET_HAND_RULE, &set_hand_rule_check, &set_hand_rule_process},

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2731,8 +2731,10 @@ static void place_door_check(const struct ScriptLine* scline)
 static void place_door_process(struct ScriptContext* context)
 {
     ThingModel doorkind = context->value->shorts[1];
-    MapSubtlCoord stl_x = slab_subtile_center(context->value->shorts[2]);
-    MapSubtlCoord stl_y = slab_subtile_center(context->value->shorts[3]);
+    MapCoord slb_x = context->value->shorts[2];
+    MapCoord slb_y = context->value->shorts[3];
+    MapSubtlCoord stl_x = slab_subtile_center(slb_x);
+    MapSubtlCoord stl_y = slab_subtile_center(slb_y);
     TbBool locked = context->value->shorts[4];
     TbBool free = context->value->shorts[5];
     TbBool success;
@@ -2751,16 +2753,14 @@ static void place_door_process(struct ScriptContext* context)
             success = player_place_door_without_check_at(stl_x, stl_y, plyridx, doorkind);
             if (success)
             {
-                struct Thing* doortng = get_door_for_position(stl_x, stl_y);
-                if (!thing_is_invalid(doortng))
+                delete_room_slabbed_objects(get_slab_number(slb_x, slb_y));
+                remove_dead_creatures_from_slab(slb_x, slb_y);
+                if (locked)
                 {
-                    if (locked)
+                    struct Thing* doortng = get_door_for_position(stl_x, stl_y);
+                    if (!thing_is_invalid(doortng))
                     {
                         lock_door(doortng);
-                    }
-                    else
-                    {
-                        unlock_door(doortng);
                     }
                 }
             }

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2731,8 +2731,8 @@ static void place_door_check(const struct ScriptLine* scline)
 static void place_door_process(struct ScriptContext* context)
 {
     ThingModel doorkind = context->value->shorts[1];
-    MapSubtlCoord stl_x = slab_subtile(context->value->shorts[2], 0);
-    MapSubtlCoord stl_y = slab_subtile(context->value->shorts[3], 0);
+    MapSubtlCoord stl_x = slab_subtile_center(context->value->shorts[2]);
+    MapSubtlCoord stl_y = slab_subtile_center(context->value->shorts[3]);
     TbBool locked = context->value->shorts[4];
     TbBool free = context->value->shorts[5];
     TbBool success;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -2749,12 +2749,19 @@ static void place_door_process(struct ScriptContext* context)
                 }
             }
             success = player_place_door_without_check_at(stl_x, stl_y, plyridx, doorkind);
-            if (success & locked)
+            if (success)
             {
                 struct Thing* doortng = get_door_for_position(stl_x, stl_y);
                 if (!thing_is_invalid(doortng))
                 {
-                    lock_door(doortng);
+                    if (locked)
+                    {
+                        lock_door(doortng);
+                    }
+                    else
+                    {
+                        unlock_door(doortng);
+                    }
                 }
             }
         }

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -4792,7 +4792,21 @@ static void use_power_on_players_creatures_check(const struct ScriptLine* scline
     const char* pwr_name = scline->tp[3];
     short pwr_id = get_rid(power_desc, pwr_name);
     short splevel = scline->np[4];
-    TbBool free = scline->np[5];
+    short free;
+    if (parameter_is_number(scline->tp[5]))
+    {
+        free = atoi(scline->tp[5]);
+    }
+    else
+    {
+        free = get_id(is_free_desc, scline->tp[5]);
+    }
+    if ((free < 0) || (free > 1))
+    {
+        SCRPTERRLOG("Unknown free value '%s' not recognized", scline->tp[5]);
+        DEALLOCATE_SCRIPT_VALUE
+        return;
+    }
 
     if (crtr_id == CREATURE_NONE)
     {
@@ -7337,12 +7351,12 @@ const struct CommandDesc command_desc[] = {
   {"LEVEL_VERSION",                     "N       ", Cmd_LEVEL_VERSION, NULL, NULL},
   {"KILL_CREATURE",                     "PC!AN   ", Cmd_KILL_CREATURE, NULL, NULL},
   {"COMPUTER_DIG_TO_LOCATION",          "PLL     ", Cmd_COMPUTER_DIG_TO_LOCATION, NULL, NULL},
-  {"USE_POWER_ON_CREATURE",             "PC!APANN", Cmd_USE_POWER_ON_CREATURE, NULL, NULL},
-  {"USE_POWER_ON_PLAYERS_CREATURES",    "PC!PANN ", Cmd_USE_POWER_ON_PLAYERS_CREATURES, &use_power_on_players_creatures_check, &use_power_on_players_creatures_process },
-  {"USE_POWER_AT_POS",                  "PNNANN  ", Cmd_USE_POWER_AT_POS, NULL, NULL},
-  {"USE_POWER_AT_SUBTILE",              "PNNANN  ", Cmd_USE_POWER_AT_POS, NULL, NULL},  //todo: Remove after mapmakers have received time to use USE_POWER_AT_POS
-  {"USE_POWER_AT_LOCATION",             "PLANN   ", Cmd_USE_POWER_AT_LOCATION, NULL, NULL},
-  {"USE_POWER",                         "PAN     ", Cmd_USE_POWER, NULL, NULL},
+  {"USE_POWER_ON_CREATURE",             "PC!APANA", Cmd_USE_POWER_ON_CREATURE, NULL, NULL},
+  {"USE_POWER_ON_PLAYERS_CREATURES",    "PC!PANA ", Cmd_USE_POWER_ON_PLAYERS_CREATURES, &use_power_on_players_creatures_check, &use_power_on_players_creatures_process },
+  {"USE_POWER_AT_POS",                  "PNNANA  ", Cmd_USE_POWER_AT_POS, NULL, NULL},
+  {"USE_POWER_AT_SUBTILE",              "PNNANA  ", Cmd_USE_POWER_AT_POS, NULL, NULL},  //todo: Remove after mapmakers have received time to use USE_POWER_AT_POS
+  {"USE_POWER_AT_LOCATION",             "PLANA   ", Cmd_USE_POWER_AT_LOCATION, NULL, NULL},
+  {"USE_POWER",                         "PAA     ", Cmd_USE_POWER, NULL, NULL},
   {"USE_SPECIAL_INCREASE_LEVEL",        "PN      ", Cmd_USE_SPECIAL_INCREASE_LEVEL, NULL, NULL},
   {"USE_SPECIAL_MULTIPLY_CREATURES",    "PN      ", Cmd_USE_SPECIAL_MULTIPLY_CREATURES, NULL, NULL},
   {"MAKE_SAFE",                         "P       ", Cmd_MAKE_SAFE, NULL, NULL},

--- a/src/lvl_script_conditions.h
+++ b/src/lvl_script_conditions.h
@@ -31,6 +31,7 @@ extern "C" {
 
 extern const struct NamedCommand variable_desc[];
 extern const struct NamedCommand dk1_variable_desc[];
+extern const struct NamedCommand is_free_desc[];
 
 
 long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, unsigned char a3);

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -187,6 +187,7 @@ enum TbScriptCommands {
     Cmd_CHANGE_SLAB_TEXTURE                = 174,
     Cmd_MOVE_PLAYER_CAMERA_TO              = 175,
     Cmd_ADD_OBJECT_TO_LEVEL_AT_POS         = 176,
+    Cmd_PLACE_DOOR                         = 177,
 };
 
 struct ScriptLine {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2745,9 +2745,9 @@ void update(void)
     player = get_my_player();
     set_previous_camera_values(player);
 
-    if ((game.operation_flags & GOF_Paused) == 0)
+    if (!flag_is_set(game.operation_flags,GOF_Paused))
     {
-        if (player->additional_flags & PlaAF_LightningPaletteIsActive)
+        if (flag_is_set(player->additional_flags,PlaAF_LightningPaletteIsActive))
         {
             PaletteSetPlayerPalette(player, engine_palette);
             clear_flag(player->additional_flags, PlaAF_LightningPaletteIsActive);
@@ -2757,7 +2757,6 @@ void update(void)
         if ((game.play_gameturn & 0x01) != 0)
             update_animating_texture_maps();
         update_things();
-        game.map_changed_for_nagivation = 0;
         process_rooms();
         process_dungeons();
         update_research();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2757,6 +2757,7 @@ void update(void)
         if ((game.play_gameturn & 0x01) != 0)
             update_animating_texture_maps();
         update_things();
+        game.map_changed_for_nagivation = 0;
         process_rooms();
         process_dungeons();
         update_research();
@@ -2788,7 +2789,6 @@ void update(void)
     message_update();
     update_all_players_cameras();
     update_player_sounds();
-    game.map_changed_for_nagivation = 0;
     SYNCDBG(6,"Finished");
 }
 

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1267,7 +1267,7 @@ TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
 {
     if (!is_door_placeable(plyr_idx, tngmodel)) {
         WARNLOG("Player %d tried to build %s but has none to place",(int)plyr_idx,door_code_name(tngmodel));
-        return 0;
+      //  return 0;
     }
     unsigned char orient = find_door_angle(stl_x, stl_y, plyr_idx);
     struct Coord3d pos;

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1267,7 +1267,7 @@ TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
 {
     if (!is_door_placeable(plyr_idx, tngmodel)) {
         WARNLOG("Player %d tried to build %s but has none to place",(int)plyr_idx,door_code_name(tngmodel));
-      //  return 0;
+        return 0;
     }
     unsigned char orient = find_door_angle(stl_x, stl_y, plyr_idx);
     struct Coord3d pos;

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1263,15 +1263,11 @@ TbBool player_place_trap_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
     return true;
 }
 
-TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel)
+TbBool player_place_door_without_check_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel)
 {
-    if (!is_door_placeable(plyr_idx, tngmodel)) {
-        WARNLOG("Player %d tried to build %s but has none to place",(int)plyr_idx,door_code_name(tngmodel));
-        return 0;
-    }
     unsigned char orient = find_door_angle(stl_x, stl_y, plyr_idx);
     struct Coord3d pos;
-    set_coords_to_slab_center(&pos,subtile_slab(stl_x),subtile_slab(stl_y));
+    set_coords_to_slab_center(&pos, subtile_slab(stl_x), subtile_slab(stl_y));
     create_door(&pos, tngmodel, orient, plyr_idx, 0);
     do_slab_efficiency_alteration(subtile_slab(stl_x), subtile_slab(stl_y));
     struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
@@ -1286,7 +1282,7 @@ TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
         remove_workshop_object_from_player(plyr_idx, door_crate_object_model(tngmodel));
         break;
     default:
-        WARNLOG("Placeable door %s amount for player %d was incorrect; fixed",door_code_name(tngmodel),(int)dungeon->owner);
+        WARNLOG("Placeable door %s amount for player %d was incorrect; fixed", door_code_name(tngmodel), (int)dungeon->owner);
         dungeon->mnfct_info.door_amount_placeable[tngmodel] = 0;
         break;
     }
@@ -1297,6 +1293,15 @@ TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
         play_non_3d_sample(door_cfg->place_sound_idx);
     }
     return 1;
+}
+
+TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel)
+{
+    if (!is_door_placeable(plyr_idx, tngmodel)) {
+        WARNLOG("Player %d tried to build %s but has none to place",(int)plyr_idx,door_code_name(tngmodel));
+        return 0;
+    }
+    return player_place_door_without_check_at(stl_x, stl_y, plyr_idx, tngmodel);
 }
 
 TbBool is_thing_directly_controlled_by_player(const struct Thing *thing, PlayerNumber plyr_idx)

--- a/src/player_instances.h
+++ b/src/player_instances.h
@@ -113,6 +113,7 @@ void set_player_zoom_to_position(struct PlayerInfo *player,struct Coord3d *pos);
 struct Room *player_build_room_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, RoomKind rkind);
 TbBool player_place_trap_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel);
 TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel);
+TbBool player_place_door_without_check_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/room_util.c
+++ b/src/room_util.c
@@ -18,32 +18,31 @@
 /******************************************************************************/
 #include "pre_inc.h"
 #include "room_util.h"
-#include "globals.h"
 
-#include "ariadne_wallhug.h"
+#include "globals.h"
 #include "bflib_basics.h"
-#include "config_creature.h"
-#include "config_terrain.h"
-#include "dungeon_data.h"
-#include "frontend.h"
-#include "game_legacy.h"
-#include "gui_soundmsgs.h"
-#include "keeperfx.hpp"
-#include "map_blocks.h"
-#include "map_utils.h"
-#include "math.h"
-#include "player_data.h"
-#include "player_instances.h"
 #include "room_data.h"
 #include "room_garden.h"
-#include "room_list.h"
-#include "room_workshop.h"
+#include "map_utils.h"
+#include "map_blocks.h"
+#include "player_data.h"
+#include "dungeon_data.h"
 #include "thing_data.h"
 #include "thing_doors.h"
+#include "thing_stats.h"
+#include "thing_physics.h"
 #include "thing_effects.h"
 #include "thing_objects.h"
-#include "thing_physics.h"
-#include "thing_stats.h"
+#include "room_list.h"
+#include "room_workshop.h"
+#include "ariadne_wallhug.h"
+#include "config_terrain.h"
+#include "config_creature.h"
+#include "gui_soundmsgs.h"
+#include "game_legacy.h"
+#include "keeperfx.hpp"
+#include "frontend.h"
+#include "math.h"
 #include "post_inc.h"
 
 /******************************************************************************/
@@ -294,19 +293,6 @@ TbBool delete_room_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, TbBool is_destro
     return true;
 }
 
-ThingModel find_door_kind(SlabKind slb)
-{
-    struct DoorConfigStats* doorst;
-    for (int tngmodel = 0; tngmodel < game.conf.trapdoor_conf.door_types_count; tngmodel++) {
-        doorst = get_door_model_stats(tngmodel);
-
-        if (doorst->slbkind[0] == slb || doorst->slbkind[1] == slb) {
-            return tngmodel;
-        }
-    }
-    return -1;
-}
-
 TbBool replace_slab_from_script(MapSlabCoord slb_x, MapSlabCoord slb_y, unsigned char slabkind)
 {
     struct Room* room = slab_room_get(slb_x, slb_y);
@@ -325,26 +311,12 @@ TbBool replace_slab_from_script(MapSlabCoord slb_x, MapSlabCoord slb_y, unsigned
         {
             if (slab_kind_is_animated(slabkind))
             {
-                if (slab_kind_is_door(slabkind))
-                {
-                    player_place_door_at(slab_subtile(slb_x, 0), slab_subtile(slb_y, 0), plyr_idx, find_door_kind(slabkind));
-                }
-                else
-                {
-                    place_animating_slab_type_on_map(slabkind, 0, slab_subtile(slb_x, 0), slab_subtile(slb_y, 0), plyr_idx);
-                }
+                place_animating_slab_type_on_map(slabkind, 0, slab_subtile(slb_x, 0), slab_subtile(slb_y, 0), plyr_idx);  
             }
             else
             {
-                if (slab_kind_is_door(slabkind))
-                {
-                    player_place_door_at(slab_subtile(slb_x, 0), slab_subtile(slb_y, 0), plyr_idx, find_door_kind(slabkind));
-                }
-                else
-                {
-                    place_slab_type_on_map(slabkind, slab_subtile(slb_x, 0), slab_subtile(slb_y, 0), plyr_idx, 0);
-                    set_alt_bit_on_slabs_around(slb_x, slb_y);
-                }
+                place_slab_type_on_map(slabkind, slab_subtile(slb_x, 0), slab_subtile(slb_y, 0), plyr_idx, 0);
+                set_alt_bit_on_slabs_around(slb_x, slb_y);
             }
             return true;
         }

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -1178,6 +1178,7 @@ void update_things(void)
     update_things_sounds_in_list(&game.thing_lists[TngList_AmbientSnds]);
     update_cave_in_things();
     player_packet_checksum_add(my_player_number,sum,"things");
+    game.map_changed_for_nagivation = 0;
     SYNCDBG(9,"Finished");
 }
 


### PR DESCRIPTION
- `PLACE_DOOR([player],[door],[slb_x],[slb_y],[locked],[free]`
- All USE_POWER_* script commands (5 of them) can now use strings for [free] block too
- [free] allows `0 / 1` or `PAID / FREE`.
- Placing a door 'PAID' means you should be able to subtract a door from the player, free it places it anyway.
- Fixed pathfinding to be correctly updated by level scripts