### PR TITLE
Fixes to summoned Familiar behavior

### DIFF
--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -679,6 +679,10 @@ long process_obey_leader(struct Thing *thing)
         set_start_state(thing);
         return 1;
     }
+    if (creature_is_being_dropped(thing))
+    {
+        return 1;
+    }
     if ((leadtng->alloc_flags & TAlF_IsControlled) != 0)
     {
         // If leader is controlled, always force followers to stay

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2228,10 +2228,18 @@ short creature_follow_leader(struct Thing *creatng)
     struct Coord3d follwr_pos;
     if (!get_free_position_behind_leader(leadtng, &follwr_pos))
     {
-        SYNCLOG("The %s index %d owned by player %d can no longer follow %s - no place amongst followers",
-            thing_model_name(creatng),(int)creatng->index,(int)creatng->owner,thing_model_name(leadtng));
-        set_start_state(creatng);
-        return 1;
+        if (thing_is_picked_up(leadtng))
+        {
+            SYNCDBG(3,"The %s index %d owned by player %d can no longer follow %s - leader is picked up",
+                thing_model_name(creatng), (int)creatng->index, (int)creatng->owner, thing_model_name(leadtng));
+        }
+        else
+        {
+            SYNCLOG("The %s index %d owned by player %d can no longer follow %s - no place amongst followers",
+                thing_model_name(creatng), (int)creatng->index, (int)creatng->owner, thing_model_name(leadtng));
+            set_start_state(creatng);
+            return 1;
+        }
     }
     int fails_amount = cctrl->follow_leader_fails;
     if (fails_amount > 12) //When set too low, group might disband before a white wall is breached

--- a/src/magic_powers.c
+++ b/src/magic_powers.c
@@ -1104,6 +1104,16 @@ static TbResult magic_use_power_hold_audience(PowerKind power_kind, PlayerNumber
             reset_interpolation_of_thing(thing);
             initialise_thing_state(thing, CrSt_CreatureInHoldAudience);
             cctrl->turns_at_job = -1;
+
+            struct Thing* famlrtng; //familiars are not in the dungeon creature list
+            for (short j = 0; j < FAMILIAR_MAX; j++)
+            {
+                if (cctrl->familiar_idx[j])
+                {
+                    famlrtng = thing_get(cctrl->familiar_idx[j]);
+                    teleport_familiar_to_summoner(famlrtng, thing);
+                }
+            }
         }
         // Thing list loop body ends
         k++;

--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -635,7 +635,6 @@ long computer_event_handle_prisoner(struct Computer2* comp, struct ComputerEvent
     struct Thing* creatng = thing_get(event->target);
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     struct CreatureModelConfig* crconf = creature_stats_get_from_thing(creatng);
-    //struct Room* origroom = get_room_thing_is_on(creatng);
     struct Room* destroom;
 
     int actions_allowed = cevent->param1;
@@ -647,7 +646,7 @@ long computer_event_handle_prisoner(struct Computer2* comp, struct ComputerEvent
         return CTaskRet_Unk1;
     }
 
-    if (dungeon_has_room_of_role(dungeon, RoRoF_Torture) && (!creature_is_being_tortured(creatng)))//avoid repeated action on same unit)
+    if (dungeon_has_room_of_role(dungeon, RoRoF_Torture) && (!creature_is_being_tortured(creatng))) // avoid repeated action on same unit
     {
         if (!creature_would_benefit_from_healing(creatng))
         {

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2791,12 +2791,12 @@ long task_move_creature_to_pos(struct Computer2 *comp, struct ComputerTask *ctas
         {
             if (thing_is_creature(thing))
             {
-                if (computer_dump_held_things_on_map(comp, thing, &ctask->move_to_pos.pos_86, ctask->move_to_pos.target_state)) {
+                if (computer_dump_held_things_on_map(comp, thing, &ctask->move_to_pos.target_pos, ctask->move_to_pos.target_state)) {
                     remove_task(comp, ctask);
                     return CTaskRet_Unk2;
                 }
                 ERRORLOG("Could not dump player %d %s into (%d,%d)",(int)dungeon->owner,
-                    thing_model_name(thing),(int)ctask->move_to_pos.pos_86.x.stl.num,(int)ctask->move_to_pos.pos_86.y.stl.num);
+                    thing_model_name(thing),(int)ctask->move_to_pos.target_pos.x.stl.num,(int)ctask->move_to_pos.target_pos.y.stl.num);
             } else
             {
                 WARNLOG("Player %d computer hand holds %s instead of creature",(int)dungeon->owner, thing_model_name(thing));
@@ -2809,11 +2809,12 @@ long task_move_creature_to_pos(struct Computer2 *comp, struct ComputerTask *ctas
         return CTaskRet_Unk0;
     }
     thing = thing_get(ctask->move_to_pos.target_thing_idx);
+    //not task in progress
     if (can_thing_be_picked_up_by_player(thing, dungeon->owner))
     {
-        if (computer_place_thing_in_power_hand(comp, thing, &ctask->move_to_pos.pos_86)) {
+        if (computer_place_thing_in_power_hand(comp, thing, &ctask->move_to_pos.target_pos)) {
             SYNCDBG(9,"Player %d picked %s index %d to move to (%d,%d)",(int)comp->dungeon->owner,thing_model_name(thing),(int)thing->index,
-                (int)ctask->move_to_pos.pos_86.x.stl.num, (int)ctask->move_to_pos.pos_86.y.stl.num);
+                (int)ctask->move_to_pos.target_pos.x.stl.num, (int)ctask->move_to_pos.target_pos.y.stl.num);
             return CTaskRet_Unk2;
         }
     }
@@ -3557,9 +3558,9 @@ TbBool create_task_move_creature_to_pos(struct Computer2 *comp, const struct Thi
         }
     }
     ctask->ttype = CTT_MoveCreatureToPos;
-    ctask->move_to_pos.pos_86.x.val = pos.x.val;
-    ctask->move_to_pos.pos_86.y.val = pos.y.val;
-    ctask->move_to_pos.pos_86.z.val = pos.z.val;
+    ctask->move_to_pos.target_pos.x.val = pos.x.val;
+    ctask->move_to_pos.target_pos.y.val = pos.y.val;
+    ctask->move_to_pos.target_pos.z.val = pos.z.val;
     ctask->move_to_pos.target_thing_idx = thing->index;
     ctask->move_to_pos.target_state = dst_state;
     ctask->created_turn = game.play_gameturn;

--- a/src/player_computer.h
+++ b/src/player_computer.h
@@ -354,20 +354,18 @@ struct ComputerTask {
         RoomIndex room_idx1;
         long repeat_num;
         RoomIndex room_idx2;
-        struct Coord3d pos_86;
     } move_to_room;
     struct {
         long evflags;
         struct Coord3d target_pos;
         long repeat_num;
         CrtrStateId target_state;
-        struct Coord3d pos_86;
     } move_to_defend;
     struct {
         short target_thing_idx;
+        struct Coord3d target_pos;
         long repeat_num;
         CrtrStateId target_state;
-        struct Coord3d pos_86;
     } move_to_pos;
     struct {
         struct Coord3d target_pos;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2019,6 +2019,21 @@ void creature_cast_spell_at_thing(struct Thing *castng, struct Thing *targetng, 
     thing_fire_shot(castng, targetng, spconf->shot_model, shot_level, hit_type);
 }
 
+void teleport_familiar_to_summoner(struct Thing *famlrtng, struct Thing* creatng)
+{
+    create_effect(&famlrtng->mappos, imp_spangle_effects[get_player_color_idx(famlrtng->owner)], famlrtng->owner);
+    move_thing_in_map(famlrtng, &creatng->mappos);
+    cleanup_current_thing_state(famlrtng);
+    reset_interpolation_of_thing(famlrtng);
+
+    famlrtng->veloc_push_add.x.val += CREATURE_RANDOM(thing, 161) - 80;
+    famlrtng->veloc_push_add.y.val += CREATURE_RANDOM(thing, 161) - 80;
+    famlrtng->veloc_push_add.z.val += 0;
+    set_flag(famlrtng->state_flags, TF1_PushAdd);
+    set_flag(famlrtng->movement_flags, TMvF_MagicFall);
+    famlrtng->move_angle_xy = 0;
+}
+
 /**
  * Spell creates creatures to help the caster. When the creatures have a limited duration they will group up with caster.
  * @param model The creature kind to be creates.
@@ -2110,17 +2125,7 @@ void thing_summon_temporary_creature(struct Thing* creatng, ThingModel model, ch
                         level_up_familiar(famlrtng);
                         if ((famcctrl->follow_leader_fails > 0) || (get_chessboard_distance(&creatng->mappos, &famlrtng->mappos) > subtile_coord(12, 0))) //if it's not getting to the summoner, teleport it there
                         {
-                            create_effect(&famlrtng->mappos, imp_spangle_effects[get_player_color_idx(famlrtng->owner)], famlrtng->owner);
-                            move_thing_in_map(famlrtng, &creatng->mappos);
-                            cleanup_current_thing_state(famlrtng);
-                            reset_interpolation_of_thing(famlrtng);
-
-                            famlrtng->veloc_push_add.x.val += CREATURE_RANDOM(thing, 161) - 80;
-                            famlrtng->veloc_push_add.y.val += CREATURE_RANDOM(thing, 161) - 80;
-                            famlrtng->veloc_push_add.z.val += 0;
-                            set_flag(famlrtng->state_flags, TF1_PushAdd);
-                            set_flag(famlrtng->movement_flags, TMvF_MagicFall);
-                            famlrtng->move_angle_xy = 0;
+                            teleport_familiar_to_summoner(famlrtng, creatng);
                         }
                     }
                     else

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6528,8 +6528,14 @@ TngUpdateRet update_creature(struct Thing *thing)
         {
             if (cctrl->summoner_idx > 0)
             {
-                struct Thing* summoner = thing_get(cctrl->summoner_idx);
-                add_creature_to_group(thing, summoner);
+                if (!creature_is_kept_in_custody(thing))
+                {
+                    struct Thing* summoner = thing_get(cctrl->summoner_idx);
+                    if (!creature_is_kept_in_custody(summoner))
+                    {
+                        add_creature_to_group(thing, summoner);
+                    }
+                }
             }
         }
     }

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -120,6 +120,7 @@ void creature_cast_spell(struct Thing *caster, SpellKind spl_idx, CrtrExpLevel s
 
 void thing_summon_temporary_creature(struct Thing* creatng, ThingModel model, char level, char count, GameTurn duration, long spl_idx);
 void level_up_familiar(struct Thing* famlrtng);
+void teleport_familiar_to_summoner(struct Thing* famlrtng, struct Thing* creatng);
 void add_creature_to_summon_list(struct Dungeon* dungeon, ThingIndex famlrtng);
 void remove_creature_from_summon_list(struct Dungeon* dungeon, ThingIndex famlrtng);
 


### PR DESCRIPTION
- Familiars get teleported on Hold Audience
- Familiars that get dropped wait until they stop falling before they consider going back to the summoner
- Captivity will prevent reunification
- Holding a familiar in hand will not break the group and will not spam log