### PR TITLE
Ignore enemies you cannot reach

### DIFF
--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -377,8 +377,18 @@ CrAttackType creature_can_have_combat_with_creature(struct Thing *fightng, struc
         // If we can see it, assume that we can reach it
         if (creature_has_melee_attack(fightng))
         {
-            //TODO COMBAT is it acceptable to assume we can do melee combat here? Why no seen_enemy update?
-            return AttckT_Melee;
+            if (move_on_ground)
+            {
+                if (creature_can_move_to_combat(fightng, enmtng) >= 0) {
+                    return AttckT_Melee;
+                }
+            }
+            else
+            {
+                if (slab_wall_hug_route(fightng, &enmtng->mappos, 8) > 0) {
+                    return AttckT_Melee;
+                }
+            }
         }
     }
     if (set_if_seen)


### PR DESCRIPTION
Melee enemies with lava in between will no longer shout and do random backwards walking. They will just ignore each other, like they did in DK1. KeeperFX changed this years ago, [here](https://github.com/dkfans/keeperfx/commit/8fe032cd107dc4bf075533d19ed22e1dcfba9705).