### PR TITLE
Roaming attacks Roaming

### DIFF
--- a/src/thing_navigate.c
+++ b/src/thing_navigate.c
@@ -389,7 +389,7 @@ TbBool creature_can_get_to_dungeon_heart(struct Thing *creatng, PlayerNumber ply
 {
     SYNCDBG(18,"Starting");
     struct PlayerInfo* player = get_player(plyr_idx);
-    if (!player_exists(player) || (player->is_active != 1))
+    if (!player_exists(player) || ((player->is_active != 1) && !player_is_roaming(plyr_idx)))
     {
         SYNCDBG(18,"The %s index %d cannot get to inactive player %d",thing_model_name(creatng),(int)creatng->index,(int)plyr_idx);
         return false;


### PR DESCRIPTION
Keepers set to roaming will try to kill other roaming keepers too.