### PR TITLE
Fixed infinite sleep loop in first 128 turns

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -5019,19 +5019,23 @@ long process_creature_needs_to_heal_critical(struct Thing *creatng)
         if (!creature_free_for_sleep(creatng, CrSt_CreatureGoingHomeToSleep)) {
             return 0;
         }
-        if ( (game.play_gameturn - cctrl->healing_sleep_check_turn > 128) &&
-          ((cctrl->lair_room_id != 0) || !room_is_invalid(get_best_new_lair_for_creature(creatng))) )
+        if ((game.play_gameturn - cctrl->healing_sleep_check_turn) > 128)
         {
-            SYNCDBG(4,"Healing critical for %s",thing_model_name(creatng));
-            if (external_set_thing_state(creatng, CrSt_CreatureGoingHomeToSleep)) {
-                return 1;
+            if ((cctrl->lair_room_id != 0) || !room_is_invalid(get_best_new_lair_for_creature(creatng)))
+            {
+                SYNCDBG(4, "Healing critical for %s", thing_model_name(creatng));
+                if (external_set_thing_state(creatng, CrSt_CreatureGoingHomeToSleep))
+                {
+                    return 1;
+                }
             }
-        } else
-        {
-            struct CreatureStats* crstat = creature_stats_get_from_thing(creatng);
-            anger_apply_anger_to_creature(creatng, crstat->annoy_no_lair, AngR_NoLair, 1);
+            else
+            {
+                struct CreatureStats* crstat = creature_stats_get_from_thing(creatng);
+                anger_apply_anger_to_creature(creatng, crstat->annoy_no_lair, AngR_NoLair, 1);
+            }
+            cctrl->healing_sleep_check_turn = game.play_gameturn;
         }
-        cctrl->healing_sleep_check_turn = game.play_gameturn;
     }
     return 0;
 }
@@ -5344,18 +5348,21 @@ long process_creature_needs_to_heal(struct Thing *creatng, const struct Creature
         if (!creature_free_for_sleep(creatng, CrSt_CreatureGoingHomeToSleep)) {
             return 0;
         }
-        if (((game.play_gameturn - cctrl->healing_sleep_check_turn) > 128)
-            && ((cctrl->lair_room_id != 0) || !room_is_invalid(get_best_new_lair_for_creature(creatng))))
+        if ((game.play_gameturn - cctrl->healing_sleep_check_turn) > 128)
         {
-            if (external_set_thing_state(creatng, CrSt_CreatureGoingHomeToSleep)) {
-                return 1;
+            if ((cctrl->lair_room_id != 0) || !room_is_invalid(get_best_new_lair_for_creature(creatng)))
+            {
+                if (external_set_thing_state(creatng, CrSt_CreatureGoingHomeToSleep))
+                {
+                    return 1;
+                }
             }
+            else
+            {
+                anger_apply_anger_to_creature(creatng, crstat->annoy_no_lair, AngR_NoLair, 1);
+            }
+            cctrl->healing_sleep_check_turn = game.play_gameturn;
         }
-        else
-        {
-            anger_apply_anger_to_creature(creatng, crstat->annoy_no_lair, AngR_NoLair, 1);
-        }
-        cctrl->healing_sleep_check_turn = game.play_gameturn;
     }
     return 0;
 }


### PR DESCRIPTION
Creatures pre-placed with critical health would not make a lair in the first 128 turns, but still counted this as a failed attempt at making a lair. This also caused a further refusal to make a lair for 128 more turns, resulting in more anger and never actually sleeping.

See this map for the bug: [map02899.zip](https://github.com/user-attachments/files/19495878/map02899.zip)
(notice that thieves do not get angry for having no lair. Change that to see it also gets angry real soon).

Now a 'do not check because we just checked' type of situation, does not count as a check.