### PR TITLE
Added a script flag that stores how many times traps are activated

### DIFF
--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -209,6 +209,8 @@ TriggerAlarm = 0
 PlaceOnBridge = 0
 ; If set to 1 allows the trap to be placed anywhere on a slab. This results in up to 9 traps per tile.
 PlaceOnSubtile = 0
+; Set to a number between 0 and 255 and it will increment scriptflag TRAP#_ACTIVATED when triggered, with # being the value.
+FlagNumber = 0
 ; Place the trap immediately without needing imps to drag the crate to arm it.
 InstantPlacement = 0
 ; Destroy the trap once it runs out of Shots.

--- a/src/api.c
+++ b/src/api.c
@@ -1289,6 +1289,7 @@ static void api_process_buffer(const char *buffer, size_t buf_size)
             variable_type != SVar_FLAG &&
             variable_type != SVar_CAMPAIGN_FLAG &&
             variable_type != SVar_BOX_ACTIVATED &&
+            variable_type != SVar_TRAP_ACTIVATED &&
             variable_type != SVar_SACRIFICED &&
             variable_type != SVar_REWARDED)
         {

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -116,6 +116,7 @@ const struct NamedCommand trapdoor_trap_commands[] = {
   {"DETECTINVISIBLE",        50},
   {"INSTANTPLACEMENT",       51},
   {"REMOVEONCEDEPLETED",     52},
+  {"FLAGNUMBER",             53},
   {NULL,                      0},
 };
 
@@ -225,6 +226,7 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
           trapst->unanimated = 0;
           trapst->unshaded = 0;
           trapst->random_start_frame = 0;
+          trapst->flag_number = 0;
           trapst->light_radius = 0;
           trapst->light_intensity = 0;
           trapst->light_flag = 0;
@@ -1195,6 +1197,22 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
               }
           }
           if (n < 1)
+          {
+              CONFWRNLOG("Incorrect value of \"%s\" parameter in [%.*s] block of %s file.",
+                  COMMAND_TEXT(cmd_num), blocknamelen, blockname, config_textname);
+          }
+          break;
+      case 53: // FLAGNUMBER
+          if (get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf)) > 0)
+          {
+              k = atoi(word_buf);
+              if ((k >= 0) && (k <= UCHAR_MAX))
+              {
+                  trapst->flag_number = k;
+                  n++;
+              }
+          }
+          if (n < 0)
           {
               CONFWRNLOG("Incorrect value of \"%s\" parameter in [%.*s] block of %s file.",
                   COMMAND_TEXT(cmd_num), blocknamelen, blockname, config_textname);

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -1212,7 +1212,7 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
                   n++;
               }
           }
-          if (n < 0)
+          if (n < 1)
           {
               CONFWRNLOG("Incorrect value of \"%s\" parameter in [%.*s] block of %s file.",
                   COMMAND_TEXT(cmd_num), blocknamelen, blockname, config_textname);

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -248,7 +248,7 @@ TbBool parse_trapdoor_trap_blocks(char *buf, long len, const char *config_textna
   const char * blockname = NULL;
   int blocknamelen = 0;
   long pos = 0;
-  int k = 0;
+  long k = 0;
   while (iterate_conf_blocks(buf, &pos, len, &blockname, &blocknamelen))
   {
     // look for blocks starting with "trap", followed by one or more digits

--- a/src/config_trapdoor.h
+++ b/src/config_trapdoor.h
@@ -71,7 +71,7 @@ struct TrapConfigStats {
     unsigned char manufct_level;
     unsigned long manufct_required;
     int shots;
-    int shots_delay;
+    GameTurnDelta shots_delay;
     unsigned short initial_delay; // Trap is placed on reload phase, value in game turns.
     unsigned char trigger_type;
     unsigned char activation_type;

--- a/src/config_trapdoor.h
+++ b/src/config_trapdoor.h
@@ -99,6 +99,7 @@ struct TrapConfigStats {
     unsigned char unanimated;
     unsigned char unshaded;
     unsigned char random_start_frame;
+    unsigned char flag_number;
     short light_radius; // Creates light if not null.
     unsigned char light_intensity;
     unsigned char light_flag;

--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -120,7 +120,7 @@ struct TrapInfo
 
 struct BoxInfo
 {
-    uint8_t               activated[CUSTOM_BOX_COUNT];
+    uint16_t              activated[CUSTOM_BOX_COUNT];
 };
 
 struct ComputerInfo

--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -284,6 +284,7 @@ struct Dungeon {
     struct Modifiers      modifier;
     struct TrapInfo       mnfct_info;
     struct BoxInfo        box_info;
+    struct BoxInfo        trap_info;
     struct Coord3d        last_combat_location;
     struct Coord3d        last_eventful_death_location;
     int                   creature_awarded[CREATURE_TYPES_MAX];

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -735,7 +735,7 @@ TbBool parse_get_varib(const char *varib_name, long *varib_id, long *varib_type)
         else if (2 == sscanf(varib_name, "TRAP%ld_ACTIVATE%c", varib_id, &c) && (c == 'D'))
         {
             // activateD
-            *varib_type = SVar_BOX_ACTIVATED;
+            *varib_type = SVar_TRAP_ACTIVATED;
         }
         else if (2 == sscanf(varib_name, "KEEPERS_DESTROYED[%n%[^]]%c", &len, arg, &c) && (c == ']'))
         {

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -272,6 +272,7 @@ const struct NamedCommand trap_config_desc[] = {
   {"DetectInvisible",         49},
   {"InstantPlacement",        50},
   {"RemoveOnceDepleted",      51},
+  {"FlagNumber",              52},
   {NULL,                       0},
 };
 
@@ -2036,6 +2037,9 @@ static void set_trap_configuration_process(struct ScriptContext *context)
             break;
         case 51: // RemoveOnceDepleted
             trapst->remove_once_depleted = value;
+            break;
+        case 52: // FlagNumber
+            trapst->flag_number = value;
             break;
         default:
             WARNMSG("Unsupported Trap configuration, variable %d.", context->value->shorts[1]);

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -644,6 +644,12 @@ TbBool parse_set_varib(const char *varib_name, long *varib_id, long *varib_type)
             *varib_type = SVar_BOX_ACTIVATED;
         }
         else
+        if (2 == sscanf(varib_name, "TRAP%ld_ACTIVATE%c", varib_id, &c) && (c == 'D'))
+        {
+            // activateD
+            *varib_type = SVar_TRAP_ACTIVATED;
+        }
+        else
         {
             *varib_id = -1;
         }
@@ -722,6 +728,11 @@ TbBool parse_get_varib(const char *varib_name, long *varib_id, long *varib_type)
     if (*varib_id == -1)
     {
         if (2 == sscanf(varib_name, "BOX%ld_ACTIVATE%c", varib_id, &c) && (c == 'D'))
+        {
+            // activateD
+            *varib_type = SVar_BOX_ACTIVATED;
+        }
+        else if (2 == sscanf(varib_name, "TRAP%ld_ACTIVATE%c", varib_id, &c) && (c == 'D'))
         {
             // activateD
             *varib_type = SVar_BOX_ACTIVATED;

--- a/src/lvl_script_conditions.c
+++ b/src/lvl_script_conditions.c
@@ -253,6 +253,9 @@ long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, short val
     case SVar_BOX_ACTIVATED:
         dungeon = get_dungeon(plyr_idx);
         return dungeon->box_info.activated[validx];
+    case SVar_TRAP_ACTIVATED:
+        dungeon = get_dungeon(plyr_idx);
+        return dungeon->trap_info.activated[validx];
     case SVar_SACRIFICED:
         dungeon = get_dungeon(plyr_idx);
         return dungeon->creature_sacrifice[validx];

--- a/src/lvl_script_lib.c
+++ b/src/lvl_script_lib.c
@@ -139,10 +139,10 @@ void set_variable(int player_idx, long var_type, long var_idx, long new_val)
         intralvl.campaign_flags[player_idx][var_idx] = new_val;
         break;
     case SVar_BOX_ACTIVATED:
-        dungeon->box_info.activated[var_idx] = saturate_set_unsigned(new_val, 8);
+        dungeon->box_info.activated[var_idx] = saturate_set_unsigned(new_val, 16);
         break;
     case SVar_TRAP_ACTIVATED:
-        dungeon->trap_info.activated[var_idx] = saturate_set_unsigned(new_val, 8);
+        dungeon->trap_info.activated[var_idx] = saturate_set_unsigned(new_val, 16);
         break;
     case SVar_SACRIFICED:
         dungeon->creature_sacrifice[var_idx] = saturate_set_unsigned(new_val, 8);

--- a/src/lvl_script_lib.c
+++ b/src/lvl_script_lib.c
@@ -141,6 +141,9 @@ void set_variable(int player_idx, long var_type, long var_idx, long new_val)
     case SVar_BOX_ACTIVATED:
         dungeon->box_info.activated[var_idx] = saturate_set_unsigned(new_val, 8);
         break;
+    case SVar_TRAP_ACTIVATED:
+        dungeon->trap_info.activated[var_idx] = saturate_set_unsigned(new_val, 8);
+        break;
     case SVar_SACRIFICED:
         dungeon->creature_sacrifice[var_idx] = saturate_set_unsigned(new_val, 8);
         if (find_temple_pool(player_idx, &pos))

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -268,6 +268,7 @@ enum ScriptVariables {
   SVar_TOTAL_SALARY                    = 64,
   SVar_CURRENT_SALARY                  = 65,
   SVar_BOX_ACTIVATED                   = 66,
+  SVar_TRAP_ACTIVATED                  = 86,
   SVar_SACRIFICED                      = 67,  // Per model
   SVar_REWARDED                        = 68,  // Per model
   SVar_EVIL_CREATURES_CONVERTED        = 69,

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -234,6 +234,7 @@ struct Thing {
         short volley_repeat;
         unsigned short volley_delay;
         unsigned short firing_at;
+        unsigned char flag_number;
       } trap;
 //TCls_Door
       struct {

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -826,6 +826,11 @@ void update_trap_trigger(struct Thing* traptng)
     }
     if (do_trig)
     {
+        struct Dungeon *dungeon = get_dungeon(traptng->owner);
+        if (!dungeon_invalid(dungeon))
+        {
+            dungeon->trap_info.activated[traptng->trap.flag_number]++;
+        }
         process_trap_charge(traptng);
     }
 }
@@ -931,6 +936,7 @@ struct Thing *create_trap(struct Coord3d *pos, ThingModel trpkind, PlayerNumber 
     thing->next_on_mapblk = 0;
     thing->parent_idx = thing->index;
     thing->owner = plyr_idx;
+    thing->trap.flag_number = trapst->flag_number;
     char start_frame;
     if (trapst->random_start_frame) {
         start_frame = -1;

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -740,11 +740,11 @@ void process_trap_charge(struct Thing* traptng)
     if (trapst->attack_sprite_anim_idx != 0)
     {
         GameTurnDelta trigger_duration;
-        if (trapst->activation_type == 2) // Effect stays on trap, so the attack animation remains visible for as long as the effect is alive.
+        if (trapst->activation_type == TrpAcT_EffectonTrap) // Effect stays on trap, so the attack animation remains visible for as long as the effect is alive.
         {
             trigger_duration = get_effect_model_stats(trapst->created_itm_model)->start_health;
         } else
-        if (trapst->activation_type == 3) // Shot stays on trap, so the attack animation remains visible for as long as the trap is alive.
+        if (trapst->activation_type == TrpAcT_ShotonTrap) // Shot stays on trap, so the attack animation remains visible for as long as the trap is alive.
         {
             trigger_duration = get_shot_model_stats(trapst->created_itm_model)->health;
         }


### PR DESCRIPTION
Added a new script flag: `TRAP#_ACTIVATED`, where the # is a number between 0 and 255 from `FlagNumber` on the trap configuration in trapdoor.cfg.

Example:

```
IF(PLAYER0,TRAP3_ACTIVATED >= 3)
	QUICK_INFORMATION(1,"There have been 3 boulders activated")
ENDIF
```

From trapdoor.cfg:
```ini
[trap1]
Name = BOULDER
FlagNumber = 3
```