### PR TITLE
Option for computers to not slap imps with speed

### DIFF
--- a/config/fxdata/keepcompp.cfg
+++ b/config/fxdata/keepcompp.cfg
@@ -384,6 +384,7 @@ Name = CHECK FOR SLAP IMP
 Mnemonic = ImpSlap1
 Values = 0 250
 Functions = check_slap_imps
+; Params = <percentage of imps>, <ignore imps with speed>, <none, <not used before game turn X>
 Params = 75 0 0 -250
 
 [check21]
@@ -405,7 +406,7 @@ Name = CHECK FOR SPEED UP
 Mnemonic = SplSpdu1
 Values = 0 200
 Functions = check_for_accelerate
-; First room to check[Library(0), Library(1), Workshop(2), Training(3), Scavenger(4)], spell_level, needs X time spell price available, not used before game turn X.
+; Params =  <First room to check[Library(0), Library(1), Workshop(2), Training(3), Scavenger(4)]>, <spell_level>, <needs X time spell price available>, <not used before game turn X>.
 Params = 0 8 3 0
 
 [check24]

--- a/src/player_compchecks.c
+++ b/src/player_compchecks.c
@@ -1089,14 +1089,16 @@ long computer_check_for_vision(struct Computer2 *comp, struct ComputerCheck * ch
 long computer_check_slap_imps(struct Computer2 *comp, struct ComputerCheck * check)
 {
     SYNCDBG(8,"Starting");
+    long slap_percentage = check->param1;
+    TbBool skip_imps_with_speed = check->param2;
     struct Dungeon* dungeon = comp->dungeon;
     if (!is_power_available(dungeon->owner, PwrK_SLAP)) {
         return CTaskRet_Unk4;
     }
-    long creatrs_num = check->param1 * dungeon->num_active_diggers / 100;
+    long creatrs_num = slap_percentage * dungeon->num_active_diggers / 100;
     if (!is_task_in_progress(comp, CTT_SlapDiggers))
     {
-        if (create_task_slap_imps(comp, creatrs_num)) {
+        if (create_task_slap_imps(comp, creatrs_num, skip_imps_with_speed)) {
             return CTaskRet_Unk1;
         }
     }

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -3036,7 +3036,7 @@ long task_slap_imps(struct Computer2 *comp, struct ComputerTask *ctask)
             i = cctrl->players_next_creature_idx;
             // Per-thing code
             // Don't slap if picked up or already slapped
-            if (!thing_is_picked_up(thing) && !creature_affected_by_slap(thing))
+            if (!thing_is_picked_up(thing) && !creature_affected_by_slap(thing) && !(creature_under_spell_effect(thing, CSAfF_Speed) && ctask->slap_imps.skip_speed))
             {
                 // Check if we really can use the spell on that creature, considering its position and state
                 if (can_cast_spell(dungeon->owner, PwrK_SLAP, thing->mappos.x.stl.num, thing->mappos.y.stl.num, thing, CastChk_Default))
@@ -3844,7 +3844,7 @@ TbBool create_task_dig_to_entrance(struct Computer2 *comp, const struct Coord3d 
     return true;
 }
 
-TbBool create_task_slap_imps(struct Computer2 *comp, long creatrs_num)
+TbBool create_task_slap_imps(struct Computer2 *comp, long creatrs_num, TbBool skip_speed)
 {
     struct ComputerTask *ctask;
     SYNCDBG(7,"Starting");
@@ -3858,6 +3858,7 @@ TbBool create_task_slap_imps(struct Computer2 *comp, long creatrs_num)
     ctask->ttype = CTT_SlapDiggers;
     ctask->attack_magic.repeat_num = creatrs_num;
     ctask->created_turn = game.play_gameturn;
+    ctask->slap_imps.skip_speed = skip_speed;
     return true;
 }
 

--- a/src/player_computer.h
+++ b/src/player_computer.h
@@ -401,6 +401,9 @@ struct ComputerTask {
         RoomKind kind;
         long area;
     } create_room;
+    struct {
+        TbBool skip_speed;
+    } slap_imps;
     };
     unsigned short cproc_idx; /**< CProcessId */
     GameTurnDelta cta_duration;
@@ -529,7 +532,7 @@ TbBool create_task_move_gold_to_treasury(struct Computer2 *comp, long num_to_mov
 TbBool create_task_move_creature_to_subtile(struct Computer2 *comp, const struct Thing *thing, MapSubtlCoord stl_x, MapSubtlCoord stl_y, CrtrStateId dst_state);
 TbBool create_task_move_creature_to_pos(struct Computer2 *comp, const struct Thing *thing, const struct Coord3d pos, CrtrStateId dst_state);
 TbBool create_task_dig_to_attack(struct Computer2 *comp, const struct Coord3d startpos, const struct Coord3d endpos, PlayerNumber victim_plyr_idx, long parent_cproc_idx);
-TbBool create_task_slap_imps(struct Computer2 *comp, long creatrs_num);
+TbBool create_task_slap_imps(struct Computer2 *comp, long creatrs_num, TbBool skip_speed);
 TbBool create_task_dig_to_neutral(struct Computer2 *comp, const struct Coord3d startpos, const struct Coord3d endpos);
 TbBool create_task_dig_to_gold(struct Computer2 *comp, const struct Coord3d startpos, const struct Coord3d endpos, long parent_cproc_idx, long count_slabs_to_dig, long gold_lookup_idx);
 TbBool create_task_dig_to_entrance(struct Computer2 *comp, const struct Coord3d startpos, const struct Coord3d endpos, long parent_cproc_idx, long entroom_idx);


### PR DESCRIPTION
Adds an option to disable this change in legacy keepcommp configs: https://github.com/dkfans/keeperfx/commit/f632a23c41a0b0e2628c5553a3f33a331d62f4db