### PR TITLE
Removed unused rules

### DIFF
--- a/config/fxdata/rules.cfg
+++ b/config/fxdata/rules.cfg
@@ -170,14 +170,9 @@ GraveyardConvertTime = 300
 ; Amount of hit points a single slab of a room has; used to compute complete amount of hit points of a room,
 ; which have to be depleted for the room to be taken over by enemy diggers.
 HitsPerSlab = 2
-ImpJobNotSoClose = 4
-ImpJobFarAway = 10
-ImpGenerateTime = 50
-ImproveArea = 31
 ; Damage did by Imp while digging - to its own slabs, and other slabs.
 DefaultImpDigDamage = 1
 DefaultImpDigOwnDamage = 2
-PerImpGoldDigSize = 30
 ; Experience imps gain from working. In xp per completed job. Try 100 for a slow but noticeable gain.
 ImpWorkExperience = 0
 ; Imps should drag own units who are knocked out back to their lair to heal
@@ -189,8 +184,6 @@ DragUnconsciousToLair = 0
 HungerHealthLoss = 50
 GameTurnsPerHungerHealthLoss = 400
 FoodHealthGain = 50
-PrisonHealthGain = 50
-GameTurnsPerPrisonHealthGain = 400
 TortureHealthLoss = 50
 GameTurnsPerTortureHealthLoss = 400
 


### PR DESCRIPTION
These variables have no code associated with them:
```
ImpJobNotSoClose
ImpJobFarAway
ImpGenerateTime
ImproveArea
PerImpGoldDigSize
PrisonHealthGain
GameTurnsPerPrisonHealthGain
```
Maybe they were on a very old "to-do list"? I recommend removing them so there's less confusion.