### PR TITLE
Hide keys when locking secret doors

### DIFF
--- a/src/lvl_filesdk1.c
+++ b/src/lvl_filesdk1.c
@@ -1459,6 +1459,7 @@ static TbBool load_level_file(LevelNumber lvnum)
         }
         reinitialise_map_rooms();
         ceiling_init();
+        init_keys();
         if (result)
         {
             load_ext_slabs(lvnum);

--- a/src/thing_doors.c
+++ b/src/thing_doors.c
@@ -143,6 +143,41 @@ struct Thing *create_door(struct Coord3d *pos, ThingModel tngmodel, unsigned cha
     return doortng; 
 }
 
+/**
+ * Hides all secret door keys
+ */
+void init_keys()
+{
+    const struct StructureList* slist = get_list_for_thing_class(TCls_Object);
+    for (int i = slist->index; i > 0;)
+    {
+        struct Thing* keytng = thing_get(i);
+        i = keytng->next_of_class;
+        if (keytng->model != ObjMdl_SpinningKey)
+        {
+            continue;
+        }
+        TRACE_THING(keytng);
+        struct Thing* doortng = find_base_thing_on_mapwho(TCls_Door, 0, keytng->mappos.x.stl.num, keytng->mappos.y.stl.num);
+        if (thing_is_invalid(doortng))
+        {
+            WARNLOG("Key (%d) has no door on position (%d,%d)", keytng->index, keytng->mappos.x.stl.num, keytng->mappos.y.stl.num);
+            continue;
+        }
+        struct DoorConfigStats* doorst = get_door_model_stats(doortng->model);
+        if (flag_is_set(doorst->model_flags, DoMF_Secret))
+        {
+            if (is_my_player_number(doortng->owner)) //On map init doors are never revealed
+            {
+                set_flag(keytng->rendering_flags,TRF_Transpar_4);
+            }
+            else
+            {
+                set_flag(keytng->rendering_flags,TRF_Invisible);
+            }
+        }
+    }
+}
 
 TbBool remove_key_on_door(struct Thing *thing)
 {
@@ -163,12 +198,12 @@ TbBool add_key_on_door(struct Thing *thing)
     {
         if (is_my_player_number(thing->owner) || !door_is_hidden_to_player(thing,my_player_number))
         {
-            keytng->rendering_flags &= ~TRF_Transpar_Flags;
-            keytng->rendering_flags |= TRF_Transpar_4;
+            clear_flag(keytng->rendering_flags,TRF_Transpar_Flags);
+            set_flag(keytng->rendering_flags,TRF_Transpar_4);
         }
         else
         {
-            keytng->rendering_flags |= TRF_Invisible;
+            set_flag(keytng->rendering_flags, TRF_Invisible);
         }
     }
     keytng->mappos.x.stl.pos = COORD_PER_STL/2;

--- a/src/thing_doors.c
+++ b/src/thing_doors.c
@@ -158,6 +158,19 @@ TbBool add_key_on_door(struct Thing *thing)
     struct Thing* keytng = create_object(&thing->mappos, ObjMdl_SpinningKey, thing->owner, 0);
     if (thing_is_invalid(keytng))
       return false;
+    struct DoorConfigStats* doorst = get_door_model_stats(thing->model);
+    if (flag_is_set(doorst->model_flags, DoMF_Secret))
+    {
+        if (is_my_player_number(thing->owner) || !door_is_hidden_to_player(thing,my_player_number))
+        {
+            keytng->rendering_flags &= ~TRF_Transpar_Flags;
+            keytng->rendering_flags |= TRF_Transpar_4;
+        }
+        else
+        {
+            keytng->rendering_flags |= TRF_Invisible;
+        }
+    }
     keytng->mappos.x.stl.pos = COORD_PER_STL/2;
     keytng->mappos.y.stl.pos = COORD_PER_STL/2;
     keytng->mappos.z.stl.num = 5;
@@ -414,6 +427,12 @@ void reveal_secret_door_to_player(struct Thing *doortng,PlayerNumber plyr_idx)
     if(!door_is_hidden_to_player(doortng,plyr_idx))
     {
         return;
+    }
+    struct Thing* keytng = find_base_thing_on_mapwho(TCls_Object, ObjMdl_SpinningKey, doortng->mappos.x.stl.num, doortng->mappos.y.stl.num);
+    if (is_my_player_number(plyr_idx)) //reveal key too
+    {
+        clear_flag(keytng->rendering_flags, TRF_Invisible);
+        set_flag(keytng->rendering_flags, TRF_Transpar_4);
     }
     event_create_event(doortng->mappos.x.val, doortng->mappos.y.val, EvKind_SecretDoorDiscovered, plyr_idx, 0);
     event_create_event(doortng->mappos.x.val, doortng->mappos.y.val, EvKind_SecretDoorSpotted, doortng->owner, 0);

--- a/src/thing_doors.h
+++ b/src/thing_doors.h
@@ -56,6 +56,7 @@ struct Thing *create_door(struct Coord3d *pos, ThingModel tngmodel, unsigned cha
 TbBool thing_is_deployed_door(const struct Thing *thing);
 TbBool thing_is_sellable_door(const struct Thing* thing);
 TbBool slab_has_sellable_door(MapSlabCoord slb_x, MapSlabCoord slb_y);
+void init_keys();
 void lock_door(struct Thing *thing);
 void unlock_door(struct Thing *thing);
 long destroy_door(struct Thing *thing);


### PR DESCRIPTION
Fixes #3723

Keys placed on secret doors are invisible, unless the secret door is revealed for you or it is your door.