### PR TITLE
Fixed crash playing drag.smk

### DIFF
--- a/src/bflib_fmvids.cpp
+++ b/src/bflib_fmvids.cpp
@@ -296,7 +296,9 @@ struct movie_t {
 		setup_video();
 		make_packet();
 		make_frame();
-		make_resampler();
+		if (m_audio_context) {
+			make_resampler();
+		}
 		m_time_base = m_format_context->streams[m_video_index]->time_base;
 	}
 
@@ -600,7 +602,7 @@ struct movie_t {
 
 	void play() {
 		while (read_frame()) {
-			if (m_packet->stream_index == m_audio_index) {
+			if (m_packet->stream_index == m_audio_index && m_audio_context) {
 				if (!decode_audio()) {
 					break;
 				}
@@ -610,7 +612,9 @@ struct movie_t {
 				}
 			}
 		}
-		flush_audio();
+		if (m_audio_context) {
+			flush_audio();
+		}
 		flush_video();
 	}
 };


### PR DESCRIPTION
The drag FMV happens to have no audio stream.

This isn't properly handled and causes a crash.