### PR TITLE
Converted script string pointers to offsets

### DIFF
--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -1039,7 +1039,6 @@ TbBool script_scan_line(char *line, TbBool preloaded, long file_version)
 short clear_script(void)
 {
     memset(&gameadd.script, 0, sizeof(struct LevelScript));
-    gameadd.script.next_string = gameadd.script.strings;
     set_script_current_condition(CONDITION_ALWAYS);
     text_line_number = 1;
     return true;

--- a/src/lvl_script.h
+++ b/src/lvl_script.h
@@ -126,8 +126,6 @@ struct ScriptValue {
     long long longlongs[4];
     unsigned long ulongs[8];
     unsigned long long ulonglongs[4];
-    unsigned char* ustrs[8];
-    char* strs[8];
   };
 };
 
@@ -183,7 +181,7 @@ struct LevelScript {
 
     // Store strings used at level here
     char strings[2048];
-    char *next_string;
+    long next_string_offset;
 };
 
 /******************************************************************************/

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -546,19 +546,30 @@ const struct NamedCommand texture_pack_desc[] = {
 };
 
 // For dynamic strings
-static char* script_strdup(const char *src)
+static long script_strdup(const char *src)
 {
-    char *ret = gameadd.script.next_string;
-    int remain_len = sizeof(gameadd.script.strings) - (gameadd.script.next_string - gameadd.script.strings);
-    if (strlen(src) >= remain_len)
+    // TODO: add string deduplication to save space
+
+    const long offset = gameadd.script.next_string_offset;
+    const long remaining_size = sizeof(gameadd.script.strings) - offset;
+    const long string_size = strlen(src) + 1;
+    if (string_size >= remaining_size)
+    {
+        return -1;
+    }
+    memcpy(&gameadd.script.strings[offset], src, string_size);
+    gameadd.script.next_string_offset += string_size;
+    return offset;
+}
+
+static const char * script_strval(long offset)
+{
+    if (offset >= sizeof(gameadd.script.strings))
     {
         return NULL;
     }
-    strcpy(ret, src);
-    gameadd.script.next_string += strlen(src) + 1;
-    return ret;
+    return &gameadd.script.strings[offset];
 }
-
 
 /**
  * Modifies player's creatures' anger.
@@ -1138,20 +1149,21 @@ static void set_trap_configuration_check(const struct ScriptLine* scline)
     value->shorts[5] = scline->np[4];
     if (trapvar == 3) // SymbolSprites
     {
-        char *tmp = malloc(strlen(scline->tp[2]) + strlen(scline->tp[3]) + 3);
-        // Pass two vars along as one merged val like: first\nsecond\m
-        strcpy(tmp, scline->tp[2]);
-        strcat(tmp, "|");
-        strcat(tmp,scline->tp[3]);
-        value->strs[2] = script_strdup(tmp); // first\0second
-        value->strs[2][strlen(scline->tp[2])] = 0;
-        free(tmp);
-        if (value->strs[2] == NULL)
+        value->longs[2] = script_strdup(scline->tp[2]);
+        if (value->longs[2] < 0)
         {
             SCRPTERRLOG("Run out script strings space");
             DEALLOCATE_SCRIPT_VALUE
             return;
         }
+        value->longs[3] = script_strdup(scline->tp[3]);
+        if (value->longs[3] < 0)
+        {
+            SCRPTERRLOG("Run out script strings space");
+            DEALLOCATE_SCRIPT_VALUE
+            return;
+        }
+        SCRIPTDBG(7, "Setting trap %s property %s to %s, %s", trapname, scline->tp[1], scline->tp[2], scline->tp[3]);
     }
     else if (trapvar == 17) // EffectType
     {
@@ -1201,6 +1213,7 @@ static void set_trap_configuration_check(const struct ScriptLine* scline)
             return;
         }
         value->shorts[2] = newvalue;
+        SCRIPTDBG(7, "Setting trap %s property %s to %d", trapname, scline->tp[1], value->shorts[2]);
     }
     else if (trapvar == 41) // DestroyedEffect
     {
@@ -1212,6 +1225,7 @@ static void set_trap_configuration_check(const struct ScriptLine* scline)
             return;
         }
         value->ulongs[1] = newvalue;
+        SCRIPTDBG(7, "Setting trap %s property %s to %lu", trapname, scline->tp[1], value->ulongs[1]);
     }
     else if (trapvar == 46) // FlameAnimationOffset
     {
@@ -1219,6 +1233,7 @@ static void set_trap_configuration_check(const struct ScriptLine* scline)
         value->shorts[4] = scline->np[3];
         value->shorts[5] = scline->np[4];
         value->shorts[6] = scline->np[5];
+        SCRIPTDBG(7, "Setting trap %s property %s to %ld, %d, %d, %d", trapname, scline->tp[1], value->longs[1], value->shorts[4], value->shorts[5], value->shorts[6]);
     }
     else if ((trapvar != 4) && (trapvar != 12) && (trapvar != 39) && (trapvar != 40))  // PointerSprites && AnimationIDs
     {
@@ -1232,6 +1247,7 @@ static void set_trap_configuration_check(const struct ScriptLine* scline)
                 return;
             }
             value->shorts[2] = newvalue;
+            SCRIPTDBG(7, "Setting trap %s property %s to %d", trapname, scline->tp[1], value->shorts[2]);
         }
         else if (trapvar == 6)
         {
@@ -1243,6 +1259,7 @@ static void set_trap_configuration_check(const struct ScriptLine* scline)
                 return;
             }
             value->ulongs[1] = newvalue;
+            SCRIPTDBG(7, "Setting trap %s property %s to %lu", trapname, scline->tp[1], value->ulongs[1]);
         }
         else
         {
@@ -1253,15 +1270,15 @@ static void set_trap_configuration_check(const struct ScriptLine* scline)
     }
     else
     {
-        value->strs[2] = script_strdup(scline->tp[2]);
-        if (value->strs[2] == NULL)
+        value->longs[2] = script_strdup(scline->tp[2]);
+        if (value->longs[2] < 0)
         {
             SCRPTERRLOG("Run out script strings space");
             DEALLOCATE_SCRIPT_VALUE
             return;
         }
+        SCRIPTDBG(7, "Setting trap %s property %s to %ld", trapname, scline->tp[1], value->longs[2]);
     }
-    SCRIPTDBG(7, "Setting trap %s property %s to %d", trapname, scline->tp[1], value->shorts[2]);
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
@@ -1297,19 +1314,18 @@ static void set_room_configuration_check(const struct ScriptLine* scline)
     value->shorts[4] = scline->np[4];
     if (roomvar == 3) // SymbolSprites
     {
-        char *tmp = malloc(strlen(scline->tp[2]) + strlen(scline->tp[3]) + 3);
-        // Pass two vars along as one merged val like: first\nsecond\m
-        strcpy(tmp, scline->tp[2]);
-        strcat(tmp, "|");
-        strcat(tmp,scline->tp[3]);
-        value->strs[2] = script_strdup(tmp); // first\0second
-        free(tmp);
-        if (value->strs[2] == NULL) {
+        value->longs[2] = script_strdup(scline->tp[2]);
+        if (value->longs[2] < 0) {
             SCRPTERRLOG("Run out script strings space");
             DEALLOCATE_SCRIPT_VALUE
             return;
         }
-        value->strs[2][strlen(scline->tp[2])] = 0;
+        value->longs[3] = script_strdup(scline->tp[3]);
+        if (value->longs[3] < 0) {
+            SCRPTERRLOG("Run out script strings space");
+            DEALLOCATE_SCRIPT_VALUE
+            return;
+        }
     }
     else if (roomvar == 5) // PanelTabIndex
     {
@@ -1481,8 +1497,8 @@ static void set_room_configuration_check(const struct ScriptLine* scline)
     }
     else // PointerSprites
     {
-        value->strs[2] = script_strdup(scline->tp[2]);
-        if (value->strs[2] == NULL)
+        value->longs[2] = script_strdup(scline->tp[2]);
+        if (value->longs[2] < 0)
         {
             SCRPTERRLOG("Run out script strings space");
             DEALLOCATE_SCRIPT_VALUE
@@ -1806,18 +1822,13 @@ static void set_trap_configuration_process(struct ScriptContext *context)
     short value3 = context->value->shorts[5];
     short value4 = context->value->shorts[6];
 
-    char *valuestr = context->value->strs[2];
-
-    if (property == 3)
-    {
-        value = get_icon_id(valuestr);
-        value2 = get_icon_id(valuestr + strlen(valuestr) + 1);
-    }else if (property == 4)
-    {
-        value = get_icon_id(valuestr);
-    }else if (property == 12 || property == 39 || property == 40 || property == 44)
-    {
-        value = get_anim_id_(valuestr);
+    if (property == 3) {
+        value = get_icon_id(script_strval(context->value->longs[2]));
+        value2 = get_icon_id(script_strval(context->value->longs[3]));
+    } else if (property == 4) {
+        value = get_icon_id(script_strval(context->value->longs[2]));
+    } else if (property == 12 || property == 39 || property == 40 || property == 44) {
+        value = get_anim_id_(script_strval(context->value->longs[2]));
     }
 
     script_set_trap_configuration(trap_type, property, value, value2, value3, value4);
@@ -1855,8 +1866,8 @@ static void set_room_configuration_process(struct ScriptContext *context)
         case 3: // SymbolSprites
             old_value = roomst->medsym_sprite_idx;
             old_value2 = roomst->bigsym_sprite_idx;
-            roomst->bigsym_sprite_idx = get_icon_id(context->value->strs[2]); // First
-            roomst->medsym_sprite_idx = get_icon_id(context->value->strs[2] + strlen(context->value->strs[2]) + 1); // Second
+            roomst->bigsym_sprite_idx = get_icon_id(script_strval(context->value->longs[2]));
+            roomst->medsym_sprite_idx = get_icon_id(script_strval(context->value->longs[3]));
             if ( (roomst->medsym_sprite_idx != old_value) || (roomst->bigsym_sprite_idx != old_value2) )
             {
                 update_room_tab_to_config();
@@ -1864,7 +1875,7 @@ static void set_room_configuration_process(struct ScriptContext *context)
             break;
         case 4: // PointerSprites
             old_value = roomst->pointer_sprite_idx;
-            roomst->pointer_sprite_idx = get_icon_id(context->value->strs[2]);
+            roomst->pointer_sprite_idx = get_icon_id(script_strval(context->value->longs[2]));
             if (roomst->pointer_sprite_idx != old_value)
             {
                 update_room_tab_to_config();
@@ -2074,22 +2085,23 @@ static void set_door_configuration_check(const struct ScriptLine* scline)
         }
         value->ulongs[1] = slab_id;
         value->shorts[4] = slab2_id;
+        SCRIPTDBG(7, "Setting door %s property %s to %lu,%d", doorname, scline->tp[1], value->ulongs[1], value->shorts[4]);
     }
     else if (doorvar == 4) // SymbolSprites
     {
-        char *tmp = malloc(strlen(scline->tp[2]) + strlen(scline->tp[3]) + 3);
-        // Pass two vars along as one merged val like: first\nsecond\m
-        strcpy(tmp, scline->tp[2]);
-        strcat(tmp, "|");
-        strcat(tmp,scline->tp[3]);
-        value->strs[2] = script_strdup(tmp); // first\0second
-        free(tmp);
-        if (value->strs[2] == NULL) {
+        value->longs[2] = script_strdup(scline->tp[2]);
+        if (value->longs[2] < 0) {
             SCRPTERRLOG("Run out script strings space");
             DEALLOCATE_SCRIPT_VALUE
             return;
         }
-        value->strs[2][strlen(scline->tp[2])] = 0;
+        value->longs[3] = script_strdup(scline->tp[3]);
+        if (value->longs[3] < 0) {
+            SCRPTERRLOG("Run out script strings space");
+            DEALLOCATE_SCRIPT_VALUE
+            return;
+        }
+        SCRIPTDBG(7, "Setting door %s property %s to %s,%s", doorname, scline->tp[1], scline->tp[2], scline->tp[3]);
     }
     else if (doorvar != 5) // Not PointerSprites
     {
@@ -2103,6 +2115,7 @@ static void set_door_configuration_check(const struct ScriptLine* scline)
                 return;
             }
             value->ulongs[1] = newvalue;
+            SCRIPTDBG(7, "Setting door %s property %s to %lu", doorname, scline->tp[1], value->ulongs[1]);
         }
         else if (doorvar == 7) // Crate
         {
@@ -2114,6 +2127,7 @@ static void set_door_configuration_check(const struct ScriptLine* scline)
                 return;
             }
             value->ulongs[1] = newvalue;
+            SCRIPTDBG(7, "Setting door %s property %s to %lu", doorname, scline->tp[1], value->ulongs[1]);
         }
         else
         {
@@ -2124,15 +2138,15 @@ static void set_door_configuration_check(const struct ScriptLine* scline)
     }
     else
     {
-        value->strs[2] = script_strdup(scline->tp[2]);
-        if (value->strs[2] == NULL)
+        value->longs[2] = script_strdup(scline->tp[2]);
+        if (value->longs[2] < 0)
         {
             SCRPTERRLOG("Run out script strings space");
             DEALLOCATE_SCRIPT_VALUE
             return;
         }
+        SCRIPTDBG(7, "Setting door %s property %s to %ld", doorname, scline->tp[1], value->longs[1]);
     }
-    SCRIPTDBG(7, "Setting door %s property %s to %lu", doorname, scline->tp[1], value->ulongs[1]);
     PROCESS_SCRIPT_VALUE(scline->command);
 }
 
@@ -2142,15 +2156,11 @@ static void set_door_configuration_process(struct ScriptContext *context)
     short property = context->value->shorts[1];
     short value = context->value->longs[1];
     short value2 = context->value->shorts[4];
-    const char* valuestr = context->value->strs[2];
-
-    if (property == 4)
-    {
-        value = get_icon_id(valuestr);
-        value2 = get_icon_id(valuestr + strlen(valuestr) + 1);
-    }else if (property == 5)
-    {
-        value = get_icon_id(valuestr);
+    if (property == 4) {
+        value = get_icon_id(script_strval(context->value->longs[2]));
+        value2 = get_icon_id(script_strval(context->value->longs[3]));
+    } else if (property == 5) {
+        value = get_icon_id(script_strval(context->value->longs[2]));
     }
 
     script_set_door_configuration(door_type,property, value, value2);
@@ -2648,14 +2658,14 @@ static void set_object_configuration_check(const struct ScriptLine *scline)
                 DEALLOCATE_SCRIPT_VALUE
                 return;
             }
-            value->strs[2] = script_strdup(new_value);
-            if (value->strs[2] == NULL)
+            value->longs[1] = number_value;
+            value->longs[2] = script_strdup(new_value);
+            if (value->longs[2] < 0)
             {
                 SCRPTERRLOG("Run out script strings space");
                 DEALLOCATE_SCRIPT_VALUE
                 return;
             }
-            value->longs[1] = number_value;
             break;
         }
         case 18: // MapIcon
@@ -4291,8 +4301,8 @@ static void set_box_tooltip_check(const struct ScriptLine* scline)
     {
         SCRPTWRNLOG("Tooltip TEXT too long; truncating to %d characters", MESSAGE_TEXT_LEN - 1);
     }
-    value->strs[2] = script_strdup(scline->tp[1]);
-    if (value->strs[2] == NULL)
+    value->longs[2] = script_strdup(scline->tp[1]);
+    if (value->longs[2] < 0)
     {
         SCRPTERRLOG("Run out script strings space");
         DEALLOCATE_SCRIPT_VALUE
@@ -4306,7 +4316,7 @@ static void set_box_tooltip_check(const struct ScriptLine* scline)
 static void set_box_tooltip_process(struct ScriptContext* context)
 {
     int idx = context->value->shorts[0];
-    snprintf(gameadd.box_tooltip[idx], MESSAGE_TEXT_LEN, "%s", context->value->strs[2]);
+    snprintf(gameadd.box_tooltip[idx], MESSAGE_TEXT_LEN, "%s", script_strval(context->value->longs[2]));
 }
 
 static void set_box_tooltip_id_check(const struct ScriptLine *scline)
@@ -5191,8 +5201,8 @@ static void set_music_check(const struct ScriptLine *scline)
         value->chars[0] = atoi(scline->tp[0]);
     } else {
         value->chars[0] = -1;
-        value->strs[1] = script_strdup(scline->tp[0]);
-        if (value->strs[1] == NULL) {
+        value->longs[1] = script_strdup(scline->tp[0]);
+        if (value->longs[1] < 0) {
             SCRPTERRLOG("Run out script strings space");
             DEALLOCATE_SCRIPT_VALUE
             return;
@@ -5208,8 +5218,9 @@ static void set_music_process(struct ScriptContext *context)
         SCRPTLOG("Stopping music");
         stop_music();
     } else if (track < 0) {
-        SCRPTLOG("Playing music from %s", context->value->strs[1]);
-        play_music(prepare_file_fmtpath(FGrp_CmpgMedia, "%s", context->value->strs[1]));
+        const char * fname = script_strval(context->value->longs[1]);
+        SCRPTLOG("Playing music from %s", fname);
+        play_music(prepare_file_fmtpath(FGrp_CmpgMedia, "%s", fname));
     } else {
         SCRPTLOG("Playing music track %d", track);
         play_music_track(track);
@@ -5234,8 +5245,8 @@ static void play_message_check(const struct ScriptLine *scline)
     else
     {
         value->bytes[4] = 1;
-        value->strs[2] = script_strdup(scline->tp[2]);
-        if (value->strs[2] == NULL) {
+        value->longs[2] = script_strdup(scline->tp[2]);
+        if (value->longs[2] < 0) {
             SCRPTERRLOG("Run out script strings space");
             DEALLOCATE_SCRIPT_VALUE
             return;
@@ -5268,7 +5279,7 @@ static void play_message_process(struct ScriptContext *context)
         }
         else
         {
-            const char * filename = prepare_file_fmtpath(FGrp_CmpgMedia,"%s", context->value->strs[2]);
+            const char * filename = prepare_file_fmtpath(FGrp_CmpgMedia,"%s", script_strval(context->value->longs[2]));
             switch (msgtype_id)
             {
                 case 1: // speech message
@@ -6712,8 +6723,8 @@ static void set_computer_process_check(const struct ScriptLine* scline)
     value->longs[3] = scline->np[4];
     value->longs[4] = scline->np[5];
     value->longs[5] = scline->np[6];
-    value->strs[6] = script_strdup(scline->tp[1]);
-    if (value->strs[6] == NULL) {
+    value->longs[6] = script_strdup(scline->tp[1]);
+    if (value->longs[6] < 0) {
         SCRPTERRLOG("Run out script strings space");
         DEALLOCATE_SCRIPT_VALUE
         return;
@@ -6725,7 +6736,7 @@ static void set_computer_process_process(struct ScriptContext* context)
 {
     int plr_start = context->value->shorts[0];
     int plr_end = context->value->shorts[1];
-    const char* procname = context->value->strs[6];
+    const char* procname = script_strval(context->value->longs[6]);
     long val1 = context->value->longs[1];
     long val2 = context->value->longs[2];
     long val3 = context->value->longs[3];
@@ -6786,8 +6797,8 @@ static void set_computer_checks_check(const struct ScriptLine* scline)
     value->longs[3] = scline->np[4];
     value->longs[4] = scline->np[5];
     value->longs[5] = scline->np[6];
-    value->strs[6] = script_strdup(scline->tp[1]);
-    if (value->strs[6] == NULL) {
+    value->longs[6] = script_strdup(scline->tp[1]);
+    if (value->longs[6] < 0) {
         SCRPTERRLOG("Run out script strings space");
         DEALLOCATE_SCRIPT_VALUE
         return;
@@ -6799,7 +6810,7 @@ static void set_computer_checks_process(struct ScriptContext* context)
 {
     int plr_start = context->value->shorts[0];
     int plr_end = context->value->shorts[1];
-    const char* chkname = context->value->strs[6];
+    const char* chkname = script_strval(context->value->longs[6]);
     long val1 = context->value->longs[1];
     long val2 = context->value->longs[2];
     long val3 = context->value->longs[3];
@@ -6865,8 +6876,8 @@ static void set_computer_event_check(const struct ScriptLine* scline)
     value->longs[3] = scline->np[4];
     value->longs[4] = scline->np[5];
     value->longs[5] = scline->np[6];
-    value->strs[6] = script_strdup(scline->tp[1]);
-    if (value->strs[6] == NULL) {
+    value->longs[6] = script_strdup(scline->tp[1]);
+    if (value->longs[6] < 0) {
         SCRPTERRLOG("Run out script strings space");
         DEALLOCATE_SCRIPT_VALUE
         return;
@@ -6878,7 +6889,7 @@ static void set_computer_event_process(struct ScriptContext* context)
 {
     int plr_start = context->value->shorts[0];
     int plr_end = context->value->shorts[1];
-    const char* evntname = context->value->strs[6];
+    const char* evntname = script_strval(context->value->longs[6]);
     long val1 = context->value->longs[1];
     long val2 = context->value->longs[2];
     long val3 = context->value->longs[3];


### PR DESCRIPTION
By storing offsets instead of pointers in the save file, some of the crashes when loading saves from a different game version is prevented.