### PR TITLE
Disable interpolated rotation for middle mouse

### DIFF
--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -37,6 +37,8 @@
 #include "frontmenu_ingame_map.h"
 #include "post_inc.h"
 
+extern void reset_mouse_light_interpolation(struct PlayerInfo *player);
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -102,6 +104,8 @@ void reset_interpolation_of_camera(struct PlayerInfo* player)
     previous_cam_mappos_y = cam->mappos.y.val;
     previous_cam_mappos_z = cam->mappos.z.val;
     reset_all_minimap_interpolation = true;
+
+    reset_mouse_light_interpolation(player);
 }
 
 void set_previous_camera_values(struct PlayerInfo* player) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2071,6 +2071,16 @@ void clear_lookups(void)
     game.columns.end = NULL;
 }
 
+void reset_mouse_light_interpolation(struct PlayerInfo *player)
+{
+    if (player->cursor_light_idx != 0)
+    {
+        struct Light* light = &game.lish.lights[player->cursor_light_idx];
+        light->disable_interp_for_turns = 2;
+        light->last_turn_drawn = 0;
+    }
+}
+
 void interp_fix_mouse_light_off_map(struct PlayerInfo *player)
 {
     // This fixes the interpolation issue of moving the mouse off map in one position then back onto the map far elsewhere.

--- a/src/packets.c
+++ b/src/packets.c
@@ -800,8 +800,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       player->cameras[CamIV_FrontView].rotation_angle_x = pckt->actn_par1;
       player->cameras[CamIV_Isometric].rotation_angle_x = pckt->actn_par1;
 
-      if ((is_my_player(player)) && (player->acamera->view_mode == PVM_FrontView)) {
-        // Fixes interpolated Things lagging for 1 turn when pressing middle mouse button to flip the camera in FrontView
+      if (is_my_player(player)) {
           reset_interpolation_of_camera(player);
       }
       return 0;


### PR DESCRIPTION
I think the crooked rotation from middle mouse button is inherent to the interpolated angle code which I can't figure out right now. I'm not sure whether that interpolated angle code can actually be fixed.

If you want a smooth rotation for middle mouse then it would be easiest to manually code the rotation.
Do we want it instant or smooth?