### PR TITLE
Traps: InstantPlacement & RemoveOnceDepleted

### DIFF
--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -209,6 +209,10 @@ TriggerAlarm = 0
 PlaceOnBridge = 0
 ; If set to 1 allows the trap to be placed anywhere on a slab. This results in up to 9 traps per tile.
 PlaceOnSubtile = 0
+; Place the trap immediately without needing imps to drag the crate to arm it.
+InstantPlacement = 0
+; Destroy the trap once it runs out of Shots.
+RemoveOnceDepleted = 0
 ; Amount of hit points the trap have.
 Health = 0
 ; Can the trap be destroyed by attacking it. If 1 it can by any attack, 0 only by units with 'DISARM ability', -1 by nobody.

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -63,58 +63,60 @@ const struct NamedCommand trapdoor_door_commands[] = {
 };
 
 const struct NamedCommand trapdoor_trap_commands[] = {
-  {"NAME",                  1},
-  {"MANUFACTURELEVEL",      2},
-  {"MANUFACTUREREQUIRED",   3},
-  {"SHOTS",                 4},
-  {"TIMEBETWEENSHOTS",      5},
-  {"SELLINGVALUE",          6},
-  {"NAMETEXTID",            7},
-  {"TOOLTIPTEXTID",         8},
-  {"CRATE",                 9},
-  {"SYMBOLSPRITES",        10},
-  {"POINTERSPRITES",       11},
-  {"PANELTABINDEX",        12},
-  {"TRIGGERTYPE",          13},
-  {"ACTIVATIONTYPE",       14},
-  {"EFFECTTYPE",           15},
-  {"ANIMATIONID",          16},
-  {"MODEL",                16},//backward compatibility
-  {"MODELSIZE",            17},
-  {"ANIMATIONSPEED",       18},
-  {"UNANIMATED",           19},
-  {"HIDDEN",               20},
-  {"SLAPPABLE",            21},
-  {"TRIGGERALARM",         22},
-  {"HEALTH",               23},
-  {"UNSHADED",             24},
-  {"RANDOMSTARTFRAME",     25},
-  {"THINGSIZE",            26},
-  {"HITTYPE",              27},
-  {"LIGHTRADIUS",          28},
-  {"LIGHTINTENSITY",       29},
-  {"LIGHTFLAGS",           30},
-  {"TRANSPARENCYFLAGS",    31},
-  {"SHOTVECTOR",           32},
-  {"DESTRUCTIBLE",         33},
-  {"UNSTABLE",             34},
-  {"UNSELLABLE",           35},
-  {"PLACEONBRIDGE",        36},
-  {"SHOTORIGIN",           37},
-  {"PLACESOUND",           38},
-  {"TRIGGERSOUND",         39},
-  {"RECHARGEANIMATIONID",  40},
-  {"ATTACKANIMATIONID",    41},
-  {"DESTROYEDEFFECT",      42},
-  {"INITIALDELAY",         43},
-  {"PLACEONSUBTILE",       44},
-  {"FLAMEANIMATIONID",     45},
-  {"FLAMEANIMATIONSPEED",  46},
-  {"FLAMEANIMATIONSIZE",   47},
-  {"FLAMEANIMATIONOFFSET",    48},
-  {"FLAMETRANSPARENCYFLAGS",  49},
-  {"DETECTINVISIBLE",         50},
-  {NULL,                       0},
+  {"NAME",                    1},
+  {"MANUFACTURELEVEL",        2},
+  {"MANUFACTUREREQUIRED",     3},
+  {"SHOTS",                   4},
+  {"TIMEBETWEENSHOTS",        5},
+  {"SELLINGVALUE",            6},
+  {"NAMETEXTID",              7},
+  {"TOOLTIPTEXTID",           8},
+  {"CRATE",                   9},
+  {"SYMBOLSPRITES",          10},
+  {"POINTERSPRITES",         11},
+  {"PANELTABINDEX",          12},
+  {"TRIGGERTYPE",            13},
+  {"ACTIVATIONTYPE",         14},
+  {"EFFECTTYPE",             15},
+  {"ANIMATIONID",            16},
+  {"MODEL",                  16}, // Backward compatibility.
+  {"MODELSIZE",              17},
+  {"ANIMATIONSPEED",         18},
+  {"UNANIMATED",             19},
+  {"HIDDEN",                 20},
+  {"SLAPPABLE",              21},
+  {"TRIGGERALARM",           22},
+  {"HEALTH",                 23},
+  {"UNSHADED",               24},
+  {"RANDOMSTARTFRAME",       25},
+  {"THINGSIZE",              26},
+  {"HITTYPE",                27},
+  {"LIGHTRADIUS",            28},
+  {"LIGHTINTENSITY",         29},
+  {"LIGHTFLAGS",             30},
+  {"TRANSPARENCYFLAGS",      31},
+  {"SHOTVECTOR",             32},
+  {"DESTRUCTIBLE",           33},
+  {"UNSTABLE",               34},
+  {"UNSELLABLE",             35},
+  {"PLACEONBRIDGE",          36},
+  {"SHOTORIGIN",             37},
+  {"PLACESOUND",             38},
+  {"TRIGGERSOUND",           39},
+  {"RECHARGEANIMATIONID",    40},
+  {"ATTACKANIMATIONID",      41},
+  {"DESTROYEDEFFECT",        42},
+  {"INITIALDELAY",           43},
+  {"PLACEONSUBTILE",         44},
+  {"FLAMEANIMATIONID",       45},
+  {"FLAMEANIMATIONSPEED",    46},
+  {"FLAMEANIMATIONSIZE",     47},
+  {"FLAMEANIMATIONOFFSET",   48},
+  {"FLAMETRANSPARENCYFLAGS", 49},
+  {"DETECTINVISIBLE",        50},
+  {"INSTANTPLACEMENT",       51},
+  {"REMOVEONCEDEPLETED",     52},
+  {NULL,                      0},
 };
 
 const struct NamedCommand door_properties_commands[] = {
@@ -207,6 +209,8 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
           trapst->notify = false;
           trapst->place_on_bridge = false;
           trapst->place_on_subtile = false;
+          trapst->instant_placement = false;
+          trapst->remove_once_depleted = false;
           trapst->health = 1;
           trapst->destructible = 0;
           trapst->unstable = 0;
@@ -1155,6 +1159,38 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
               if (k >= 0)
               {
                   trapst->detect_invisible = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%.*s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), blocknamelen, blockname, config_textname);
+          }
+          break;
+      case 51: // INSTANTPLACEMENT
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  trapst->instant_placement = k;
+                  n++;
+              }
+          }
+          if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%.*s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), blocknamelen, blockname, config_textname);
+          }
+          break;
+      case 52: // REMOVEONCEDEPLETED
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if (k >= 0)
+              {
+                  trapst->remove_once_depleted = k;
                   n++;
               }
           }

--- a/src/config_trapdoor.h
+++ b/src/config_trapdoor.h
@@ -83,6 +83,8 @@ struct TrapConfigStats {
     TbBool notify;
     TbBool place_on_bridge;
     TbBool place_on_subtile;
+    TbBool instant_placement;
+    TbBool remove_once_depleted;
     HitPoints health;
     char destructible;
     char unstable;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -220,57 +220,59 @@ const struct NamedCommand creature_select_criteria_desc[] = {
 };
 
 const struct NamedCommand trap_config_desc[] = {
-  {"NameTextID",           1},
-  {"TooltipTextID",        2},
-  {"SymbolSprites",        3},
-  {"PointerSprites",       4},
-  {"PanelTabIndex",        5},
-  {"Crate",                6},
-  {"ManufactureLevel",     7},
-  {"ManufactureRequired",  8},
-  {"Shots",                9},
-  {"TimeBetweenShots",    10},
-  {"SellingValue",        11},
-  {"AnimationID",         12},
-  {"Model",               12}, //legacy name
-  {"ModelSize",           13},
-  {"AnimationSpeed",      14},
-  {"TriggerType",         15},
-  {"ActivationType",      16},
-  {"EffectType",          17},
-  {"Hidden",              18},
-  {"TriggerAlarm",        19},
-  {"Slappable",           20},
-  {"Unanimated",          21},
-  {"Health",              22},
-  {"Unshaded",            23},
-  {"RandomStartFrame",    24},
-  {"ThingSize",           25},
-  {"HitType",             26},
-  {"LightRadius",         27},
-  {"LightIntensity",      28},
-  {"LightFlags",          29},
-  {"TransparencyFlags",   30},
-  {"ShotVector",          31},
-  {"Destructible",        32},
-  {"Unstable",            33},
-  {"Unsellable",          34},
-  {"PlaceOnBridge",       35},
-  {"ShotOrigin",          36},
-  {"PlaceSound",          37},
-  {"TriggerSound",        38},
-  {"RechargeAnimationID", 39},
-  {"AttackAnimationID",   40},
-  {"DestroyedEffect",     41},
-  {"InitialDelay",        42},
-  {"PlaceOnSubtile",      43},
-  {"FlameAnimationID",       44},
-  {"FlameAnimationSpeed",    45},
-  {"FlameAnimationSize",     46},
-  {"FlameAnimationOffset",   47},
-  {"FlameTransparencyFlags", 48},
-  {"DetectInvisible",        49},
-  {NULL,                      0},
+  {"NameTextID",               1},
+  {"TooltipTextID",            2},
+  {"SymbolSprites",            3},
+  {"PointerSprites",           4},
+  {"PanelTabIndex",            5},
+  {"Crate",                    6},
+  {"ManufactureLevel",         7},
+  {"ManufactureRequired",      8},
+  {"Shots",                    9},
+  {"TimeBetweenShots",        10},
+  {"SellingValue",            11},
+  {"AnimationID",             12},
+  {"Model",                   12}, // Legacy name.
+  {"ModelSize",               13},
+  {"AnimationSpeed",          14},
+  {"TriggerType",             15},
+  {"ActivationType",          16},
+  {"EffectType",              17},
+  {"Hidden",                  18},
+  {"TriggerAlarm",            19},
+  {"Slappable",               20},
+  {"Unanimated",              21},
+  {"Health",                  22},
+  {"Unshaded",                23},
+  {"RandomStartFrame",        24},
+  {"ThingSize",               25},
+  {"HitType",                 26},
+  {"LightRadius",             27},
+  {"LightIntensity",          28},
+  {"LightFlags",              29},
+  {"TransparencyFlags",       30},
+  {"ShotVector",              31},
+  {"Destructible",            32},
+  {"Unstable",                33},
+  {"Unsellable",              34},
+  {"PlaceOnBridge",           35},
+  {"ShotOrigin",              36},
+  {"PlaceSound",              37},
+  {"TriggerSound",            38},
+  {"RechargeAnimationID",     39},
+  {"AttackAnimationID",       40},
+  {"DestroyedEffect",         41},
+  {"InitialDelay",            42},
+  {"PlaceOnSubtile",          43},
+  {"FlameAnimationID",        44},
+  {"FlameAnimationSpeed",     45},
+  {"FlameAnimationSize",      46},
+  {"FlameAnimationOffset",    47},
+  {"FlameTransparencyFlags",  48},
+  {"DetectInvisible",         49},
+  {"InstantPlacement",        50},
+  {"RemoveOnceDepleted",      51},
+  {NULL,                       0},
 };
 
 const struct NamedCommand room_config_desc[] = {
@@ -1727,6 +1729,8 @@ static void new_trap_type_check(const struct ScriptLine* scline)
     trapst->notify = false;
     trapst->place_on_bridge = false;
     trapst->place_on_subtile = false;
+    trapst->instant_placement = false;
+    trapst->remove_once_depleted = false;
     trapst->health = 1;
     trapst->destructible = 0;
     trapst->unstable = 0;
@@ -2015,6 +2019,12 @@ static void set_trap_configuration_process(struct ScriptContext *context)
             break;
         case 49: // DetectInvisible
             trapst->detect_invisible = value;
+            break;
+        case 50: // InstantPlacement
+            trapst->instant_placement = value;
+            break;
+        case 51: // RemoveOnceDepleted
+            trapst->remove_once_depleted = value;
             break;
         default:
             WARNMSG("Unsupported Trap configuration, variable %d.", context->value->shorts[1]);

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1259,6 +1259,7 @@ TbBool player_place_trap_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
     }
     else if (trap_cfg->instant_placement)
     {
+        remove_workshop_item_from_amount_stored(plyr_idx, TCls_Trap, tngmodel, WrkCrtF_NoOffmap);
         remove_workshop_object_from_player(plyr_idx, trap_crate_object_model(tngmodel));
         rearm_trap(traptng);
         dungeon->lvstats.traps_armed++;

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1226,8 +1226,9 @@ struct Room *player_build_room_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, Play
 
 TbBool player_place_trap_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel)
 {
-    if (!is_trap_placeable(plyr_idx, tngmodel)) {
-        WARNLOG("Player %d tried to build %s but has none to place",(int)plyr_idx,trap_code_name(tngmodel));
+    if (!is_trap_placeable(plyr_idx, tngmodel))
+    {
+        WARNLOG("Player %d tried to build %s but has none to place", (int)plyr_idx, trap_code_name(tngmodel));
         return false;
     }
     struct TrapConfigStats* trap_cfg = get_trap_model_stats(tngmodel);
@@ -1240,18 +1241,25 @@ TbBool player_place_trap_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumb
     {
         set_coords_to_slab_center(&pos, subtile_slab(stl_x), subtile_slab(stl_y));
     }
-    delete_room_slabbed_objects(get_slab_number(subtile_slab(stl_x),subtile_slab(stl_y)));
+    delete_room_slabbed_objects(get_slab_number(subtile_slab(stl_x), subtile_slab(stl_y)));
     struct Thing* traptng = create_trap(&pos, tngmodel, plyr_idx);
-    if (thing_is_invalid(traptng)) {
+    if (thing_is_invalid(traptng))
+    {
         return false;
     }
     traptng->mappos.z.val = get_thing_height_at(traptng, &traptng->mappos);
     traptng->trap.revealed = 0;
     struct Dungeon* dungeon = get_players_num_dungeon(plyr_idx);
-
     remove_workshop_item_from_amount_placeable(plyr_idx, TCls_Trap, tngmodel);
-    if (placing_offmap_workshop_item(plyr_idx, TCls_Trap, tngmodel)) {
+    if (placing_offmap_workshop_item(plyr_idx, TCls_Trap, tngmodel))
+    {
         remove_workshop_item_from_amount_stored(plyr_idx, TCls_Trap, tngmodel, WrkCrtF_NoStored);
+        rearm_trap(traptng);
+        dungeon->lvstats.traps_armed++;
+    }
+    else if (trap_cfg->instant_placement)
+    {
+        remove_workshop_object_from_player(plyr_idx, trap_crate_object_model(tngmodel));
         rearm_trap(traptng);
         dungeon->lvstats.traps_armed++;
     }

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -738,11 +738,11 @@ void process_trap_charge(struct Thing* traptng)
     if (trapst->attack_sprite_anim_idx != 0)
     {
         GameTurnDelta trigger_duration;
-        if (trapst->activation_type == 2) //Effect stays on trap, so the attack animation remains visible for as long as the effect is alive
+        if (trapst->activation_type == 2) // Effect stays on trap, so the attack animation remains visible for as long as the effect is alive.
         {
             trigger_duration = get_effect_model_stats(trapst->created_itm_model)->start_health;
         } else
-        if (trapst->activation_type == 3) //Shot stays on trap, so the attack animation remains visible for as long as the trap is alive
+        if (trapst->activation_type == 3) // Shot stays on trap, so the attack animation remains visible for as long as the trap is alive.
         {
             trigger_duration = get_shot_model_stats(trapst->created_itm_model)->health;
         }
@@ -773,14 +773,14 @@ void process_trap_charge(struct Thing* traptng)
             set_flag(traptng->rendering_flags, TRF_Transpar_4);
             if (!is_neutral_thing(traptng) && !is_hero_thing(traptng))
             {
-                if (placing_offmap_workshop_item(traptng->owner, TCls_Trap, traptng->model))
+                if ((placing_offmap_workshop_item(traptng->owner, TCls_Trap, traptng->model)) || (trapst->remove_once_depleted))
                 {
-                    //When there's only offmap traps, destroy the disarmed one so the player can place a new one.
+                    // When there's only offmap traps, destroy the disarmed one so the player can place a new one.
                     delete_thing_structure(traptng, 0);
                 }
                 else
                 {
-                    //Trap is available to be rearmed, so earmark a workshop crate for it.
+                    // Trap is available to be rearmed, so earmark a workshop crate for it.
                     remove_workshop_item_from_amount_placeable(traptng->owner, traptng->class_id, traptng->model);
                 }
             }

--- a/src/thing_traps.h
+++ b/src/thing_traps.h
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 /******************************************************************************/
-/******************************************************************************/
+
 #pragma pack(1)
 #define INFINITE_CHARGES 255
 
@@ -67,9 +67,8 @@ enum TrapActivationTypes {
 
 struct Thing;
 
-/******************************************************************************/
-
 #pragma pack()
+
 /******************************************************************************/
 TbBool slab_has_trap_on(MapSlabCoord slb_x, MapSlabCoord slb_y);
 TbBool slab_has_sellable_trap_on(MapSlabCoord slb_x, MapSlabCoord slb_y);


### PR DESCRIPTION
Two new properties for traps: ``InstantPlacement`` & ``RemoveOnceDepleted``.
```
; Place the trap immediately without needing imps to drag the crate to arm it.
InstantPlacement = 0
; Destroy the trap once it runs out of Shots.
RemoveOnceDepleted = 0
```
Good for tower defense map.

NOTE:
I messed up with my own experimental build and merged it onto the original branch of this PR.

So I closed the previous PR, deleted the branch and made a new one, sorry for the inconvenience... 🫨