### PR TITLE
Utilize low indices instead of high indices

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1642,9 +1642,9 @@ void clear_things_and_persons_data(void)
         // Create the list of free indices (skip index 0 since that's INVALID_THING
         if (i > 0) {
             if (i < SYNCED_THINGS_COUNT) {
-                game.synced_free_things[i-1] = i;
+                game.synced_free_things[SYNCED_THINGS_COUNT-i] = i;
             } else {
-                game.unsynced_free_things[i-1-SYNCED_THINGS_COUNT] = i;
+                game.unsynced_free_things[THINGS_COUNT-i] = i;
             }
         }
     }
@@ -1729,9 +1729,9 @@ void delete_all_thing_structures(void)
           delete_thing_structure(thing, 1);
       }
         if (i < SYNCED_THINGS_COUNT) {
-            game.synced_free_things[i-1] = i;
+            game.synced_free_things[SYNCED_THINGS_COUNT-i] = i;
         } else {
-            game.unsynced_free_things[i-1-SYNCED_THINGS_COUNT] = i;
+            game.unsynced_free_things[THINGS_COUNT-i] = i;
         }
     }
     game.synced_free_things_count = SYNCED_THINGS_COUNT-1;


### PR DESCRIPTION
Dragonlich had some performance concerns, this might fix that. But it's a good change regardless. I had a look and noticed that the first creatures on a map have their index start out very high, at the limit of 8191 (allocating in reverse order), this is easy to change just by reversing the list of available indices. I also printed all the values in a logging test to be sure this change isn't "off by 1".

If it doesn't improve performance then worse performance is most likely because we upped the `THINGS_COUNT` to 12288 (8192+4096) and there's a lot of loops in the game which loop through those 12k things a few dozen times every gameturn.