### PR TITLE
potentional unrolled_loop crash fix

### DIFF
--- a/src/bflib_render_gpoly.c
+++ b/src/bflib_render_gpoly.c
@@ -856,6 +856,8 @@ void unrolled_loop(int pixel_span_len, int tex_x_accum_high,int tex_x_accum_comb
 
     pixel_dst = &screen_line_offset[gpoly_countdown[span_mod16]];
 
+    if (pixel_dst < LOC_vec_screen) return;
+
     pixel_span_remaining_count = pixel_span_len;
     int fade_lookup_index = __ROL4__(tex_x_accum_combined & 0xFF0000FF, 8);
     uint8_t *texture_map = LOC_vec_map;


### PR DESCRIPTION
potentional fix for
https://keeperfx.net/dev/crash-report/171
I haven't reproduced it myself

crashlog mentions 3440x1440x32 res so likely only happens on ultrawides