### PR TITLE
Add named commands for Trigger and ActivationType in trapdoors.cfg

### DIFF
--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -184,7 +184,7 @@ InitialDelay = 0
 ; LINE_OF_SIGHT: Line of sight.
 ; PRESSURE_SUBTILE: Pressure activated (subtile).
 ; ALWAYS: Whenever after reloading.
-TriggerType = 0
+TriggerType = NONE
 ; Type of effect on activation.
 ; HEAD_FOR_TARGET_90: Trap shot head for target.
 ; EFFECT_ON_TRAP: Trap effect.
@@ -193,7 +193,7 @@ TriggerType = 0
 ; CREATURE_SHOT: Shoot like a creature would.
 ; CREATURE_SPAWN: Spawns a creature, at level 1.
 ; POWER: Keeper spell.
-ActivationType = 0
+ActivationType = NONE
 ; The shot/effect/slab/creature/keeper power, based on the Activation Type. Accepts both names and numbers.
 EffectType = 0
 ; Controls which things will be affected by the AreaDamage of the spell (1~8), see magic.cfg.
@@ -511,7 +511,7 @@ ManufactureLevel = 4
 ManufactureRequired = 75000
 Shots = 1
 TimeBetweenShots = 0
-TriggerType = 0
+TriggerType = NONE
 ActivationType = SHOT_ON_TRAP
 EffectType = SHOT_TRAP_TNT
 HitType = 9

--- a/config/fxdata/trapdoor.cfg
+++ b/config/fxdata/trapdoor.cfg
@@ -177,21 +177,22 @@ Shots = 0
 TimeBetweenShots = 0
 ; If set the trap is on 'reloading phase' at placement, value defines how long in game turns before it can start shooting.
 InitialDelay = 0
+
 ; How to trigger the trap.
-; 1: Line of sight 90 degrees.
-; 2: Pressure activated (tile).
-; 3: Line of sight.
-; 4: Pressure activated (subtile).
-; 5: Whenever after reloading.
+; LINE_OF_SIGHT_90: Line of sight 90 degrees.
+; PRESSURE_SLAB: Pressure activated (tile).
+; LINE_OF_SIGHT: Line of sight.
+; PRESSURE_SUBTILE: Pressure activated (subtile).
+; ALWAYS: Whenever after reloading.
 TriggerType = 0
 ; Type of effect on activation.
-; 1: Trap shot head for target.
-; 2: Trap effect.
-; 3: Trap shot stay on trap.
-; 4: Change the slab into another slab type.
-; 5: Shoot like a creature would.
-; 6: Spawns a creature, at level 1.
-; 7: Keeper spell.
+; HEAD_FOR_TARGET_90: Trap shot head for target.
+; EFFECT_ON_TRAP: Trap effect.
+; SHOT_ON_TRAP: Trap shot stay on trap.
+; SLAB_CHANGE: Change the slab into another slab type.
+; CREATURE_SHOT: Shoot like a creature would.
+; CREATURE_SPAWN: Spawns a creature, at level 1.
+; POWER: Keeper spell.
 ActivationType = 0
 ; The shot/effect/slab/creature/keeper power, based on the Activation Type. Accepts both names and numbers.
 EffectType = 0
@@ -277,8 +278,8 @@ ManufactureLevel = 3
 ManufactureRequired = 25000
 Shots = 1
 TimeBetweenShots = 0
-TriggerType = 1
-ActivationType = 1
+TriggerType = LINE_OF_SIGHT_90
+ActivationType = HEAD_FOR_TARGET_90
 EffectType = SHOT_BOULDER
 HitType = 9
 Hidden = 0
@@ -315,8 +316,8 @@ ManufactureLevel = 0
 ManufactureRequired = 18000
 Shots = 12
 TimeBetweenShots = 2000
-TriggerType = 2
-ActivationType = 3
+TriggerType = PRESSURE_SLAB
+ActivationType = SHOT_ON_TRAP
 EffectType = SHOT_ALARM
 HitType = 2
 Hidden = 1
@@ -355,8 +356,8 @@ ManufactureLevel = 1
 ManufactureRequired = 20000
 Shots = 5
 TimeBetweenShots = 200
-TriggerType = 2
-ActivationType = 2
+TriggerType = PRESSURE_SLAB
+ActivationType = EFFECT_ON_TRAP
 EffectType = EFFECT_GAS_3
 HitType = 4
 Hidden = 1
@@ -394,8 +395,8 @@ ManufactureLevel = 2
 ManufactureRequired = 20000
 Shots = 6
 TimeBetweenShots = 140
-TriggerType = 2
-ActivationType = 3
+TriggerType = PRESSURE_SLAB
+ActivationType = SHOT_ON_TRAP
 EffectType = SHOT_TRAP_LIGHTNING
 HitType = 4
 Hidden = 1
@@ -433,8 +434,8 @@ ManufactureLevel = 4
 ManufactureRequired = 20000
 Shots = 3
 TimeBetweenShots = 84
-TriggerType = 2
-ActivationType = 3
+TriggerType = PRESSURE_SLAB
+ActivationType = SHOT_ON_TRAP
 EffectType = SHOT_TRAP_WORD_OF_POWER
 HitType = 4
 Hidden = 1
@@ -472,8 +473,8 @@ ManufactureLevel = 3
 ManufactureRequired = 20000
 Shots = 1
 TimeBetweenShots = 0
-TriggerType = 2
-ActivationType = 4
+TriggerType = PRESSURE_SLAB
+ActivationType = SLAB_CHANGE
 EffectType = LAVA
 HitType = 4
 Hidden = 1
@@ -511,7 +512,7 @@ ManufactureRequired = 75000
 Shots = 1
 TimeBetweenShots = 0
 TriggerType = 0
-ActivationType = 3
+ActivationType = SHOT_ON_TRAP
 EffectType = SHOT_TRAP_TNT
 HitType = 9
 Hidden = 0

--- a/src/config_trapdoor.c
+++ b/src/config_trapdoor.c
@@ -57,6 +57,26 @@ static const struct NamedCommand door_properties_commands[] = {
     {NULL,                   0},
   };
 
+static const struct NamedCommand trap_trigger_type_commands[] = {
+    {"NONE",             TrpTrg_None},
+    {"LINE_OF_SIGHT_90", TrpTrg_LineOfSight90},
+    {"PRESSURE_SLAB",    TrpTrg_Pressure_Slab},
+    {"LINE_OF_SIGHT",    TrpTrg_LineOfSight},
+    {"PRESSURE_SUBTILE", TrpTrg_Pressure_Subtile},
+    {"ALWAYS",           TrpTrg_Always},
+};
+
+static const struct NamedCommand trap_activation_type_commands[] = {
+    {"NONE",                TrpAcT_None},
+    {"HEAD_FOR_TARGET_90",  TrpAcT_HeadforTarget90},
+    {"EFFECT_ON_TRAP",      TrpAcT_EffectonTrap},
+    {"SHOT_ON_TRAP",        TrpAcT_ShotonTrap},
+    {"SLAB_CHANGE",         TrpAcT_SlabChange},
+    {"CREATURE_SHOT",       TrpAcT_CreatureShot},
+    {"CREATURE_SPAWN",      TrpAcT_CreatureSpawn},
+    {"POWER",               TrpAcT_Power},
+};
+
 static void assign_update_trap_tab(const struct NamedField* named_field, int64_t value, const struct NamedFieldSet* named_fields_set, int idx, unsigned char src)
 {
     assign_default(named_field,value,named_fields_set,idx,src);
@@ -205,8 +225,8 @@ const struct NamedField trapdoor_trap_named_fields[] = {
     {"SYMBOLSPRITES",          1, field(game.conf.trapdoor_conf.trap_cfgstats[0].medsym_sprite_idx),                0,   LONG_MIN,         ULONG_MAX, NULL,                        value_icon, assign_icon_update_trap_tab},
     {"POINTERSPRITES",         0, field(game.conf.trapdoor_conf.trap_cfgstats[0].pointer_sprite_idx),               0,   LONG_MIN,         ULONG_MAX, NULL,                        value_icon, assign_icon_update_trap_tab},
     {"PANELTABINDEX",          0, field(game.conf.trapdoor_conf.trap_cfgstats[0].panel_tab_idx),                    0,   LONG_MIN,         ULONG_MAX, NULL,                     value_default, assign_update_trap_tab},
-    {"TRIGGERTYPE",            0, field(game.conf.trapdoor_conf.trap_cfgstats[0].trigger_type),                     0,   LONG_MIN,         ULONG_MAX, NULL,                     value_default, assign_default},
-    {"ACTIVATIONTYPE",         0, field(game.conf.trapdoor_conf.trap_cfgstats[0].activation_type),                  0,   LONG_MIN,         ULONG_MAX, NULL,                     value_default, assign_default},
+    {"TRIGGERTYPE",            0, field(game.conf.trapdoor_conf.trap_cfgstats[0].trigger_type),                     0,   LONG_MIN,         ULONG_MAX, trap_trigger_type_commands,value_default, assign_default},
+    {"ACTIVATIONTYPE",         0, field(game.conf.trapdoor_conf.trap_cfgstats[0].activation_type),                  0,   LONG_MIN,         ULONG_MAX, trap_activation_type_commands,value_default, assign_default},
     {"EFFECTTYPE",             0, field(game.conf.trapdoor_conf.trap_cfgstats[0].created_itm_model),                0,   LONG_MIN,         ULONG_MAX, NULL,            value_activationeffect, assign_default},
     {"ANIMATIONID",            0, field(game.conf.trapdoor_conf.trap_cfgstats[0].sprite_anim_idx),                  0,   LONG_MIN,         ULONG_MAX, NULL,                      value_animid, assign_refresh_trap_anim_anim_id},
     {"MODEL",                  0, field(game.conf.trapdoor_conf.trap_cfgstats[0].sprite_anim_idx),                  0,   LONG_MIN,         ULONG_MAX, NULL,                      value_animid, assign_refresh_trap_anim_anim_id}, // Backward compatibility.


### PR DESCRIPTION
numbers will still work same as before, just an option to be more readable now