### PR TITLE
Make multiplayer instantly notify you if the custom sprite zip counts are different between players

### DIFF
--- a/src/bflib_network.cpp
+++ b/src/bflib_network.cpp
@@ -2269,6 +2269,11 @@ void SystemUserMsgCallback(unsigned long plr_id, void *msgbuf, unsigned long msg
   PlayerMapMsgHandler(plr_id, msg->client_data_table, msglen-1);
 }
 
+unsigned long get_host_player_id(void)
+{
+  return hostId;
+}
+
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/bflib_network.h
+++ b/src/bflib_network.h
@@ -235,6 +235,7 @@ TbError LbNetwork_EnumerateServices(TbNetworkCallbackFunc callback, void *user_d
 TbError LbNetwork_EnumeratePlayers(struct TbNetworkSessionNameEntry *sesn, TbNetworkCallbackFunc callback, void *user_data);
 TbError LbNetwork_EnumerateSessions(TbNetworkCallbackFunc callback, void *ptr);
 TbError LbNetwork_Stop(void);
+unsigned long get_host_player_id(void);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/custom_sprites.c
+++ b/src/custom_sprites.c
@@ -87,6 +87,8 @@ static int num_added_sprite = 0;
 static int num_added_icons = 0;
 unsigned char base_pal[PALETTE_SIZE];
 
+int total_sprite_zip_count = 0;
+
 static unsigned char big_scratch_data[1024*1024*16] = {0};
 unsigned char *big_scratch = big_scratch_data;
 
@@ -234,6 +236,7 @@ static int load_file_sprites(const char *path, const char *file_desc)
         {
             SYNCDBG(0, "Unable to load per-map icons from %s", file_desc);
         }
+        total_sprite_zip_count++;
     }
 
     return add_flag;
@@ -263,6 +266,7 @@ static void load_dir_sprites(const char *dir_path, const char *dir_desc)
 
         if (dir_desc != NULL)
             LbJustLog("Found %d sprite zip file(s) from %s, loaded %d with animations and %d with icons. Used %d/%d sprite slots.\n", cnt_zip, dir_desc, cnt_sprite, cnt_icon, next_free_sprite, KEEPERSPRITE_ADD_NUM);
+        total_sprite_zip_count += cnt_zip;
     }
 }
 
@@ -328,6 +332,7 @@ void init_custom_sprites(LevelNumber lvnum)
     SYNCDBG(8, "Starting");
     free_spritesheet(&custom_sprites);
     custom_sprites = create_spritesheet();
+    total_sprite_zip_count = 0;
     // This is a workaround because get_selected_level_number is zeroed on res change
     if (lvnum == SPRITE_LAST_LEVEL)
     {

--- a/src/custom_sprites.h
+++ b/src/custom_sprites.h
@@ -30,6 +30,8 @@ struct ObjectConfigStats;
 #define SPRITE_LAST_LEVEL -1
 void init_custom_sprites(LevelNumber level_no);
 
+extern int total_sprite_zip_count;
+
 short get_anim_id(const char *name, struct ObjectConfigStats* objst);
 short get_anim_id_(const char* name);
 short get_icon_id(const char *name);

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -383,7 +383,7 @@ void handle_autostart_multiplayer_messaging(void)
     static int message_length = 0;
 
     if (previous_player_count == 1 && net_number_of_enum_players == 2) {
-        if (my_player_number == 0 && message_char_index == -1 &&
+        if (my_player_number == get_host_player_id() && message_char_index == -1 &&
             (autostart_multiplayer_campaign[0] != '\0' || autostart_multiplayer_level > 0)) {
           // Prepare the campaign:level message
           if (!message_prepared) {
@@ -409,7 +409,7 @@ void handle_autostart_multiplayer_messaging(void)
       }
 
       // Send message one character per frame
-      if (message_char_index >= 0 && my_player_number == 0) {
+      if (message_char_index >= 0 && my_player_number == get_host_player_id()) {
         struct ScreenPacket *nspck;
         nspck = &net_screen_packet[my_player_number];
         if ((nspck->networkstatus_flags & 0xF8) == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2758,6 +2758,7 @@ void update(void)
 void first_gameturn_actions() {
     if (game.play_gameturn == 1) {
         apply_default_flee_and_imprison_setting();
+        send_sprite_zip_count_to_other_players();
     }
 }
 

--- a/src/net_sync.c
+++ b/src/net_sync.c
@@ -135,13 +135,7 @@ static void populate_desync_diagnostics(void)
 /******************************************************************************/
 long get_resync_sender(void)
 {
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++) {
-        struct PlayerInfo* player = get_player(i);
-        if (player_exists(player) && ((player->allocflags & PlaF_CompCtrl) == 0)) {
-            return i;
-        }
-    }
-    return -1;
+    return get_host_player_id();
 }
 
 TbBool send_resync_game(void)

--- a/src/packets.c
+++ b/src/packets.c
@@ -106,6 +106,7 @@ extern "C" {
 extern TbBool process_players_global_cheats_packet_action(PlayerNumber plyr_idx, struct Packet* pckt);
 extern TbBool process_players_dungeon_control_cheats_packet_action(PlayerNumber plyr_idx, struct Packet* pckt);
 extern TbBool change_campaign(const char *cmpgn_fname);
+extern int total_sprite_zip_count;
 /******************************************************************************/
 void set_packet_action(struct Packet *pckt, unsigned char pcktype, long par1, long par2, unsigned short par3, unsigned short par4)
 {
@@ -1129,6 +1130,11 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         query_creature(player, pckt->actn_par1, pckt->actn_par2, pckt->actn_par3);
         return false;
     }
+    case PckA_SpriteZipCountSync:
+    {
+        process_sprite_zip_count_sync(plyr_idx, pckt->actn_par1);
+        return true;
+    }
     default:
       return process_players_global_cheats_packet_action(plyr_idx, pckt);
   }
@@ -1901,6 +1907,33 @@ void force_application_close()
     {
         // We're in the frontend, just exit directly
         exit_keeper = 1;
+    }
+}
+
+void send_sprite_zip_count_to_other_players(void)
+{
+    struct PlayerInfo* my_player = get_my_player();
+    if (my_player != INVALID_PLAYER)
+    {
+        set_players_packet_action(my_player, PckA_SpriteZipCountSync, total_sprite_zip_count, 0, 0, 0);
+    }
+}
+
+void process_sprite_zip_count_sync(long plyr_idx, long zip_count)
+{
+    if (zip_count != total_sprite_zip_count)
+    {
+        if (my_player_number == 0)
+        {
+            message_add_fmt(MsgType_Player, 0,
+                "Verify /fxdata/ is the same across both PCs.");
+            message_add_fmt(MsgType_Player, 0,
+                "%s has %ld .zip files, %s has %d .zip files.",
+                network_player_name(plyr_idx), zip_count,
+                network_player_name(my_player_number), total_sprite_zip_count);
+            message_add_fmt(MsgType_Player, 0,
+                "WARNING: Custom sprite files mismatch detected!");
+        }
     }
 }
 

--- a/src/packets.c
+++ b/src/packets.c
@@ -1923,7 +1923,7 @@ void process_sprite_zip_count_sync(long plyr_idx, long zip_count)
 {
     if (zip_count != total_sprite_zip_count)
     {
-        if (my_player_number == 0)
+        if (my_player_number == get_host_player_id())
         {
             message_add_fmt(MsgType_Player, 0,
                 "Verify /fxdata/ is the same across both PCs.");

--- a/src/packets.h
+++ b/src/packets.h
@@ -185,6 +185,7 @@ enum TbPacketAction {
         PckA_PlyrQueryCreature,
         PckA_CheatGiveDoorTrap,
         PckA_RoomspaceHighlightToggle,
+        PckA_SpriteZipCountSync,
 };
 
 /** Packet flags for non-action player operation. */
@@ -338,6 +339,8 @@ TbBool player_sell_room_at_subtile(long plyr_idx, long stl_x, long stl_y);
 void set_tag_untag_mode(PlayerNumber plyr_idx);
 TbBool packets_process_cheats(PlayerNumber plyr_idx, MapCoord x, MapCoord y,
     struct Packet* pckt, MapSubtlCoord stl_x, MapSubtlCoord stl_y, MapSlabCoord slb_x, MapSlabCoord slb_y);
+void send_sprite_zip_count_to_other_players(void);
+void process_sprite_zip_count_sync(long plyr_idx, long zip_count);
 /******************************************************************************/
 #ifdef __cplusplus
 }


### PR DESCRIPTION
there's definitely way more you could do with checksumming lots of files, but I'm only bothering with checking the filecount here.

I've also standardized the `get_host_player_id` method.