### PR TITLE
don't warn when stuff is free

### DIFF
--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -349,7 +349,7 @@ long take_money_from_dungeon_f(PlayerNumber plyr_idx, GoldAmount amount_take, Tb
     GoldAmount take_remain = amount_take;
     GoldAmount total_money = dungeon->total_money_owned;
     if (take_remain <= 0) {
-        WARNLOG("%s: No gold needed to be taken from player %d",func_name,(int)plyr_idx);
+        SYNCDBG(7, "%s: No gold needed to be taken from player %d",func_name,(int)plyr_idx);
         return 0;
     }
     if (take_remain > total_money)


### PR DESCRIPTION
take_money_from_dungeon_f currently keeps printing
``Warning: [21705] take_money_from_dungeon_f: pay_for_spell: No gold needed to be taken from player 1``
when  a mapmaker made something free, being free doesn't mean something is going wrong