### PR TITLE
Computer saves creatures based on heal requirement

### DIFF
--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -1070,7 +1070,7 @@ long count_creatures_for_defend_pickup(struct Computer2 *comp)
                     struct CreatureModelConfig* crconf = creature_stats_get_from_thing(i);
                     if (crconf->health > 0)
                     {
-                        if (100 * i->health / (game.conf.crtr_conf.exp.health_increase_on_exp * crconf->health * cctrl->exp_level / 100 + crconf->health) > 20)
+                        if (100 * i->health / (game.conf.crtr_conf.exp.health_increase_on_exp * crconf->health * cctrl->exp_level / 100 + crconf->health) > crconf->heal_requirement) //before it was 20%
                         {
                             ++count;
                         }


### PR DESCRIPTION
Like was always documented in imp.cfg:
```ini
; When a creature health falls below requirement, the creature refuse work and go to sleep.
; In battle, it will priorize using the Heal spell when available.
; Also a computer player will pick the creature and place it in lair.
; This works for autonomous computer players and for assistance players.
; The value is scaled 0..255, where 0 means never heal and 255 means heal even if small fraction of health was lost.
; Should be larger than CriticalHealthPercentage in rules.cfg.
HealRequirement = 20
```

What it actually do was just look below 20% health. (yes, %, not per 255).