### PR TITLE
Optimize for cheat menu

### DIFF
--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -2137,6 +2137,50 @@ TbBool cmd_luatypedump(PlayerNumber plyr_idx, char * args)
     return true;
 }
 
+TbBool cmd_cheat_menu(PlayerNumber plyr_idx, char * args)
+{
+    if ((game.flags_font & FFlg_AlexCheat) == 0) {
+        targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require 'cheat mode'");
+        return false;
+    }
+    char * pr2str = strsep(&args, " ");
+    if (pr2str == NULL) {
+        targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require parameter 1 as menu type");
+        return false;
+    }
+
+    int menu_type = -1;
+    if (strcmp(pr2str, "0") == 0 || strcasecmp(pr2str, "none") == 0)
+        menu_type = 0;
+    else if (strcmp(pr2str, "1") == 0 || strcasecmp(pr2str, "main") == 0)
+        menu_type = 1;
+    else if (strcmp(pr2str, "2") == 0 || strcasecmp(pr2str, "creature") == 0)
+        menu_type = 2;
+    else if (strcmp(pr2str, "3") == 0 || strcasecmp(pr2str, "instance") == 0)
+        menu_type = 3;
+
+    if (menu_type < 0) {
+        targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "menu type is invalid. possible values: 0/1/2/3, none/main/creature/instance");
+        return false;
+    }
+
+    if (menu_type != 1)
+        close_main_cheat_menu();
+    if (menu_type != 2)
+        close_creature_cheat_menu();
+    if (menu_type != 3)
+        close_instance_cheat_menu();
+
+    if (menu_type == 1)
+        toggle_main_cheat_menu();
+    if (menu_type == 2)
+        toggle_creature_cheat_menu();
+    if (menu_type == 3)
+        toggle_instance_cheat_menu();
+
+    return true;
+}
+
 
 struct ConsoleCommand {
     const char * name;
@@ -2245,6 +2289,7 @@ static const struct ConsoleCommand console_commands[] = {
     { "quick.show", cmd_quick_show},
     { "lua", cmd_lua},
     { "luatypedump", cmd_luatypedump},
+    { "cheat.menu", cmd_cheat_menu},
 };
 static const int console_command_count = sizeof(console_commands) / sizeof(*console_commands);
 

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -840,6 +840,11 @@ TbBool draw_spell_cursor(ThingIndex tng_idx, MapSubtlCoord stl_x, MapSubtlCoord 
             i = get_power_overcharge_level(player);
             set_pointer_graphic(MousePG_SpellCharge0+i);
             draw_spell_cost = compute_power_price(player->id_number, pwkind, i);
+
+            // cheat mode. Everything is free. show charging level instead of none when cost is zero.
+            if (draw_spell_cost == 0)
+                draw_spell_cost = -(i+1);
+
             return true;
         }
     }
@@ -1102,7 +1107,10 @@ void redraw_display(void)
         lbDisplay.DrawFlags = 0;
         LbTextSetFont(winfont);
         char text[16];
-        snprintf(text, sizeof(text), "%ld", draw_spell_cost);
+        if (draw_spell_cost > 0)
+            snprintf(text, sizeof(text), "%ld", draw_spell_cost);
+	else
+            snprintf(text, sizeof(text), "lv%ld", (-draw_spell_cost));
         long pos_y = GetMouseY() - (LbTextStringHeight(text) * units_per_pixel / 16) / 2 - 2 * units_per_pixel / 16;
         long pos_x = GetMouseX() - (LbTextStringWidth(text) * units_per_pixel / 16) / 2;
         LbTextDrawResized(pos_x, pos_y, tx_units_per_px, text);

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -95,6 +95,10 @@ TbBool first_person_see_item_desc = false;
 long old_mx;
 long old_my;
 
+//arbitrary state machine, not deserving own enum
+int synthetic_left = 0;
+int synthetic_right = 0;
+
 /******************************************************************************/
 void get_dungeon_control_nonaction_inputs(void);
 void get_creature_control_nonaction_inputs(void);
@@ -1849,8 +1853,6 @@ short get_creature_control_action_inputs(void)
 
 void get_packet_control_mouse_clicks(void)
 {
-    static int synthetic_left = 0; //arbitrary state machine, not deserving own enum
-    static int synthetic_right = 0;
     SYNCDBG(8,"Starting");
 
     if (flag_is_set(game.operation_flags, GOF_Paused))

--- a/src/front_input.h
+++ b/src/front_input.h
@@ -104,6 +104,8 @@ struct GuiButton;
 /******************************************************************************/
 extern long old_mx;
 extern long old_my;
+extern int synthetic_left;
+extern int synthetic_right;
 /******************************************************************************/
 void input(void);
 short get_inputs(void);

--- a/src/gui_boxmenu.c
+++ b/src/gui_boxmenu.c
@@ -27,6 +27,7 @@
 #include "bflib_video.h"
 #include "bflib_vidraw.h"
 #include "frontend.h"
+#include "front_input.h"
 #include "creature_instances.h"
 #include "player_data.h"
 #include "player_instances.h"
@@ -776,14 +777,16 @@ TbBool gui_process_option_inputs(struct GuiBox *gbox, struct GuiBoxOption *goptn
 {
   if (left_button_released || right_button_released)
   {
-      short button_num;
-      if (left_button_released)
-      {
-          left_button_released = 0;
-          button_num = 1;
+    short button_num;
+    if (left_button_released)
+    {
+      left_button_released = 0;
+      synthetic_left = 0;
+      button_num = 1;
     } else
     {
       right_button_released = 0;
+      synthetic_right = 0;
       button_num = 2;
     }
     if (goptn->numfield_4 == 1)
@@ -824,6 +827,7 @@ short gui_process_inputs(void)
       {
         dragging_box.gbox = NULL;
         left_button_released = 0;
+        synthetic_left = 0;
       }
       result = true;
     } else

--- a/src/packets.c
+++ b/src/packets.c
@@ -1483,21 +1483,8 @@ void process_players_creature_control_packet_action(long plyr_idx)
       if (creature_control_invalid(cctrl))
         break;
       i = pckt->actn_par1;
-      inst_inf = creature_instance_info_get(i);
-      // Fix the issue of FPInstantCast=1 instance not working in the instance cheat menu.
-      // Cheat mode no need check any, just do it.
-      if (1 || !inst_inf->instant)
-      {
-        cctrl->active_instance_id = i;
-      } else
-      if (cctrl->instance_id == CrInst_NULL)
-      {
-          i = pckt->actn_par1;
-          process_player_use_instance(thing, i, pckt);
-          if (plyr_idx == my_player_number) {
-              instant_instance_selected(i);
-          }
-      }
+      // Cheat mode no need check any, just do/select it.
+      cctrl->active_instance_id = i;
       break;
       case PckA_DirectCtrlDragDrop:
       {

--- a/src/packets.c
+++ b/src/packets.c
@@ -1352,6 +1352,7 @@ void process_players_creature_control_packet_control(long idx)
             }
             else
             {
+                // cheat mode
                 inst_inf = creature_instance_info_get(i);
                 process_player_use_instance(cctng, i, pckt);
             }
@@ -1372,6 +1373,11 @@ void process_players_creature_control_packet_control(long idx)
                     {
                         process_player_use_instance(cctng, i, pckt);
                     }
+                }
+                else
+                {
+                    // cheat mode
+                    process_player_use_instance(cctng, i, pckt);
                 }
             }
         }
@@ -1478,7 +1484,9 @@ void process_players_creature_control_packet_action(long plyr_idx)
         break;
       i = pckt->actn_par1;
       inst_inf = creature_instance_info_get(i);
-      if (!inst_inf->instant)
+      // Fix the issue of FPInstantCast=1 instance not working in the instance cheat menu.
+      // Cheat mode no need check any, just do it.
+      if (1 || !inst_inf->instant)
       {
         cctrl->active_instance_id = i;
       } else


### PR DESCRIPTION
add optional entry for cheat menu in console command.
especially for the creature cheat menu, avoid having to enter possession mode to activate it.

optimize spell text info when everything as free.
show charging level instead of none when cost is zero.

fix the issue where selecting the cheat menu options would result in additional spellcasting behavior.
typically, avoid additional attack behavior when selecting the instance cheat menu options in possession mode.
fix the issue of FPInstantCast=1 instance not working in the instance cheat menu.
