### PR TITLE
Fixed dropped units counted as enemy controlled

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -930,7 +930,7 @@ TbBool creature_is_kept_in_custody_by_enemy(const struct Thing *thing)
         creature_is_being_dropped(thing))
     {
         struct Room* room = get_room_thing_is_on(thing);
-        if (room_is_invalid(room))
+        if (room_is_invalid(room) && !creature_is_being_dropped(thing))
         {
             //If the creature is not inside a room, or moving
             struct CreatureControl* cctrl = creature_control_get_from_thing(thing);


### PR DESCRIPTION
Units that you picked up from an enemy room and you dropped in your dungeon but not on a room, would temporarily be counted as being controlled by the enemy while they were in the air. This because the game assumed they were being dropped by the enemy on a torture room or prison.