### PR TITLE
Fixed Script variables when AI sells doors

### DIFF
--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -3300,7 +3300,9 @@ long task_sell_traps_and_doors(struct Computer2 *comp, struct ComputerTask *ctas
                     case WrkCrtS_Offmap:
                         remove_workshop_item_from_amount_placeable(dungeon->owner, TCls_Door, model);
                         item_sold = true;
+                        dungeon->doors_sold++;
                         value = compute_value_percentage(doorst->selling_value, game.conf.rules.game.door_sale_percent);
+                        dungeon->manufacture_gold += value;
                         SYNCDBG(9,"Offmap door %s crate sold for %d gold",door_code_name(model),(int)value);
                         break;
                     case WrkCrtS_Stored:
@@ -3308,6 +3310,8 @@ long task_sell_traps_and_doors(struct Computer2 *comp, struct ComputerTask *ctas
                         remove_workshop_object_from_player(dungeon->owner, door_crate_object_model(model));
                         item_sold = true;
                         value = compute_value_percentage(doorst->selling_value, game.conf.rules.game.door_sale_percent);
+                        dungeon->doors_sold++;
+                        dungeon->manufacture_gold += value;
                         SYNCDBG(9,"Stored door %s crate sold for %ld gold by player %d",door_code_name(model),(long)value,(int)dungeon->owner);
                         break;
                     default:
@@ -3334,6 +3338,8 @@ long task_sell_traps_and_doors(struct Computer2 *comp, struct ComputerTask *ctas
                         remove_workshop_item_from_amount_placeable(dungeon->owner, TCls_Trap, model);
                         item_sold = true;
                         value = compute_value_percentage(trapst->selling_value, game.conf.rules.game.trap_sale_percent);
+                        dungeon->traps_sold++;
+                        dungeon->manufacture_gold += value;
                         SYNCDBG(9,"Offmap trap %s crate sold for %ld gold",trap_code_name(model),value);
                         break;
                     case WrkCrtS_Stored:
@@ -3341,6 +3347,8 @@ long task_sell_traps_and_doors(struct Computer2 *comp, struct ComputerTask *ctas
                         remove_workshop_object_from_player(dungeon->owner, trap_crate_object_model(model));
                         item_sold = true;
                         value = compute_value_percentage(trapst->selling_value, game.conf.rules.game.trap_sale_percent);
+                        dungeon->traps_sold++;
+                        dungeon->manufacture_gold += value;
                         SYNCDBG(9,"Stored trap %s crate sold for %ld gold by player %d",trap_code_name(model),(long)value,(int)dungeon->owner);
                         break;
                     default:
@@ -3369,6 +3377,8 @@ long task_sell_traps_and_doors(struct Computer2 *comp, struct ComputerTask *ctas
                         stl_x = stl_slab_center_subtile(doortng->mappos.x.stl.num);
                         stl_y = stl_slab_center_subtile(doortng->mappos.y.stl.num);
                         value = compute_value_percentage(doorst->selling_value, game.conf.rules.game.door_sale_percent);
+                        dungeon->doors_sold++;
+                        dungeon->manufacture_gold += value;
                         destroy_door(doortng);
                         if (is_my_player_number(dungeon->owner))
                         {
@@ -3408,8 +3418,9 @@ long task_sell_traps_and_doors(struct Computer2 *comp, struct ComputerTask *ctas
                         MapSubtlCoord stl_y;
                         item_sold = true;
                         stl_x = stl_slab_center_subtile(traptng->mappos.x.stl.num);
-                        stl_y = stl_slab_center_subtile(traptng->mappos.y.stl.num);
-                        remove_traps_around_subtile(stl_x, stl_y, &value);
+                        stl_y = stl_slab_center_subtile(traptng->mappos.y.stl.num);                        
+                        dungeon->traps_sold += remove_traps_around_subtile(stl_x, stl_y, &value);
+                        dungeon->manufacture_gold += value;
                         if (is_my_player_number(dungeon->owner))
                         {
                             play_non_3d_sample(115);

--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -948,7 +948,7 @@ long computer_check_for_money(struct Computer2 *comp, struct ComputerCheck * che
         }
     }
     // Try selling traps and doors - aggressive way
-    if ((money_left < check->param2) && is_room_of_role_available(dungeon->owner, RoRoF_CratesManufctr))
+    if ((money_left < check->param2) && dungeon_has_room_of_role(dungeon, RoRoF_CratesManufctr))
     {
         if (dungeon_has_any_buildable_traps(dungeon) || dungeon_has_any_buildable_doors(dungeon) ||
             player_has_deployed_trap_of_model(dungeon->owner, -1) || player_has_deployed_door_of_model(dungeon->owner, -1, 0))
@@ -963,7 +963,7 @@ long computer_check_for_money(struct Computer2 *comp, struct ComputerCheck * che
         }
     }
     // Try selling traps and doors - cautious way
-    if ((money_left < check->param1) && is_room_of_role_available(dungeon->owner, RoRoF_CratesManufctr))
+    if ((money_left < check->param1) && dungeon_has_room_of_role(dungeon, RoRoF_CratesManufctr))
     {
         if (dungeon_has_any_buildable_traps(dungeon) || dungeon_has_any_buildable_doors(dungeon))
         {


### PR DESCRIPTION
So, the variables like DOORS_SOLD and MANUFACTURE_GOLD now get filled when the AI sells his traps/doors/crates.

Also fixes the selling the AI does when he has, but cannot build, a workshop.