### PR TITLE
Fixed tile being tagged when right-clicking to cancel drag-tagging

### DIFF
--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -344,7 +344,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         {
             player->cursor_clicked_subtile_x = stl_x;
             player->cursor_clicked_subtile_y = stl_y;
-            player->cursor_button_down = 1;
+            player->cursor_button_down = (!player->render_roomspace.drag_mode);
             unset_packet_control(pckt, PCtr_RBtnClick);
         }
     }


### PR DESCRIPTION
Fixes #4164