### PR TITLE
On stacked objects, show tooltip of any object

### DIFF
--- a/src/config_objects.c
+++ b/src/config_objects.c
@@ -96,7 +96,7 @@ static const struct NamedField objects_named_fields[] = {
     {"LIGHTRADIUS",              0, field(game.conf.object_conf.object_cfgstats[0].ilght.radius),                  0, LONG_MIN,ULONG_MAX, NULL,                        value_stltocoord,assign_default},
     {"LIGHTISDYNAMIC",           0, field(game.conf.object_conf.object_cfgstats[0].ilght.is_dynamic),              0, LONG_MIN,ULONG_MAX, NULL,                        value_default,   assign_default},
     {"MAPICON",                  0, field(game.conf.object_conf.object_cfgstats[0].map_icon),                      0, LONG_MIN,ULONG_MAX, NULL,                        value_icon,      assign_icon},
-    {"TOOLTIPTEXTID",            0, field(game.conf.object_conf.object_cfgstats[0].tooltip_stridx),               -1, SHRT_MIN, SHRT_MAX, NULL,                        value_default,   assign_default},
+    {"TOOLTIPTEXTID",            0, field(game.conf.object_conf.object_cfgstats[0].tooltip_stridx),     GUIStr_Empty, SHRT_MIN, SHRT_MAX, NULL,                        value_default,   assign_default},
     {"TOOLTIPTEXTID",            1, field(game.conf.object_conf.object_cfgstats[0].tooltip_optional),              0,        0,        1, NULL,                        value_default,   assign_default},
     {"AMBIENCESOUND",            0, field(game.conf.object_conf.object_cfgstats[0].fp_smpl_idx),                   0,        0,ULONG_MAX, NULL,                        value_default,   assign_default},
     {"UPDATEFUNCTION",           0, field(game.conf.object_conf.object_cfgstats[0].updatefn_idx),                  0, LONG_MIN,ULONG_MAX, object_update_functions_desc,value_default,   assign_default},

--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -159,7 +159,7 @@ TbBool setup_object_tooltips(struct Coord3d *pos)
     struct Thing* thing = thing_get(player->thing_under_hand);
     if (thing_is_invalid(thing))
     {
-        thing = get_nearest_object_at_position(pos->x.stl.num, pos->y.stl.num);
+        thing = get_nearest_object_with_tooltip_at_position(pos->x.stl.num, pos->y.stl.num);
     }
     struct ObjectConfigStats* objst;
     if (!thing_is_invalid(thing))

--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -159,17 +159,21 @@ TbBool setup_object_tooltips(struct Coord3d *pos)
     struct Thing* thing = thing_get(player->thing_under_hand);
     if (thing_is_invalid(thing))
     {
-        thing = get_nearest_object_with_tooltip_at_position(pos->x.stl.num, pos->y.stl.num);
+        thing = get_nearest_object_with_tooltip_at_position(pos->x.stl.num, pos->y.stl.num,0);
     }
     struct ObjectConfigStats* objst;
+    if (thing_is_invalid(thing))
+    {
+        if (!settings.tooltips_on)
+        {
+            return false;
+        }
+        thing = get_nearest_object_with_tooltip_at_position(pos->x.stl.num, pos->y.stl.num, 1);
+    }
     if (!thing_is_invalid(thing))
     {
         update_gui_tooltip_target(thing);
         objst = get_object_model_stats(thing->model);
-        if ((!settings.tooltips_on) && (objst->tooltip_optional))
-        {
-            return false;
-        }
         if ((objst->tooltip_stridx >= 0) && (objst->tooltip_stridx != GUIStr_Empty))
         {
             if ((help_tip_time > 20) || (player->work_state == PSt_CreatrQuery))

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -272,7 +272,7 @@ struct Thing *process_object_being_picked_up(struct Thing *thing, long plyr_idx)
     case ObjMdl_GoldPot:
     case ObjMdl_Goldl:
     case ObjMdl_GoldBag:
-      i = thing->creature.gold_carried;
+      i = thing->valuable.gold_stored;
       if (i != 0)
       {
         pos.x.val = thing->mappos.x.val;

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -4131,6 +4131,12 @@ struct Thing *get_creature_of_model_training_at_subtile_and_owned_by(MapSubtlCoo
     return get_thing_on_map_block_with_filter(i, filter, &param, &n);
 }
 
+struct Thing* get_nearest_object_with_tooltip_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    return get_object_around_owned_by_and_matching_bool_filter(
+        subtile_coord_center(stl_x), subtile_coord_center(stl_y), -1, thing_is_object_with_tooltip);
+}
+
 struct Thing *get_nearest_object_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
   return get_object_around_owned_by_and_matching_bool_filter(

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -4131,10 +4131,18 @@ struct Thing *get_creature_of_model_training_at_subtile_and_owned_by(MapSubtlCoo
     return get_thing_on_map_block_with_filter(i, filter, &param, &n);
 }
 
-struct Thing* get_nearest_object_with_tooltip_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+struct Thing* get_nearest_object_with_tooltip_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool optional)
 {
-    return get_object_around_owned_by_and_matching_bool_filter(
-        subtile_coord_center(stl_x), subtile_coord_center(stl_y), -1, thing_is_object_with_tooltip);
+    if (optional)
+    {
+        return get_object_around_owned_by_and_matching_bool_filter(
+            subtile_coord_center(stl_x), subtile_coord_center(stl_y), -1, thing_is_object_with_optional_tooltip);
+    }
+    else
+    {
+        return get_object_around_owned_by_and_matching_bool_filter(
+            subtile_coord_center(stl_x), subtile_coord_center(stl_y), -1, thing_is_object_with_mandatory_tooltip);
+    }
 }
 
 struct Thing *get_nearest_object_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y)

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -248,6 +248,7 @@ struct Thing *get_door_for_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 struct Thing *get_door_for_position_for_trap_placement(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool slab_has_door_thing_on(MapSlabCoord slb_x, MapSlabCoord slb_y);
 struct Thing *get_nearest_object_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+struct Thing* get_nearest_object_with_tooltip_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 struct Thing *get_nearest_thing_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void remove_dead_creatures_from_slab(MapSlabCoord slb_x, MapSlabCoord slb_y);
 long count_creatures_near_and_owned_by_or_allied_with(MapCoord pos_x, MapCoord pos_y, long distance_stl, PlayerNumber plyr_idx);

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -248,7 +248,7 @@ struct Thing *get_door_for_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 struct Thing *get_door_for_position_for_trap_placement(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool slab_has_door_thing_on(MapSlabCoord slb_x, MapSlabCoord slb_y);
 struct Thing *get_nearest_object_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
-struct Thing* get_nearest_object_with_tooltip_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+struct Thing* get_nearest_object_with_tooltip_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool optional);
 struct Thing *get_nearest_thing_at_position(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void remove_dead_creatures_from_slab(MapSlabCoord slb_x, MapSlabCoord slb_y);
 long count_creatures_near_and_owned_by_or_allied_with(MapCoord pos_x, MapCoord pos_y, long distance_stl, PlayerNumber plyr_idx);

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -287,6 +287,16 @@ TbBool object_can_be_damaged (const struct Thing* thing)
     return false;
 }
 
+TbBool thing_is_object_with_tooltip(const struct Thing* thing)
+{
+    if (thing_is_invalid(thing))
+        return false;
+    if (thing->class_id != TCls_Object)
+        return false;
+    struct ObjectConfigStats* objst = get_object_model_stats(thing->model);;
+    return (((objst->tooltip_stridx >= 0) && (objst->tooltip_stridx != GUIStr_Empty)) || (objst->tooltip_stridx == -1));
+}
+
 TbBool thing_is_object(const struct Thing *thing)
 {
     if (thing_is_invalid(thing))

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -287,14 +287,22 @@ TbBool object_can_be_damaged (const struct Thing* thing)
     return false;
 }
 
-TbBool thing_is_object_with_tooltip(const struct Thing* thing)
+TbBool thing_is_object_with_tooltip(const struct Thing* thing, TbBool is_optional)
 {
     if (thing_is_invalid(thing))
         return false;
     if (thing->class_id != TCls_Object)
         return false;
-    struct ObjectConfigStats* objst = get_object_model_stats(thing->model);;
-    return (((objst->tooltip_stridx >= 0) && (objst->tooltip_stridx != GUIStr_Empty)) || (objst->tooltip_stridx == -1));
+    struct ObjectConfigStats* objst = get_object_model_stats(thing->model);
+    return ((objst->tooltip_stridx != GUIStr_Empty) && (objst->tooltip_optional == is_optional));
+}
+TbBool thing_is_object_with_mandatory_tooltip(const struct Thing* thing)
+{
+    return thing_is_object_with_tooltip(thing, 0);
+}
+TbBool thing_is_object_with_optional_tooltip(const struct Thing* thing)
+{
+    return thing_is_object_with_tooltip(thing, 1);
 }
 
 TbBool thing_is_object(const struct Thing *thing)

--- a/src/thing_objects.h
+++ b/src/thing_objects.h
@@ -161,7 +161,9 @@ struct Thing *create_object(const struct Coord3d *pos, ThingModel model, unsigne
 void destroy_object(struct Thing *thing);
 TngUpdateRet update_object(struct Thing *thing);
 TbBool thing_is_object(const struct Thing *thing);
-TbBool thing_is_object_with_tooltip(const struct Thing* thing);
+TbBool thing_is_object_with_mandatory_tooltip(const struct Thing* thing);
+TbBool thing_is_object_with_optional_tooltip(const struct Thing* thing);
+TbBool thing_is_object_with_tooltip(const struct Thing* thing, TbBool is_optional);
 void change_object_owner(struct Thing *objtng, PlayerNumber nowner);
 void destroy_food(struct Thing *foodtng);
 

--- a/src/thing_objects.h
+++ b/src/thing_objects.h
@@ -161,6 +161,7 @@ struct Thing *create_object(const struct Coord3d *pos, ThingModel model, unsigne
 void destroy_object(struct Thing *thing);
 TngUpdateRet update_object(struct Thing *thing);
 TbBool thing_is_object(const struct Thing *thing);
+TbBool thing_is_object_with_tooltip(const struct Thing* thing);
 void change_object_owner(struct Thing *objtng, PlayerNumber nowner);
 void destroy_food(struct Thing *foodtng);
 


### PR DESCRIPTION
Fixes an issue where an object without a tooltip stacked on top of an object without a tooltip would block the tooltip of the object below.