### PR TITLE
EVENT PAY DAY now has 0 as do it 0 instead 1 times

### DIFF
--- a/config/fxdata/keepcompp.cfg
+++ b/config/fxdata/keepcompp.cfg
@@ -737,6 +737,7 @@ Name = EVENT PAY DAY
 Mnemonic = PayDay1
 Values = 0 12 1195
 Functions = event_check_payday none
+; Params = <Max amount of workshop items to sell to afford payday>, <Max amount of gold piles to move to treasure room>, <unused>, <Not used before game turn X>.
 Params = 0 0 0 0
 
 [event15]

--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -887,7 +887,7 @@ long computer_event_check_payday(struct Computer2 *comp, struct ComputerEvent *c
         if (!is_task_in_progress(comp, CTT_SellTrapsAndDoors))
         {
             SYNCDBG(8,"Creating task to sell player %d traps and doors",(int)dungeon->owner);
-            if (create_task_sell_traps_and_doors(comp, cevent->param2, 3*(dungeon->creatures_total_pay-dungeon->total_money_owned)/2,true)) {
+            if (create_task_sell_traps_and_doors(comp, cevent->param1, 3*(dungeon->creatures_total_pay-dungeon->total_money_owned)/2,true)) {
                 return CTaskRet_Unk1;
             }
         }

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2949,7 +2949,12 @@ long task_move_gold_to_treasury(struct Computer2 *comp, struct ComputerTask *cta
     SYNCDBG(9,"Starting for player %d",(int)dungeon->owner);
     struct Thing *thing;
     struct Coord3d pos;
-    long i;
+    long i = ctask->move_gold.items_amount;
+    if (i <= 0)
+    {
+        remove_task(comp, ctask);
+        return CTaskRet_Unk1;
+    }
     thing = thing_get(comp->held_thing_idx);
     if (!thing_is_invalid(thing))
     {
@@ -2971,13 +2976,6 @@ long task_move_gold_to_treasury(struct Computer2 *comp, struct ComputerTask *cta
         remove_task(comp, ctask);
         return CTaskRet_Unk0;
     }
-    i = ctask->move_gold.items_amount;
-    ctask->move_gold.items_amount--;
-    if (i <= 0)
-    {
-        remove_task(comp, ctask);
-        return CTaskRet_Unk1;
-    }
     thing = find_gold_laying_in_dungeon(comp->dungeon);
     if (!thing_is_invalid(thing))
     {
@@ -2991,6 +2989,7 @@ long task_move_gold_to_treasury(struct Computer2 *comp, struct ComputerTask *cta
             pos.y.val = subtile_coord_center(slab_subtile_center(slb_num_decode_y(room->slabs_list)));
             pos.z.val = subtile_coord(1,0);
             if (computer_place_thing_in_power_hand(comp, thing, &pos)) {
+                ctask->move_gold.items_amount--;
                 SYNCDBG(9,"Player %d picked %s index %d to place in %s index %d",(int)comp->dungeon->owner,
                     thing_model_name(thing),(int)thing->index,room_code_name(room->kind),(int)room->index);
                 return CTaskRet_Unk2;
@@ -3274,6 +3273,10 @@ long task_sell_traps_and_doors(struct Computer2 *comp, struct ComputerTask *ctas
         return CTaskRet_Unk0;
     }
     SYNCDBG(19,"Starting for player %d",(int)dungeon->owner);
+    if (ctask->sell_traps_doors.items_amount <= 0) {
+        remove_task(comp, ctask);
+        return CTaskRet_Unk1;
+    }
     if ((ctask->sell_traps_doors.gold_gain <= ctask->sell_traps_doors.gold_gain_limit) && (dungeon->total_money_owned <= ctask->sell_traps_doors.total_money_limit))
     {
         i = 0;
@@ -3443,10 +3446,6 @@ long task_sell_traps_and_doors(struct Computer2 *comp, struct ComputerTask *ctas
                 player_add_offmap_gold(dungeon->owner, value);
                 // Mark that we've sold the item; if enough was sold, end the task
                 ctask->sell_traps_doors.items_amount--;
-                if (ctask->sell_traps_doors.items_amount <= 0) {
-                    remove_task(comp, ctask);
-                    return CTaskRet_Unk1;
-                }
                 return CTaskRet_Unk1;
             }
         }

--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -956,7 +956,7 @@ long computer_check_for_money(struct Computer2 *comp, struct ComputerCheck * che
             if (!is_task_in_progress(comp, CTT_SellTrapsAndDoors))
             {
                 SYNCDBG(8,"Creating task to sell any player %d traps and doors",(int)dungeon->owner);
-                if (create_task_sell_traps_and_doors(comp, 5, max(check->param2-money_left,1),true)) {
+                if (create_task_sell_traps_and_doors(comp, 6, max(check->param2-money_left,1),true)) {
                     ret = CTaskRet_Unk1;
                 }
             }
@@ -970,7 +970,7 @@ long computer_check_for_money(struct Computer2 *comp, struct ComputerCheck * che
             if (!is_task_in_progress(comp, CTT_SellTrapsAndDoors))
             {
                 SYNCDBG(8,"Creating task to sell player %d trap and door boxes",(int)dungeon->owner);
-                if (create_task_sell_traps_and_doors(comp, 5, max(check->param1-money_left,1),false)) {
+                if (create_task_sell_traps_and_doors(comp, 6, max(check->param1-money_left,1),false)) {
                     ret = CTaskRet_Unk1;
                 }
             }


### PR DESCRIPTION
On payday the AI would by default sell 0 workshop items to afford payday, and move 0 gold piles to the treasure room. However, the selling and moving tasks would do the activity the first time before it reached the check how many were left, doing it always one time more than specified.

I moved the number check to _before_ it was executed, so now it will actually do it 0 times.

Also, both of these options used the same param, so if you set it to 5, you would move 6 piles and sell 6 traps. I split it into 2 params for more configurability.

Also documented the params in keepcompp.cfg.