### PR TITLE
Added Eventful death meta location

### DIFF
--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -241,7 +241,7 @@ VisualRange = 5
 ; Index of the half-transparent swipe appearing when using melee combat in possession.
 PossessSwipeIndex = 1
 ; The way of dying if there are no special circumstances to select another death kind.
-; NORMAL - FLESHEXPLODE - GASFLESHEXPLODE - SMOKEEXPLODE - ICEEXPLODE - SPECIALEVENT (normal, but updates LAST_EVENT script location).
+; NORMAL - FLESHEXPLODE - GASFLESHEXPLODE - SMOKEEXPLODE - ICEEXPLODE.
 NaturalDeathKind = NORMAL
 ; Place where a shot fired by the creature originates, relative to creature position.
 ShotOrigin = 0 0 256

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -110,6 +110,7 @@ TortureKind = NULL
 ;   ARACHNID - creature is kind of spider.
 ;   DIPTERA - creature is kind of fly.
 ;   LORD - creature is lord of the land, usually arrives to level as final boss, and at arrival you can hear "beware, the lord of the land approaches".
+;   EVENTFULL_DEATH - when the creature dies the LAST_EVENT script variable is updated, so mapmaker can use the location.
 ;   SPECTATOR - creature is just a spectator for multiplayer games.
 ;   EVIL - creature has evil nature.
 ;   NEVER_CHICKENS - creature isn't affected by Chicken spell.

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -110,7 +110,7 @@ TortureKind = NULL
 ;   ARACHNID - creature is kind of spider.
 ;   DIPTERA - creature is kind of fly.
 ;   LORD - creature is lord of the land, usually arrives to level as final boss, and at arrival you can hear "beware, the lord of the land approaches".
-;   EVENTFULL_DEATH - when the creature dies the LAST_EVENT script variable is updated, so mapmaker can use the location.
+;   EVENTFULL_DEATH - when the creature dies the LAST_DEATH_EVENT[] script variable is updated, so mapmaker can use the location.
 ;   SPECTATOR - creature is just a spectator for multiplayer games.
 ;   EVIL - creature has evil nature.
 ;   NEVER_CHICKENS - creature isn't affected by Chicken spell.

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -110,7 +110,7 @@ TortureKind = NULL
 ;   ARACHNID - creature is kind of spider.
 ;   DIPTERA - creature is kind of fly.
 ;   LORD - creature is lord of the land, usually arrives to level as final boss, and at arrival you can hear "beware, the lord of the land approaches".
-;   EVENTFULL_DEATH - when the creature dies the LAST_DEATH_EVENT[] script variable is updated, so mapmaker can use the location.
+;   EVENTFUL_DEATH - when the creature dies the LAST_DEATH_EVENT[] script variable is updated, so mapmaker can use the location.
 ;   SPECTATOR - creature is just a spectator for multiplayer games.
 ;   EVIL - creature has evil nature.
 ;   NEVER_CHICKENS - creature isn't affected by Chicken spell.

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -240,7 +240,7 @@ VisualRange = 5
 ; Index of the half-transparent swipe appearing when using melee combat in possession.
 PossessSwipeIndex = 1
 ; The way of dying if there are no special circumstances to select another death kind.
-; NORMAL - FLESHEXPLODE - GASFLESHEXPLODE - SMOKEEXPLODE - ICEEXPLODE.
+; NORMAL - FLESHEXPLODE - GASFLESHEXPLODE - SMOKEEXPLODE - ICEEXPLODE - SPECIALEVENT (normal, but updates LAST_EVENT script location).
 NaturalDeathKind = NORMAL
 ; Place where a shot fired by the creature originates, relative to creature position.
 ShotOrigin = 0 0 256

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -62,7 +62,7 @@ enum CreatureModelFlags {
     CMF_Fat              = 0x040000, // Creature too fat to walk a full animation.
     CMF_NoStealHero      = 0x080000, // Prevent the creature from being stolen with the Steal Hero special.
     CMF_PreferSteal      = 0x100000, // The creature can be generated from Steal Hero special if there's nothing to steal.
-    CMF_EventfullDeath   = 0x200000, // The LAST_EVENT script variable is updated on death.
+    CMF_EventfullDeath   = 0x200000, // The LAST_DEATH_EVENT[] script location is updated on death.
 };
 
 enum CreatureJobFlags {

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -62,6 +62,7 @@ enum CreatureModelFlags {
     CMF_Fat              = 0x040000, // Creature too fat to walk a full animation.
     CMF_NoStealHero      = 0x080000, // Prevent the creature from being stolen with the Steal Hero special.
     CMF_PreferSteal      = 0x100000, // The creature can be generated from Steal Hero special if there's nothing to steal.
+    CMF_EventfullDeath   = 0x200000, // The LAST_EVENT script variable is updated on death.
 };
 
 enum CreatureJobFlags {

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -62,7 +62,7 @@ enum CreatureModelFlags {
     CMF_Fat              = 0x040000, // Creature too fat to walk a full animation.
     CMF_NoStealHero      = 0x080000, // Prevent the creature from being stolen with the Steal Hero special.
     CMF_PreferSteal      = 0x100000, // The creature can be generated from Steal Hero special if there's nothing to steal.
-    CMF_EventfullDeath   = 0x200000, // The LAST_DEATH_EVENT[] script location is updated on death.
+    CMF_EventfulDeath   = 0x200000, // The LAST_DEATH_EVENT[] script location is updated on death.
 };
 
 enum CreatureJobFlags {

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -162,7 +162,6 @@ enum CreatureDeathKind {
     Death_GasFleshExplode,
     Death_SmokeExplode,
     Death_IceExplode,
-    Death_Event,
 };
 
 enum CreatureAttackType {

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -161,6 +161,7 @@ enum CreatureDeathKind {
     Death_GasFleshExplode,
     Death_SmokeExplode,
     Death_IceExplode,
+    Death_Event,
 };
 
 enum CreatureAttackType {

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -123,6 +123,7 @@ const struct NamedCommand creatmodel_properties_commands[] = {
   {"FAT",               31},
   {"NO_STEAL_HERO",     32},
   {"PREFER_STEAL",      33},
+  {"EVENTFULL_DEATH",   34},
   {NULL,                 0},
   };
 
@@ -778,6 +779,10 @@ TbBool parse_creaturemodel_attributes_blocks(long crtr_model,char *buf,long len,
                 break;
             case 33: // PREFER_STEAL
                 crconf->model_flags |= CMF_PreferSteal;
+                n++;
+                break;
+            case 34: // EVENTFULL_DEATH
+                crconf->model_flags |= CMF_EventfullDeath;
                 n++;
                 break;
             default:

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -123,7 +123,7 @@ const struct NamedCommand creatmodel_properties_commands[] = {
   {"FAT",               31},
   {"NO_STEAL_HERO",     32},
   {"PREFER_STEAL",      33},
-  {"EVENTFULL_DEATH",   34},
+  {"EVENTFUL_DEATH",   34},
   {NULL,                 0},
   };
 
@@ -780,8 +780,8 @@ TbBool parse_creaturemodel_attributes_blocks(long crtr_model,char *buf,long len,
                 crconf->model_flags |= CMF_PreferSteal;
                 n++;
                 break;
-            case 34: // EVENTFULL_DEATH
-                crconf->model_flags |= CMF_EventfullDeath;
+            case 34: // EVENTFUL_DEATH
+                crconf->model_flags |= CMF_EventfulDeath;
                 n++;
                 break;
             default:

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -194,7 +194,6 @@ const struct NamedCommand creature_deathkind_desc[] = {
     {"GASFLESHEXPLODE", Death_GasFleshExplode},
     {"SMOKEEXPLODE",    Death_SmokeExplode},
     {"ICEEXPLODE",      Death_IceExplode},
-    {"SPECIALEVENT",    Death_Event},
     {NULL,              0},
     };
 

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -193,6 +193,7 @@ const struct NamedCommand creature_deathkind_desc[] = {
     {"GASFLESHEXPLODE", Death_GasFleshExplode},
     {"SMOKEEXPLODE",    Death_SmokeExplode},
     {"ICEEXPLODE",      Death_IceExplode},
+    {"SPECIALEVENT",    Death_Event},
     {NULL,              0},
     };
 

--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -285,6 +285,7 @@ struct Dungeon {
     struct TrapInfo       mnfct_info;
     struct BoxInfo        box_info;
     struct Coord3d        last_combat_location;
+    struct Coord3d        last_eventfull_death_location;
     int                   creature_awarded[CREATURE_TYPES_MAX];
     unsigned char         creature_entrance_level;
     unsigned long         evil_creatures_converted;

--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -285,7 +285,7 @@ struct Dungeon {
     struct TrapInfo       mnfct_info;
     struct BoxInfo        box_info;
     struct Coord3d        last_combat_location;
-    struct Coord3d        last_eventfull_death_location;
+    struct Coord3d        last_eventful_death_location;
     int                   creature_awarded[CREATURE_TYPES_MAX];
     unsigned char         creature_entrance_level;
     unsigned long         evil_creatures_converted;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -3983,7 +3983,7 @@ static void set_creature_configuration_process(struct ScriptContext* context)
             break;
         }
         default:
-            CONFWRNLOG("Unrecognized Appearence command (%d)", creature_variable);
+            CONFWRNLOG("Unrecognized Appearance command (%d)", creature_variable);
             break;
         }
     }

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -812,6 +812,16 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
               clear_flag(crconf->model_flags,CMF_PreferSteal);
           }
           break;
+      case 34: // EVENTFULL_DEATH
+          if (val4 >= 1)
+          {
+              set_flag(crconf->model_flags, CMF_EventfullDeath);
+          }
+          else
+          {
+              clear_flag(crconf->model_flags, CMF_EventfullDeath);
+          }
+          break;
       default:
           SCRPTERRLOG("Unknown creature property '%ld'", val3);
           break;

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -812,14 +812,14 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
               clear_flag(crconf->model_flags,CMF_PreferSteal);
           }
           break;
-      case 34: // EVENTFULL_DEATH
+      case 34: // EVENTFUL_DEATH
           if (val4 >= 1)
           {
-              set_flag(crconf->model_flags, CMF_EventfullDeath);
+              set_flag(crconf->model_flags, CMF_EventfulDeath);
           }
           else
           {
-              clear_flag(crconf->model_flags, CMF_EventfullDeath);
+              clear_flag(crconf->model_flags, CMF_EventfulDeath);
           }
           break;
       default:

--- a/src/map_locations.c
+++ b/src/map_locations.c
@@ -94,7 +94,7 @@ TbBool get_coords_at_meta_action(struct Coord3d *pos, PlayerNumber target_plyr_i
         src = &dungeon->last_combat_location;
         break;
     case MML_LAST_DEATH_EVENT:
-        src = &dungeon->last_eventfull_death_location;
+        src = &dungeon->last_eventful_death_location;
         break;
     case MML_ACTIVE_CTA:
         if ((dungeon->cta_stl_x == 0) && (dungeon->cta_stl_y == 0))

--- a/src/map_locations.c
+++ b/src/map_locations.c
@@ -93,6 +93,9 @@ TbBool get_coords_at_meta_action(struct Coord3d *pos, PlayerNumber target_plyr_i
     case MML_RECENT_COMBAT:
         src = &dungeon->last_combat_location;
         break;
+    case MML_LAST_DEATH_EVENT:
+        src = &dungeon->last_eventfull_death_location;
+        break;
     case MML_ACTIVE_CTA:
         if ((dungeon->cta_stl_x == 0) && (dungeon->cta_stl_y == 0))
             return false;
@@ -440,6 +443,35 @@ TbBool get_map_location_id_f(const char *locname, TbMapLocation *location, const
             }
         }
         *location = (((unsigned long)MML_RECENT_COMBAT) << 12)
+            | ((unsigned long)i << 4)
+            | MLoc_METALOCATION;
+        return true;
+    }
+    else if (strncmp(locname, "LAST_DEATH_EVENT", strlen("LAST_DEATH_EVENT")) == 0)
+    {
+        if (strcmp(locname, "LAST_DEATH_EVENT") == 0)
+        {
+            if (game.game_kind == GKind_MultiGame)
+            {
+                WARNLOG(" %s (line %lu) : LOCATION = '%s' cannot be used on Multiplayer maps", func_name, ln_num, locname);
+                i = PLAYER0;
+            }
+            else
+            {
+                i = my_player_number;
+            }
+        }
+        else
+        {
+            i = get_player_name_from_location_string(locname);
+            if (i == -1)
+            {
+                ERRORMSG("%s(line %lu): Invalid LOCATION = '%s'", func_name, ln_num, locname);
+                *location = MLoc_NONE;
+                return false;
+            }
+        }
+        *location = (((unsigned long)MML_LAST_DEATH_EVENT) << 12)
             | ((unsigned long)i << 4)
             | MLoc_METALOCATION;
         return true;

--- a/src/map_locations.h
+++ b/src/map_locations.h
@@ -51,6 +51,7 @@ enum MetaLocation {
   MML_LAST_EVENT = 1,
   MML_RECENT_COMBAT,
   MML_ACTIVE_CTA,
+  MML_LAST_DEATH_EVENT,
 };
 
 /******************************************************************************/

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2719,12 +2719,13 @@ struct Thing* cause_creature_death(struct Thing *thing, CrDeathFlags flags)
     remove_parent_thing_from_things_in_list(&game.thing_lists[TngList_Shots],thing->index);
     ThingModel crmodel = thing->model;
     struct CreatureStats* crstat = creature_stats_get_from_thing(thing);
-    if (!thing_exists(thing)) {
-        flags |= CrDed_NoEffects;
+    if (!thing_exists(thing)) 
+    {
+        set_flag(flags,CrDed_NoEffects);
     }
-    if (((flags & CrDed_NoEffects) == 0) && (crstat->rebirth != 0)
+    if ((!flag_is_set(flags,CrDed_NoEffects)) && (crstat->rebirth != 0)
      && (cctrl->lairtng_idx > 0) && (crstat->rebirth-1 <= cctrl->explevel)
-        && ((flags & CrDed_NoRebirth) == 0))
+        && (!flag_is_set(flags,CrDed_NoRebirth)) )
     {
         creature_rebirth_at_lair(thing);
         return INVALID_THING;
@@ -2736,10 +2737,12 @@ struct Thing* cause_creature_death(struct Thing *thing, CrDeathFlags flags)
         // If the creature is leaving dungeon, or being transformed, then CrDed_NotReallyDying should be set
         update_dead_creatures_list_for_owner(thing);
     }
-    if ((flags & CrDed_NoEffects) != 0)
+    if (flag_is_set(flags, CrDed_NoEffects))
     {
-        if ((game.flags_cd & MFlg_DeadBackToPool) != 0)
+        if (flag_is_set(game.flags_cd, MFlg_DeadBackToPool))
+        {
             add_creature_to_pool(crmodel, 1);
+        }
         delete_thing_structure(thing, 0);
     } else
     if (!creature_model_bleeds(thing->model))

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2515,16 +2515,6 @@ struct Thing* thing_death_normal(struct Thing *thing)
 }
 
 /**
- * Normal death but it is noted as an event to hook script commands.
- * @param thing
- */
-struct Thing* thing_death_with_event(struct Thing* thing)
-{
-    memcpy(&gameadd.triggered_object_location, &thing->mappos, sizeof(struct Coord3d));
-    return thing_death_normal(thing);
-}
-
-/**
  * Creates an effect of death with bloody flesh explosion, killing the creature.
  * @param thing
  */
@@ -2668,8 +2658,6 @@ struct Thing* creature_death_as_nature_intended(struct Thing *thing)
         return thing_death_smoke_explosion(thing);
     case Death_IceExplode:
         return thing_death_ice_explosion(thing);
-    case Death_Event:
-        return thing_death_with_event(thing);
     default:
         WARNLOG("Unexpected %s death cause %d",thing_model_name(thing), crstat->natural_death_kind);
         return INVALID_THING;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2725,9 +2725,13 @@ struct Thing* cause_creature_death(struct Thing *thing, CrDeathFlags flags)
         // If the creature is leaving dungeon, or being transformed, then CrDed_NotReallyDying should be set
         update_dead_creatures_list_for_owner(thing);
     }
-    if (flag_is_set(get_creature_model_flags(thing), CMF_EventfullDeath)) //updates MML_LAST_EVENT for mapmakers
+    if (flag_is_set(get_creature_model_flags(thing), CMF_EventfullDeath)) //updates LAST_DEATH_EVENT for mapmakers
     {
-        memcpy(&gameadd.triggered_object_location, &thing->mappos, sizeof(struct Coord3d));
+        struct Dungeon* dungeon = get_dungeon(thing->owner);
+        if (!dungeon_invalid(dungeon))
+        {
+            memcpy(&dungeon->last_eventfull_death_location, &thing->mappos, sizeof(struct Coord3d));
+        }
     }
     if (flag_is_set(flags, CrDed_NoEffects))
     {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2732,10 +2732,14 @@ struct Thing* cause_creature_death(struct Thing *thing, CrDeathFlags flags)
     }
     creature_throw_out_gold(thing);
     // Beyond this point, the creature thing is bound to be deleted
-    if (((flags & CrDed_NotReallyDying) == 0) || ((game.conf.rules.game.classic_bugs_flags & ClscBug_ResurrectRemoved) != 0))
+    if ((!flag_is_set(flags,CrDed_NotReallyDying)) || (flag_is_set(game.conf.rules.game.classic_bugs_flags,ClscBug_ResurrectRemoved)))
     {
         // If the creature is leaving dungeon, or being transformed, then CrDed_NotReallyDying should be set
         update_dead_creatures_list_for_owner(thing);
+    }
+    if (flag_is_set(get_creature_model_flags(thing), CMF_EventfullDeath)) //updates MML_LAST_EVENT for mapmakers
+    {
+        memcpy(&gameadd.triggered_object_location, &thing->mappos, sizeof(struct Coord3d));
     }
     if (flag_is_set(flags, CrDed_NoEffects))
     {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2725,12 +2725,12 @@ struct Thing* cause_creature_death(struct Thing *thing, CrDeathFlags flags)
         // If the creature is leaving dungeon, or being transformed, then CrDed_NotReallyDying should be set
         update_dead_creatures_list_for_owner(thing);
     }
-    if (flag_is_set(get_creature_model_flags(thing), CMF_EventfullDeath)) //updates LAST_DEATH_EVENT for mapmakers
+    if (flag_is_set(get_creature_model_flags(thing), CMF_EventfulDeath)) //updates LAST_DEATH_EVENT for mapmakers
     {
         struct Dungeon* dungeon = get_dungeon(thing->owner);
         if (!dungeon_invalid(dungeon))
         {
-            memcpy(&dungeon->last_eventfull_death_location, &thing->mappos, sizeof(struct Coord3d));
+            memcpy(&dungeon->last_eventful_death_location, &thing->mappos, sizeof(struct Coord3d));
         }
     }
     if (flag_is_set(flags, CrDed_NoEffects))

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2515,6 +2515,16 @@ struct Thing* thing_death_normal(struct Thing *thing)
 }
 
 /**
+ * Normal death but it is noted as an event to hook script commands.
+ * @param thing
+ */
+struct Thing* thing_death_with_event(struct Thing* thing)
+{
+    memcpy(&gameadd.triggered_object_location, &thing->mappos, sizeof(struct Coord3d));
+    return thing_death_normal(thing);
+}
+
+/**
  * Creates an effect of death with bloody flesh explosion, killing the creature.
  * @param thing
  */
@@ -2658,6 +2668,8 @@ struct Thing* creature_death_as_nature_intended(struct Thing *thing)
         return thing_death_smoke_explosion(thing);
     case Death_IceExplode:
         return thing_death_ice_explosion(thing);
+    case Death_Event:
+        return thing_death_with_event(thing);
     default:
         WARNLOG("Unexpected %s death cause %d",thing_model_name(thing), crstat->natural_death_kind);
         return INVALID_THING;


### PR DESCRIPTION
Added new meta location `LAST_DEATH_EVENT[player]` that holds the location of the last creature to die with the `EVENTFUL_DEATH` creature property.

Can be used to spawn objects/effects through script at the location of the death, or point objectives to it.