### PR TITLE
Fixed spell charging in battle menu

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1810,7 +1810,7 @@ void get_packet_control_mouse_clicks(void)
     static int synthetic_right = 0;
     SYNCDBG(8,"Starting");
 
-    if (flag_is_set(game.operation_flags, GOF_Paused)) //  || busy_doing_gui )
+    if (flag_is_set(game.operation_flags, GOF_Paused))
     {
         return;
     }

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1810,7 +1810,7 @@ void get_packet_control_mouse_clicks(void)
     static int synthetic_right = 0;
     SYNCDBG(8,"Starting");
 
-    if ( flag_is_set(game.operation_flags,GOF_Paused)  || busy_doing_gui )
+    if (flag_is_set(game.operation_flags, GOF_Paused)) //  || busy_doing_gui )
     {
         return;
     }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -685,7 +685,7 @@ short game_is_busy_doing_gui(void)
     PowerKind pwkind = player->chosen_power_kind;
     struct Thing *thing;
     thing = thing_get(battle_creature_over);
-    if (can_cast_power_on_thing(player->id_number, thing, pwkind))
+    if (!thing_is_invalid(thing) && can_cast_power_on_thing(player->id_number, thing, pwkind))
     {
         return true;
     }

--- a/src/packets.c
+++ b/src/packets.c
@@ -165,7 +165,7 @@ TbBool process_dungeon_control_packet_spell_overcharge(long plyr_idx)
     struct Dungeon* dungeon = get_players_dungeon(player);
     SYNCDBG(6,"Starting for player %d state %s",(int)plyr_idx,player_state_code_name(player->work_state));
     struct Packet* pckt = get_packet_direct(player->packet_num);
-    if ((pckt->control_flags & PCtr_LBtnHeld) != 0)
+    if (flag_is_set(pckt->control_flags,PCtr_LBtnHeld))
     {
         struct PowerConfigStats *powerst = get_power_model_stats(player->chosen_power_kind);
 

--- a/src/packets.c
+++ b/src/packets.c
@@ -1185,6 +1185,8 @@ void process_players_creature_control_packet_control(long idx)
         return;
     if ((ccctrl->stateblock_flags != 0) || (cctng->active_state == CrSt_CreatureUnconscious))
         return;
+    if (flag_is_set(pckt->control_flags, PCtr_Gui))
+        return;
     long speed_limit = get_creature_speed(cctng);
     if ((pckt->control_flags & PCtr_MoveUp) != 0)
     {

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -668,10 +668,10 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     packet_left_button_double_clicked[plyr_idx] = 0;
     player->mouse_on_map = is_mouse_on_map(pckt);
     remember_cursor_subtile(player);
-    if ((pckt->control_flags & PCtr_Gui) != 0)
+    process_dungeon_control_packet_spell_overcharge(plyr_idx);
+    if (flag_is_set(pckt->control_flags,PCtr_Gui))
         return false;
     TbBool ret = true;
-    process_dungeon_control_packet_spell_overcharge(plyr_idx);
     if ((pckt->control_flags & PCtr_RBtnHeld) != 0)
     {
         player->field_4D6++;


### PR DESCRIPTION
In DK1 it is possible to charge spells on the battle menu. This broke in #1342
Restored the original behavior.