### PR TITLE
Make room panel tabs interactable when you own it but can't make it.

### DIFF
--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1124,7 +1124,7 @@ void maintain_room(struct GuiButton *gbtn)
         ERRORDBG(8,"Cannot do; player %d has no dungeon",(int)my_player_number);
         return;
     }
-    if (dungeon->room_buildable[rkind] & 1) {
+    if (dungeon->room_kind[rkind] > 0){
         gbtn->btype_value &= LbBFeF_IntValueMask;
         gbtn->flags |= LbBtnF_Enabled;
     } else {
@@ -1147,7 +1147,7 @@ void maintain_big_room(struct GuiButton *gbtn)
     gbtn->content.lval = rkind;
     gbtn->sprite_idx = game.chosen_room_spridx;
     gbtn->tooltip_stridx = game.chosen_room_tooltip;
-    if (dungeon->room_buildable[rkind] & 1) {
+    if (dungeon->room_kind[rkind] > 0) {
         gbtn->btype_value &= LbBFeF_IntValueMask;
         gbtn->flags |= LbBtnF_Enabled;
     } else {
@@ -1584,30 +1584,30 @@ void gui_area_room_button(struct GuiButton *gbtn)
     RoomKind rkind = gbtn->content.lval;
     draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, GPS_rpanel_frame_portrt_empty);
     struct Dungeon* dungeon = get_my_dungeon();
-    if ((dungeon->room_buildable[rkind] & 1) // One can build it now
-         || (dungeon->room_resrchable[rkind] == 1) // One can research it at any time
-         || (dungeon->room_resrchable[rkind] == 2) // One can research it and get instantly then found
-         || ((dungeon->room_resrchable[rkind] == 4) && (dungeon->room_buildable[rkind] & 2)) // Player able to research
-         )
+    if ((gbtn->flags & LbBtnF_Enabled) != 0)
     {
-        if ((gbtn->flags & LbBtnF_Enabled) != 0)
-        {
-            if (dungeon->room_kind[rkind] > 0)
-                draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, GPS_rpanel_frame_portrt_light);
-            int spr_idx = (dungeon->total_money_owned < get_room_kind_stats(rkind)->cost) + gbtn->sprite_idx;
-            if ((gbtn->gbactn_1 == 0) && (gbtn->gbactn_2 == 0)) {
-                draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, spr_idx);
+        if (dungeon->room_kind[rkind] > 0)
+            draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, GPS_rpanel_frame_portrt_light);
+            if (dungeon->room_buildable[rkind] & 1) {// One can build it now
+                int spr_idx = (dungeon->total_money_owned < get_room_kind_stats(rkind)->cost) + gbtn->sprite_idx;
             } else {
-                draw_gui_panel_sprite_rmleft(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, spr_idx, 44);
+                int spr_idx = gbtn->sprite_idx;
             }
-        } else
-        {
-            // Draw a question mark over the button, to indicate it can be researched
-            draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, GPS_rpanel_frame_portrt_qmark);
+        if ((gbtn->gbactn_1 == 0) && (gbtn->gbactn_2 == 0)) {
+            draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, spr_idx);
+        } else {
+            draw_gui_panel_sprite_rmleft(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, spr_idx, 44);
         }
+    } else if (dungeon->room_kind[rkind] <= 0) 
+        && ((dungeon->room_resrchable[rkind] == 1) // One can research it at any time
+        || (dungeon->room_resrchable[rkind] == 2) // One can research it and get instantly when found
+        || ((dungeon->room_resrchable[rkind] == 4) && (dungeon->room_buildable[rkind] & 2))) // Player able to research
+    {
+        // Draw a question mark over the button, to indicate it can be researched
+        draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, GPS_rpanel_frame_portrt_qmark);
     }
-    lbDisplay.DrawFlags = flg_mem;
 }
+lbDisplay.DrawFlags = flg_mem;
 
 void pick_up_next_creature(struct GuiButton *gbtn)
 {


### PR DESCRIPTION
Aim is to change room logic so that:
* if room is owned but cannot make it (yet or at all), the room icon can be interacted with (but you cannot make it, only left-click to see how many you have and capacity, or right click to zoom to one).

This initial step lays some groundwork but needs checking and refining.

To do:
* like with the traps, have this state be enabled but only partially interactable - don't let the player make the room, but let them see info and zoom.
* replace cost with the "cannot make" manufacture symbol.
* Add tooltip relating to this.