### PR TITLE
Research script command adds it to the back

### DIFF
--- a/src/room_library.c
+++ b/src/room_library.c
@@ -283,8 +283,8 @@ TbBool update_players_research_amount(PlayerNumber plyr_idx, long rtyp, long rki
 
 TbBool update_or_add_players_research_amount(PlayerNumber plyr_idx, long rtyp, long rkind, long amount)
 {
-  if (!update_players_research_amount(plyr_idx, rtyp, rkind, amount))
-    return false;
+  if (update_players_research_amount(plyr_idx, rtyp, rkind, amount))
+    return true;
   return add_research_to_player(plyr_idx, rtyp, rkind, amount);
 }
 

--- a/src/room_library.c
+++ b/src/room_library.c
@@ -273,8 +273,8 @@ TbBool update_players_research_amount(PlayerNumber plyr_idx, long rtyp, long rki
         if ((resrch->rtyp == rtyp) && (resrch->rkind == rkind))
         {
             resrch->req_amount = amount;
+            n++;
         }
-        n++;
     }
     if (n > 0)
         return true;

--- a/src/room_library.c
+++ b/src/room_library.c
@@ -283,8 +283,8 @@ TbBool update_players_research_amount(PlayerNumber plyr_idx, long rtyp, long rki
 
 TbBool update_or_add_players_research_amount(PlayerNumber plyr_idx, long rtyp, long rkind, long amount)
 {
-  if (update_players_research_amount(plyr_idx, rtyp, rkind, amount))
-    return true;
+  if (!update_players_research_amount(plyr_idx, rtyp, rkind, amount))
+    return false;
   return add_research_to_player(plyr_idx, rtyp, rkind, amount);
 }
 


### PR DESCRIPTION
From the RESEARCH script command documentation:

```
Changes amount of research points needed to discover an item in library. It doesn't affect research order, only amount of points. If the item never was in research list, it's added at end.
```

It was not added to the end. Tested on latest alpha and version 0.4.8.
With this PR it does.