### PR TITLE
CONCEAL_MAP_RECT now works for players other than PLAYER0

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -899,7 +899,7 @@ static void display_objective_process(struct ScriptContext *context)
 
 static void conceal_map_rect_check(const struct ScriptLine *scline)
 {
-    ALLOCATE_SCRIPT_VALUE(scline->command, 0);
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[0]);
     TbBool conceal_all = false;
 
     if (scline->np[5] == -1)


### PR DESCRIPTION
Fixes #3905

However, it only fixes impenetrable rock when the command is in an IF statement; it seems that something is re-revealing it when the map loads.