### PR TITLE
Hero parties will retry original job after a while

### DIFF
--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -143,6 +143,7 @@ struct CreatureControl {
     unsigned char flgfield_2;
     unsigned char combat_flags;
     unsigned char party_objective;
+    unsigned char original_party_objective;
     unsigned long wait_to_turn;
     short distance_to_destination;
     ThingIndex opponents_melee[COMBAT_MELEE_OPPONENTS_LIMIT];

--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -908,6 +908,7 @@ struct Thing *script_process_new_party(struct Party *party, PlayerNumber plyr_id
           {
               struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
               cctrl->party_objective = member->objectv;
+              cctrl->original_party_objective = cctrl->party_objective;
               cctrl->wait_to_turn = game.play_gameturn + member->countdown;
               cctrl->hero.wait_time = game.play_gameturn + member->countdown;
               if (thing_is_invalid(grptng))

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -877,7 +877,7 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
             return true;
         }
         SYNCDBG(8,"Can't defend own heart, switching to attack player %d heart", (int)cctrl->party.target_plyr_idx);
-        cctrl->party_objective = CHeroTsk_AttackDnHeart;
+        cctrl->party_objective = CHeroTsk_AttackEnemies;
         return false;
     case CHeroTsk_DefendRooms:
         if (good_setup_defend_rooms(creatng))
@@ -885,7 +885,7 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
             return true;
         }
         SYNCDBG(8,"Can't defend rooms, switching to defending heart");
-        cctrl->party_objective = CHeroTsk_DefendHeart;
+        cctrl->party_objective = CHeroTsk_AttackEnemies;
         return false;
     case CHeroTsk_Default:
     default:

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -1012,6 +1012,10 @@ short good_doing_nothing(struct Thing *creatng)
         {
             SYNCDBG(4,"No enemy dungeon to perform %s index %d task",
                 thing_model_name(creatng),(int)creatng->index);
+            if (cctrl->original_party_objective > CHeroTsk_Default)
+            {
+                cctrl->party_objective = cctrl->original_party_objective;
+            }
             cctrl->wait_to_turn = game.play_gameturn + 16;
             if (creature_choose_random_destination_on_valid_adjacent_slab(creatng))
             {

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -764,14 +764,14 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
         if (good_setup_attack_rooms(creatng, target_plyr_idx)) {
             return true;
         }
-        WARNLOG("Can't attack player %d rooms, switching to attack heart", (int)target_plyr_idx);
+        SYNCDBG(8,"Can't attack player %d rooms, switching to attack heart", (int)target_plyr_idx);
         cctrl->party_objective = CHeroTsk_AttackDnHeart;
         return false;
     case CHeroTsk_SabotageRooms:
         if (good_setup_sabotage_rooms(creatng, target_plyr_idx)) {
             return true;
         }
-        WARNLOG("Can't attack player %d rooms, switching to attack heart", (int)target_plyr_idx);
+        SYNCDBG(8,"Can't attack player %d rooms, switching to attack heart", (int)target_plyr_idx);
         cctrl->party_objective = CHeroTsk_AttackDnHeart;
         return false;
     case CHeroTsk_AttackDnHeart:
@@ -779,14 +779,14 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
         {
             return true;
         }
-        ERRORLOG("Cannot wander to player %d heart", (int)target_plyr_idx);
+        SYNCDBG(8,"Cannot wander to player %d heart", (int)target_plyr_idx);
         return false;
     case CHeroTsk_SnipeDnHeart:
         if (good_setup_rush_to_dungeon_heart(creatng, target_plyr_idx))
         {
             return true;
         }
-        ERRORLOG("Cannot rush to player %d heart", (int)target_plyr_idx);
+        SYNCDBG(8,"Cannot rush to player %d heart", (int)target_plyr_idx);
         return false;
     case CHeroTsk_StealGold:
     {
@@ -796,14 +796,14 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
             if (good_setup_loot_treasure_room(creatng, target_plyr_idx)) {
                 return true;
             }
-            WARNLOG("Can't loot player %d treasury, switching to attack heart", (int)target_plyr_idx);
+            SYNCDBG(8,"Can't loot player %d treasury, switching to attack heart", (int)target_plyr_idx);
             cctrl->party_objective = CHeroTsk_AttackDnHeart;
         } else
         {
             if (good_setup_wander_to_exit(creatng)) {
                 return true;
             }
-            WARNLOG("Can't wander to exit after looting player %d treasury, switching to attack heart", (int)target_plyr_idx);
+            SYNCDBG(8, "Can't wander to exit after looting player %d treasury, switching to attack heart", (int)target_plyr_idx);
             cctrl->party_objective = CHeroTsk_AttackDnHeart;
         }
         return false;
@@ -814,14 +814,14 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
             if (good_setup_loot_research_room(creatng, target_plyr_idx)) {
                 return true;
             }
-            WARNLOG("Can't loot player %d spells, switching to attack heart", (int)target_plyr_idx);
+            SYNCDBG(8,"Can't loot player %d spells, switching to attack heart", (int)target_plyr_idx);
             cctrl->party_objective = CHeroTsk_AttackDnHeart;
         } else
         {
             if (good_setup_wander_to_exit(creatng)) {
                 return true;
             }
-            WARNLOG("Can't wander to exit after looting player %d spells, switching to attack heart", (int)target_plyr_idx);
+            SYNCDBG(8,"Can't wander to exit after looting player %d spells, switching to attack heart", (int)target_plyr_idx);
             cctrl->party_objective = CHeroTsk_AttackDnHeart;
         }
         return false;
@@ -856,7 +856,7 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
                 return true;
             }
         }
-        WARNLOG("Can't attack player %d creature, switching to attack heart", (int)cctrl->party.target_plyr_idx);
+        SYNCDBG(8,"Can't attack player %d creature, switching to attack heart", (int)cctrl->party.target_plyr_idx);
         cctrl->party_objective = CHeroTsk_AttackDnHeart;
         return false;
     case CHeroTsk_DefendSpawn:
@@ -868,7 +868,7 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
         {
             return true;
         }
-        WARNLOG("Can't patrol location, switching to defending rooms");
+        SYNCDBG(8,"Can't patrol location, switching to defending rooms");
         cctrl->party_objective = CHeroTsk_DefendRooms;
         return false;
     case CHeroTsk_DefendHeart:
@@ -876,7 +876,7 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
         {
             return true;
         }
-        WARNLOG("Can't defend own heart, switching to attack player %d heart", (int)cctrl->party.target_plyr_idx);
+        SYNCDBG(8,"Can't defend own heart, switching to attack player %d heart", (int)cctrl->party.target_plyr_idx);
         cctrl->party_objective = CHeroTsk_AttackDnHeart;
         return false;
     case CHeroTsk_DefendRooms:
@@ -884,7 +884,7 @@ TbBool good_creature_setup_task_in_dungeon(struct Thing *creatng, PlayerNumber t
         {
             return true;
         }
-        WARNLOG("Can't defend rooms, switching to defending heart");
+        SYNCDBG(8,"Can't defend rooms, switching to defending heart");
         cctrl->party_objective = CHeroTsk_DefendHeart;
         return false;
     case CHeroTsk_Default:


### PR DESCRIPTION
Before: When heroes fail their party job, they will try to attack an enemy dungeon heart. If they can't find one they will idle until they do.

Now: When heroes fail their party job:
- If it is defensive they will try to attack enemies (better for maps with secret doors and disconnected dungeons)
- If attack enemies fails, or if it was not defensive, they will switch to attack dungeon heart
- If they cannot find an enemy dungeon heart, they will switch back to their original job

Also, stopped logging all those objective changes unless playing in heavylog.