### PR TITLE
Added launch argument for specifying log filename

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4241,14 +4241,14 @@ short process_command_line(unsigned short argc, char *argv[])
   return (bad_param==0);
 }
 
-const char* determine_log_filename(unsigned short argc, char *argv[])
+const char* determine_log_filename(unsigned short argument_count, char *argument_values[])
 {
-    for (int i = 1; i < argc; i++) {
-        if (argv[i] && (argv[i][0] == '-' || argv[i][0] == '/')) {
-            char* flag = argv[i] + 1;
-            if (strcasecmp(flag, "log") == 0 && i + 1 < argc) {
+    for (int argument_index = 1; argument_index < argument_count; argument_index++) {
+        if (argument_values[argument_index] && (argument_values[argument_index][0] == '-' || argument_values[argument_index][0] == '/')) {
+            char* argument_name = argument_values[argument_index] + 1;
+            if (strcasecmp(argument_name, "log") == 0 && argument_index + 1 < argument_count) {
                 remove("keeperfx.log");
-                return argv[i + 1];
+                return argument_values[argument_index + 1];
             }
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4177,6 +4177,10 @@ short process_command_line(unsigned short argc, char *argv[])
         WARNLOG("Flag '%s' disabled for release builds.", parstr);
 #endif // FUNCTESTING
       }
+      else if (strcasecmp(parstr, "log") == 0)
+      {
+          narg++;
+      }
       else if(strcasecmp(parstr, "exitonfailedtest") == 0)
       {
 #ifdef FUNCTESTING
@@ -4239,16 +4243,12 @@ short process_command_line(unsigned short argc, char *argv[])
 
 const char* determine_log_filename(unsigned short argc, char *argv[])
 {
-    // Quick scan for server/connect flags to determine log file
     for (int i = 1; i < argc; i++) {
         if (argv[i] && (argv[i][0] == '-' || argv[i][0] == '/')) {
             char* flag = argv[i] + 1;
-            if (strcasecmp(flag, "server") == 0) {
+            if (strcasecmp(flag, "log") == 0 && i + 1 < argc) {
                 remove("keeperfx.log");
-                return "keeperfx_host.log";
-            } else if (strcasecmp(flag, "connect") == 0) {
-                remove("keeperfx.log");
-                return "keeperfx_client.log";
+                return argv[i + 1];
             }
         }
     }


### PR DESCRIPTION
`-log blah.log`

So use these when self-joining multiplayer in same game directory:
```
"C:\Games\Dungeon Keeper\keeperfx.exe" -log keeperfx-server.log -server -campaign keeporig -level 50
```
```
"C:\Games\Dungeon Keeper\keeperfx.exe" -log keeperfx-client.log -connect localhost
```