### PR TITLE
Added overlay for if trap/door is available but not manufacturable

### DIFF
--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -948,6 +948,25 @@ void gui_area_trap_button(struct GuiButton *gbtn)
     {
         draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, i);
     }
+        // Overlay "can't make" sprite if not buildable but placeable/built
+    if (manufctr->tngclass == TCls_Trap)
+    {
+        if (!is_trap_buildable(my_player_number, manufctr->tngmodel)
+          && (is_trap_placeable(my_player_number, manufctr->tngmodel)
+          || is_trap_built(my_player_number, manufctr->tngmodel)))
+        {
+            draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, GPS_rpanel_cant_make);
+        }
+    }
+    else if (manufctr->tngclass == TCls_Door)
+    {
+        if (!is_door_buildable(my_player_number, manufctr->tngmodel)
+          && (is_door_placeable(my_player_number, manufctr->tngmodel)
+          || is_door_built(my_player_number, manufctr->tngmodel)))
+        {
+            draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, GPS_rpanel_cant_make);
+        }
+    }
     lbDisplay.DrawFlags = flg_mem;
 }
 

--- a/src/sprites.h
+++ b/src/sprites.h
@@ -738,13 +738,16 @@ enum GUIPanelSprite {
     GPS_keepower_timebomb_std_l = 566,
     GPS_keepower_timebomb_dis_l = 567,
 
-    GPS_message_rpanel_msg_exclam2_act = 776,
-    GPS_message_rpanel_msg_exclam2_std = 777,
     GPS_message_rpanel_msg_payday_act = 778,
     GPS_message_rpanel_msg_payday_std = 779,
-
     GPS_message_rpanel_msg_alarm_act = 800,
     GPS_message_rpanel_msg_alarm_std = 801,
+    GPS_message_rpanel_msg_exclam2_act = 833,
+    GPS_message_rpanel_msg_exclam2_std = 834,
+    GPS_message_rpanel_msg_exclam2r_act = 835,
+    GPS_message_rpanel_msg_exclam2r_std = 836,
+
+    GPS_rpanel_cant_make = 837,
 
     GUI_PANEL_SPRITES_COUNT = 900,
     GUI_PANEL_SPRITES_NEW = 512,


### PR DESCRIPTION
Overlays a little 🚫 if the trap/door cannot be manufactured (but is/was available).