### PR TITLE
Handle flipping sprites with offset not centered

### DIFF
--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -299,7 +299,6 @@ void get_keepsprite_unscaled_dimensions(long kspr_anim, long angle, long frame, 
     }
     *unsc_w += kspr->offset_x;
     *unsc_h += kspr->offset_y;
-
 }
 
 short get_creature_model_graphics(long crmodel, unsigned short seq_idx)

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -7738,7 +7738,14 @@ void process_keeper_sprite(short x, short y, unsigned short kspr_base, short ksp
     sprite_rot = llabs(lltemp);
     kspr_idx = keepersprite_index(kspr_base);
     global_scaler = scale;
-    scaled_x = ((scale * (long)creature_sprites->offset_x) >> 5) + (long)x;
+    if (needs_xflip)
+    {
+        scaled_x = ((long)x - ((scale * (long)(creature_sprites->FrameWidth + creature_sprites->offset_x)) >> 5));
+    }
+    else
+    {
+        scaled_x = ((scale * (long)creature_sprites->offset_x) >> 5) + (long)x;
+    }
     scaled_y = ((scale * (long)creature_sprites->offset_y) >> 5) + (long)y;
     SYNCDBG(17,"Scaled (%d,%d)",(int)scaled_x,(int)scaled_y);
     if (thing_is_invalid(thing_being_displayed))


### PR DESCRIPTION
Fixes this bug:
https://github.com/user-attachments/assets/4dfee3cf-d67e-4016-9c21-d3a79c33f4ce

This is caused because this sprite here, the offset is centered, and when the sprite was mirrored the offset was not considered.

![3E](https://github.com/user-attachments/assets/cddd83cc-c31e-40d0-a2b9-450ecbc8fb64)
