### PR TITLE
Update all events, not just the first 12

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1612,7 +1612,7 @@ void gui_go_to_event(struct GuiButton *gbtn)
     player = get_my_player();
     dungeon = get_players_dungeon(player);
     if (dungeon->visible_event_idx) {
-        set_players_packet_action(player, PckA_Unknown083, dungeon->visible_event_idx, 0, 0, 0);
+        set_players_packet_action(player, PckA_ZoomToEvent, dungeon->visible_event_idx, 0, 0, 0);
     }
 }
 

--- a/src/map_events.c
+++ b/src/map_events.c
@@ -733,7 +733,11 @@ ThingIndex get_thing_index_event_is_attached_to(const struct Event *event)
 struct Thing *event_is_attached_to_thing(EventIndex evidx)
 {
     struct Event* event = &game.event[evidx];
-    long i = get_thing_index_event_is_attached_to(event);
+    if ((event->flags & EvF_Exists) == 0) 
+    {
+        return INVALID_THING;
+    }
+    ThingIndex i = get_thing_index_event_is_attached_to(event);
     return thing_get(i);
 }
 
@@ -777,7 +781,7 @@ void event_process_events(void)
 
 void update_all_events(void)
 {
-    for (long i = EVENT_BUTTONS_COUNT; i > 0; i--)
+    for (long i = EVENTS_COUNT; i > 0; i--)
     {
         struct Thing* thing = event_is_attached_to_thing(i);
         if (!thing_is_invalid(thing))

--- a/src/map_events.c
+++ b/src/map_events.c
@@ -750,7 +750,7 @@ void event_process_events(void)
             continue;
         }
         struct PlayerInfo*player = get_player(event->owner);
-        if (player->view_type == PVT_DungeonTop)
+        if (player->view_type <= PVT_DungeonTop) //Freeze lifespan of events of human player on map or possession
         {
             if (event->lifespan_turns > 0) {
                 event->lifespan_turns--;

--- a/src/map_events.h
+++ b/src/map_events.h
@@ -28,7 +28,7 @@ extern "C" {
 /******************************************************************************/
 #define EVENT_BUTTONS_COUNT    12
 #define EVENT_KIND_COUNT       36
-#define EVENTS_COUNT          1000
+#define EVENTS_COUNT          200
 #define INVALID_EVENT &game.event[0]
 
 enum EventKinds {

--- a/src/packets.c
+++ b/src/packets.c
@@ -796,7 +796,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
   case PckA_UpdatePause:
       process_pause_packet(pckt->actn_par1, pckt->actn_par2);
       return 1;
-  case PckA_Unknown083:
+  case PckA_ZoomToEvent:
       if (player->work_state == PSt_CreatrInfo)
         turn_off_query(plyr_idx);
       event_move_player_towards_event(player, pckt->actn_par1);

--- a/src/packets.h
+++ b/src/packets.h
@@ -111,7 +111,7 @@ enum TbPacketAction {
         PckA_SetViewType,//80
         PckA_ZoomFromMap,
         PckA_UpdatePause,
-        PckA_Unknown083,
+        PckA_ZoomToEvent,
         PckA_ZoomToRoom,
         PckA_ZoomToTrap,//85
         PckA_ZoomToDoor,


### PR DESCRIPTION
Fixed an issue with the eye being at (0,0), instead of where the button eye pointed too. It only updated locations of the first 12 out of 1000 events, because it got confused with there being just 12 buttons.