### PR TITLE
SET_CREATURE_CONFIGURATION swap [slot] and [value]

### DIFF
--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -97,6 +97,13 @@ PrisonKind = NULL
 ; Defines the kind of creature it will become if it dies from torture.
 ; The same rule applies as above, except it does not consider the 'HUMANOID_SKELETON' property.
 TortureKind = NULL
+; Creature immunities. Takes 'SpellFlags', see magic.cfg for the names or numbers.
+; Special cases:
+; LIGHT - Prevents 'LIGHT', but does not stop 'ILLUMINATED' from working.
+; POISON_CLOUD - Prevents damages/status from effects with 'AreaAffectType' set to 1/2/3.
+; MAD_KILLING - Prevents 'MAD_KILLING', but does not stop 'MAD_PSYCHO' anger job.
+; FEAR - Prevents 'FEAR', but does not stop fleeing/real fear.
+; WIND - Prevents the creature from being blown away from shots with 'UpdateLogic' set to 2.
 ; Set to 0, leave empty, or remove the field for the creature to have no immunities.
 SpellImmunity = 0
 ; Creature properties:
@@ -129,13 +136,6 @@ SpellImmunity = 0
 ;   ILLUMINATED - A bright light will shine from the Creature.
 ;   ALLURING_SCVNGR - When scavenging will give the keeper a portal boost compared to rival keepers.
 Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK NO_CORPSE_ROTTING
-; Creature immunities. Takes 'SpellFlags', see magic.cfg for the names or numbers.
-; Special cases:
-; LIGHT - Prevents 'LIGHT', but does not stop 'ILLUMINATED' from working.
-; POISON_CLOUD - Prevents damages/status from effects with 'AreaAffectType' set to 1/2/3.
-; MAD_KILLING - Prevents 'MAD_KILLING', but does not stop 'MAD_PSYCHO' anger job.
-; FEAR - Prevents 'FEAR', but does not stop fleeing/real fear.
-; WIND - Prevents the creature from being blown away from shots with 'UpdateLogic' set to 2.
 
 [attraction]
 ; Rooms required to attract the creature from entrance, and number of slabs which is needed (max 3 rooms).

--- a/levels/legacy_crtr/avatar.cfg
+++ b/levels/legacy_crtr/avatar.cfg
@@ -10,7 +10,6 @@ Defence = 110
 Luck = 8
 DamageToBoulder = 20
 Properties = BLEEDS HUMANOID_SKELETON IMMUNE_TO_BOULDER ONE_OF_KIND NO_STEAL_HERO
-SpellImmunity = CHICKEN
 
 [attraction]
 EntranceRoom = NULL NULL NULL

--- a/levels/legacy_crtr/ghost.cfg
+++ b/levels/legacy_crtr/ghost.cfg
@@ -10,7 +10,6 @@ Luck = 4
 ; In the original game, you could force-feed creatures even if they did not have any needs for eating. Setting HungerFill to 1 while HungerRate is set to 0 enables this mechanic.
 HungerFill = 1
 Properties = FLYING SEE_INVISIBLE EVIL
-SpellImmunity = POISON_CLOUD
 
 [experience]
 Powers = SWING_WEAPON_FIST NULL INVISIBILITY REBOUND NULL WIND NULL DRAIN NULL NULL

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -3379,43 +3379,43 @@ static void set_creature_configuration_check(const struct ScriptLine* scline)
     {
         if (creatvar == 1) // POWERS
         {
-            if ((atoi(scline->tp[2]) >= CREATURE_MAX_LEVEL) || (atoi(scline->tp[2]) <= 0)) //Powers
-            {
-                SCRPTERRLOG("Value %d out of range, only %d slots for Powers.", atoi(scline->tp[2]), CREATURE_MAX_LEVEL - 1);
-                DEALLOCATE_SCRIPT_VALUE
-                return;
-            }
-            value1 = atoi(scline->tp[2]);
             long instance = 0;
-            if (!parameter_is_number(scline->tp[3]))
+            if (!parameter_is_number(scline->tp[2]))
             {
-                instance = get_id(instance_desc, scline->tp[3]);
+                instance = get_id(instance_desc, scline->tp[2]);
 
             }
             else
             {
-                instance = atoi(scline->tp[3]);
+                instance = atoi(scline->tp[2]);
             }
             if (instance >= 0)
             {
-                value2 = instance;
+                value1 = instance;
             }
             else
             {
-                SCRPTERRLOG("Unknown instance %s ", scline->tp[3]);
+                SCRPTERRLOG("Unknown instance %s ", scline->tp[2]);
                 DEALLOCATE_SCRIPT_VALUE
                 return;
             }
+            if ((atoi(scline->tp[3]) >= CREATURE_MAX_LEVEL) || (atoi(scline->tp[3]) <= 0)) //Powers
+            {
+                SCRPTERRLOG("Value %d out of range, only %d slots for Powers.", atoi(scline->tp[3]), CREATURE_MAX_LEVEL - 1);
+                DEALLOCATE_SCRIPT_VALUE
+                return;
+            }
+            value2 = atoi(scline->tp[3]);
         } else 
         if (creatvar == 2) // POWERSLEVELREQUIRED
         {
-            if ((atoi(scline->tp[2]) > CREATURE_MAX_LEVEL) || (atoi(scline->tp[2]) <= 0))//slot
+            if ((atoi(scline->tp[2]) <= 0) || (atoi(scline->tp[2]) > CREATURE_MAX_LEVEL)) //value
             {
                 SCRPTERRLOG("Value %d out of range, only %d levels for PowersLevelRequired supported", atoi(scline->tp[2]), CREATURE_MAX_LEVEL);
                 DEALLOCATE_SCRIPT_VALUE
                 return;
             }
-            if ((atoi(scline->tp[3]) <= 0) || (atoi(scline->tp[3]) > CREATURE_MAX_LEVEL)) //value
+            if ((atoi(scline->tp[3]) > CREATURE_MAX_LEVEL) || (atoi(scline->tp[3]) <= 0)) //slot
             {
                 SCRPTERRLOG("Value %d out of range, only %d levels for PowersLevelRequired supported", atoi(scline->tp[3]), CREATURE_MAX_LEVEL);
                 DEALLOCATE_SCRIPT_VALUE
@@ -3426,21 +3426,20 @@ static void set_creature_configuration_check(const struct ScriptLine* scline)
         } else
         if (creatvar == 3) // LEVELSTRAINVALUES
         {
-            if ((atoi(scline->tp[2]) <= 0) || (atoi(scline->tp[2]) > CREATURE_MAX_LEVEL)) //slot
+            if (atoi(scline->tp[2]) < 0) //value
             {
-                SCRPTERRLOG("Value %d out of range, only %d levels for LevelsTrainValues supported", atoi(scline->tp[2]), CREATURE_MAX_LEVEL - 1);
+                SCRPTERRLOG("Value %d out of range.", atoi(scline->tp[2]));
                 DEALLOCATE_SCRIPT_VALUE
-                return;
+                    return;
             }
-            if (atoi(scline->tp[3]) < 0) //value
+            if ((atoi(scline->tp[3]) <= 0) || (atoi(scline->tp[3]) > CREATURE_MAX_LEVEL)) //slot
             {
-                SCRPTERRLOG("Value %d out of range.", atoi(scline->tp[3]));
+                SCRPTERRLOG("Value %d out of range, only %d levels for LevelsTrainValues supported", atoi(scline->tp[3]), CREATURE_MAX_LEVEL - 1);
                 DEALLOCATE_SCRIPT_VALUE
                 return;
             }
             value1 = atoi(scline->tp[2]);
             value2 = atoi(scline->tp[3]);
-
         } else
         if (creatvar == 4) // GROWUP
         {
@@ -4057,17 +4056,17 @@ static void set_creature_configuration_process(struct ScriptContext* context)
         {
         case 1: // POWERS
         {
-            crstat->learned_instance_id[value-1] = value2;
+            crstat->learned_instance_id[value2-1] = value;
             break;
         }
         case 2: // POWERSLEVELREQUIRED
         {
-            crstat->learned_instance_level[value-1] = value2;
+            crstat->learned_instance_level[value2-1] = value;
             break;
         }
         case 3: // LEVELSTRAINVALUES
         {
-            crstat->to_level[value-1] = value2;
+            crstat->to_level[value2-1] = value;
             break;
         }
         case 4: // GROWUP


### PR DESCRIPTION
For `Powers`, `PowersLevelRequired` an `LevelsTrainValues` now the [value] would hold the value, and [value2] holds the slot.

This to more closely match [SET_POWER_CONFIGURATION](https://github.com/dkfans/keeperfx/wiki/Level-Script-commands#set_power_configuration) and the rest of SET_CREATURE_CONFIGURATION.