### PR TITLE
supress flee error

### DIFF
--- a/src/creature_battle.c
+++ b/src/creature_battle.c
@@ -200,7 +200,7 @@ long get_flee_position(struct Thing *creatng, struct Coord3d *pos)
         {
             if (!is_hero_thing(creatng))
             {
-                ERRORLOG("The %s index %d has no dungeon heart or lair to flee to", thing_model_name(creatng), (int)creatng->index);
+                SYNCLOG("The %s index %d has no dungeon heart or lair to flee to", thing_model_name(creatng), (int)creatng->index);
             }
             return 0;
         }
@@ -222,7 +222,7 @@ TbBool setup_combat_flee_position(struct Thing *thing)
     {
         if (!is_hero_thing(thing))
         {
-            ERRORLOG("Couldn't get a flee position for %s index %d", thing_model_name(thing), (int)thing->index);
+            SYNCLOG("Couldn't get a flee position for %s index %d", thing_model_name(thing), (int)thing->index);
         }
         cctrl->flee_pos.x.stl.pos = thing->mappos.x.stl.pos;
         cctrl->flee_pos.y.stl.pos = thing->mappos.y.stl.pos;


### PR DESCRIPTION
a unit in a disconnected dungeon seems common enough that this is just clutter in the log file