### PR TITLE
Removed TUTORIAL_FLASH_BUTTON duration check

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -6119,12 +6119,6 @@ static void tutorial_flash_button_check(const struct ScriptLine* scline)
         DEALLOCATE_SCRIPT_VALUE
         return;
     }
-    if (scline->np[1] < 0)
-    {
-        SCRPTERRLOG("Duration must be positive number");
-        DEALLOCATE_SCRIPT_VALUE
-        return;
-    }
     value->shorts[1] = saturate_set_signed(id, 16);
     value->longs[1] = scline->np[1];
     PROCESS_SCRIPT_VALUE(scline->command);


### PR DESCRIPTION
This broke the original campaign tutorial flashing buttons.