### PR TITLE
Prisoners do not stay grouped with free creatures

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2225,6 +2225,11 @@ short creature_follow_leader(struct Thing *creatng)
         set_start_state(creatng);
         return 1;
     }
+    if (player_keeping_creature_in_custody(creatng) != player_keeping_creature_in_custody(leadtng))
+    {
+        remove_creature_from_group(creatng);
+        return 0;
+    }
     struct Coord3d follwr_pos;
     if (!get_free_position_behind_leader(leadtng, &follwr_pos))
     {


### PR DESCRIPTION
Fixes an issue where angry high level warlocks can persuade a prisoner to leave both prison and the dungeon.