### PR TITLE
Fixed corruption on change_slab_owner

### DIFF
--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -3410,7 +3410,7 @@ static void change_slab_owner_check(const struct ScriptLine *scline)
         SCRPTWRNLOG("Fill type %s not recognized", scline->tp[3]);
     }
 
-    command_add_value(Cmd_CHANGE_SLAB_OWNER, scline->np[2], scline->np[0], scline->np[1], get_id(fill_desc, scline->tp[3]));
+    command_add_value(Cmd_CHANGE_SLAB_OWNER, scline->np[2], scline->np[0], scline->np[1], filltype);
 }
 
 static void change_slab_owner_process(struct ScriptContext *context)

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -3869,17 +3869,6 @@ long take_over_room(struct Room* room, PlayerNumber newowner)
     // Mark that player 'knows' about such room
     research_found_room(newowner, room->kind);
 
-    if (oldowner == game.neutral_player_num)
-    {
-        room->owner = newowner;
-        room->health = compute_room_max_health(room->slabs_count, room->efficiency);
-        add_room_to_players_list(room, newowner);
-        change_room_map_element_ownership(room, newowner);
-        redraw_room_map_elements(room);
-        do_room_unprettying(room, newowner);
-        do_room_integration(room);
-        return 1;
-    } else
     if (oldowner != newowner)
     {
         reset_state_of_creatures_working_in_room(room);


### PR DESCRIPTION
Fixes 4173

Corruption was caused because player neutral was excluded from room lists. This was fine, until neutral got dungeon structures too.