### PR TITLE
Fixed quickly looking left in possession

### DIFF
--- a/src/packets.c
+++ b/src/packets.c
@@ -1182,8 +1182,6 @@ void process_players_creature_control_packet_control(long idx)
         return;
     if ((ccctrl->stateblock_flags != 0) || (cctng->active_state == CrSt_CreatureUnconscious))
         return;
-    if (flag_is_set(pckt->control_flags, PCtr_Gui))
-        return;
     long speed_limit = get_creature_speed(cctng);
     if ((pckt->control_flags & PCtr_MoveUp) != 0)
     {


### PR DESCRIPTION
Fixes #4061

I believe the lines I now removed from #3761 were only added to handle the cheat menu. If this is correct I am perfectly happy to accept some buggy spell charging if you have cheat menus open.