### PR TITLE
allow for variable flashing speed of certain sprites

### DIFF
--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -303,7 +303,7 @@ void gui_area_autopilot_button(struct GuiButton *gbtn)
     {
         if ((dungeon->computer_enabled & 0x01) != 0)
         {
-          if (game.play_gameturn & 1)
+          if ((game.play_gameturn % (2 * flash_rate)) >= flash_rate)
             spr_idx += 2;
         }
         if ((gbtn->gbactn_1 == 0) && (gbtn->gbactn_2 == 0))
@@ -555,7 +555,7 @@ void gui_area_big_room_button(struct GuiButton *gbtn)
     if ((roomst->cost * boxsize) <= dungeon->total_money_owned)
     {
         if ((player->work_state == PSt_BuildRoom) && (player->chosen_room_kind == game.chosen_room_kind)
-          && ((game.play_gameturn & 1) == 0))
+          && ((game.play_gameturn % (2 * flash_rate)) >= flash_rate))
         {
             draw_gui_panel_sprite_rmleft(gbtn->scr_pos_x - 4*units_per_px/16, gbtn->scr_pos_y - 32*units_per_px/16, ps_units_per_px, gbtn->sprite_idx, 44);
         } else {
@@ -635,7 +635,7 @@ void gui_area_spell_button(struct GuiButton *gbtn)
             {
                 if ((((i != PSt_CallToArms) || !player_uses_power_call_to_arms(my_player_number))
                   && ((i != PSt_SightOfEvil) || !player_uses_power_sight(my_player_number)))
-                 || ((game.play_gameturn & 1) == 0))
+                 || ((game.play_gameturn % (2 * flash_rate)) >= flash_rate))
                 {
                     draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, spr_idx);
                     drawn = true;
@@ -705,7 +705,7 @@ void gui_area_big_spell_button(struct GuiButton *gbtn)
     char* text = buf_sprintf("%ld", (long)price);
     if (dungeon->total_money_owned >= price)
     {
-        if ((player->work_state == powerst->work_state) && ((game.play_gameturn & 1) != 0)) {
+        if ((player->work_state == powerst->work_state) && ((game.play_gameturn % (2 * flash_rate)) >= flash_rate)) {
             draw_gui_panel_sprite_rmleft(gbtn->scr_pos_x - 4*units_per_px/16, gbtn->scr_pos_y - 32*units_per_px/16, ps_units_per_px, gbtn->sprite_idx, 44);
         } else {
             draw_gui_panel_sprite_left(gbtn->scr_pos_x - 4*units_per_px/16, gbtn->scr_pos_y - 32*units_per_px/16, ps_units_per_px, gbtn->sprite_idx);
@@ -1037,7 +1037,7 @@ void gui_area_big_trap_button(struct GuiButton *gbtn)
     } else
     if ((((manufctr->tngclass == TCls_Trap) && (player->chosen_trap_kind == manufctr->tngmodel) && (player->work_state == PSt_PlaceTrap))
       || ((manufctr->tngclass == TCls_Door) && (player->chosen_door_kind == manufctr->tngmodel) && (player->work_state == PSt_PlaceDoor)))
-      && ((game.play_gameturn & 1) == 0) )
+      && ((game.play_gameturn % (2 * flash_rate)) >= flash_rate) )
     {
         draw_gui_panel_sprite_rmleft(gbtn->scr_pos_x - 4*units_per_px/16, gbtn->scr_pos_y - 32*units_per_px/16, ps_units_per_px, gbtn->sprite_idx, 44);
     } else {
@@ -1895,7 +1895,7 @@ void gui_area_ally(struct GuiButton *gbtn)
         return;
     }
     int ps_units_per_px = simple_gui_panel_sprite_height_units_per_px(gbtn, GPS_plyrsym_symbol_player_any_dis, 100);
-    if (game.play_gameturn & 1)
+    if ((game.play_gameturn % (2 * flash_rate)) >= flash_rate)
     {
         struct PlayerInfo* player = get_my_player();
         if (player_allied_with(player, plyr_idx)) {
@@ -1938,6 +1938,10 @@ void gui_area_stat_button(struct GuiButton *gbtn)
         draw_button_string(gbtn, 60, text);
     }
 }
+
+int flash_rate = flash_rate_amount; // adjust as needed (higher = slower flashing)
+// default/original is k=1 (flash every other turn).
+// need to link k to a config/rules file so it's user-adjustable
 
 void maintain_event_button(struct GuiButton *gbtn)
 {
@@ -2002,7 +2006,7 @@ void maintain_event_button(struct GuiButton *gbtn)
     }
     gbtn->sprite_idx = event_button_info[event->kind].bttn_sprite;
     if (((event->kind == EvKind_FriendlyFight) || (event->kind == EvKind_EnemyFight))
-        && ((event->mappos_x != 0) || (event->mappos_y != 0)) && ((game.play_gameturn & 0x01) != 0))
+        && ((event->mappos_x != 0) || (event->mappos_y != 0)) && ((game.play_gameturn % (2 * flash_rate)) >= flash_rate))
     {
         // Fight icon flashes when there are fights to show
         gbtn->sprite_idx += 2;
@@ -2021,13 +2025,13 @@ void maintain_event_button(struct GuiButton *gbtn)
         }
     } else
     if (((event->kind == EvKind_Information) || (event->kind == EvKind_QuickInformation))
-      && (event->target < 0) && ((game.play_gameturn & 0x01) != 0))
+      && (event->target < 0) && ((game.play_gameturn % (2 * flash_rate)) >= flash_rate))
     {
         // Unread information flashes
         gbtn->sprite_idx += 2;
     } else
     if ((event->kind == EvKind_HeartAttacked)
-        && ((event->mappos_x != 0) || (event->mappos_y != 0)) && ((game.play_gameturn & 0x01) != 0))
+        && ((event->mappos_x != 0) || (event->mappos_y != 0)) && ((game.play_gameturn % (2 * flash_rate)) >= flash_rate))
     {
         // Heart alert icon flashes when heart is being attacked
         gbtn->sprite_idx += 2;
@@ -2277,7 +2281,7 @@ void gui_area_player_creature_info(struct GuiButton *gbtn)
     {
         unsigned long spr_idx = get_player_colored_icon_idx(player_has_heart(plyr_idx) ? GPS_plyrsym_symbol_player_red_std_a : GPS_plyrsym_symbol_player_red_dead, plyr_idx);
         if (((dungeon->num_active_creatrs < dungeon->max_creatures_attracted) && (!game.pool.is_empty))
-            || ((game.play_gameturn & 1) != 0))
+            || ((game.play_gameturn % (2 * flash_rate)) >= flash_rate))
         {
             draw_gui_panel_sprite_left_player(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, spr_idx, plyr_idx);
         } else


### PR DESCRIPTION
I need to tidy this up - some are when 0, some are when 1. Aim is to store some integer somewhere in the setting/rules file that is configurable, and have all flashing effects alternate every n frames (instead of 1).

Also need to do this for minimap neutral territory.