### PR TITLE
Narrow down desync issues

### DIFF
--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -132,9 +132,9 @@ struct LogThingDesyncInfo {
     ThingModel model;             // Model within the class
     PlayerNumber owner;           // Owner player of the thing
     TbBigChecksum random_seed;    // Thing's random seed
-    MapSubtlCoord pos_x;          // Position X coordinate
-    MapSubtlCoord pos_y;          // Position Y coordinate
-    MapSubtlCoord pos_z;          // Position Z coordinate
+    long pos_x;                   // Position X coordinate (full .val)
+    long pos_y;                   // Position Y coordinate (full .val)
+    long pos_z;                   // Position Z coordinate (full .val)
     GameTurn creation_turn;       // Turn when thing was created
     ThingIndex index;             // Thing's index
     HitPoints health;             // Thing's health

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -597,13 +597,6 @@ TbBigChecksum get_thing_checksum(const struct Thing* thing)
     CHECKSUM_ADD(checksum, thing->mappos.z.val);
     CHECKSUM_ADD(checksum, thing->health);
 
-    if (thing->class_id == TCls_Creature) {
-        struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-        CHECKSUM_ADD(checksum, cctrl->inst_turn);
-        CHECKSUM_ADD(checksum, cctrl->instance_id);
-        CHECKSUM_ADD(checksum, thing->max_frames);
-        CHECKSUM_ADD(checksum, thing->current_frame);
-    }
     return checksum;
 }
 
@@ -639,9 +632,9 @@ void store_checksums_for_desync_analysis(void)
             info->model = thing->model;
             info->owner = thing->owner;
             info->random_seed = thing->random_seed;
-            info->pos_x = thing->mappos.x.stl.num;
-            info->pos_y = thing->mappos.y.stl.num;
-            info->pos_z = thing->mappos.z.stl.num;
+            info->pos_x = thing->mappos.x.val;
+            info->pos_y = thing->mappos.y.val;
+            info->pos_z = thing->mappos.z.val;
             info->creation_turn = thing->creation_turn;
             info->index = thing->index;
             info->health = thing->health;
@@ -729,32 +722,40 @@ static void log_analyze_individual_thing_differences(void)
         if (host_checksum != 0 && client_checksum != 0) {
             if (client_checksum != host_checksum) {
                 ERRORLOG("    Thing INDEX %d MISMATCH - Client: %08lx vs Host: %08lx", i, client_checksum, host_checksum);
-                ERRORLOG("      CLIENT Thing[%d]: %s/%s owner:%d (%ld,%ld,%ld) health:%ld seed:%08lx creation_turn:%ld",
+                ERRORLOG("      CLIENT Thing[%d]: %s/%s owner:%d pos_val:(%ld,%ld,%ld) pos_stl:(%d,%d,%d) health:%ld seed:%08lx creation_turn:%ld",
                          client_info->index, thing_class_code_name(client_info->class_id),
                          thing_class_and_model_name(client_info->class_id, client_info->model),
-                         client_info->owner, client_info->pos_x, client_info->pos_y, client_info->pos_z,
+                         client_info->owner,
+                         client_info->pos_x, client_info->pos_y, client_info->pos_z,
+                         (int)(client_info->pos_x >> 8), (int)(client_info->pos_y >> 8), (int)(client_info->pos_z >> 8),
                          client_info->health, client_info->random_seed, client_info->creation_turn);
-                ERRORLOG("      HOST Thing[%d]: %s/%s owner:%d (%ld,%ld,%ld) health:%ld seed:%08lx creation_turn:%ld",
+                ERRORLOG("      HOST Thing[%d]: %s/%s owner:%d pos_val:(%ld,%ld,%ld) pos_stl:(%d,%d,%d) health:%ld seed:%08lx creation_turn:%ld",
                          host_info->index, thing_class_code_name(host_info->class_id),
                          thing_class_and_model_name(host_info->class_id, host_info->model),
-                         host_info->owner, host_info->pos_x, host_info->pos_y, host_info->pos_z,
+                         host_info->owner,
+                         host_info->pos_x, host_info->pos_y, host_info->pos_z,
+                         (int)(host_info->pos_x >> 8), (int)(host_info->pos_y >> 8), (int)(host_info->pos_z >> 8),
                          host_info->health, host_info->random_seed, host_info->creation_turn);
                 mismatched_count++;
             }
         } else if (host_checksum != 0 && client_checksum == 0) {
             ERRORLOG("    Thing INDEX %d MISSING on client - Host had checksum: %08lx", i, host_checksum);
-            ERRORLOG("      HOST Thing[%d]: %s/%s owner:%d (%ld,%ld,%ld) health:%ld seed:%08lx creation_turn:%ld",
+            ERRORLOG("      HOST Thing[%d]: %s/%s owner:%d pos_val:(%ld,%ld,%ld) pos_stl:(%d,%d,%d) health:%ld seed:%08lx creation_turn:%ld",
                      host_info->index, thing_class_code_name(host_info->class_id),
                      thing_class_and_model_name(host_info->class_id, host_info->model),
-                     host_info->owner, host_info->pos_x, host_info->pos_y, host_info->pos_z,
+                     host_info->owner,
+                     host_info->pos_x, host_info->pos_y, host_info->pos_z,
+                     (int)(host_info->pos_x >> 8), (int)(host_info->pos_y >> 8), (int)(host_info->pos_z >> 8),
                      host_info->health, host_info->random_seed, host_info->creation_turn);
             mismatched_count++;
         } else if (host_checksum == 0 && client_checksum != 0) {
             ERRORLOG("    Thing INDEX %d EXTRA on client (host has none) - Client checksum: %08lx", i, client_checksum);
-            ERRORLOG("      CLIENT Thing[%d]: %s/%s owner:%d (%ld,%ld,%ld) health:%ld seed:%08lx creation_turn:%ld",
+            ERRORLOG("      CLIENT Thing[%d]: %s/%s owner:%d pos_val:(%ld,%ld,%ld) pos_stl:(%d,%d,%d) health:%ld seed:%08lx creation_turn:%ld",
                      client_info->index, thing_class_code_name(client_info->class_id),
                      thing_class_and_model_name(client_info->class_id, client_info->model),
-                     client_info->owner, client_info->pos_x, client_info->pos_y, client_info->pos_z,
+                     client_info->owner,
+                     client_info->pos_x, client_info->pos_y, client_info->pos_z,
+                     (int)(client_info->pos_x >> 8), (int)(client_info->pos_y >> 8), (int)(client_info->pos_z >> 8),
                      client_info->health, client_info->random_seed, client_info->creation_turn);
             mismatched_count++;
         }


### PR DESCRIPTION
A recent log had its desync issues hidden, so this rectifies that. Either one of these:
```
cctrl->inst_turn
cctrl->instance_id
thing->max_frames
thing->current_frame
```
were being altered every turn, or the position was being slightly altered every turn. To simplify things we'll sync a few less fields, we've already got plenty.