### PR TITLE
Remove room from neutral dungeon when claimed

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -710,6 +710,7 @@ long instf_destroy(struct Thing *creatng, long *param)
         if (room->owner == game.neutral_player_num)
         {
             claim_room(room, creatng);
+            remove_room_from_players_list(room, game.neutral_player_num);
         } else
         {
             MapCoord ccor_x = subtile_coord_center(room->central_stl_x);

--- a/src/room_data.h
+++ b/src/room_data.h
@@ -222,6 +222,7 @@ long count_slabs_of_room_type(PlayerNumber plyr_idx, RoomKind rkind);
 long claim_enemy_room(struct Room *room,struct Thing *claimtng);
 long claim_room(struct Room *room,struct Thing *claimtng);
 long take_over_room(struct Room* room, PlayerNumber newowner);
+TbBool remove_room_from_players_list(struct Room* room, PlayerNumber plyr_idx);
 void destroy_room_leaving_unclaimed_ground(struct Room *room, TbBool create_rubble);
 TbBool create_effects_on_room_slabs(struct Room *room, ThingModel effkind, long effrange, PlayerNumber effowner);
 TbBool clear_dig_on_room_slabs(struct Room *room, PlayerNumber plyr_idx);


### PR DESCRIPTION
Fixes infinite loop bug on rooms

To reproduce the bug it fixes:
1) Start this map: https://keeperfx.net/workshop/item/517/colorful-wonderland
2) Wait a few seconds before green claims the neutral portal
3) Steal the portal away from them (with cheat menu is fine)
4) Have green claim the portal again (or put it back to green with cheat menu)
-> The entrance now has room-index 125, and room->next_of_owner 125, which is an infinite loop.

It could eventually cause hangs. The reported hang happened 50.000 game turns further along, when `find_room_nearest_to_position` came across the room on a computer player process. I suspect more reported hangs have had the same cause. Like [this one](https://keeperfx.net/dev/crash-report/122).