### PR TITLE
Use max parallel jobs by default in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ VER_STRING = $(VER_MAJOR).$(VER_MINOR).$(VER_RELEASE).$(BUILD_NUMBER) $(PACKAGE_
 
 # Enable parallel compilation by default. Users can still override with: make -j8, make -j1, etc.
 ifndef MAKEFLAGS
-  MAKEFLAGS = -j
+  MAKEFLAGS = -j$(shell nproc)
 endif
 
 # load depenency packages


### PR DESCRIPTION
If you want more control over the cores used, you can write `-j8` or whatever and then that will be used instead. So this only affects the default. I think having a fast default is a good idea, as it provides the best first impression, especially to anyone new.

I also removed some "blank line spam" in the output - I think you get spammed with even more blank lines than usual when using more jobs.