### PR TITLE
Enable red fade when entering/exiting possession in multiplayer

### DIFF
--- a/src/vidfade.c
+++ b/src/vidfade.c
@@ -280,6 +280,9 @@ void ProperForcedFadePalette(unsigned char *pal, long fade_steps, enum TbPalette
 
 long PaletteFadePlayer(struct PlayerInfo *player)
 {
+    if (player->main_palette == NULL) {
+        return 0;
+    }
     long i;
     unsigned char palette[PALETTE_SIZE];
     // Find the fade step


### PR DESCRIPTION
I don't see any crashes, but I've added a safety check.