### PR TITLE
Computer Players build smaller lairs with huge portal limit

### DIFF
--- a/config/fxdata/keepcompp.cfg
+++ b/config/fxdata/keepcompp.cfg
@@ -114,7 +114,7 @@ Params = 0 0 0 0 0 0
 Name = BUILD A LAIR ROOM
 Mnemonic = RoomLair
 ; Values = <priority>, <room_width>, <room_height>, <room_kind>, <room_link>.
-; Lair size is also impacted by MAX_CREATURES in level script.
+; The first lair could be 1 wider and heigher if MAX_CREATURES from script suggests they won't fit otherwise.
 Values = 0 5 5 14 7
 Functions = check_any_room setup_any_room process_task completed_task paused_task 
 Params = 0 0 0 0 0 0

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5489,7 +5489,7 @@ static void set_computer_process_process(struct ScriptContext* context)
         for (long k = 0; k < COMPUTER_PROCESSES_COUNT; k++)
         {
             struct ComputerProcess* cproc = &comp->processes[k];
-            if (flag_is_set(cproc->flags, ComProc_ListEnd))
+            if (flag_is_set(cproc->flags, ComProc_Unkn0002))
                 break;
             if (strcasecmp(procname, cproc->name) == 0)
             {

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5489,7 +5489,7 @@ static void set_computer_process_process(struct ScriptContext* context)
         for (long k = 0; k < COMPUTER_PROCESSES_COUNT; k++)
         {
             struct ComputerProcess* cproc = &comp->processes[k];
-            if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+            if (flag_is_set(cproc->flags, ComProc_ListEnd))
                 break;
             if (strcasecmp(procname, cproc->name) == 0)
             {

--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -227,18 +227,13 @@ long computer_event_find_link(struct Computer2 *comp, struct ComputerEvent *ceve
     for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
     {
         struct ComputerProcess* cproc = &comp->processes[i];
-        if (flag_is_set(cproc->flags, ComProc_ListEnd))
-        {
-            //JUSTLOG("TESTLOG: %d %s is ComProc_ListEnd", i, cproc->name);
+        if (flag_is_set(cproc->flags, ComProc_Unkn0002))
             break;
-        }
         if (cproc->parent == cevent->process)
         {
-            cproc = &comp->processes[i+1];
             clear_flag(cproc->flags, (ComProc_Unkn0008|ComProc_Unkn0001|ComProc_Unkn0004));
             cproc->last_run_turn = 0;
             cproc_idx = 1;
-            JUSTLOG("TESTLOG: Reactivate %d %s",i+1, cproc->name);
         }
     }
     return cproc_idx;
@@ -541,7 +536,7 @@ long computer_event_check_rooms_full(struct Computer2 *comp, struct ComputerEven
             for (long i = 0; i <= COMPUTER_PROCESSES_COUNT; i++)
             {
                 struct ComputerProcess* cproc = &comp->processes[i];
-                if (flag_is_set(cproc->flags, ComProc_ListEnd))
+                if (flag_is_set(cproc->flags, ComProc_Unkn0002))
                     break;
                 if (cproc->parent == bldroom->process_idx)
                 {
@@ -700,7 +695,7 @@ long computer_event_rebuild_room(struct Computer2* comp, struct ComputerEvent* c
         for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
         {
             struct ComputerProcess* cproc = &comp->processes[i];
-            if (flag_is_set(cproc->flags, ComProc_ListEnd))
+            if (flag_is_set(cproc->flags, ComProc_Unkn0002))
                 break;
             if ((cproc->func_check == cpfl_computer_check_any_room) && (cproc->confval_4 == event->target))
             {

--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -227,13 +227,18 @@ long computer_event_find_link(struct Computer2 *comp, struct ComputerEvent *ceve
     for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
     {
         struct ComputerProcess* cproc = &comp->processes[i];
-        if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+        if (flag_is_set(cproc->flags, ComProc_ListEnd))
+        {
+            //JUSTLOG("TESTLOG: %d %s is ComProc_ListEnd", i, cproc->name);
             break;
+        }
         if (cproc->parent == cevent->process)
         {
+            cproc = &comp->processes[i+1];
             clear_flag(cproc->flags, (ComProc_Unkn0008|ComProc_Unkn0001|ComProc_Unkn0004));
             cproc->last_run_turn = 0;
             cproc_idx = 1;
+            JUSTLOG("TESTLOG: Reactivate %d %s",i+1, cproc->name);
         }
     }
     return cproc_idx;
@@ -536,7 +541,7 @@ long computer_event_check_rooms_full(struct Computer2 *comp, struct ComputerEven
             for (long i = 0; i <= COMPUTER_PROCESSES_COUNT; i++)
             {
                 struct ComputerProcess* cproc = &comp->processes[i];
-                if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+                if (flag_is_set(cproc->flags, ComProc_ListEnd))
                     break;
                 if (cproc->parent == bldroom->process_idx)
                 {
@@ -695,7 +700,7 @@ long computer_event_rebuild_room(struct Computer2* comp, struct ComputerEvent* c
         for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
         {
             struct ComputerProcess* cproc = &comp->processes[i];
-            if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+            if (flag_is_set(cproc->flags, ComProc_ListEnd))
                 break;
             if ((cproc->func_check == cpfl_computer_check_any_room) && (cproc->confval_4 == event->target))
             {

--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -227,7 +227,7 @@ long computer_event_find_link(struct Computer2 *comp, struct ComputerEvent *ceve
     for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
     {
         struct ComputerProcess* cproc = &comp->processes[i];
-        if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+        if (flag_is_set(cproc->flags, ComProc_ListEnd))
             break;
         if (cproc->parent == cevent->process)
         {
@@ -536,7 +536,7 @@ long computer_event_check_rooms_full(struct Computer2 *comp, struct ComputerEven
             for (long i = 0; i <= COMPUTER_PROCESSES_COUNT; i++)
             {
                 struct ComputerProcess* cproc = &comp->processes[i];
-                if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+                if (flag_is_set(cproc->flags, ComProc_ListEnd))
                     break;
                 if (cproc->parent == bldroom->process_idx)
                 {
@@ -695,7 +695,7 @@ long computer_event_rebuild_room(struct Computer2* comp, struct ComputerEvent* c
         for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
         {
             struct ComputerProcess* cproc = &comp->processes[i];
-            if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+            if (flag_is_set(cproc->flags, ComProc_ListEnd))
                 break;
             if ((cproc->func_check == cpfl_computer_check_any_room) && (cproc->confval_4 == event->target))
             {

--- a/src/player_compprocs.c
+++ b/src/player_compprocs.c
@@ -1292,7 +1292,7 @@ struct ComputerProcess * find_best_process(struct Computer2 *comp)
     for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
     {
         struct ComputerProcess* cproc = &comp->processes[i];
-        if (flag_is_set(cproc->flags, ComProc_ListEnd))
+        if (flag_is_set(cproc->flags, ComProc_Unkn0002))
             break;
         if (any_flag_is_set(cproc->flags, (ComProc_Unkn0020|ComProc_Unkn0010|ComProc_Unkn0008|ComProc_Unkn0004|ComProc_Unkn0001)))
             continue;

--- a/src/player_compprocs.c
+++ b/src/player_compprocs.c
@@ -1292,7 +1292,7 @@ struct ComputerProcess * find_best_process(struct Computer2 *comp)
     for (int i = 0; i < COMPUTER_PROCESSES_COUNT + 1; i++)
     {
         struct ComputerProcess* cproc = &comp->processes[i];
-        if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+        if (flag_is_set(cproc->flags, ComProc_ListEnd))
             break;
         if (any_flag_is_set(cproc->flags, (ComProc_Unkn0020|ComProc_Unkn0010|ComProc_Unkn0008|ComProc_Unkn0004|ComProc_Unkn0001)))
             continue;

--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -191,22 +191,20 @@ struct ComputerTask *computer_setup_build_room(struct Computer2 *comp, RoomKind 
 {
     struct Dungeon* dungeon = comp->dungeon;
     long i;
-    if (room_role_matches(rkind,RoRoF_LairStorage))
-    {
-        if (width_slabs*height_slabs < dungeon->max_creatures_attracted)
-        {
-            width_slabs++;
-            if (width_slabs * height_slabs < dungeon->max_creatures_attracted)
-            {
-                height_slabs++;
-            }
-        }
-    }
     long max_slabs = height_slabs;
     if (max_slabs < width_slabs)
         max_slabs = width_slabs;
     long area_min = (max_slabs + 1) / 2 + 1;
     long area_max = area_min / 3 + 2 * area_min;
+    if (room_role_matches(rkind,RoRoF_LairStorage))
+    {
+        if (width_slabs*height_slabs < dungeon->max_creatures_attracted)
+        {
+            i = LbSqrL(dungeon->max_creatures_attracted);
+            width_slabs = i + 1;
+            height_slabs = i + 1;
+        }
+    }
     const long arr_length = sizeof(look_through_rooms)/sizeof(look_through_rooms[0]);
     for (long area = area_min; area < area_max; area++)
     {
@@ -931,7 +929,7 @@ long computer_check_for_money(struct Computer2 *comp, struct ComputerCheck * che
         for (long i = 0; i <= COMPUTER_PROCESSES_COUNT; i++)
         {
             struct ComputerProcess* cproc = &comp->processes[i];
-            if (flag_is_set(cproc->flags, ComProc_ListEnd))
+            if (flag_is_set(cproc->flags, ComProc_Unkn0002))
                 break;
             //TODO COMPUTER_PLAYER comparing function pointers is a bad practice
             if (cproc->func_check == cpfl_computer_check_dig_to_gold)
@@ -1271,10 +1269,9 @@ TbBool setup_a_computer_player(PlayerNumber plyr_idx, long comp_model)
         }
         memcpy(newproc, cproc, sizeof(struct ComputerProcess));
         newproc->parent = i;
-        JUSTLOG("Process %ld is %s, from %s", i, newproc->name, cproc->name);
     }
     newproc = &comp->processes[i];
-    newproc->flags |= ComProc_ListEnd;
+    newproc->flags |= ComProc_Unkn0002;
 
     for (i=0; i < COMPUTER_CHECKS_COUNT; i++)
     {
@@ -1358,7 +1355,7 @@ void computer_check_events(struct Computer2 *comp)
                       (event->kind == cevent->mevent_kind) )
                 {
                     if (computer_event_func_list[cevent->func_event](comp, cevent, event) == 1) {
-                        JUSTLOG("Player %d reacted on %s",(int)dungeon->owner,cevent->name);
+                        SYNCDBG(5,"Player %d reacted on %s",(int)dungeon->owner,cevent->name);
                         cevent->last_test_gameturn = game.play_gameturn;
                     }
                 }
@@ -1501,7 +1498,7 @@ struct ComputerProcess *computer_player_find_process_by_func_setup(PlayerNumber 
         return NULL;
   }
   struct ComputerProcess* cproc = &comp->processes[0];
-  while (!flag_is_set(cproc->flags, ComProc_ListEnd))
+  while (!flag_is_set(cproc->flags, ComProc_Unkn0002))
   {
       if (computer_process_func_list[cproc->func_setup] == func_setup)
       {

--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -191,20 +191,26 @@ struct ComputerTask *computer_setup_build_room(struct Computer2 *comp, RoomKind 
 {
     struct Dungeon* dungeon = comp->dungeon;
     long i;
+    if (room_role_matches(rkind,RoRoF_LairStorage))
+    {
+        //the first lair might be bigger if the portal limit is high
+        if (!dungeon_has_room(dungeon, rkind))
+        {
+            if (width_slabs * height_slabs < dungeon->max_creatures_attracted)
+            {
+                width_slabs++;
+                if (width_slabs * height_slabs < dungeon->max_creatures_attracted)
+                {
+                    height_slabs++;
+                }
+            }
+        }
+    }
     long max_slabs = height_slabs;
     if (max_slabs < width_slabs)
         max_slabs = width_slabs;
     long area_min = (max_slabs + 1) / 2 + 1;
     long area_max = area_min / 3 + 2 * area_min;
-    if (room_role_matches(rkind,RoRoF_LairStorage))
-    {
-        if (width_slabs*height_slabs < dungeon->max_creatures_attracted)
-        {
-            i = LbSqrL(dungeon->max_creatures_attracted);
-            width_slabs = i + 1;
-            height_slabs = i + 1;
-        }
-    }
     const long arr_length = sizeof(look_through_rooms)/sizeof(look_through_rooms[0]);
     for (long area = area_min; area < area_max; area++)
     {

--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -1268,7 +1268,7 @@ TbBool setup_a_computer_player(PlayerNumber plyr_idx, long comp_model)
           break;
         }
         memcpy(newproc, cproc, sizeof(struct ComputerProcess));
-        newproc->parent = i;
+        newproc->parent = cpt->processes[i];
     }
     newproc = &comp->processes[i];
     newproc->flags |= ComProc_ListEnd;

--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -929,7 +929,7 @@ long computer_check_for_money(struct Computer2 *comp, struct ComputerCheck * che
         for (long i = 0; i <= COMPUTER_PROCESSES_COUNT; i++)
         {
             struct ComputerProcess* cproc = &comp->processes[i];
-            if (flag_is_set(cproc->flags, ComProc_Unkn0002))
+            if (flag_is_set(cproc->flags, ComProc_ListEnd))
                 break;
             //TODO COMPUTER_PLAYER comparing function pointers is a bad practice
             if (cproc->func_check == cpfl_computer_check_dig_to_gold)
@@ -1271,7 +1271,7 @@ TbBool setup_a_computer_player(PlayerNumber plyr_idx, long comp_model)
         newproc->parent = i;
     }
     newproc = &comp->processes[i];
-    newproc->flags |= ComProc_Unkn0002;
+    newproc->flags |= ComProc_ListEnd;
 
     for (i=0; i < COMPUTER_CHECKS_COUNT; i++)
     {
@@ -1498,7 +1498,7 @@ struct ComputerProcess *computer_player_find_process_by_func_setup(PlayerNumber 
         return NULL;
   }
   struct ComputerProcess* cproc = &comp->processes[0];
-  while (!flag_is_set(cproc->flags, ComProc_Unkn0002))
+  while (!flag_is_set(cproc->flags, ComProc_ListEnd))
   {
       if (computer_process_func_list[cproc->func_setup] == func_setup)
       {

--- a/src/player_computer.h
+++ b/src/player_computer.h
@@ -140,7 +140,7 @@ enum ToolDigResults {
 
 enum CompProcessFlags {
     ComProc_Unkn0001 = 0x0001,
-    ComProc_Unkn0002 = 0x0002, /**< Last? */
+    ComProc_ListEnd  = 0x0002, /**< Last? */
     ComProc_Unkn0004 = 0x0004, /**< Finished */
     ComProc_Unkn0008 = 0x0008, /**< Done (for subprocesses) */
     ComProc_Unkn0010 = 0x0010,

--- a/src/player_computer.h
+++ b/src/player_computer.h
@@ -140,7 +140,7 @@ enum ToolDigResults {
 
 enum CompProcessFlags {
     ComProc_Unkn0001 = 0x0001,
-    ComProc_ListEnd  = 0x0002, /**< Last? */
+    ComProc_Unkn0002 = 0x0002, /**< Last? */
     ComProc_Unkn0004 = 0x0004, /**< Finished */
     ComProc_Unkn0008 = 0x0008, /**< Done (for subprocesses) */
     ComProc_Unkn0010 = 0x0010,


### PR DESCRIPTION
The MAX_CREATURE script variable determined the lair size the computer tried to make. Meaning that with a portal limit of 100, it would immediately try a 10x10 lair.
As this is suboptimal, now it will build lairs just 1 size larger than the configured size in keepcommp.cfg for the first lair, and then normal sized lairs on top of that for additional lairs when the first is full.

Also fixed expanding lairs/treasure rooms, just the part that recently broke in the computer event refactor.