### PR TITLE
Added hand_blocked_turns lua param and a SET_HAND_RULE overwrite

### DIFF
--- a/config/fxdata/lua/classes/Creature.lua
+++ b/config/fxdata/lua/classes/Creature.lua
@@ -20,6 +20,7 @@
 ---@field hunger_loss integer amount of chickens it won't eat but would have wanted to
 ---@field force_health_flower_displayed boolean always displays health flower
 ---@field force_health_flower_hidden boolean always hides health flower
+---@field hand_blocked_turns integer stops creature from being picked up, can be overwritten with SET_HAND_RULE. Set to -1 to be infinite.
 ---@field creature_kills integer how many creatires th creature has killed
 if not Creature then Creature = {} end
 

--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -410,6 +410,7 @@ unsigned char sound_flag;
     SpellKind active_teleport_spell;
     SpellKind active_timebomb_spell;
     short vertical_speed;
+    GameTurnDelta hand_blocked_turns;
 };
 
 struct Persons {

--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -233,6 +233,10 @@ static int thing_set_field(lua_State *L) {
         } else if (strcmp(key, "hunger_loss") == 0)
         {
             cctrl->hunger_loss = luaL_checkinteger(L, 3);
+        }
+        else if (strcmp(key, "hand_blocked_turns") == 0)
+        {
+            cctrl->hand_blocked_turns = luaL_checkinteger(L, 3);
         } else if (strcmp(key, "force_health_flower_displayed") == 0)
         {
             cctrl->force_health_flower_displayed = lua_toboolean(L, 3);
@@ -342,6 +346,8 @@ static int thing_get_field(lua_State *L) {
             lua_pushinteger(L, cctrl->force_health_flower_displayed);
         } else if (strcmp(key, "force_health_flower_hidden") == 0) {
             lua_pushinteger(L, cctrl->force_health_flower_hidden);
+        } else if (strcmp(key, "hand_blocked_turns") == 0) {
+            lua_pushinteger(L, cctrl->hand_blocked_turns);
         } else {
             return luaL_error(L, "Unknown field or method '%s' for Creature thing", key);
         }

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -152,6 +152,7 @@ const struct NamedCommand hand_rule_desc[] = {
   {"FIGHTING",              HandRule_Fighting},
   {"DROPPED_TIME_HIGHER",   HandRule_DroppedTimeHigher},
   {"DROPPED_TIME_LOWER",    HandRule_DroppedTimeLower},
+  {"BLOCKED_FOR_PICKUP",    HandRule_BlockedPickup},
   {NULL,                    0},
 };
 

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -1661,6 +1661,12 @@ static TbBool hand_rule_fighting(struct HandRule *hand_rule, const struct Thing 
     return (get_creature_gui_job(thing) == CrGUIJob_Fighting) ? !hand_rule->allow : !!hand_rule->allow;
 }
 
+static TbBool hand_rule_block_pickup(struct HandRule* hand_rule, const struct Thing* thing)
+{
+    struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
+    return ((cctrl->hand_blocked_turns == 0) || hand_rule->allow);
+}
+
 typedef TbBool (*HandTestFn) (struct HandRule *rule, const struct Thing *thing);
 static HandTestFn hand_rule_test_fns[] = {
     hand_rule_unset,
@@ -1676,6 +1682,7 @@ static HandTestFn hand_rule_test_fns[] = {
     hand_rule_fighting,
     hand_rule_dropped_time_higher,
     hand_rule_dropped_time_lower,
+    hand_rule_block_pickup,
 };
 
 TbBool eval_hand_rule_for_thing(struct HandRule *rule, const struct Thing *thing_to_pick)
@@ -1688,14 +1695,26 @@ TbBool thing_pickup_is_blocked_by_hand_rule(const struct Thing *thing_to_pick, P
     if (thing_is_creature(thing_to_pick) && thing_to_pick->owner == plyr_idx)
     {
         struct HandRule hand_rule;
-        for (int i = HAND_RULE_SLOTS_COUNT - 1; i >= 0; i--) {
+        TbBool overwrite_default_block = false;
+        for (int i = HAND_RULE_SLOTS_COUNT - 1; i >= 0; i--) 
+        {
             hand_rule = dungeon->hand_rules[thing_to_pick->model][i];
-            if (
-                hand_rule.enabled
+            if (hand_rule.enabled
                 && hand_rule.type != HandRule_Unset
-                && eval_hand_rule_for_thing(&hand_rule, thing_to_pick)
-            )
+                && eval_hand_rule_for_thing(&hand_rule, thing_to_pick))
+            {
+                if (hand_rule.type == HandRule_BlockedPickup)
+                {
+                    overwrite_default_block = true;
+                }
+
                 return true;
+            }
+        }
+        if (overwrite_default_block == false)
+        {
+            struct CreatureControl* cctrl = creature_control_get_from_thing(thing_to_pick);
+            return (cctrl->hand_blocked_turns != 0);
         }
     }
     return false;

--- a/src/power_hand.h
+++ b/src/power_hand.h
@@ -102,7 +102,8 @@ enum HandRuleType {
     HandRule_Working,
     HandRule_Fighting,
     HandRule_DroppedTimeHigher,
-    HandRule_DroppedTimeLower
+    HandRule_DroppedTimeLower,
+    HandRule_BlockedPickup
 };
 
 enum HandRuleAction {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6419,6 +6419,8 @@ TngUpdateRet update_creature(struct Thing *thing)
         cctrl->frozen_on_hit--;
     if (cctrl->force_visible > 0)
         cctrl->force_visible--;
+    if (cctrl->hand_blocked_turns > 0)
+        cctrl->hand_blocked_turns--;
     if (cctrl->regular_creature.navigation_map_changed == 0)
         cctrl->regular_creature.navigation_map_changed = game.map_changed_for_nagivation;
     if ((cctrl->stopped_for_hand_turns == 0) || (cctrl->instance_id == CrInst_EAT))


### PR DESCRIPTION
Creature with the hand_blocked_turns will be blocked by default from pickup, unless you have handrules for the creature.
When you do have handrules for the creature, explicitly set BLOCKED_FOR_PICKUP in the relevant SET_HAND_RULE rules.