### PR TITLE
Summon creature keeper powers can summon temporary units

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -2146,6 +2146,8 @@ SoundPlayed = 0
 Cooldown = 35
 Power =  0   0   1   1    2    2    3    3    4    9
 Cost = 700 700 950 950 1150 1150 2100 2100 3000
+; Giving powers with CreatureType a duration, makes the creatures temporary
+Duration = 0
 ; Becomes more expensive after every 7 units.
 CostFormula = DWARF
 Castability = OWNED_GROUND NEEDS_DELAY

--- a/src/magic_powers.c
+++ b/src/magic_powers.c
@@ -1201,6 +1201,8 @@ static TbResult magic_use_power_imp(PowerKind power_kind, PlayerNumber plyr_idx,
 {
     struct Thing *heartng;
     struct Coord3d pos;
+    struct Dungeon *dungeon;
+    struct CreatureControl* cctrl;
     struct PowerConfigStats *powerst = get_power_model_stats(power_kind);
     if (!i_can_allocate_free_control_structure()
      || !i_can_allocate_free_thing_structure(FTAF_FreeEffectIfNoSlots)) {
@@ -1227,6 +1229,19 @@ static TbResult magic_use_power_imp(PowerKind power_kind, PlayerNumber plyr_idx,
     {
         ERRORLOG("There was place to create new creature, but creation failed");
         return Lb_OK;
+    }
+    // Temporary unit
+    if (powerst->duration > 0)
+    {
+        cctrl = creature_control_get_from_thing(thing);
+        dungeon = get_dungeon(thing->owner);
+        add_creature_to_summon_list(dungeon, thing->index);
+        //Just set it to self-summoned
+        cctrl->summoner_idx = thing->index;
+        cctrl->summon_spl_idx = 0;
+        remove_first_creature(thing); //temporary units are not real creatures
+        cctrl->unsummon_turn = game.play_gameturn + powerst->duration;
+        set_flag(cctrl->flgfield_2, TF2_SummonedCreature);
     }
     if (powerst->strength[power_level] != 0)
     {
@@ -1272,7 +1287,8 @@ static TbResult magic_use_power_tunneller(PowerKind power_kind, PlayerNumber ply
     create_effect(&thing->mappos, TngEff_CeilingBreach, thing->owner); //do breach before fail, for better player feedback
     if (thing_is_invalid(thing))
     {
-        return Lb_FAIL;
+        ERRORLOG("There was place to create new creature, but creation failed");
+        return Lb_OK;
     }
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     if (powerst->duration > 0)


### PR DESCRIPTION
Powers with UseFunction as `magic_use_power_tunneller` or `magic_use_power_imp` can accept the 'duration' field to create temporary creatures.