### PR TITLE
Lua: Thing that gets deleted is removed from hand

### DIFF
--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -63,16 +63,16 @@ static int lua_delete_thing(lua_State *L)
 {
     struct Thing *thing = luaL_checkThing(L, 1);
 
+    if (thing_is_picked_up(thing))
+    {
+        for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+        {
+            if (remove_thing_from_power_hand(thing, plyr_idx))
+                break;
+        }
+    }
     if (thing->class_id == TCls_Creature)
     {
-        if (thing_is_picked_up(thing))
-        {
-            for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
-            {
-                if (remove_creature_from_power_hand(thing, plyr_idx))
-                    break;
-            }
-        }
         kill_creature(thing, INVALID_THING, -1, CrDed_NoEffects | CrDed_NotReallyDying);
     }
     else

--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -65,6 +65,14 @@ static int lua_delete_thing(lua_State *L)
 
     if (thing->class_id == TCls_Creature)
     {
+        if (thing_is_picked_up(thing))
+        {
+            for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+            {
+                if (remove_creature_from_power_hand(thing, plyr_idx))
+                    break;
+            }
+        }
         kill_creature(thing, INVALID_THING, -1, CrDed_NoEffects | CrDed_NotReallyDying);
     }
     else

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -1095,7 +1095,7 @@ TbBool process_creature_in_dungeon_hand(struct Dungeon *dungeon, struct Thing *t
         if ((cctrl->armageddon_teleport_turn != 0) && (cctrl->armageddon_teleport_turn <= game.play_gameturn))
         {
             cctrl->armageddon_teleport_turn = 0;
-            if (remove_creature_from_power_hand(thing, dungeon->owner))
+            if (remove_thing_from_power_hand(thing, dungeon->owner))
             {
                 teleport_armageddon_influenced_creature(thing);
                 return false;
@@ -1421,19 +1421,17 @@ TbBool place_thing_in_power_hand(struct Thing *thing, PlayerNumber plyr_idx)
     return true;
 }
 
-TbBool remove_creature_from_power_hand(struct Thing *thing, PlayerNumber plyr_idx)
+TbBool remove_thing_from_power_hand(struct Thing *thing, PlayerNumber plyr_idx)
 {
     if (!thing_is_in_power_hand_list(thing, plyr_idx)) {
         return false;
     }
     if (thing_is_creature(thing))
     {
-        remove_thing_from_limbo(thing);
         set_start_state(thing);
-        remove_thing_from_power_hand_list(thing, plyr_idx);
-        return true;
     }
-    return false;
+    remove_thing_from_limbo(thing);
+    return remove_thing_from_power_hand_list(thing, plyr_idx);;
 }
 
 TbResult use_power_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, unsigned short tng_idx)

--- a/src/power_hand.h
+++ b/src/power_hand.h
@@ -77,7 +77,7 @@ void delete_power_hand(PlayerNumber owner);
 void stop_creatures_around_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x,  MapSubtlCoord stl_y);
 
 TbBool place_thing_in_power_hand(struct Thing *thing, PlayerNumber plyr_idx);
-TbBool remove_creature_from_power_hand(struct Thing *thing, PlayerNumber plyr_idx);
+TbBool remove_thing_from_power_hand(struct Thing *thing, PlayerNumber plyr_idx);
 void drop_held_thing_on_ground(struct Dungeon *dungeon, struct Thing *droptng, const struct Coord3d *dstpos);
 void drop_gold_coins(const struct Coord3d *pos, long value, long plyr_idx);
 TbBool is_dangerous_drop_subtile(MapSubtlCoord stl_x, MapSubtlCoord stl_y);


### PR DESCRIPTION
Creatures that were in hand and deleted from lua would bug out the hand.

To test the bug, run a map with this lua script and pick up an avatar within 200 game turns:

```lua
function OnGameStart()
    DeleteAvatarWithTimer()
end

    function DeleteAvatarWithTimer()
        local creatures = GetCreatures()
        for index, creature in ipairs(creatures) do
            if creature.model == 'AVATAR' then
                local trigger = RegisterTimerEvent(function (currentTurn, triggerData) triggerData.avatar:delete() end, 200, false)
                trigger.triggerData.avatar = creature
            end
        end
    end
    ```
    
    With this PR it is cleared from hands.