### PR TITLE
PIERCE_WALLS shot property

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -470,21 +470,22 @@ WithstandHitAgainst =
 ; CAN_COLLIDE - The shot can collide with other shots.
 ; DIGGING - Damages earth and walls.
 ; DISARMING - Damages traps.
+; EXPLODE_FLESH - Creatures killed by the shot are blown to bits.
 ; FIXED_DAMAGE - Does fixed damage value, ignoring caster and target stats.
 ; GROUP_UP - Causes friendly creatures hit to group up with the caster.
 ; HIDDEN_PROJECTILE - The created shot animation is not drawn so a custom effect can be used.
 ; LIFE_DRAIN - Gives caster 50% of damage dealt by ranged shot.
 ; NAVIGABLE - Flies towards target.
+; NEVER_BLOCK - For STRENGTH_BASED shots, has them ignore Defence and Dexterity to always hit.
 ; NO_AIR_DAMAGE - Health is not removed by movement.
 ; NO_HIT - Cannot hit the target.
 ; NO_STUN - Will kill units even with imprisonment on.
+; PENETRATING - Shot passes through creatures and things to hit those behind. Set DestroyOnHit to 0.
 ; REBOUND_IMMUNE - Will pass through Rebound spell.
 ; SLAPPABLE - Can be slapped.
 ; STRENGTH_BASED - Damage calculated from creature strength.
 ; WIND_IMMUNE - Shot can not be blown away.
-; EXPLODE_FLESH - Creatures killed by the shot are blown to bits.
-; PENETRATING - Shot passes through creature to hit those behind. Set DestroyOnHit to 0.
-; NEVER_BLOCK - For STRENGTH_BASED shots, has them ignore Defence and Dexterity to always hit.
+; WALL_PIERCE - Shot passes through walls.
 Properties = 
 ; Logic used when firing the shot.
 ; 0 Default.

--- a/src/config_magic.c
+++ b/src/config_magic.c
@@ -243,6 +243,7 @@ const struct NamedCommand shotmodel_properties_commands[] = {
   {"BLOCKS_REBIRTH",      19},
   {"PENETRATING",         20},
   {"NEVER_BLOCK",         21},
+  {"WALL_PIERCE",         22},
   {NULL,                   0},
   };
 
@@ -1264,16 +1265,20 @@ TbBool parse_magic_shot_blocks(char *buf, long len, const char *config_textname,
                 shotst->model_flags |= ShMF_Disarming;
                 n++;
                 break;
-            case 19: // BlocksRebirth
+            case 19: // BLOCKS_REBIRTH
                 shotst->model_flags |= ShMF_BlocksRebirth;
                 n++;
                 break;
-            case 20: // Penetrating
+            case 20: // PENETRATING
                 shotst->model_flags |= ShMF_Penetrating;
                 n++;
                 break;
-            case 21: // NeverBlock
+            case 21: // NEVER_BLOCK
                 shotst->model_flags |= ShMF_NeverBlock;
+                n++;
+                break;
+            case 22: // WALL_PIERCE
+                shotst->model_flags |= ShMF_WallPierce;
                 n++;
                 break;
             default:

--- a/src/config_magic.h
+++ b/src/config_magic.h
@@ -122,6 +122,7 @@ enum ShotModelFlags {
     ShMF_BlocksRebirth  = 0x4000,
     ShMF_Penetrating    = 0x8000,
     ShMF_NeverBlock     = 0x10000,
+    ShMF_WallPierce     = 0x20000,
 };
 
 #define PwCast_None           (0LL)

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -699,7 +699,7 @@ TbBool shot_hit_wall_at(struct Thing *shotng, struct Coord3d *pos)
     {
         return detonate_shot(shotng, true);
     }
-    if (!(shotst->model_flags & ShMF_Penetrating))
+    if (!flag_is_set(shotst->model_flags,ShMF_WallPierce))
     {
         if (shotng->bounce_angle <= 0)
         {
@@ -1649,7 +1649,7 @@ TngUpdateRet move_shot(struct Thing *shotng)
     {
         if (shot_hit_something_while_moving(shotng, &pos))
         {
-            if ( (!(shotst->model_flags & ShMF_Penetrating)) || (!thing_exists(shotng)) ) // Shot may have been destroyed when it hit something
+            if ( (!flag_is_set(shotst->model_flags,ShMF_Penetrating)) || (!thing_exists(shotng)) ) // Shot may have been destroyed when it hit something
             {
                 return TUFRet_Deleted;
             }

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -771,13 +771,16 @@ long shot_hit_door_at(struct Thing *shotng, struct Coord3d *pos)
     {
         return detonate_shot(shotng, true);
     }
-    if (shotng->bounce_angle <= 0)
+    if (!(shotst->model_flags & ShMF_Penetrating))
     {
-        slide_thing_against_wall_at(shotng, pos, blocked_flags);
-    }
-    else
-    {
-        bounce_thing_off_wall_at(shotng, pos, blocked_flags);
+        if (shotng->bounce_angle <= 0)
+        {
+            slide_thing_against_wall_at(shotng, pos, blocked_flags);
+        }
+        else
+        {
+            bounce_thing_off_wall_at(shotng, pos, blocked_flags);
+        }
     }
     return false;
 }


### PR DESCRIPTION
- PENETRATING shot property no longer allows shots to go through walls. This allows for shots that pierce creatures and rebound of walls.
- PIERCE_WALLS property does allow shots to go through walls
- Strength based shots can now be PENETRATING too when hitting doors..