### PR TITLE
Allow Orientation param in ADD_OBJECT_TO_LEVEL script command

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -7032,7 +7032,7 @@ static void add_object_to_level_at_pos_check(const struct ScriptLine* scline)
     short angle = 0;
     if (parameter_is_number(scline->tp[5]))
     {
-        angle = atoi(scline->tp[5]);
+        angle = atoi(scline->tp[5]) % LbFPMath_TAU;
     }
     else
     {
@@ -7078,7 +7078,7 @@ static void add_object_to_level_check(const struct ScriptLine* scline)
     short angle = 0;
     if (parameter_is_number(scline->tp[4]))
     {
-        angle = atoi(scline->tp[4]);
+        angle = atoi(scline->tp[4]) % LbFPMath_TAU;
     }
     else
     {

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -7014,8 +7014,8 @@ static void add_object_to_level_at_pos_check(const struct ScriptLine* scline)
     value->shorts[0] = tngmodel;
     if (!subtile_coords_invalid(scline->np[1], scline->np[2]))
     {
-        value->shorts[4] = scline->np[1];
-        value->shorts[5] = scline->np[2];
+        value->shorts[2] = scline->np[1];
+        value->shorts[3] = scline->np[2];
     }
     else
     {
@@ -7024,24 +7024,27 @@ static void add_object_to_level_at_pos_check(const struct ScriptLine* scline)
         return;
     }
     value->longs[2] = scline->np[3];
-    PlayerNumber plyr_idx = get_rid(player_desc, scline->tp[4]);
+    PlayerNumber plyr_idx = get_rid(player_desc, scline->tp[4]); // Optional variable
     if ((plyr_idx == -1) || (plyr_idx == ALL_PLAYERS))
     {
         plyr_idx = PLAYER_NEUTRAL;
     }
     short angle = 0;
-    if (parameter_is_number(scline->tp[5]))
+    if (strcmp(scline->tp[5], "") != 0) // Optional variable
     {
-        angle = atoi(scline->tp[5]) % LbFPMath_TAU;
-    }
-    else
-    {
-        angle = get_rid(orientation_desc, scline->tp[5]);
-        if (angle < 0)
+        if (parameter_is_number(scline->tp[5]))
         {
-            SCRPTERRLOG("Unknown orientation: %s", scline->tp[5]);
-            DEALLOCATE_SCRIPT_VALUE
-            return;
+            angle = atoi(scline->tp[5]) % LbFPMath_TAU;
+        }
+        else
+        {
+            angle = get_rid(orientation_desc, scline->tp[5]);
+            if (angle < 0)
+            {
+                SCRPTERRLOG("Unknown orientation: %s", scline->tp[5]);
+                DEALLOCATE_SCRIPT_VALUE
+                return;
+            }
         }
     }
 
@@ -7070,24 +7073,27 @@ static void add_object_to_level_check(const struct ScriptLine* scline)
     value->ulongs[1] = location;
     value->longs[2] = scline->np[2];
     PlayerNumber plyr_idx = get_rid(player_desc, scline->tp[3]);
-    if ((plyr_idx == -1) || (plyr_idx == ALL_PLAYERS))
+    if ((plyr_idx == -1) || (plyr_idx == ALL_PLAYERS)) //Optional variable
     {
         plyr_idx = PLAYER_NEUTRAL;
     }
 
     short angle = 0;
-    if (parameter_is_number(scline->tp[4]))
+    if (strcmp(scline->tp[4], "") != 0) //Optional variable
     {
-        angle = atoi(scline->tp[4]) % LbFPMath_TAU;
-    }
-    else
-    {
-        angle = get_rid(orientation_desc, scline->tp[4]);
-        if (angle < 0)
+        if (parameter_is_number(scline->tp[4]))
         {
-            SCRPTERRLOG("Unknown orientation: %s", scline->tp[4]);
-            DEALLOCATE_SCRIPT_VALUE
-            return;
+            angle = atoi(scline->tp[4]) % LbFPMath_TAU;
+        }
+        else
+        {
+            angle = get_rid(orientation_desc, scline->tp[4]);
+            if (angle < 0)
+            {
+                SCRPTERRLOG("Unknown orientation: %s", scline->tp[4]);
+                DEALLOCATE_SCRIPT_VALUE
+                return;
+            }
         }
     }
 
@@ -7107,7 +7113,7 @@ static void add_object_to_level_process(struct ScriptContext* context)
 
 static void add_object_to_level_at_pos_process(struct ScriptContext* context)
 {
-    script_process_new_object(context->value->shorts[0], context->value->shorts[4], context->value->shorts[5], context->value->longs[2], context->value->chars[2],context->value->shorts[6]);
+    script_process_new_object(context->value->shorts[0], context->value->shorts[2], context->value->shorts[3], context->value->longs[2], context->value->chars[2],context->value->shorts[6]);
 }
 
 static void set_computer_globals_check(const struct ScriptLine* scline)

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -498,6 +498,18 @@ const struct NamedCommand is_free_desc[] = {
   {NULL, 0}
 };
 
+const struct NamedCommand orientation_desc[] = {
+  {"North",     ANGLE_NORTH},
+  {"NorthEast", ANGLE_NORTHEAST},
+  {"East",      ANGLE_EAST},
+  {"SouthEast", ANGLE_SOUTHEAST},
+  {"South",     ANGLE_SOUTH},
+  {"SouthWest", ANGLE_SOUTHWEST},
+  {"West",      ANGLE_WEST},
+  {"NorthWest", ANGLE_NORTHWEST},
+  {NULL, 0}
+};
+
 const struct NamedCommand texture_pack_desc[] = {
   {"NONE",         0},
   {"STANDARD",     1},
@@ -7017,8 +7029,24 @@ static void add_object_to_level_at_pos_check(const struct ScriptLine* scline)
     {
         plyr_idx = PLAYER_NEUTRAL;
     }
+    short angle = 0;
+    if (parameter_is_number(scline->tp[5]))
+    {
+        angle = atoi(scline->tp[5]);
+    }
+    else
+    {
+        angle = get_rid(orientation_desc, scline->tp[5]);
+        if (angle < 0)
+        {
+            SCRPTERRLOG("Unknown orientation: %s", scline->tp[5]);
+            DEALLOCATE_SCRIPT_VALUE
+            return;
+        }
+    }
+
     value->chars[2] = plyr_idx;
-    value->shorts[6] = atoi(scline->tp[5]);
+    value->shorts[6] = angle;
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
@@ -7046,8 +7074,25 @@ static void add_object_to_level_check(const struct ScriptLine* scline)
     {
         plyr_idx = PLAYER_NEUTRAL;
     }
+
+    short angle = 0;
+    if (parameter_is_number(scline->tp[4]))
+    {
+        angle = atoi(scline->tp[4]);
+    }
+    else
+    {
+        angle = get_rid(orientation_desc, scline->tp[4]);
+        if (angle < 0)
+        {
+            SCRPTERRLOG("Unknown orientation: %s", scline->tp[4]);
+            DEALLOCATE_SCRIPT_VALUE
+            return;
+        }
+    }
+
     value->chars[2] = plyr_idx;
-    value->shorts[6] = atoi(scline->tp[4]);
+    value->shorts[6] = angle;
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -7017,7 +7017,7 @@ static void add_object_to_level_at_pos_check(const struct ScriptLine* scline)
     {
         plyr_idx = PLAYER_NEUTRAL;
     }
-    value->chars[6] = plyr_idx;
+    value->chars[7] = plyr_idx;
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
@@ -7060,7 +7060,7 @@ static void add_object_to_level_process(struct ScriptContext* context)
 
 static void add_object_to_level_at_pos_process(struct ScriptContext* context)
 {
-    script_process_new_object(context->value->shorts[0], context->value->shorts[1], context->value->shorts[2], context->value->longs[2], context->value->chars[6]);
+    script_process_new_object(context->value->shorts[0], context->value->shorts[1], context->value->shorts[2], context->value->longs[2], context->value->chars[7]);
 }
 
 static void set_computer_globals_check(const struct ScriptLine* scline)

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -7002,8 +7002,8 @@ static void add_object_to_level_at_pos_check(const struct ScriptLine* scline)
     value->shorts[0] = tngmodel;
     if (!subtile_coords_invalid(scline->np[1], scline->np[2]))
     {
-        value->shorts[1] = scline->np[1];
-        value->shorts[2] = scline->np[2];
+        value->shorts[4] = scline->np[1];
+        value->shorts[5] = scline->np[2];
     }
     else
     {
@@ -7017,7 +7017,8 @@ static void add_object_to_level_at_pos_check(const struct ScriptLine* scline)
     {
         plyr_idx = PLAYER_NEUTRAL;
     }
-    value->chars[7] = plyr_idx;
+    value->chars[2] = plyr_idx;
+    value->shorts[6] = atoi(scline->tp[5]);
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
@@ -7046,6 +7047,7 @@ static void add_object_to_level_check(const struct ScriptLine* scline)
         plyr_idx = PLAYER_NEUTRAL;
     }
     value->chars[2] = plyr_idx;
+    value->shorts[6] = atoi(scline->tp[4]);
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
@@ -7054,13 +7056,13 @@ static void add_object_to_level_process(struct ScriptContext* context)
     struct Coord3d pos;
     if (get_coords_at_location(&pos,context->value->ulongs[1],true))
     {
-        script_process_new_object(context->value->shorts[0], pos.x.stl.num, pos.y.stl.num, context->value->longs[2], context->value->chars[2]);
+        script_process_new_object(context->value->shorts[0], pos.x.stl.num, pos.y.stl.num, context->value->longs[2], context->value->chars[2], context->value->shorts[6]);
     }
 }
 
 static void add_object_to_level_at_pos_process(struct ScriptContext* context)
 {
-    script_process_new_object(context->value->shorts[0], context->value->shorts[1], context->value->shorts[2], context->value->longs[2], context->value->chars[7]);
+    script_process_new_object(context->value->shorts[0], context->value->shorts[4], context->value->shorts[5], context->value->longs[2], context->value->chars[2],context->value->shorts[6]);
 }
 
 static void set_computer_globals_check(const struct ScriptLine* scline)
@@ -7385,7 +7387,7 @@ const struct CommandDesc command_desc[] = {
   {"DELETE_FROM_PARTY",                 "ACN     ", Cmd_DELETE_FROM_PARTY, &delete_from_party_check, NULL},
   {"ADD_PARTY_TO_LEVEL",                "PAAN    ", Cmd_ADD_PARTY_TO_LEVEL, NULL, NULL},
   {"ADD_CREATURE_TO_LEVEL",             "PCANNN  ", Cmd_ADD_CREATURE_TO_LEVEL, NULL, NULL},
-  {"ADD_OBJECT_TO_LEVEL",               "AANp    ", Cmd_ADD_OBJECT_TO_LEVEL, &add_object_to_level_check, &add_object_to_level_process},
+  {"ADD_OBJECT_TO_LEVEL",               "AANpa   ", Cmd_ADD_OBJECT_TO_LEVEL, &add_object_to_level_check, &add_object_to_level_process},
   {"IF",                                "PAOAa   ", Cmd_IF, &if_check, NULL},
   {"IF_ACTION_POINT",                   "NP      ", Cmd_IF_ACTION_POINT, NULL, NULL},
   {"ENDIF",                             "        ", Cmd_ENDIF, NULL, NULL},
@@ -7535,7 +7537,7 @@ const struct CommandDesc command_desc[] = {
   {"SET_PLAYER_MODIFIER",               "PAN     ", Cmd_SET_PLAYER_MODIFIER, &set_player_modifier_check, &set_player_modifier_process},
   {"ADD_TO_PLAYER_MODIFIER",            "PAN     ", Cmd_ADD_TO_PLAYER_MODIFIER, &add_to_player_modifier_check, &add_to_player_modifier_process},
   {"CHANGE_SLAB_TEXTURE",               "NNAa    ", Cmd_CHANGE_SLAB_TEXTURE , &change_slab_texture_check, &change_slab_texture_process},
-  {"ADD_OBJECT_TO_LEVEL_AT_POS",        "ANNNp   ", Cmd_ADD_OBJECT_TO_LEVEL_AT_POS, &add_object_to_level_at_pos_check, &add_object_to_level_at_pos_process},
+  {"ADD_OBJECT_TO_LEVEL_AT_POS",        "ANNNpa  ", Cmd_ADD_OBJECT_TO_LEVEL_AT_POS, &add_object_to_level_at_pos_check, &add_object_to_level_at_pos_process},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 

--- a/src/lvl_script_conditions.h
+++ b/src/lvl_script_conditions.h
@@ -32,6 +32,7 @@ extern "C" {
 extern const struct NamedCommand variable_desc[];
 extern const struct NamedCommand dk1_variable_desc[];
 extern const struct NamedCommand is_free_desc[];
+extern const struct NamedCommand orientation_desc[];
 
 
 long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, short validx);

--- a/src/lvl_script_lib.c
+++ b/src/lvl_script_lib.c
@@ -49,7 +49,7 @@ void command_init_value(struct ScriptValue* value, unsigned long var_index, unsi
     value->condit_idx = get_script_current_condition();
 }
 
-struct Thing *script_process_new_object(ThingModel tngmodel, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long arg, PlayerNumber plyr_idx)
+struct Thing *script_process_new_object(ThingModel tngmodel, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long arg, PlayerNumber plyr_idx, short move_angle)
 {
     struct Coord3d pos;
     pos.x.val = subtile_coord_center(stl_x);
@@ -61,6 +61,7 @@ struct Thing *script_process_new_object(ThingModel tngmodel, MapSubtlCoord stl_x
         ERRORLOG("Couldn't create %s at location %ld, %ld",thing_class_and_model_name(TCls_Object, tngmodel),stl_x, stl_y);
         return INVALID_THING;
     }
+    thing->move_angle_xy = move_angle;
     if (thing_is_dungeon_heart(thing))
     {
         struct Dungeon* dungeon = get_dungeon(thing->owner);

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -302,7 +302,7 @@ enum ScriptVariables {
 struct Thing* script_get_creature_by_criteria(PlayerNumber plyr_idx, ThingModel crmodel, long criteria);
 ThingModel parse_creature_name(const char *creature_name);
 struct ScriptValue *allocate_script_value(void);
-struct Thing *script_process_new_object(ThingModel tngmodel, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long arg, PlayerNumber plyr_idx);
+struct Thing *script_process_new_object(ThingModel tngmodel, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long arg, PlayerNumber plyr_idx,short move_angle);
 struct Thing* script_process_new_effectgen(ThingModel crmodel, TbMapLocation location, long range);
 void command_init_value(struct ScriptValue* value, unsigned long var_index, unsigned long plr_range_id);
 void command_add_value(unsigned long var_index, unsigned long plr_range_id, long val2, long val3, long val4);

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -302,7 +302,7 @@ enum ScriptVariables {
 struct Thing* script_get_creature_by_criteria(PlayerNumber plyr_idx, ThingModel crmodel, long criteria);
 ThingModel parse_creature_name(const char *creature_name);
 struct ScriptValue *allocate_script_value(void);
-struct Thing *script_process_new_object(ThingModel tngmodel, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long arg, PlayerNumber plyr_idx,short move_angle);
+struct Thing *script_process_new_object(ThingModel tngmodel, MapSubtlCoord stl_x, MapSubtlCoord stl_y, long arg, PlayerNumber plyr_idx, short move_angle);
 struct Thing* script_process_new_effectgen(ThingModel crmodel, TbMapLocation location, long range);
 void command_init_value(struct ScriptValue* value, unsigned long var_index, unsigned long plr_range_id);
 void command_add_value(unsigned long var_index, unsigned long plr_range_id, long val2, long val3, long val4);


### PR DESCRIPTION
`ADD_OBJECT_TO_LEVEL([object],[location],[property],[player]*,[orientation]*)`
`ADD_OBJECT_TO_LEVEL_AT_POS([object],[subtile_x],[subtile_y],[property],[player]*,[orientation]*)`

Where orientation are values between 0 and 2047, or the strings used in unearth:

![image](https://github.com/user-attachments/assets/e38208a8-fa6c-44d3-afa9-9d5d980b4f51)