### PR TITLE
Fix potential issues with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,25 +554,51 @@ obj/cu/%.o: $(CU_DIR)/Sources/Framework/%.c
 obj/cu/%.o: $(CU_DIR)/Sources/Basic/%.c
 	$(CPP) $(CXXFLAGS) $(CU_INC) -o"$@" "$<"
 
-obj/std/%.o obj/hvlog/%.o: src/%.cpp libexterns $(GENSRC)
-	-$(ECHO) 'Building file: $<'
+
+define BUILD_CPP_FILES_CMD
+	-$(ECHO) 'Building cpp file: $<'
 	@grep -E "#include \"(\.\./)?(\.\./)?pre_inc.h\"" "$<" >/dev/null || echo "\n\nAll files should have #include \"pre_inc.h\" as first include\n\n" >&2 | false
 	@grep -E "#include \"(\.\./)?(\.\./)?post_inc.h\"" "$<" >/dev/null || echo "\n\nAll files should have #include \"post_inc.h\" as last include\n\n" >&2 | false
 	$(CPP) $(CXXFLAGS) -o"$@" "$<"
 	-$(ECHO) ' '
+endef
 
-obj/std/%.o obj/hvlog/%.o: src/%.c libexterns $(GENSRC)
-	-$(ECHO) 'Building file: $<'
+obj/std/%.o: src/%.cpp libexterns $(GENSRC)
+	$(BUILD_CPP_FILES_CMD)
+
+obj/hvlog/%.o: src/%.cpp libexterns $(GENSRC)
+	$(BUILD_CPP_FILES_CMD)
+
+
+define BUILD_CC_FILES_CMD
+	-$(ECHO) 'Building cc file: $<'
 	@grep -E "#include \"(\.\./)?(\.\./)?pre_inc.h\"" "$<" >/dev/null || echo "\n\nAll files should have #include \"pre_inc.h\" as first include\n\n" >&2 | false
 	@grep -E "#include \"(\.\./)?(\.\./)?post_inc.h\"" "$<" >/dev/null || echo "\n\nAll files should have #include \"post_inc.h\" as last include\n\n" >&2 | false
 	$(CC) $(CFLAGS) -o"$@" "$<"
 	-$(ECHO) ' '
+endef
+
+obj/std/%.o: src/%.c libexterns $(GENSRC)
+	$(BUILD_CC_FILES_CMD)
+
+obj/hvlog/%.o: src/%.c libexterns $(GENSRC)
+	$(BUILD_CC_FILES_CMD)
+
 
 # Windows resources compilation
-obj/std/%.res obj/hvlog/%.res: res/%.rc res/keeperfx_icon.ico $(GENSRC)
+
+define BUILD_RESOURCE_CMD
 	-$(ECHO) 'Building resource: $<'
 	$(WINDRES) -i "$<" --input-format=rc -o "$@" -O coff -I"obj/"
 	-$(ECHO) ' '
+endef
+
+obj/std/%.res: res/%.rc res/keeperfx_icon.ico $(GENSRC)
+	$(BUILD_RESOURCE_CMD)
+
+obj/hvlog/%.res: res/%.rc res/keeperfx_icon.ico $(GENSRC)
+	$(BUILD_RESOURCE_CMD)
+
 
 # Creation of Windows icon files from PNG files
 res/%.ico: res/%016-08bpp.png res/%032-08bpp.png res/%048-08bpp.png res/%064-08bpp.png res/%128-08bpp.png res/%128-24bpp.png res/%256-24bpp.png res/%512-24bpp.png $(PNGTOICO)

--- a/pkg_gfx.mk
+++ b/pkg_gfx.mk
@@ -314,25 +314,49 @@ pkg/data/tmap%.dat:
 	-$(ECHO) 'Finished building: $@'
 	-$(ECHO) ' '
 
-pkg/ldata/%.raw pkg/data/%.raw:
+define BUILD_RAW_IMAGE_CMD
 	-$(ECHO) 'Building RAW image: $@'
 	$(PNGTORAW) -o "$@" -p "$(word 2,$^)" -f raw -l 100 "$<"
 	-$(ECHO) 'Finished building: $@'
 	-$(ECHO) ' '
+endef
 
-pkg/ldata/%.dat pkg/data/%.dat:
+pkg/ldata/%.raw:
+	$(BUILD_RAW_IMAGE_CMD)
+
+pkg/data/%.raw:
+	$(BUILD_RAW_IMAGE_CMD)
+
+
+define BUILD_TABULATED_SPRITES_CMD
 	-$(ECHO) 'Building tabulated sprites: $@'
 	$(MKDIR) "$(@D)"
 	$(PNGTORAW) -b -o "$@" -p "$(word 2,$^)" -f sspr -l 0 "$<"
 	-$(ECHO) 'Finished building: $@'
 	-$(ECHO) ' '
+endef
 
-pkg/creatrs/%.jty pkg/data/%.jty:
+pkg/ldata/%.dat:
+	$(BUILD_TABULATED_SPRITES_CMD)
+
+pkg/data/%.dat:
+	$(BUILD_TABULATED_SPRITES_CMD)
+
+
+define BUILD_JONTY_SPRITES_CMD
 	-$(ECHO) 'Building jonty sprites: $@'
 	@$(MKDIR) "$(@D)"
 	$(PNGTORAW) -m -o "$@" -p "$(word 2,$^)" -f jspr -l 0 "$<"
 	-$(ECHO) 'Finished building: $@'
 	-$(ECHO) ' '
+endef
+
+pkg/creatrs/%.jty:
+	$(BUILD_JONTY_SPRITES_CMD)
+
+pkg/data/%.jty:
+	$(BUILD_JONTY_SPRITES_CMD)
+
 
 gfx/%:: | gfx/LICENSE ;
 


### PR DESCRIPTION
There is an issue with writing multiple targets on the same line and using wildcard characters.

It will result in certain targets not being executed, so the first run of 'make package' after running 'make clean' always fails.
And 4.4 version of Make will have clear warnings about 'pattern recipe did not update peer target'.