### PR TITLE
Party members rejoin slow party leader faster

### DIFF
--- a/config/fxdata/magic.cfg
+++ b/config/fxdata/magic.cfg
@@ -341,7 +341,7 @@ SymbolSprites = 382 440
 Name = SPELL_SUMMON_FAMILIAR
 CastAtThing = 0
 ShotModel = NOSHOT
-SummonCreature = BIRD -3 1
+SummonCreature = BIRD 0 1
 ; Set duration to 0 to make a regular creature.
 Duration = 2000
 SelfCasted = 1 1035 1

--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -515,7 +515,7 @@ void update_creature_graphic_anim(struct Thing *thing)
                 thing->anim_speed = i;
             }
         }
-    } else
+    } else // chickened
     {
         thing->rendering_flags &= ~(TRF_Transpar_Flags);
         if (cctrl->distance_to_destination == 0)

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2264,10 +2264,11 @@ short creature_follow_leader(struct Thing *creatng)
     MapCoordDelta distance_to_follower_pos = get_chessboard_distance(&creatng->mappos, &follwr_pos);
     TbBool cannot_reach_leader = creature_cannot_move_directly_to(creatng, &leadtng->mappos);
     int speed = get_creature_speed(leadtng);
+    int follower_speed = get_creature_speed(creatng);
     // If we're too far from the designated position, do a speed run
     if (distance_to_follower_pos > subtile_coord(12,0))
     {
-        speed = 2 * speed;
+        speed = max((2 * speed),(5 * follower_speed / 4));
         if (speed >= MAX_VELOCITY)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)
@@ -2287,6 +2288,7 @@ short creature_follow_leader(struct Thing *creatng)
         } else {
             speed = speed + 1;
         }
+        speed = max(follower_speed, speed);
         if (speed >= MAX_VELOCITY)
             speed = MAX_VELOCITY;
         if (creature_move_to(creatng, &follwr_pos, speed, 0, 0) == -1)


### PR DESCRIPTION
When a party leader is far away, the party members may travel 200% the speed of the leader to catch up. When they are quite far, they may move at 125% speed.

Now, when the natural speed of the follower is faster than that catch-up speed, the follower may move 125% (far) or 100% of his own speed instead.

So, a Samurai following a Giant, will now catch up faster, and would no longer be limited to being twice as fast as the giant.

Also very useful for slow druids with fast bird familiars.