### PR TITLE
Allow pressing ALT+F4 in multiplayer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3276,12 +3276,8 @@ TbBool keeper_wait_for_screen_focus(void)
     do {
         if ( !LbWindowsControl() )
         {
-          if ((game.system_flags & GSF_NetworkActive) == 0)
-          {
-            exit_keeper = 1;
-            break;
-          }
-          SYNCLOG("Alex's point reached");
+          force_application_close();
+          break;
         }
         if (LbIsActive())
           return true;
@@ -3643,12 +3639,9 @@ static TbBool wait_at_frontend(void)
     {
       if (!LbWindowsControl())
       {
-        if ((game.system_flags & GSF_NetworkActive) == 0)
-        {
-            exit_keeper = 1;
-            SYNCDBG(0,"Windows Control exit condition invoked");
-            break;
-        }
+        force_application_close();
+        SYNCDBG(0,"Windows Control exit condition invoked");
+        break;
       }
       update_mouse();
       update_key_modifiers();

--- a/src/packets.c
+++ b/src/packets.c
@@ -681,6 +681,25 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       player->display_flags |= PlaF6_PlyrHasQuit;
       process_quit_packet(player, 0);
       return 1;
+  case PckA_ForceApplicationClose:
+      {
+        extern unsigned char exit_keeper;
+        if (is_my_player(player))
+        {
+          turn_off_all_menus();
+          frontend_save_continue_game(true);
+          free_swipe_graphic();
+          // For ALT+F4, just exit directly without network cleanup
+          exit_keeper = 1;
+        }
+        else
+        {
+          // Other player force-quit, just mark them as quit
+          player->display_flags |= PlaF6_PlyrHasQuit;
+          process_quit_packet(player, 0);
+        }
+        return 1;
+      }
   case PckA_SaveGameAndQuit:
       if (is_my_player(player))
       {
@@ -1849,6 +1868,32 @@ void apply_default_flee_and_imprison_setting(void)
     
     if (tendencies_to_toggle) {
         set_players_packet_action(player, PckA_ToggleTendency, tendencies_to_toggle, 0, 0, 0);
+    }
+}
+
+// Using Alt-F4, or similar operating system close requests
+void force_application_close()
+{
+    extern unsigned char exit_keeper;
+    extern int frontend_menu_state;
+    
+    // Check if we're in gameplay vs frontend
+    if (frontend_menu_state == 0)
+    {
+        struct PlayerInfo* player = get_my_player();
+        if (player != INVALID_PLAYER)
+        {
+            set_players_packet_action(player, PckA_ForceApplicationClose, 0, 0, 0, 0);
+        }
+        else
+        {
+            exit_keeper = 1;
+        }
+    }
+    else
+    {
+        // We're in the frontend, just exit directly
+        exit_keeper = 1;
     }
 }
 

--- a/src/packets.h
+++ b/src/packets.h
@@ -30,7 +30,7 @@ extern "C" {
 enum TbPacketAction {
         PckA_None = 0,
         PckA_QuitToMainMenu, // Quit
-        PckA_UnusedSlot002,
+        PckA_ForceApplicationClose,
         PckA_SaveGameAndQuit,
         PckA_NoOperation,
         PckA_FinishGame, // 5
@@ -309,6 +309,7 @@ void unset_packet_control(struct Packet *pckt, unsigned long flag);
 void unset_players_packet_control(struct PlayerInfo *player, unsigned long flag);
 void set_players_packet_position(struct Packet *pckt, long x, long y, unsigned char context);
 void set_packet_pause_toggle(void);
+void force_application_close(void);
 void apply_default_flee_and_imprison_setting(void);
 TbBool process_dungeon_control_packet_clicks(long idx);
 TbBool process_players_dungeon_control_packet_action(long idx);


### PR DESCRIPTION
It also handles right-clicking the taskbar and clicking Close, or in windowed mode clicking the `X` in the corner.

`PckA_QuitToMainMenu` packet is used, then `exit_keeper = 1` is set and the window instantly closes. So the opponent receives the packet that the player quitted to main menu.