### PR TITLE
Refactor multiplayer checksum sync code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,10 +138,6 @@
 #define strcasecmp _stricmp
 #endif
 
-extern "C" void compute_multiplayer_checksum_sync(void);
-
-int test_variable;
-
 char cmndline[CMDLN_MAXLEN+1];
 unsigned short bf_argc;
 char *bf_argv[CMDLN_MAXLEN+1];
@@ -207,14 +203,13 @@ extern "C" {
 TbBool force_player_num = false;
 
 /******************************************************************************/
-
 extern void faststartup_network_game(CoroutineLoop *context);
 extern void faststartup_saved_packet_game(void);
 extern TngUpdateRet damage_creatures_with_physical_force(struct Thing *thing, ModTngFilterParam param);
-void first_gameturn_actions(void);
 extern CoroutineLoopState set_not_has_quit(CoroutineLoop *context);
 extern void startup_network_game(CoroutineLoop *context, TbBool local);
-
+void first_gameturn_actions(void);
+void compute_multiplayer_checksum_sync(void);
 /******************************************************************************/
 
 TbClockMSec timerstarttime = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2708,7 +2708,6 @@ void update(void)
         if ((game.view_mode_flags & GNFldD_ComputerPlayerProcessing) != 0)
             process_computer_players2();
         process_players();
-        compute_multiplayer_checksum_sync();
         process_action_points();
         player = get_my_player();
         if (player->view_mode == PVM_CreatureView)
@@ -2720,6 +2719,7 @@ void update(void)
         PaletteFadePlayer(player);
         process_armageddon();
         update_global_lighting();
+        compute_multiplayer_checksum_sync();
 #if (BFDEBUG_LEVEL > 9)
         lights_stats_debug_dump();
         things_stats_debug_dump();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,6 +138,8 @@
 #define strcasecmp _stricmp
 #endif
 
+extern "C" void compute_multiplayer_checksum_sync(void);
+
 int test_variable;
 
 char cmndline[CMDLN_MAXLEN+1];
@@ -2706,6 +2708,7 @@ void update(void)
         if ((game.view_mode_flags & GNFldD_ComputerPlayerProcessing) != 0)
             process_computer_players2();
         process_players();
+        compute_multiplayer_checksum_sync();
         process_action_points();
         player = get_my_player();
         if (player->view_mode == PVM_CreatureView)

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -295,7 +295,6 @@ static TbBigChecksum compute_things_checksum(void)
     sum += compute_things_list_checksum(&game.thing_lists[TngList_Shots]);
     sum += compute_things_list_checksum(&game.thing_lists[TngList_Objects]);
     sum += compute_things_list_checksum(&game.thing_lists[TngList_Effects]);
-    sum += compute_things_list_checksum(&game.thing_lists[TngList_EffectElems]);
     sum += compute_things_list_checksum(&game.thing_lists[TngList_DeadCreatrs]);
     sum += compute_things_list_checksum(&game.thing_lists[TngList_EffectGens]);
     sum += compute_things_list_checksum(&game.thing_lists[TngList_Doors]);

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -35,6 +35,9 @@
 #include "keeperfx.hpp"
 #include "frontend.h"
 #include "thing_effects.h"
+#include "thing_data.h"
+#include "room_data.h"
+#include "room_list.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
@@ -210,7 +213,7 @@ CoroutineLoopState perform_checksum_verification(CoroutineLoop *con)
     return CLS_CONTINUE;
 }
 
-TbBigChecksum compute_player_checksum(struct PlayerInfo *player)
+static TbBigChecksum compute_player_checksum(struct PlayerInfo *player)
 {
     TbBigChecksum sum = 0;
     if (((player->allocflags & PlaF_CompCtrl) == 0) && (player->acamera != NULL))
@@ -237,7 +240,102 @@ TbBigChecksum compute_players_checksum(void)
             sum += compute_player_checksum(player);
         }
     }
+    sum += game.action_rand_seed;
     return sum;
+}
+
+/**
+ * Computes checksum for things in a specific list without updating them.
+ * Used for multiplayer synchronization verification to detect desync issues.
+ * @param list The thing list to compute checksum for. Can be NULL.
+ * @return The checksum value, or 0 if list is NULL or empty.
+ */
+static TbBigChecksum compute_things_list_checksum(struct StructureList *list)
+{
+    TbBigChecksum sum = 0;
+    unsigned long k = 0;
+    int i = list->index;
+    while (i != 0)
+    {
+        struct Thing* thing = thing_get(i);
+        if (thing_is_invalid(thing))
+        {
+            ERRORLOG("Jump to invalid thing detected in list");
+            break;
+        }
+        i = thing->next_of_class;
+        sum += get_thing_checksum(thing);
+        k++;
+        if (k > THINGS_COUNT)
+        {
+            ERRORLOG("Infinite loop detected in thing list");
+            break;
+        }
+    }
+    return sum;
+}
+
+/**
+ * Computes checksum for all creatures in the game.
+ * @return The creatures checksum value for multiplayer sync verification.
+ */
+static TbBigChecksum compute_creatures_checksum(void)
+{
+    return compute_things_list_checksum(&game.thing_lists[TngList_Creatures]);
+}
+
+/**
+ * Computes checksum for all non-creature things (traps, shots, objects, effects, etc).
+ * @return The combined checksum value for multiplayer sync verification.
+ */
+static TbBigChecksum compute_things_checksum(void)
+{
+    TbBigChecksum sum = 0;
+    sum += compute_things_list_checksum(&game.thing_lists[TngList_Traps]);
+    sum += compute_things_list_checksum(&game.thing_lists[TngList_Shots]);
+    sum += compute_things_list_checksum(&game.thing_lists[TngList_Objects]);
+    sum += compute_things_list_checksum(&game.thing_lists[TngList_Effects]);
+    sum += compute_things_list_checksum(&game.thing_lists[TngList_EffectElems]);
+    sum += compute_things_list_checksum(&game.thing_lists[TngList_DeadCreatrs]);
+    sum += compute_things_list_checksum(&game.thing_lists[TngList_EffectGens]);
+    sum += compute_things_list_checksum(&game.thing_lists[TngList_Doors]);
+    return sum;
+}
+
+/**
+ * Computes checksum for all rooms based on core room properties.
+ * @return The rooms checksum value for multiplayer sync verification.
+ */
+static TbBigChecksum compute_rooms_checksum(void)
+{
+    TbBigChecksum sum = 0;
+    for (struct Room* room = start_rooms; room < end_rooms; room++)
+    {
+        if (!room_exists(room)) {
+            continue;
+        }
+        sum += room->slabs_count + room->central_stl_x + room->central_stl_y + room->efficiency + room->used_capacity;
+    }
+    return sum;
+}
+
+/**
+ * Centralized function to compute all game state checksums for multiplayer sync verification.
+ * Used only in multiplayer games to detect desynchronization between networked players.
+ */
+void compute_multiplayer_checksum_sync(void)
+{
+    TbBigChecksum creatures_sum = compute_creatures_checksum();
+    player_packet_checksum_add(my_player_number, creatures_sum, "creatures");
+
+    TbBigChecksum things_sum = compute_things_checksum();
+    player_packet_checksum_add(my_player_number, things_sum, "things");
+
+    TbBigChecksum rooms_sum = compute_rooms_checksum();
+    player_packet_checksum_add(my_player_number, rooms_sum, "rooms");
+
+    TbBigChecksum players_sum = compute_players_checksum();
+    player_packet_checksum_add(my_player_number, players_sum, "players");
 }
 
 /**

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -398,6 +398,7 @@ TbBigChecksum get_thing_checksum(const struct Thing* thing)
     else if ((thing->class_id == TCls_EffectElem) || (thing->class_id == TCls_AmbientSnd))
     {
         // No syncing on Effect Elements or Sounds
+        return 0;
     }
     else if (thing->class_id == TCls_Effect)
     {
@@ -408,11 +409,11 @@ TbBigChecksum get_thing_checksum(const struct Thing* thing)
                 (ulong)thing->mappos.x.val +
                 (ulong)thing->mappos.y.val +
                 (ulong)thing->health;
+        } else {
+            // No syncing on Effects that do not affect the area around them
+            return 0;
         }
-        //else: No syncing on Effects that do not affect the area around them
-    }
-    else
-    {
+    } else {
         csum += (ulong)thing->mappos.z.val +
             (ulong)thing->mappos.x.val +
             (ulong)thing->mappos.y.val +

--- a/src/net_sync.h
+++ b/src/net_sync.h
@@ -30,11 +30,17 @@ extern "C" {
 /******************************************************************************/
 #pragma pack(1)
 
+struct Thing;
 
 #pragma pack()
 /******************************************************************************/
 void resync_game(void);
 CoroutineLoopState perform_checksum_verification(CoroutineLoop *con);
+void compute_multiplayer_checksum_sync(void);
+TbBigChecksum compute_players_checksum(void);
+void player_packet_checksum_add(PlayerNumber plyr_idx, TbBigChecksum sum, const char *area_name);
+short checksums_different(void);
+TbBigChecksum get_thing_checksum(const struct Thing *thing);
 
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/packets.c
+++ b/src/packets.c
@@ -245,30 +245,6 @@ TbBool player_sell_room_at_subtile(long plyr_idx, long stl_x, long stl_y)
     return true;
 }
 
-TbBigChecksum get_thing_simple_checksum(const struct Thing *tng)
-{
-    return (ulong)tng->mappos.x.val + (ulong)tng->mappos.y.val + (ulong)tng->mappos.z.val
-         + (ulong)tng->move_angle_xy + (ulong)tng->owner;
-}
-
-  TbBigChecksum get_packet_save_checksum(void)
-  {
-      TbBigChecksum sum = 0;
-      for (long tng_idx = 0; tng_idx < THINGS_COUNT; tng_idx++)
-      {
-          struct Thing* tng = thing_get(tng_idx);
-          if ((tng->alloc_flags & TAlF_Exists) != 0)
-          {
-              // It would be nice to completely ignore effects, but since
-              // thing indices are used in packets, lack of effect may cause desync too.
-              if ((tng->class_id != TCls_AmbientSnd) && (tng->class_id != TCls_EffectElem))
-              {
-                  sum += get_thing_simple_checksum(tng);
-              }
-          }
-      }
-      return sum;
-}
 
 void process_pause_packet(long curr_pause, long new_pause)
 {

--- a/src/packets.h
+++ b/src/packets.h
@@ -322,9 +322,7 @@ void process_pause_packet(long a1, long a2);
 void process_quit_packet(struct PlayerInfo *player, short complete_quit);
 void process_packets(void);
 void clear_packets(void);
-TbBigChecksum compute_players_checksum(void);
-void player_packet_checksum_add(PlayerNumber plyr_idx, TbBigChecksum sum, const char *area_name);
-short checksums_different(void);
+TbBigChecksum compute_replay_integrity(void);
 void post_init_packets(void);
 
 TbBool open_new_packet_file_for_save(void);

--- a/src/packets_misc.c
+++ b/src/packets_misc.c
@@ -172,13 +172,14 @@ void post_init_packets(void)
     clear_packets();
 }
 
-static TbBigChecksum get_thing_simple_checksum(const struct Thing *tng)
-{
-    return (ulong)tng->mappos.x.val + (ulong)tng->mappos.y.val + (ulong)tng->mappos.z.val
-         + (ulong)tng->move_angle_xy + (ulong)tng->owner;
-}
-
-static TbBigChecksum get_packet_save_checksum(void)
+/**
+ * Computes verification checksum for -packetsave/-packetload replay files.
+ * NOT used for multiplayer - only for single-player replay integrity checking.
+ * Sums position/movement data of all things except ambient sounds and effect elements.
+ *
+ * @return Checksum value for detecting replay file corruption
+ */
+TbBigChecksum compute_replay_integrity(void)
 {
     TbBigChecksum sum = 0;
     for (long tng_idx = 0; tng_idx < THINGS_COUNT; tng_idx++)
@@ -190,7 +191,8 @@ static TbBigChecksum get_packet_save_checksum(void)
             // thing indices are used in packets, lack of effect may cause desync too.
             if ((tng->class_id != TCls_AmbientSnd) && (tng->class_id != TCls_EffectElem))
             {
-                sum += get_thing_simple_checksum(tng);
+                sum += (ulong)tng->mappos.x.val + (ulong)tng->mappos.y.val + (ulong)tng->mappos.z.val
+                     + (ulong)tng->move_angle_xy + (ulong)tng->owner;
             }
         }
     }
@@ -204,7 +206,7 @@ short save_packets(void)
     TbBigChecksum chksum;
     SYNCDBG(6,"Starting");
     if (game.packet_checksum_verify)
-        chksum = get_packet_save_checksum();
+        chksum = compute_replay_integrity();
     else
         chksum = 0;
     LbFileSeek(game.packet_save_fp, 0, Lb_FILE_SEEK_END);
@@ -349,7 +351,7 @@ void load_packets_for_turn(GameTurn nturn)
     if (game.packet_checksum_verify)
     {
         pckt = get_packet(my_player_number);
-        if (get_packet_save_checksum() != tot_chksum)
+        if (compute_replay_integrity() != tot_chksum)
         {
             ERRORLOG("PacketSave checksum - Out of sync (GameTurn %lu)", game.play_gameturn);
             if (!is_onscreen_msg_visible())

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -1101,10 +1101,6 @@ void process_players(void)
             update_player_objectives(i);
         }
     }
-    TbBigChecksum sum = 0;
-    sum += compute_players_checksum();
-    sum += game.action_rand_seed;
-    player_packet_checksum_add(my_player_number,sum,"players");
     SYNCDBG(17,"Finished");
 }
 

--- a/src/room_util.c
+++ b/src/room_util.c
@@ -137,7 +137,6 @@ void recompute_rooms_count_in_dungeons(void)
 void process_rooms(void)
 {
   SYNCDBG(7,"Starting");
-  TbBigChecksum sum = 0;
   for (struct Room* room = start_rooms; room < end_rooms; room++)
   {
       if (!room_exists(room))
@@ -145,12 +144,10 @@ void process_rooms(void)
       if (room_role_matches(room->kind, RoRoF_FoodSpawn)) {
           room_grow_food(room);
       }
-      sum += room->slabs_count + room->central_stl_x + room->central_stl_y + room->efficiency + room->used_capacity;
       if (room_has_surrounding_flames(room->kind) && ((game.view_mode_flags & GNFldD_RoomFlameProcessing) != 0)) {
           process_room_surrounding_flames(room);
       }
   }
-  player_packet_checksum_add(my_player_number, sum, "rooms");
   recompute_rooms_count_in_dungeons();
   SYNCDBG(9,"Finished");
 }

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -977,12 +977,10 @@ TngUpdateRet switch_object_on_destoyed_slab_to_new_owner(struct Thing *thing, Mo
 /**
  * Makes per game turn update of all things in given StructureList.
  * @param list List of things to process.
- * @return Returns checksum computed from status of all things in list.
  */
-TbBigChecksum update_things_in_list(struct StructureList *list)
+void update_things_in_list(struct StructureList *list)
 {
     SYNCDBG(18,"Starting");
-    TbBigChecksum sum = 0;
     unsigned long k = 0;
     int i = list->index;
     while (i != 0)
@@ -1004,7 +1002,6 @@ TbBigChecksum update_things_in_list(struct StructureList *list)
           }
       }
       set_previous_thing_position(thing);
-      sum += get_thing_checksum(thing);
       // Per-thing code ends
       k++;
       if (k > THINGS_COUNT)
@@ -1013,8 +1010,7 @@ TbBigChecksum update_things_in_list(struct StructureList *list)
         break;
       }
     }
-    SYNCDBG(19,"Finished, %d items, checksum %06lX",(int)k,(unsigned long)sum);
-    return sum;
+    SYNCDBG(19,"Finished, %d items",(int)k);
 }
 
 /**
@@ -1126,22 +1122,18 @@ void update_things(void)
     optimised_lights = 0;
     total_lights = 0;
     do_lights = game.lish.light_enabled;
-    TbBigChecksum sum = 0;
-    sum += update_things_in_list(&game.thing_lists[TngList_Creatures]);
+    update_things_in_list(&game.thing_lists[TngList_Creatures]);
     update_creatures_not_in_list();
-    player_packet_checksum_add(my_player_number,sum,"creatures");
-    sum = 0;
-    sum += update_things_in_list(&game.thing_lists[TngList_Traps]);
-    sum += update_things_in_list(&game.thing_lists[TngList_Shots]);
-    sum += update_things_in_list(&game.thing_lists[TngList_Objects]);
-    sum += update_things_in_list(&game.thing_lists[TngList_Effects]);
-    sum += update_things_in_list(&game.thing_lists[TngList_EffectElems]);
-    sum += update_things_in_list(&game.thing_lists[TngList_DeadCreatrs]);
-    sum += update_things_in_list(&game.thing_lists[TngList_EffectGens]);
-    sum += update_things_in_list(&game.thing_lists[TngList_Doors]);
+    update_things_in_list(&game.thing_lists[TngList_Traps]);
+    update_things_in_list(&game.thing_lists[TngList_Shots]);
+    update_things_in_list(&game.thing_lists[TngList_Objects]);
+    update_things_in_list(&game.thing_lists[TngList_Effects]);
+    update_things_in_list(&game.thing_lists[TngList_EffectElems]);
+    update_things_in_list(&game.thing_lists[TngList_DeadCreatrs]);
+    update_things_in_list(&game.thing_lists[TngList_EffectGens]);
+    update_things_in_list(&game.thing_lists[TngList_Doors]);
     update_things_sounds_in_list(&game.thing_lists[TngList_AmbientSnds]);
     update_cave_in_things();
-    player_packet_checksum_add(my_player_number,sum,"things");
     game.map_changed_for_nagivation = 0;
     SYNCDBG(9,"Finished");
 }

--- a/src/thing_list.h
+++ b/src/thing_list.h
@@ -277,7 +277,7 @@ unsigned long update_things_sounds_in_list(struct StructureList *list);
 void stop_all_things_playing_samples(void);
 unsigned long update_cave_in_things(void);
 unsigned long update_creatures_not_in_list(void);
-unsigned long update_things_in_list(struct StructureList *list);
+void update_things_in_list(struct StructureList *list);
 void init_player_start(struct PlayerInfo *player, TbBool keep_prev);
 void setup_computer_players(void);
 void setup_zombie_players(void);
@@ -324,7 +324,6 @@ TbBool apply_anger_to_all_players_creatures_excluding(PlayerNumber plyr_idx, lon
 void break_mapwho_infinite_chain(const struct Map *mapblk);
 
 TbBool update_thing(struct Thing *thing);
-TbBigChecksum get_thing_checksum(const struct Thing *thing);
 short update_thing_sound(struct Thing *thing);
 struct Thing* find_players_dungeon_heart(PlayerNumber plyridx);
 struct Thing* find_players_backup_dungeon_heart(PlayerNumber plyridx);


### PR DESCRIPTION
I've centralized all the multiplayer checksum computing to be done all at once, instead of being scattered throughout the codebase. I put them in `net_sync.c`, which is where they should be, and added a function called `compute_multiplayer_checksum_sync`, which is called in `update()`. This will make it all easier to understand and much cleaner.

It perhaps even avoids a bug where we compute checksum for a Thing and then another function later changes the Thing. For example:

Old:

1. update_things and checksums for things
2. update_rooms and checksums for rooms
3. update other stuff <--- maybe a function here also modifies a Thing, so its original checksum calculation becomes moot.
3. exchange_packets_and_do_network_stuff

New:

1. update_things
2. update_rooms
3. update_other_stuff
4. update checksums for things, rooms, players, etc. (ALL DONE AT ONCE)
5. exchange_packets_and_do_network_stuff