### PR TITLE
hold down Shift key corresponding to highest spell level.

### DIFF
--- a/config/fxdata/rules.cfg
+++ b/config/fxdata/rules.cfg
@@ -116,6 +116,9 @@ FriendlyFightAreaDamagePercent = 33
 ; Maximum weight that can be pushed around by wind and shots. 0 no maximum.
 ; Set it to 600 and a creature with 300 weight will only get blown half as far as normal.
 WeightCalculatePush = 0
+; hold down Shift key corresponding to highest spell level
+; 0: disabled, 1: enabled
+MaxLevelByHoldShiftKey = 0
 
 [rooms]
 ScavengeCostFrequency = 64

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -153,6 +153,7 @@ static const struct NamedField rules_magic_named_fields[] = {
   {"FRIENDLYFIGHTAREARANGEPERCENT",  0, field(game.conf.rules.magic.friendly_fight_area_range_percent ),   0, LONG_MIN, LONG_MAX,NULL,value_default, assign_default},
   {"FRIENDLYFIGHTAREADAMAGEPERCENT", 0, field(game.conf.rules.magic.friendly_fight_area_damage_percent),   0, LONG_MIN, LONG_MAX,NULL,value_default, assign_default},
   {"WEIGHTCALCULATEPUSH",            0, field(game.conf.rules.magic.weight_calculate_push             ),   0,        0, SHRT_MAX,NULL,value_default, assign_default},
+  {"MAXLEVELBYHOLDSHIFTKEY",         0, field(game.conf.rules.magic.max_level_by_hold_shift_key       ),   0,        0,        1,NULL,value_default, assign_default},
   {NULL},
 };
 

--- a/src/config_rules.h
+++ b/src/config_rules.h
@@ -137,6 +137,7 @@ struct MagicRulesConfig {
     long friendly_fight_area_range_percent;
     TbBool armageddon_teleport_neutrals;
     short weight_calculate_push;
+    TbBool max_level_by_hold_shift_key;
 };
 
 struct RoomRulesConfig {

--- a/src/magic_powers.c
+++ b/src/magic_powers.c
@@ -2223,6 +2223,9 @@ int get_power_overcharge_level(struct PlayerInfo *player)
     return i;
 }
 
+/**
+ * @return Is it necessary to continue trying the operation of increasing spell level
+ */
 TbBool update_power_overcharge(struct PlayerInfo *player, int pwkind)
 {
   struct Dungeon *dungeon;
@@ -2238,7 +2241,14 @@ TbBool update_power_overcharge(struct PlayerInfo *player, int pwkind)
   if (powerst->cost[i] <= dungeon->total_money_owned)
   {
     // If we have more money, increase overcharge
-    player->cast_expand_level++;
+    if (((player->cast_expand_level+1) >> 2) <= POWER_MAX_LEVEL)
+    {
+      player->cast_expand_level++;
+    }
+    if (((player->cast_expand_level+1) >> 2) <= POWER_MAX_LEVEL)
+    {
+      return true;
+    }
   } else
   {
     // If we don't have money, decrease the charge
@@ -2252,7 +2262,7 @@ TbBool update_power_overcharge(struct PlayerInfo *player, int pwkind)
     else
       player->cast_expand_level = 0;
   }
-  return (i < POWER_MAX_LEVEL);
+  return false;
 }
 
 /**

--- a/src/packets.c
+++ b/src/packets.c
@@ -163,6 +163,26 @@ TbBool process_dungeon_control_packet_spell_overcharge(long plyr_idx)
     struct Dungeon* dungeon = get_players_dungeon(player);
     SYNCDBG(6,"Starting for player %d state %s",(int)plyr_idx,player_state_code_name(player->work_state));
     struct Packet* pckt = get_packet_direct(player->packet_num);
+
+    while (game.conf.rules.magic.max_level_by_hold_shift_key && key_modifiers == KMod_SHIFT)
+    {
+        struct PowerConfigStats *powerst = get_power_model_stats(player->chosen_power_kind);
+
+        if (powerst->overcharge_check_idx == OcC_CallToArms_expand
+        || powerst->overcharge_check_idx == OcC_SightOfEvil_expand
+        || powerst->overcharge_check_idx == OcC_General_expand)
+        {
+            if (player_uses_power_call_to_arms(plyr_idx))
+                break;
+
+            while(update_power_overcharge(player, player->chosen_power_kind))
+            {}
+
+            return true;
+        }
+        break;
+    }
+
     if (flag_is_set(pckt->control_flags,PCtr_LBtnHeld))
     {
         struct PowerConfigStats *powerst = get_power_model_stats(player->chosen_power_kind);


### PR DESCRIPTION
add new option rule[rules.cfg/magic/MaxLevelByHoldShiftKey].

Default disabled.
If enabled and hold down Shift key, set the spell level to the highest.