### PR TITLE
Fixed AI moving creatures to rooms they cannot use

### DIFF
--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2720,6 +2720,15 @@ long task_move_creature_to_room(struct Computer2 *comp, struct ComputerTask *cta
             crconf = creature_stats_get_from_thing(thing);
             CreatureJob jobpref;
             jobpref = get_job_for_room(room->kind, JoKF_AssignComputerDrop|JoKF_AssignAreaWithinRoom, crconf->job_primary|crconf->job_secondary);
+            struct CreatureJobConfig* jobcfg = get_config_for_job(jobpref);
+            if (!creature_job_player_check_func_list[jobcfg->func_plyr_check_idx](thing, dungeon->owner, jobpref))
+            {
+                SYNCDBG(13, "Cannot assign %s for %s index %d owner %d; check callback failed", creature_job_code_name(jobpref), thing_model_name(thing), (int)thing->index, (int)thing->owner);
+                if (computer_dump_held_things_on_map(comp, thing, &pos, CrSt_Unused) > 0)
+                {
+                    return CTaskRet_Unk2;
+                }
+            } else 
             if (get_drop_position_for_creature_job_in_room(&pos, room, jobpref, thing))
             {
                 if (computer_dump_held_things_on_map(comp, thing, &pos, CrSt_Unused) > 0) {


### PR DESCRIPTION
Computers with the MvTrain1 check (which include computer player 0 and move only computer assist), would move creatures to a training room even when they could not train anymore. Now they correctly do the 'can this room be used' check.