### PR TITLE
Fixes for Maiden and Spiderling

### DIFF
--- a/config/creatrs/bird.cfg
+++ b/config/creatrs/bird.cfg
@@ -71,7 +71,7 @@ EyeEffect = NULL
 MaxAngleChange = 15
 
 [appearance]
-WalkingAnimSpeed = 100
+WalkingAnimSpeed = 30
 FootstepPitch = 400
 VisualRange = 18
 PossessSwipeIndex = 6

--- a/config/creatrs/maiden.cfg
+++ b/config/creatrs/maiden.cfg
@@ -66,13 +66,13 @@ AngerJobs = KILL_DIGGERS LEAVE_DUNGEON
 
 [senses]
 Hearing = 8
-EyeHeight = 500
+EyeHeight = 430
 FieldOfView = 1024
 EyeEffect = NULL
-MaxAngleChange = 8
+MaxAngleChange = 15
 
 [appearance]
-WalkingAnimSpeed = 120
+WalkingAnimSpeed = 75
 FootstepPitch = 300
 VisualRange = 18
 PossessSwipeIndex = 6

--- a/config/creatrs/maiden.cfg
+++ b/config/creatrs/maiden.cfg
@@ -66,7 +66,7 @@ AngerJobs = KILL_DIGGERS LEAVE_DUNGEON
 
 [senses]
 Hearing = 8
-EyeHeight = 430
+EyeHeight = 410
 FieldOfView = 1024
 EyeEffect = NULL
 MaxAngleChange = 15

--- a/config/creatrs/spiderling.cfg
+++ b/config/creatrs/spiderling.cfg
@@ -71,12 +71,12 @@ EyeEffect = MIST_BLOB
 MaxAngleChange = 18
 
 [appearance]
-WalkingAnimSpeed = 100
+WalkingAnimSpeed = 80
 FootstepPitch = 80
 VisualRange = 16
-PossessSwipeIndex = 1
+PossessSwipeIndex = 6
 NaturalDeathKind = NORMAL
-ShotOrigin = 0 0 200
+ShotOrigin = 0 0 90
 CorpseVanishEffect = 0
 PickUpOffset = 0 5
 StatusOffset = 0 -60


### PR DESCRIPTION
Fixed animation speed and rotation speed for the maiden because she only could turn as slow as a biledemon, i set a value that i think is the best

Fixed anim speed of spiderling and removed the Weapon Swipe to the Claw Sprite and i set the Shot offset to the right height