### PR TITLE
move turn increase

### DIFF
--- a/src/gui_msgs.c
+++ b/src/gui_msgs.c
@@ -203,7 +203,7 @@ void message_update(void)
     while (i >= 0)
     {
         struct GuiMessage* gmsg = &game.messages[i];
-        if (gmsg->creation_turn < game.play_gameturn)
+        if (gmsg->expiration_turn <= game.play_gameturn)
         {
             game.active_messages_count--;
             game.messages[game.active_messages_count].text[0] = 0;
@@ -258,7 +258,7 @@ void message_add(char type, PlayerNumber plyr_idx, const char *text)
     }
     snprintf(game.messages[0].text, sizeof(game.messages[0].text), "%s", text);
     game.messages[0].plyr_idx = plyr_idx;
-    game.messages[0].creation_turn = game.play_gameturn + GUI_MESSAGES_DELAY;
+    game.messages[0].expiration_turn = game.play_gameturn + GUI_MESSAGES_DELAY;
     game.messages[0].target_idx = -1;
     game.messages[0].type = type;
     if (game.active_messages_count < GUI_MESSAGES_COUNT) {
@@ -289,7 +289,7 @@ void targeted_message_add(char type, PlayerNumber plyr_idx, PlayerNumber target_
     }
     snprintf(game.messages[0].text, sizeof(game.messages[0].text), "%s", full_msg_text);
     game.messages[0].plyr_idx = plyr_idx;
-    game.messages[0].creation_turn = game.play_gameturn + timeout;
+    game.messages[0].expiration_turn = game.play_gameturn + timeout;
     game.messages[0].target_idx = target_idx;
     game.messages[0].type = type;
     if (game.active_messages_count < GUI_MESSAGES_COUNT) {

--- a/src/gui_msgs.h
+++ b/src/gui_msgs.h
@@ -46,13 +46,13 @@ enum MessageTypes {
 struct GuiMessage_OLD { // sizeof = 0x45 (69)
     char text[64];
 PlayerNumber plyr_idx;
-unsigned long creation_turn;
+unsigned long expiration_turn;
 };
 
 struct GuiMessage {
     char text[64];
 PlayerNumber plyr_idx;
-unsigned long creation_turn;
+unsigned long expiration_turn;
 PlayerNumber target_idx;
 char type;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2746,6 +2746,7 @@ void update(void)
         things_stats_debug_dump();
         creature_stats_debug_dump();
 #endif
+        game.play_gameturn++;
     }
 
     message_update();

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -297,7 +297,6 @@ void update_player_sounds(void)
         {
             update_3d_sound_receiver(player);
         }
-        game.play_gameturn++;
     }
     find_nearest_rooms_for_ambient_sound();
     process_3d_sounds();


### PR DESCRIPTION
`game.play_gameturn++` being in `update_player_sounds()` has bothered me for a long time, it's a very important line so it shouldn't be hidden away. I've moved it to `update()` at the bottom of the "not paused" block.

Since `game.play_gameturn++` was near the top of the `update_player_sounds()` function (also in a "not paused" block), I believe moving it to where it is now only potentially affects `message_update()` and `update_all_players_cameras()`.

I don't think `update_all_players_cameras()` really uses the gameturn. `message_update()` does, so I've changed a `<` to a `<=`. And renamed a variable which had an incorrect name (surprisingly - not caused by my recent mass renaming).