### PR TITLE
Fixed initial exploring looking through corners

### DIFF
--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -561,9 +561,9 @@ void fill_in_explored_area(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlC
     {
         { 0, 0},
         { 1,-1},
-        { 1, 1},
-        {-1, 1},
         {-1,-1},
+        {-1, 1},
+        { 1, 1},
         { 0, 0}
     };
 


### PR DESCRIPTION
Fixes this bug:

![image](https://github.com/user-attachments/assets/95681a88-1bfa-41bd-b95e-fa81820b4e7f)
On the above image, on a map with this structure (with the red tiles attached to your dungeon), the highlighted slab is explored. Everything inside that open space should remain hidden though.