### PR TITLE
Shots with TrapLightning update logic use MaxRange

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -1292,6 +1292,7 @@ Health = 64
 Damage = 16
 HitType = 4
 Speed = 0
+MaxRange = 3072
 BaseExperienceGain = 256
 DestroyOnHit = 0
 TargetHitstopTurns = 6

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -325,6 +325,7 @@ void god_lightning_choose_next_creature(struct Thing *shotng)
     long best_dist = LONG_MAX;
     struct Thing* best_thing = INVALID_THING;
     const struct StructureList* slist = get_list_for_thing_class(TCls_Creature);
+    struct ShotConfigStats* shotst = get_shot_model_stats(shotng->model);
     unsigned long k = 0;
     int i = slist->index;
     while (i != 0)
@@ -344,11 +345,7 @@ void god_lightning_choose_next_creature(struct Thing *shotng)
             long dist = get_2d_distance(&shotng->mappos, &thing->mappos);
             if (dist < best_dist)
             {
-                const struct PowerConfigStats *powerst = get_power_model_stats(PwrK_LIGHTNING);
-                KeepPwrLevel power_level = shotng->shot.shot_level;
-                if (power_level > POWER_MAX_LEVEL)
-                    power_level = POWER_MAX_LEVEL;
-                if (subtile_coord(powerst->strength[power_level],0) > dist)
+                if (shotst->max_range > dist)
                 {
                     if (line_of_sight_2d(&shotng->mappos, &thing->mappos)) {
                         best_dist = dist;

--- a/src/thing_shots.c
+++ b/src/thing_shots.c
@@ -1832,7 +1832,6 @@ TngUpdateRet update_shot(struct Thing *thing)
         case ShUL_TrapLightning:
             if (((game.play_gameturn - thing->creation_turn) % 16) == 0)
             {
-              thing->shot.shot_level = 5;
               god_lightning_choose_next_creature(thing);
               target = thing_get(thing->shot.target_idx);
               if (thing_exists(target))


### PR DESCRIPTION
instead of the 5th power value of power_lightning times 256.