### PR TITLE
Fixed bug where Computer Keepers sometimes didn't build more than one lair

### DIFF
--- a/src/map_events.h
+++ b/src/map_events.h
@@ -33,39 +33,39 @@ extern "C" {
 
 enum EventKinds {
     EvKind_Nothing = 0,
-    EvKind_HeartAttacked,
-    EvKind_EnemyFight,
+    EvKind_HeartAttacked,                  // ComputerKeeper: AttkHrt1 [event4] --> sends 99% of creatures to defend heart
+    EvKind_EnemyFight,                     // ComputerKeeper: Fight1/Fight2 [event7/8] --> engages in battle
     EvKind_Objective,
-    EvKind_Breach,
-    EvKind_NewRoomResrch, //5
+    EvKind_Breach,                         // ComputerKeeper: DnBreach [event1] --> sends 75% of creatures to defend against breach
+    EvKind_NewRoomResrch,
     EvKind_NewCreature,
     EvKind_NewSpellResrch,
     EvKind_NewTrap,
     EvKind_NewDoor,
-    EvKind_CreatrScavenged, //10
-    EvKind_TreasureRoomFull,
-    EvKind_CreaturePayday,
+    EvKind_CreatrScavenged,
+    EvKind_TreasureRoomFull,               // ComputerKeeper: RomFTrsr [event5] --> builds treasury room
+    EvKind_CreaturePayday,                 // ComputerKeeper: PayDay1 [event14] --> prepares gold for payday
     EvKind_AreaDiscovered,
     EvKind_SpellPickedUp,
-    EvKind_RoomTakenOver, //15
+    EvKind_RoomTakenOver,
     EvKind_CreatrIsAnnoyed,
-    EvKind_NoMoreLivingSet,
+    EvKind_NoMoreLivingSet,                // ComputerKeeper: RomFLair [event6] --> builds lair room
     EvKind_AlarmTriggered,
-    EvKind_RoomUnderAttack,
-    EvKind_NeedTreasureRoom,//20
+    EvKind_RoomUnderAttack,                // ComputerKeeper: AttkRom1/2 [event2/3] --> sends 75% of creatures to defend room
+    EvKind_NeedTreasureRoom,
     EvKind_Information,
-    EvKind_RoomLost,
+    EvKind_RoomLost,                       // ComputerKeeper: RoomLost [event15] --> rebuilds lost room
     EvKind_CreatrHungry,
     EvKind_TrapCrateFound,
-    EvKind_DoorCrateFound, //25
+    EvKind_DoorCrateFound,
     EvKind_DnSpecialFound,
     EvKind_QuickInformation,
     EvKind_FriendlyFight,
     EvKind_WorkRoomUnreachable,
-    EvKind_StorageRoomUnreachable, //30
-    EvKind_PrisonerStarving,
-    EvKind_TorturedHurt,
-    EvKind_EnemyDoor,
+    EvKind_StorageRoomUnreachable,
+    EvKind_PrisonerStarving,               // ComputerKeeper: MoanPris1/2/3 [event16/17/18] --> heals/tortures prisoners
+    EvKind_TorturedHurt,                   // ComputerKeeper: SaveTort1 [event19] --> saves low-health tortured creatures
+    EvKind_EnemyDoor,                      // ComputerKeeper: DoorAtck1 [event20] --> attacks enemy doors
     EvKind_SecretDoorDiscovered,
     EvKind_SecretDoorSpotted,
 };

--- a/src/room_entrance.c
+++ b/src/room_entrance.c
@@ -333,47 +333,52 @@ TbBool generate_creature_at_random_entrance(struct Dungeon * dungeon, ThingModel
 void generate_creature_for_dungeon(struct Dungeon * dungeon)
 {
     SYNCDBG(9,"Starting");
-
     ThingModel crmodel = calculate_creature_to_generate_for_dungeon(dungeon);
 
     if (crmodel > 0)
     {
         struct CreatureModelConfig* crconf = creature_stats_get(crmodel);
         long lair_space = calculate_free_lair_space(dungeon);
+
+        // Creature cannot enter dungeon unless player has enough gold
         if ((long)crconf->pay > dungeon->total_money_owned)
         {
             SYNCDBG(8,"The %s will not come as player %d has less than %d gold",creature_code_name(crmodel),(int)dungeon->owner,(int)crconf->pay);
             if (is_my_player_number(dungeon->owner)) {
                 output_message(SMsg_GoldLow, MESSAGE_DURATION_TREASURY);
             }
-        } else
-        if (lair_space > 0)
+        }
+        else if (lair_space >= 0)
         {
-            SYNCDBG(8,"The %s will come to player %d",creature_code_name(crmodel),(int)dungeon->owner);
-            generate_creature_at_random_entrance(dungeon, crmodel);
-        } else
-        if (lair_space == 0)
-        {
-            SYNCDBG(8,"The %s will come to player %d even though lair is full",creature_code_name(crmodel),(int)dungeon->owner);
-            generate_creature_at_random_entrance(dungeon, crmodel);
-            RoomKind rkind = find_first_available_roomkind_with_role(dungeon->owner,RoRoF_LairStorage);
-            if (rkind == RoK_NONE)
-            {
-                rkind = find_first_roomkind_with_role(RoRoF_LairStorage);
+            // Creatures can only enter the dungeon if your Lair has space for them. But one homeless creature is also allowed.
+            if (lair_space > 0) {
+                SYNCDBG(8,"The %s will come to player %d",creature_code_name(crmodel),(int)dungeon->owner);
+            } else {
+                SYNCDBG(8,"The %s will come to player %d even though lair is full",creature_code_name(crmodel),(int)dungeon->owner);
             }
-            if (dungeon_has_room_of_role(dungeon, RoRoF_LairStorage))
-            {
-                event_create_event_or_update_nearby_existing_event(0, 0, EvKind_NoMoreLivingSet, dungeon->owner, 0);
-                output_room_message(dungeon->owner, rkind, OMsg_RoomTooSmall);
-            } else
-            {
-                output_room_message(dungeon->owner, rkind, OMsg_RoomNeeded);
-            }
-        } else
+            generate_creature_at_random_entrance(dungeon, crmodel);
+        }
+        else
         {
+            // Lair is over capacity
             SYNCDBG(8,"The %s will not come as player %d has lair capacity exceeded",creature_code_name(crmodel),(int)dungeon->owner);
         }
-    } else
+        // Notify player they're out of lair space and play important EvKind_NoMoreLivingSet event for Computer Player.
+        if (lair_space <= 0)
+        {
+            RoomKind rkind = find_first_available_roomkind_with_role(dungeon->owner, RoRoF_LairStorage);
+            if (rkind == RoK_NONE) {
+                rkind = find_first_roomkind_with_role(RoRoF_LairStorage);
+            }
+            if (dungeon_has_room_of_role(dungeon, RoRoF_LairStorage)) {
+                event_create_event_or_update_nearby_existing_event(0, 0, EvKind_NoMoreLivingSet, dungeon->owner, 0);
+                output_room_message(dungeon->owner, rkind, OMsg_RoomTooSmall);
+            } else {
+                output_room_message(dungeon->owner, rkind, OMsg_RoomNeeded);
+            }
+        }
+    }
+    else
     {
         SYNCDBG(9,"There is no creature for player %d",(int)dungeon->owner);
     }


### PR DESCRIPTION
Fixes #3512

Basically in `generate_creature_for_dungeon()` when the `lair_space` calculation landed on a negative value (due to a fat dragon wanting 4 lair space) since it didn't land on precisely 0 it skipped sending the `EvKind_NoMoreLivingSet` event which was required for Computer Keepers to realize that they needed to build a new lair. (`EvKind_NoMoreLivingSet` is `[event6]` in `keepcompp.cfg`)

The reason it was rare is because it needed to be a creature with a high `LairSize` value in order to make the calculation go into the negatives, there's only a few creatures that have high `LairSize` and if you set them all to 1 that fixes (hides) the bug too.