### PR TITLE
Potential fix for hatchery both full and empty bug

### DIFF
--- a/src/creature_states_gardn.c
+++ b/src/creature_states_gardn.c
@@ -93,13 +93,16 @@ void person_eat_food(struct Thing *creatng, struct Thing *foodtng, struct Room *
     } else
     {
         int required_cap = get_required_room_capacity_for_object(RoRoF_FoodStorage, foodtng->model, 0);
-        if (room->used_capacity >= required_cap) {
+        if (room->used_capacity >= required_cap)
+        {
             room->used_capacity -= required_cap;
-        } else {
+            delete_thing_structure(foodtng, 0);
+        } else
+        {
             ERRORLOG("Trying to remove some food not in room");
-            room->used_capacity = 0;
+            delete_thing_structure(foodtng, 0);
+            update_room_contents(room);
         }
-        delete_thing_structure(foodtng, 0);
     }
     struct Dungeon* dungeon = get_dungeon(creatng->owner);
     dungeon->lvstats.chickens_eaten++;


### PR DESCRIPTION
Untested because we have no path to reproduce.

Theory is that setting used_capacity to 0 on an error might cause problems, so I recalculate the correct capacity instead.
This is the bug:

![image](https://github.com/user-attachments/assets/d5696828-e59a-4868-856b-891c3af667e1)

The hatchery is full. This means no new chickens spawn, no extra hatcheries are build and creatures go there to eat. But there are no chickens, so there is nothing to eat and creatures die from hunger.
A human player can sell/remake the hatchery, the computer player will be stuck with starving creatures forever.