### PR TITLE
Fixed room efficiency on low slabs

### DIFF
--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -479,7 +479,7 @@ long calculate_effeciency_score_for_room_slab(SlabCodedCoords slab_num, PlayerNu
             if ((slabmap_owner(round_slb) == slabmap_owner(slb)) && (round_slb->kind == slb->kind))
             {
                 eff_score += 2;
-            } else if((slabmap_owner(round_slb) == slabmap_owner(slb)) || ((synergy_slab_num >= 0) && !(get_slab_kind_stats(synergy_slab_num)->is_ownable) && (round_slb->kind == synergy_slab_num)))
+            } else if (((slabmap_owner(round_slb) == slabmap_owner(slb)) || !(get_slab_kind_stats(synergy_slab_num)->is_ownable)) && ((round_slb->kind == synergy_slab_num) && (synergy_slab_num >= 0)))
             {
                 eff_score += 2;
             } else


### PR DESCRIPTION
Fixed bug introduced here:
https://github.com/dkfans/keeperfx/pull/3979/files

Where rooms like this are 100% efficient:
![image](https://github.com/user-attachments/assets/1ee04679-3612-4230-97f5-fbd50e992777)
