### PR TITLE
Add invalid creature check in group leader selection

### DIFF
--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -363,6 +363,12 @@ static short creatures_group_has_special_digger_to_lead(struct Thing* grptng)
     while (i > 0)
     {
         ctng = thing_get(i);
+        if (thing_is_invalid(ctng))
+        {
+            ERRORLOG("Invalid creature in group %s index %d", thing_model_name(grptng), (int)grptng->index);
+            return 0;
+        }
+
         cctrl = creature_control_get_from_thing(ctng);
         potential_leader = creature_could_be_lead_digger(ctng, cctrl);
         if (potential_leader == 2)


### PR DESCRIPTION
Introduces a validity check for creatures in the group leader selection loop. Logs an error and returns early if an invalid creature is encountered, improving robustness and error reporting.

based on https://keeperfx.net/dev/crash-report/93
currently it kept spamming `Error: creatures_group_has_special_digger_to_lead: Request of invalid thing (no 11077) intercepted` until CREATURES_COUNT was reached