### PR TITLE
Area affect damage from correct shot

### DIFF
--- a/src/config_effects.c
+++ b/src/config_effects.c
@@ -233,6 +233,17 @@ TbBool load_effects_config(const char *conf_fname, unsigned short flags)
 }
 
 /**
+ * Returns Code Name (name to use in script file) of given effect element model.
+ */
+const char* effect_element_code_name(ThingModel tngmodel)
+{
+    const char* name = get_conf_parameter_text(effectelem_desc, tngmodel);
+    if (name[0] != '\0')
+        return name;
+    return "INVALID";
+}
+
+/**
  * Returns Code Name (name to use in script file) of given effect model.
  */
 const char *effect_code_name(ThingModel tngmodel)

--- a/src/config_effects.h
+++ b/src/config_effects.h
@@ -138,6 +138,7 @@ TbBool load_effects_config(const char *conf_fname,unsigned short flags);
 struct EffectConfigStats *get_effect_model_stats(ThingModel tngmodel);
 struct EffectGeneratorConfigStats *get_effectgenerator_model_stats(ThingModel tngmodel);
 const char *effect_code_name(ThingModel tngmodel);
+const char* effect_element_code_name(ThingModel tngmodel);
 const char *effectgenerator_code_name(ThingModel tngmodel);
 short effect_or_effect_element_id(const char * code_name);
 /******************************************************************************/

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -4091,7 +4091,7 @@ void create_effect_around_thing(struct Thing *thing, long eff_kind)
             {
                 if (eff_kind != 0)
                 {
-                    create_used_effect_or_element(&pos, eff_kind, thing->owner);
+                    create_used_effect_or_element(&pos, eff_kind, thing->owner, thing->index);
                 }
                 pos.z.val += COORD_PER_STL;
             }

--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -154,7 +154,7 @@ void process_dungeon_destroy(struct Thing* heartng)
         if (dungeon->heart_destroy_turn < 32)
         {
             if (GAME_RANDOM(96) < (dungeon->heart_destroy_turn << 6) / 32 + 32) {
-                create_used_effect_or_element(central_pos, objst->effect.particle, plyr_idx);
+                create_used_effect_or_element(central_pos, objst->effect.particle, plyr_idx, heartng->index);
             }
         }
         else
@@ -167,7 +167,7 @@ void process_dungeon_destroy(struct Thing* heartng)
         dungeon->heart_destroy_turn++;
         if (dungeon->heart_destroy_turn < 32)
         {
-            create_used_effect_or_element(central_pos, objst->effect.particle, plyr_idx);
+            create_used_effect_or_element(central_pos, objst->effect.particle, plyr_idx, heartng->index);
         }
         else
         { // Got to next phase
@@ -196,10 +196,10 @@ void process_dungeon_destroy(struct Thing* heartng)
         // Final phase - destroy the heart, both pedestal room and container thing
     {
         struct Thing* efftng;
-        efftng = create_used_effect_or_element(central_pos, objst->effect.explosion1, plyr_idx);
+        efftng = create_used_effect_or_element(central_pos, objst->effect.explosion1, plyr_idx, heartng->index);
         if (!thing_is_invalid(efftng))
             efftng->shot_effect.hit_type = THit_HeartOnlyNotOwn;
-        efftng = create_used_effect_or_element(central_pos, objst->effect.explosion2, plyr_idx);
+        efftng = create_used_effect_or_element(central_pos, objst->effect.explosion2, plyr_idx, heartng->index);
         if (!thing_is_invalid(efftng))
             efftng->shot_effect.hit_type = THit_HeartOnlyNotOwn;
         destroy_dungeon_heart_room(plyr_idx, heartng);

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -226,7 +226,7 @@ long packet_place_door(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber pl
 TbBool all_dungeons_destroyed(const struct PlayerInfo *win_player);
 void reset_gui_based_on_player_mode(void);
 void reinit_tagged_blocks_for_player(PlayerNumber plyr_idx);
-void draw_flame_breath(struct Coord3d *pos1, struct Coord3d *pos2, long delta_step, long num_per_step, short ef_or_efel_model);
+void draw_flame_breath(struct Coord3d *pos1, struct Coord3d *pos2, long delta_step, long num_per_step, short ef_or_efel_model, ThingIndex parent_idx);
 void draw_lightning(const struct Coord3d* pos1, const struct Coord3d* pos2, long eeinterspace, short ef_or_efel_model);
 void toggle_hero_health_flowers(void);
 void check_players_won(void);

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -396,7 +396,7 @@ static void process_fx_line(struct ScriptFxLine *fx_line)
         {
             if (fx_line->effect != 0)
             {
-                create_used_effect_or_element(&fx_line->here, fx_line->effect, PLAYER_NEUTRAL);
+                create_used_effect_or_element(&fx_line->here, fx_line->effect, PLAYER_NEUTRAL, 0);
             }
         }
 

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -994,7 +994,7 @@ static int script_transfer_creature(PlayerNumber plyr_idx, ThingModel crmodel, l
             dungeon->creatures_transferred++;
             remove_thing_from_power_hand_list(thing, plyr_idx);
             struct SpecialConfigStats* specst = get_special_model_stats(SpcKind_TrnsfrCrtr);
-            create_used_effect_or_element(&thing->mappos, specst->effect_id, plyr_idx);
+            create_used_effect_or_element(&thing->mappos, specst->effect_id, plyr_idx, thing->index);
             kill_creature(thing, INVALID_THING, -1, CrDed_NoEffects | CrDed_NotReallyDying);
         }
     }
@@ -2480,7 +2480,7 @@ static void create_effect_at_pos_process(struct ScriptContext* context)
     {
         pos.z.val += context->value->longs[2];
     }
-    struct Thing* efftng = create_used_effect_or_element(&pos, context->value->shorts[0], game.neutral_player_num);
+    struct Thing* efftng = create_used_effect_or_element(&pos, context->value->shorts[0], game.neutral_player_num, 0);
     if (!thing_is_invalid(efftng))
     {
         if (thing_in_wall_at(efftng, &efftng->mappos))
@@ -2510,7 +2510,7 @@ static void create_effect_process(struct ScriptContext *context)
     {
         pos.z.val += context->value->longs[2];
     }
-    struct Thing* efftng = create_used_effect_or_element(&pos, context->value->shorts[0], game.neutral_player_num);
+    struct Thing* efftng = create_used_effect_or_element(&pos, context->value->shorts[0], game.neutral_player_num, 0);
     if (!thing_is_invalid(efftng))
     {
         if (thing_in_wall_at(efftng, &efftng->mappos))

--- a/src/magic.c
+++ b/src/magic.c
@@ -1429,7 +1429,7 @@ static TbResult magic_use_power_apply_spell(PowerKind power_kind, PlayerNumber p
     {
         struct Coord3d effpos = thing->mappos;
         effpos.z.val = get_ceiling_height_above_thing_at(thing, &thing->mappos);
-        create_used_effect_or_element(&effpos, powerst->effect_id, thing->owner);
+        create_used_effect_or_element(&effpos, powerst->effect_id, thing->owner, 0);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,7 +316,7 @@ void process_keeper_spell_aura(struct Thing *thing)
     pos.y.val = thing->mappos.y.val - (delta_y >> 8);
     pos.z.val = thing->mappos.z.val;
 
-    create_used_effect_or_element(&pos, cctrl->spell_aura, thing->owner);
+    create_used_effect_or_element(&pos, cctrl->spell_aura, thing->owner, thing->index);
 }
 
 unsigned long lightning_is_close_to_player(struct PlayerInfo *player, struct Coord3d *pos)
@@ -547,7 +547,7 @@ long process_boulder_collision(struct Thing *boulder, struct Coord3d *pos, int d
     return 0; // Default: No collision OR boulder destroyed on door
 }
 
-void draw_flame_breath(struct Coord3d *pos1, struct Coord3d *pos2, long delta_step, long num_per_step, short ef_or_efel_model)
+void draw_flame_breath(struct Coord3d *pos1, struct Coord3d *pos2, long delta_step, long num_per_step, short ef_or_efel_model, ThingIndex parent_idx)
 {
   MapCoordDelta dist_x;
   MapCoordDelta dist_y;
@@ -643,7 +643,7 @@ void draw_flame_breath(struct Coord3d *pos1, struct Coord3d *pos2, long delta_st
                 {
                     struct Thing *eelemtng;
 
-                    eelemtng = create_used_effect_or_element(&tngpos, ef_or_efel_model, game.neutral_player_num);
+                    eelemtng = create_used_effect_or_element(&tngpos, ef_or_efel_model, game.neutral_player_num, parent_idx);
                     if (!thing_is_invalid(eelemtng)) {
                         eelemtng->sprite_size = sprsize >> 8;
                     }
@@ -721,7 +721,7 @@ void draw_lightning(const struct Coord3d *pos1, const struct Coord3d *pos2, long
             tngpos.z.val = curpos.z.val + deviat_z;
             if ((tngpos.x.val < subtile_coord(gameadd.map_subtiles_x,0)) && (tngpos.y.val < subtile_coord(gameadd.map_subtiles_y,0)))
             {
-                create_used_effect_or_element(&tngpos, ef_or_efel_model, game.neutral_player_num);
+                create_used_effect_or_element(&tngpos, ef_or_efel_model, game.neutral_player_num, 0);
             }
             if (UNSYNC_RANDOM(6) >= 3) {
                 deviat_x -= 32;

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -733,6 +733,7 @@ void process_timebomb(struct Thing *creatng)
 void timebomb_explode(struct Thing *creatng)
 {
     struct SpellConfig* spconf = get_spell_config(SplK_TimeBomb);
+    //todo Create a shot that explodes, instead of only using the stats
     struct ShotConfigStats* shotst = get_shot_model_stats(spconf->shot_model);
     SYNCDBG(8, "Explode Timebomb")
     //struct Thing* castng = creatng; //todo cleanup
@@ -746,11 +747,11 @@ void timebomb_explode(struct Thing *creatng)
         HitTargetFlags hit_targets = hit_type_to_hit_targets(shotst->area_hit_type);
         explosion_affecting_area(creatng, &creatng->mappos, dist, damage, (shotst->area_blow * weight) / weight_divisor, hit_targets);
     }
-    struct Thing *efftng = create_used_effect_or_element(&creatng->mappos, TngEff_Explosion5, creatng->owner);
+    struct Thing *efftng = create_used_effect_or_element(&creatng->mappos, TngEff_Explosion5, creatng->owner, creatng->index);
     if (!thing_is_invalid(efftng))
     {
-        create_used_effect_or_element(&creatng->mappos, shotst->explode.effect1_model, creatng->owner);
-        create_used_effect_or_element(&creatng->mappos, shotst->explode.effect2_model, creatng->owner);
+        create_used_effect_or_element(&creatng->mappos, shotst->explode.effect1_model, creatng->owner, creatng->index);
+        create_used_effect_or_element(&creatng->mappos, shotst->explode.effect2_model, creatng->owner, creatng->index);
         if (shotst->explode.around_effect1_model != 0)
         {
             create_effect_around_thing(creatng, shotst->explode.around_effect1_model);

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -733,7 +733,6 @@ void process_timebomb(struct Thing *creatng)
 void timebomb_explode(struct Thing *creatng)
 {
     struct SpellConfig* spconf = get_spell_config(SplK_TimeBomb);
-    //todo Create a shot that explodes, instead of only using the stats
     struct ShotConfigStats* shotst = get_shot_model_stats(spconf->shot_model);
     SYNCDBG(8, "Explode Timebomb")
     //struct Thing* castng = creatng; //todo cleanup

--- a/src/power_specials.c
+++ b/src/power_specials.c
@@ -585,7 +585,7 @@ void activate_dungeon_special(struct Thing *cratetng, struct PlayerInfo *player)
             {
                 output_message(specst->speech, 0, true);
             }
-            create_used_effect_or_element(&pos, specst->effect_id, player->id_number);
+            create_used_effect_or_element(&pos, specst->effect_id, player->id_number, cratetng->index);
         }
     }
 }
@@ -609,7 +609,7 @@ void resurrect_creature(struct Thing *boxtng, PlayerNumber owner, ThingModel crm
           output_message(SMsg_CommonAcknowledge, 0, true);
     }
     struct SpecialConfigStats* specst = get_special_model_stats(SpcKind_Resurrect);
-    create_used_effect_or_element(&boxtng->mappos, specst->effect_id, owner);
+    create_used_effect_or_element(&boxtng->mappos, specst->effect_id, owner, boxtng->index);
     remove_events_thing_is_attached_to(boxtng);
     force_any_creature_dragging_owned_thing_to_drop_it(boxtng);
     if ((game.conf.rules.game.classic_bugs_flags & ClscBug_ResurrectForever) == 0) {
@@ -651,7 +651,7 @@ void transfer_creature(struct Thing *boxtng, struct Thing *transftng, unsigned c
     if (!from_script)
     {
         struct SpecialConfigStats* specst = get_special_model_stats(SpcKind_TrnsfrCrtr);
-        create_used_effect_or_element(&boxtng->mappos, specst->effect_id, plyr_idx);
+        create_used_effect_or_element(&boxtng->mappos, specst->effect_id, plyr_idx, boxtng->index);
         remove_events_thing_is_attached_to(boxtng);
         force_any_creature_dragging_owned_thing_to_drop_it(boxtng);
         delete_thing_structure(boxtng, 0);

--- a/src/thing_corpses.c
+++ b/src/thing_corpses.c
@@ -531,7 +531,7 @@ void delete_corpse(struct Thing *deadtng)
     struct CreatureStats* crstat = creature_stats_get(deadtng->model);
     if (crstat->corpse_vanish_effect != 0)
     {
-        create_used_effect_or_element(&deadtng->mappos, crstat->corpse_vanish_effect, deadtng->owner);
+        create_used_effect_or_element(&deadtng->mappos, crstat->corpse_vanish_effect, deadtng->owner, deadtng->index);
     }
     delete_thing_structure(deadtng, 0);
 }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1879,15 +1879,7 @@ void creature_cast_spell(struct Thing *castng, SpellKind spl_idx, long shot_lvl,
     {
         thing_summon_temporary_creature(castng, spconf->crtr_summon_model, spconf->crtr_summon_level, spconf->crtr_summon_amount, spconf->duration, spl_idx);
     }
-    // Check if the spell has an effect associated
-    if (spconf->cast_effect_model != 0)
-    {
-        struct Thing* efthing = create_used_effect_or_element(&castng->mappos, spconf->cast_effect_model, castng->owner);
-        if (!thing_is_invalid(efthing))
-        {
-            efthing->parent_idx = castng->index;
-        }
-    }
+    create_used_effect_or_element(&castng->mappos, spconf->cast_effect_model, castng->owner, castng->index);
 }
 
 void update_creature_count(struct Thing *creatng)
@@ -3306,7 +3298,7 @@ void thing_fire_shot(struct Thing *firing, struct Thing *target, ThingModel shot
         if (thing_is_invalid(shotng))
           return;
 
-        draw_flame_breath(&pos1, &pos2, shotst->effect_spacing, shotst->effect_amount,shotst->effect_id);
+        draw_flame_breath(&pos1, &pos2, shotst->effect_spacing, shotst->effect_amount,shotst->effect_id, shotng->index);
         shotng->health = shotst->health;
         shotng->shot.damage = damage;
         shotng->parent_idx = firing->index;

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -211,8 +211,8 @@ struct Thing {
       } creature;
 //TCls_Effect
       struct {
-        char unused;
-        short unused2;
+        int parent_class_id;
+        ThingModel parent_model;
         unsigned char hit_type;
       } shot_effect;
       struct {

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -932,6 +932,9 @@ struct Thing *create_used_effect_or_element(const struct Coord3d *pos, EffectOrE
     if (parent_idx > 0)
     {
         efftng->parent_idx = parent_idx;
+        struct Thing* parent = thing_get(parent_idx);
+        efftng->shot_effect.parent_class_id = parent->class_id;
+        efftng->shot_effect.parent_model = parent->model;
     }
     return efftng;
 }
@@ -1199,11 +1202,11 @@ void word_of_power_affecting_area(struct Thing *efftng, struct Thing *tngsrc, st
     if (efftng->creation_turn != game.play_gameturn) {
         return;
     }
+    
     struct ShotConfigStats* shotst;
-    struct Thing* shottng = thing_get(efftng->parent_idx);
-    if (thing_is_shot(shottng))
+    if (efftng->shot_effect.parent_class_id == TCls_Shot)
     {
-        shotst = get_shot_model_stats(shottng->model);
+        shotst = get_shot_model_stats(efftng->shot_effect.parent_model);
     }
     else
     {

--- a/src/thing_effects.h
+++ b/src/thing_effects.h
@@ -277,7 +277,7 @@ TbBool thing_is_effect(const struct Thing *thing);
 struct Thing *create_effect(const struct Coord3d *pos, ThingModel effmodel, PlayerNumber owner);
 struct Thing *create_effect_generator(struct Coord3d *pos, ThingModel model, unsigned short range, unsigned short owner, long parent_idx);
 struct Thing *create_effect_element(const struct Coord3d *pos, ThingModel eelmodel, PlayerNumber owner);
-struct Thing* create_used_effect_or_element(const struct Coord3d* pos, EffectOrEffElModel effect_id, PlayerNumber plyr_idx);
+struct Thing* create_used_effect_or_element(const struct Coord3d* pos, EffectOrEffElModel effect_id, PlayerNumber plyr_idx, ThingIndex parent_idx);
 TngUpdateRet update_effect_element(struct Thing *thing);
 TngUpdateRet update_effect(struct Thing *thing);
 TngUpdateRet process_effect_generator(struct Thing *thing);

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1287,10 +1287,10 @@ static TngUpdateRet object_update_dungeon_heart(struct Thing *heartng)
         if (heartng->health <= 0)
         {
             struct Thing* efftng;
-            efftng = create_used_effect_or_element(&heartng->mappos, objst->effect.explosion1, heartng->owner);
+            efftng = create_used_effect_or_element(&heartng->mappos, objst->effect.explosion1, heartng->owner, heartng->index);
             if (!thing_is_invalid(efftng))
                 efftng->shot_effect.hit_type = THit_HeartOnlyNotOwn;
-            efftng = create_used_effect_or_element(&heartng->mappos, objst->effect.explosion2, heartng->owner);
+            efftng = create_used_effect_or_element(&heartng->mappos, objst->effect.explosion2, heartng->owner, heartng->index);
             if (!thing_is_invalid(efftng))
                 efftng->shot_effect.hit_type = THit_HeartOnlyNotOwn;
             destroy_dungeon_heart_room(heartng->owner, heartng);

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -128,8 +128,8 @@ TbBool detonate_shot(struct Thing *shotng, TbBool destroy)
         HitTargetFlags hit_targets = hit_type_to_hit_targets(shotst->area_hit_type);
         explosion_affecting_area(shotng, &shotng->mappos, dist, damage, shotst->area_blow, hit_targets);
     }
-    create_used_effect_or_element(&shotng->mappos, shotst->explode.effect1_model, shotng->owner);
-    create_used_effect_or_element(&shotng->mappos, shotst->explode.effect2_model, shotng->owner);
+    create_used_effect_or_element(&shotng->mappos, shotst->explode.effect1_model, shotng->owner, shotng->index);
+    create_used_effect_or_element(&shotng->mappos, shotst->explode.effect2_model, shotng->owner, shotng->index);
     if (shotst->explode.around_effect1_model != 0)
     {
         create_effect_around_thing(shotng, shotst->explode.around_effect1_model);
@@ -457,11 +457,11 @@ SubtlCodedCoords process_dig_shot_hit_wall(struct Thing *thing, long blocked_fla
     return result;
 }
 
-struct Thing *create_shot_hit_effect(struct Coord3d *effpos, long effowner, EffectOrEffElModel eff_kind, long snd_idx, long snd_range)
+struct Thing *create_shot_hit_effect(struct Coord3d *effpos, long effowner, EffectOrEffElModel eff_kind, long snd_idx, long snd_range, ThingIndex parent_idx)
 {
     struct Thing* efftng = INVALID_THING;
     if (eff_kind != 0) {
-        efftng = create_used_effect_or_element(effpos, eff_kind, effowner);
+        efftng = create_used_effect_or_element(effpos, eff_kind, effowner, parent_idx);
         TRACE_THING(efftng);
     }
     if (snd_idx > 0)
@@ -601,7 +601,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
         doortng = get_door_for_position(hit_stl_x, hit_stl_y);
         if (!thing_is_invalid(doortng))
         {
-            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->hit_door.effect_model, shotst->hit_door.sndsample_idx, shotst->hit_door.sndsample_range);
+            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->hit_door.effect_model, shotst->hit_door.sndsample_idx, shotst->hit_door.sndsample_range, shotng->index);
             if (!shotst->hit_door.withstand)
               destroy_shot = 1;
             i = calculate_shot_real_damage_to_door(doortng, shotng);
@@ -610,14 +610,14 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
         } else
         if (cube_is_water(cube_id))
         {
-            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->hit_water.effect_model, shotst->hit_water.sndsample_idx, shotst->hit_water.sndsample_range);
+            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->hit_water.effect_model, shotst->hit_water.sndsample_idx, shotst->hit_water.sndsample_range, shotng->index);
             if (!shotst->hit_water.withstand) {
                 destroy_shot = 1;
             }
         } else
         if (cube_is_lava(cube_id))
         {
-            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->hit_lava.effect_model, shotst->hit_lava.sndsample_idx, shotst->hit_lava.sndsample_range);
+            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->hit_lava.effect_model, shotst->hit_lava.sndsample_idx, shotst->hit_lava.sndsample_range, shotng->index);
             if (!shotst->hit_lava.withstand) {
                 destroy_shot = 1;
             }
@@ -636,7 +636,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
                     eff_kind = shotst->dig.effect_model;
                 }
             }
-            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, eff_kind, smpl_idx, range);
+            efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, eff_kind, smpl_idx, range, shotng->index);
             if (!shotst->hit_generic.withstand) {
                 destroy_shot = 1;
             }
@@ -662,7 +662,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
             doortng = get_door_for_position(hit_stl_x, hit_stl_y);
             if (!thing_is_invalid(doortng))
             {
-                efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->hit_door.effect_model, shotst->hit_door.sndsample_idx, shotst->hit_door.sndsample_range);
+                efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, shotst->hit_door.effect_model, shotst->hit_door.sndsample_idx, shotst->hit_door.sndsample_range, shotng->index);
                 if (!shotst->hit_door.withstand)
                     destroy_shot = 1;
                 i = calculate_shot_real_damage_to_door(doortng, shotng);
@@ -683,7 +683,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
                         eff_kind = shotst->dig.effect_model;
                     }
                 }
-                efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, eff_kind, smpl_idx, range);
+                efftng = create_shot_hit_effect(&shotng->mappos, shotng->owner, eff_kind, smpl_idx, range, shotng->index);
 
                 if (!shotst->hit_generic.withstand) {
                     destroy_shot = 1;
@@ -737,7 +737,7 @@ long shot_hit_door_at(struct Thing *shotng, struct Coord3d *pos)
             // If the shot hit is supposed to create effect thing
             if (shotst->hit_door.effect_model != 0)
             {
-                efftng = create_used_effect_or_element(&shotng->mappos, shotst->hit_door.effect_model, shotng->owner);
+                efftng = create_used_effect_or_element(&shotng->mappos, shotst->hit_door.effect_model, shotng->owner, shotng->index);
             }
             // If the shot hit is supposed to create sound
             int n = shotst->hit_door.sndsample_idx;
@@ -877,7 +877,7 @@ static TbBool shot_hit_trap_at(struct Thing* shotng, struct Thing* target, struc
         struct TrapConfigStats* trapst = get_trap_model_stats(target->model);
         if (trapst->destroyed_effect != 0)
         {
-            create_used_effect_or_element(&target->mappos, trapst->destroyed_effect, target->owner);
+            create_used_effect_or_element(&target->mappos, trapst->destroyed_effect, target->owner, shotng->index);
         }
         if (((trapst->unstable == 1) && !(shotst->model_flags & ShMF_Disarming)) || trapst->unstable == 2)
         {
@@ -913,7 +913,7 @@ static TbBool shot_hit_object_at(struct Thing *shotng, struct Thing *target, str
     {
         if (shotst->hit_heart.effect_model != 0)
         {
-            create_used_effect_or_element(&shotng->mappos, shotst->hit_heart.effect_model, shotng->owner);
+            create_used_effect_or_element(&shotng->mappos, shotst->hit_heart.effect_model, shotng->owner, shotng->index);
         }
         if (shotst->hit_heart.sndsample_idx > 0)
         {
@@ -1012,18 +1012,18 @@ void create_relevant_effect_for_shot_hitting_thing(struct Thing *shotng, struct 
     {
         thing_play_sample(target, shotst->hit_creature.sndsample_idx, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
         if (shotst->hit_creature.effect_model != 0) {
-            create_used_effect_or_element(&shotng->mappos, shotst->hit_creature.effect_model, shotng->owner);
+            create_used_effect_or_element(&shotng->mappos, shotst->hit_creature.effect_model, shotng->owner, shotng->index);
         }
         if (creature_affected_by_spell(target, SplK_Freeze))
         {
             if (shotst->effect_frozen != 0) {
-                create_used_effect_or_element(&shotng->mappos, shotst->effect_frozen, shotng->owner);
+                create_used_effect_or_element(&shotng->mappos, shotst->effect_frozen, shotng->owner, shotng->index);
             }
         } else
         if (creature_model_bleeds(target->model))
         {
             if (shotst->effect_bleeding != 0) {
-                create_used_effect_or_element(&shotng->mappos, shotst->effect_bleeding, shotng->owner);
+                create_used_effect_or_element(&shotng->mappos, shotst->effect_bleeding, shotng->owner, shotng->index);
             }
         }
     }
@@ -1032,7 +1032,7 @@ void create_relevant_effect_for_shot_hitting_thing(struct Thing *shotng, struct 
         // TODO for a later PR: introduces trap/object hit, for now it uses the on hit creature sound and effect.
         thing_play_sample(target, shotst->hit_creature.sndsample_idx, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
         if (shotst->hit_creature.effect_model != 0) {
-            create_used_effect_or_element(&shotng->mappos, shotst->hit_creature.effect_model, shotng->owner);
+            create_used_effect_or_element(&shotng->mappos, shotst->hit_creature.effect_model, shotng->owner, shotng->index);
         }
     }
 }
@@ -1741,7 +1741,7 @@ TngUpdateRet update_shot(struct Thing *thing)
                     pos1.z.val = thing->mappos.z.val - UNSYNC_RANDOM(shotst->visual.random_range) + (shotst->visual.random_range / 2);
                     if (shotst->visual.effect_model != 0)
                     {
-                        create_used_effect_or_element(&pos1, shotst->visual.effect_model, thing->owner);
+                        create_used_effect_or_element(&pos1, shotst->visual.effect_model, thing->owner, thing->index);
                     }
                 }
             }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -693,6 +693,8 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
     }
     if (!thing_is_invalid(efftng)) {
         efftng->shot_effect.hit_type = shotst->area_hit_type;
+        efftng->shot_effect.parent_class_id = TCls_Shot;
+        efftng->shot_effect.parent_model = shotng->model;
     }
     if ( destroy_shot )
     {
@@ -763,6 +765,8 @@ long shot_hit_door_at(struct Thing *shotng, struct Coord3d *pos)
     }
     if (!thing_is_invalid(efftng)) {
         efftng->shot_effect.hit_type = shotst->area_hit_type;
+        efftng->shot_effect.parent_class_id = TCls_Shot;
+        efftng->shot_effect.parent_model = shotng->model;
     }
     if ( shot_explodes )
     {

--- a/src/thing_stats.c
+++ b/src/thing_stats.c
@@ -125,6 +125,9 @@ const char *thing_class_and_model_name(int class_id, int model)
     case TCls_Effect:
         snprintf(name_buffer[bid], sizeof(name_buffer[0]), "%s effect", effect_code_name(model));
         break;
+    case TCls_EffectElem:
+        snprintf(name_buffer[bid], sizeof(name_buffer[0]), "%s effect element", effect_element_code_name(model));
+        break;
     case TCls_EffectGen:
         snprintf(name_buffer[bid], sizeof(name_buffer[0]), "%s effectgenerator", effectgenerator_code_name(model));
         break;

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -478,6 +478,8 @@ void activate_trap_effect_on_trap(struct Thing *traptng)
     if (!thing_is_invalid(efftng)) 
     {
         efftng->shot_effect.hit_type = trapst->hit_type;
+        efftng->shot_effect.parent_class_id = TCls_Trap;
+        efftng->shot_effect.parent_model = traptng->model;
         efftng->parent_idx = traptng->index;
         SYNCDBG(18,"Created %s",thing_model_name(efftng));
     }


### PR DESCRIPTION
Shots that exploded to create effects would take the damage from the Word of Power shot or Word of Power Trap shot depending on if it was a trap or not that created it. Now it takes it from the actual shot that created the effect.