### PR TITLE
Fix initial seed desync in multiplayer

### DIFF
--- a/src/main_game.c
+++ b/src/main_game.c
@@ -487,24 +487,25 @@ void init_seeds()
     {
         // Unsynced seeds - these values will be different per-player in multiplayer
         unsigned long calender_time = (unsigned long)LbTimeSec();
-        game.unsync_random_seed = calender_time;
-        game.sound_random_seed = calender_time * 7919 + 7927; // Use prime multipliers for different seed
+        game.unsync_random_seed = calender_time * 9007 + 9011;  // Use prime multipliers for different seeds
+        game.sound_random_seed = calender_time * 7919 + 7927;
 
         // If doing -packetload then use the replay's stored seed
         if (game.packet_save_head.action_seed != 0) {
             game.action_random_seed = game.packet_save_head.action_seed;
         } else {
-            game.action_random_seed = game.unsync_random_seed;
+            game.action_random_seed = calender_time * 9311 + 9319;
         }
 
-        // Network seed must be synchronized before setting derived seeds
+        // Network seed must be synchronized for multiplayer before setting derived seeds
         if ((game.system_flags & GSF_NetworkActive) != 0) {
-            init_network_seed(); // Synchronize random seed across network for multiplayer
+            init_network_seed();
         }
 
-        // AI and player systems get their own derived seeds
-        game.ai_random_seed = game.action_random_seed * 9377 + 9439;
-        game.player_random_seed = game.action_random_seed * 9439 + 9377;
+        // AI and Player systems get their own derived seeds
+        game.ai_random_seed = game.action_random_seed * 9377 + 9391;
+        game.player_random_seed = game.action_random_seed * 9473 + 9479;
+        
         initial_replay_seed = game.action_random_seed;
         lua_set_random_seed(game.action_random_seed);
     }

--- a/src/packets.h
+++ b/src/packets.h
@@ -251,7 +251,7 @@ enum ChecksumKind {
 struct PlayerInfo;
 struct CatalogueEntry;
 
-extern unsigned long start_seed;
+extern unsigned long initial_replay_seed;
 
 /**
  * Stores data exchanged between players each turn and used to re-create their input.

--- a/src/packets_misc.c
+++ b/src/packets_misc.c
@@ -33,7 +33,7 @@ extern "C" {
 /******************************************************************************/
 #define PACKET_TURN_SIZE (NET_PLAYERS_COUNT*sizeof(struct PacketEx) + sizeof(TbBigChecksum))
 struct Packet bad_packet;
-unsigned long start_seed;
+unsigned long initial_replay_seed;
 extern TbBool IMPRISON_BUTTON_DEFAULT;
 extern TbBool FLEE_BUTTON_DEFAULT;
 extern TbBool get_skip_heart_zoom_feature(void);
@@ -286,7 +286,7 @@ TbBool open_new_packet_file_for_save(void)
     game.packet_save_head.frontview_zoom_level = settings.frontview_zoom_level;
     game.packet_save_head.isometric_tilt = settings.isometric_tilt;
     game.packet_save_head.video_rotate_mode = settings.video_rotate_mode;
-    game.packet_save_head.action_seed = start_seed;
+    game.packet_save_head.action_seed = initial_replay_seed;
     game.packet_save_head.skip_heart_zoom = get_skip_heart_zoom_feature();
     game.packet_save_head.default_imprison_tendency = IMPRISON_BUTTON_DEFAULT;
     game.packet_save_head.default_flee_tendency = FLEE_BUTTON_DEFAULT;


### PR DESCRIPTION
I introduced a desync when I added the new seeds, so this should hopefully fix it.

Also cleaned up `init_seeds()`