### PR TITLE
Hide multiplayer logging behind launch argument -mplog

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -114,7 +114,7 @@ unsigned long long LbSystemClockMilliseconds(void);
 #define SYNCLOG(format, ...) LbSyncLog("[%lu] %s: " format "\n", get_gameturn(), __func__ , ##__VA_ARGS__)
 #define JUSTLOG(format, ...) LbJustLog("[%lu] %s: " format "\n", get_gameturn(), __func__ , ##__VA_ARGS__)
 extern TbBool detailed_multiplayer_logging;
-#define MULTIPLAYER_LOG(format, ...) do { if (detailed_multiplayer_logging) { LbJustLog("[%lu][%llu ms] %s: " format "\n", get_gameturn(), LbSystemClockMilliseconds(), __func__ , ##__VA_ARGS__); } } while(0)
+#define MULTIPLAYER_LOG(format, ...) do { if (detailed_multiplayer_logging && game.game_kind == GKind_MultiGame) { LbJustLog("[%lu][%llu ms] %s: " format "\n", get_gameturn(), LbSystemClockMilliseconds(), __func__ , ##__VA_ARGS__); } } while(0)
 #define SCRPTLOG(format, ...) LbScriptLog(text_line_number,"%s: " format "\n", __func__ , ##__VA_ARGS__)
 #define SCRPTERRLOG(format, ...) LbErrorLog("%s(line %lu): " format "\n", __func__ , text_line_number, ##__VA_ARGS__)
 #define SCRPTWRNLOG(format, ...) LbWarnLog("%s(line %lu): " format "\n", __func__ , text_line_number, ##__VA_ARGS__)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4155,6 +4155,10 @@ short process_command_line(unsigned short argc, char *argv[])
       {
           set_flag(start_params.debug_flags, DFlg_ShowGameTurns);
       } else
+      if (strcasecmp(parstr, "mplog") == 0)
+      {
+          detailed_multiplayer_logging = true;
+      } else
       if (strcasecmp(parstr, "compuchat") == 0)
       {
           if (strcasecmp(pr2str,"scarce") == 0) {

--- a/src/net_resync.cpp
+++ b/src/net_resync.cpp
@@ -64,7 +64,7 @@ struct Boing {
 
 static struct Boing boing;
 
-TbBool detailed_multiplayer_logging = true;
+TbBool detailed_multiplayer_logging = false;
 
 #define CONSECUTIVE_RESYNC_DECAY_SECONDS 30
 #define CONSECUTIVE_RESYNC_THRESHOLD_FOR_LAG_INCREASE 3


### PR DESCRIPTION
It also won't display in singleplayer anymore, even if the launch argument is used.