### PR TITLE
Allow negative countdown values on `ADD_TO_PARTY`

### DIFF
--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -909,6 +909,7 @@ struct Thing *script_process_new_party(struct Party *party, PlayerNumber plyr_id
               struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
               cctrl->party_objective = member->objectv;
               cctrl->wait_to_turn = game.play_gameturn + member->countdown;
+              cctrl->hero.wait_time = game.play_gameturn + member->countdown;
               if (thing_is_invalid(grptng))
               {
                   // If it is the first creature - set it as only group member and leader

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -919,7 +919,7 @@ short good_doing_nothing(struct Thing *creatng)
         return 1;
     }
     // Do some wandering also if can't find any task to do
-    if (cctrl->wait_to_turn > (long)game.play_gameturn)
+    if ((long)cctrl->wait_to_turn > (long)game.play_gameturn)
     {
         if (creature_choose_random_destination_on_valid_adjacent_slab(creatng)) {
             creatng->continue_state = CrSt_GoodDoingNothing;
@@ -996,7 +996,7 @@ short good_doing_nothing(struct Thing *creatng)
     if (target_plyr_idx == -1)
     {
         nturns = game.play_gameturn - cctrl->hero.wait_time;
-        if (nturns > 400)
+        if ((game.play_gameturn >= 400) && (nturns > 400))
         {
             cctrl->hero.wait_time = game.play_gameturn;
             cctrl->hero.byte_8C = 1;

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -996,7 +996,7 @@ short good_doing_nothing(struct Thing *creatng)
     if (target_plyr_idx == -1)
     {
         nturns = game.play_gameturn - cctrl->hero.wait_time;
-        if ((game.play_gameturn >= 400) && (nturns > 400))
+        if ((nturns > 400) && (cctrl->hero.look_for_enemy_dungeon_turn != 0))
         {
             cctrl->hero.wait_time = game.play_gameturn;
             cctrl->hero.byte_8C = 1;

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -113,7 +113,7 @@ long good_find_best_enemy_dungeon(struct Thing* creatng)
             continue;
         }
         player = get_player(plyr_idx);
-        if (game.conf.rules.game.classic_bugs_flags & ClscBug_AlwaysTunnelToRed)
+        if (flag_is_set(game.conf.rules.game.classic_bugs_flags,ClscBug_AlwaysTunnelToRed))
         {
             if (creature_can_get_to_dungeon_heart(creatng, plyr_idx))
             {


### PR DESCRIPTION
When parties spawn they will wait 400 turns always, in addition to the countdown. Now you can set a negative countdown, to have a party wait less than 400 turns in total.

Naturally setting the countdown smaller than -400 has no further effect.