### PR TITLE
Align function declarations to definitions

### DIFF
--- a/src/game_merge.h
+++ b/src/game_merge.h
@@ -150,7 +150,7 @@ LevelNumber set_continue_level_number(LevelNumber lvnum);
 LevelNumber get_selected_level_number(void);
 LevelNumber set_selected_level_number(LevelNumber lvnum);
 TbBool activate_bonus_level(struct PlayerInfo *player);
-TbBool is_bonus_level_visible(struct PlayerInfo *player, long bn_lvnum);
+TbBool is_bonus_level_visible(struct PlayerInfo *player, LevelNumber bn_lvnum);
 void hide_all_bonus_levels(struct PlayerInfo *player);
 unsigned short get_extra_level_kind_visibility(unsigned short elv_kind);
 void update_extra_levels_visibility(void);

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -80,7 +80,7 @@ extern long nav_map_initialised;
 #define navmap_tile_number(stl_x,stl_y) ((stl_y)*game.navigation_map_size_x+(stl_x))
 /******************************************************************************/
 struct Map *get_map_block_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
-struct Map *get_map_block_at_pos(long stl_num);
+struct Map *get_map_block_at_pos(SubtlCodedCoords stl_num);
 TbBool map_block_invalid(const struct Map *mapblk);
 
 void reveal_map_subtile(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx);


### PR DESCRIPTION
`is_bonus_level_visible` and `get_map_block_at_pos` are declared with primitive types while defined with typedef'ed aliases.

This is an error when compiling with modern gcc/64 bit linux.