### PR TITLE
Use bitfield instead of enumerated masking.

### DIFF
--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -280,7 +280,7 @@ static TbBool cmd_magic_instance(PlayerNumber plyr_idx, char * args)
     crconf->learned_instance_id[slot] = instance;
     for (long i = 0; i < THINGS_COUNT; i++) {
         struct Thing * thing = thing_get(i);
-        if ((thing->alloc_flags & TAlF_Exists) != 0) {
+        if (thing->alloc_flags.TAlF_Exists) {
             if (thing->class_id == TCls_Creature) {
                 creature_increase_available_instances(thing);
             }

--- a/src/creature_control.c
+++ b/src/creature_control.c
@@ -149,7 +149,7 @@ struct Thing *create_and_control_creature_as_controller(struct PlayerInfo *playe
     const struct Camera* cam = player->acamera;
     set_selected_creature(player, thing);
     player->view_mode_restore = cam->view_mode;
-    thing->alloc_flags |= TAlF_IsControlled;
+    thing->alloc_flags.TAlF_IsControlled = 1;
     thing->rendering_flags |= TRF_Invisible;
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     cctrl->creature_state_flags |= TF2_Spectator;

--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -242,7 +242,7 @@ TbBool remove_creature_from_group_without_leader_consideration(struct Thing *cre
     // Finish removing the thing from group
     cctrl->group_info &= ~TngGroup_LeaderIndex;
     cctrl->group_info &= ~TngGroup_MemberCount;
-    creatng->alloc_flags &= ~TAlF_IsFollowingLeader;
+    creatng->alloc_flags.TAlF_IsFollowingLeader = 0;
     // Find leader of the party
     struct Thing *leadtng;
     if (was_leader) {
@@ -263,13 +263,13 @@ TbBool remove_creature_from_group_without_leader_consideration(struct Thing *cre
         if (creature_control_invalid(cctrl)) {
             WARNLOG("Group had only one member, %s index %d",thing_model_name(creatng),(int)creatng->index);
         }
-        leadtng->alloc_flags &= ~TAlF_IsFollowingLeader;
+        leadtng->alloc_flags.TAlF_IsFollowingLeader = 0;
         return false;
     }
     // If there is still more than one creature
     if (was_leader) {
         internal_update_leader_index_in_group(leadtng);
-        leadtng->alloc_flags &= ~TAlF_IsFollowingLeader;
+        leadtng->alloc_flags.TAlF_IsFollowingLeader = 0;
         leader_find_positions_for_followers(leadtng);
     }
     return true;
@@ -489,7 +489,7 @@ TbBool add_creature_to_group(struct Thing *creatng, struct Thing *grptng)
         // Remove member count from non-leader creature; the leader will have it computed somewhere else
         crctrl->group_info &= ~TngGroup_MemberCount;
     }
-    creatng->alloc_flags |= TAlF_IsFollowingLeader;
+    creatng->alloc_flags.TAlF_IsFollowingLeader = 1;
     return true;
 }
 
@@ -507,7 +507,7 @@ long add_creature_to_group_as_leader(struct Thing *creatng, struct Thing *grptng
         leadtng = grptng;
     // Change old leader to normal group member, and add new one to chain as its head
     internal_add_member_to_group_chain_head(creatng, leadtng);
-    leadtng->alloc_flags |= TAlF_IsFollowingLeader;
+    leadtng->alloc_flags.TAlF_IsFollowingLeader = 1;
     // Now go through all group members and set leader index
     internal_update_leader_index_in_group(creatng);
     return 1;
@@ -637,7 +637,7 @@ long process_obey_leader(struct Thing *thing)
     {
         return 1;
     }
-    if ((leadtng->alloc_flags & TAlF_IsControlled) != 0)
+    if (leadtng->alloc_flags.TAlF_IsControlled)
     {
         // If leader is controlled, always force followers to stay
         if (thing->active_state != CrSt_CreatureFollowLeader) {

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -446,14 +446,14 @@ long instf_creature_fire_shot(struct Thing *creatng, int32_t *param)
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     if (cctrl->targtng_idx == 0)
     {
-        if ((creatng->alloc_flags & TAlF_IsControlled) == 0)
+        if (!creatng->alloc_flags.TAlF_IsControlled)
         {
             hittype = THit_CrtrsOnlyNotOwn;
         }
         else
             hittype = THit_CrtrsNObjcts;
     }
-    else if ((creatng->alloc_flags & TAlF_IsControlled) != 0)
+    else if (creatng->alloc_flags.TAlF_IsControlled)
     {
         target = thing_get(cctrl->targtng_idx);
         TRACE_THING(target);
@@ -1131,7 +1131,7 @@ TbBool validate_source_basic
     int32_t param2
     )
 {
-    if ((source->alloc_flags & TAlF_IsControlled) != 0)
+    if (source->alloc_flags.TAlF_IsControlled)
     {
         // If this creature is under player's control (Possession).
         return false;

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -2602,7 +2602,7 @@ void creature_drag_object(struct Thing *creatng, struct Thing *dragtng)
     TRACE_THING(dragtng);
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     cctrl->dragtng_idx = dragtng->index;
-    dragtng->alloc_flags |= TAlF_IsDragged;
+    dragtng->alloc_flags.TAlF_IsDragged = 1;
     dragtng->state_flags |= TF1_IsDragged1;
     dragtng->owner = game.neutral_player_num;
     if (dragtng->light_id != 0) {
@@ -2624,7 +2624,7 @@ void creature_drop_dragged_object(struct Thing *creatng, struct Thing *dragtng)
     cctrl->dragtng_idx = 0;
     struct CreatureControl* dragctrl = creature_control_get_from_thing(dragtng);
     dragctrl->dragtng_idx = 0;
-    dragtng->alloc_flags &= ~TAlF_IsDragged;
+    dragtng->alloc_flags.TAlF_IsDragged = 0;
     dragtng->state_flags &= ~TF1_IsDragged1;
     move_thing_in_map(dragtng, &creatng->mappos);
     if (dragtng->light_id != 0) {
@@ -4507,7 +4507,7 @@ struct Thing *thing_update_enemy_to_fight_with(struct Thing *thing)
     {
         enemytng = thing_get(cctrl->seek_enemy.enemy_idx);
         TRACE_THING(enemytng);
-        if (((enemytng->alloc_flags & TAlF_Exists) == 0) || (cctrl->seek_enemy.enemy_creation_turn != enemytng->creation_turn))
+        if (!enemytng->alloc_flags.TAlF_Exists || (cctrl->seek_enemy.enemy_creation_turn != enemytng->creation_turn))
         {
           enemytng = INVALID_THING;
           cctrl->seek_enemy.enemy_creation_turn = 0;
@@ -4913,7 +4913,7 @@ TbBool can_change_from_state_to(const struct Thing *thing, CrtrStateId curr_stat
     if (curr_stati->state_type == CrStTyp_Move)
       curr_stati = get_thing_state_info_num(thing->continue_state);
     struct CreatureStateConfig* next_stati = get_thing_state_info_num(next_state);
-    if ((thing->alloc_flags & TAlF_IsControlled) != 0)
+    if (thing->alloc_flags.TAlF_IsControlled)
     {
         if ( (next_stati->state_type != CrStTyp_Idle) )
         {
@@ -4969,7 +4969,7 @@ short set_start_state_f(struct Thing *thing,const char *func_name)
     struct CreatureModelConfig* crconf;
     SYNCDBG(8,"%s: Starting for %s index %d, owner %d, last state %s, stacked %s",func_name,thing_model_name(thing),
         (int)thing->index,(int)thing->owner,creature_state_code_name(thing->active_state),creature_state_code_name(thing->continue_state));
-    if ((thing->alloc_flags & TAlF_IsControlled) != 0)
+    if (thing->alloc_flags.TAlF_IsControlled)
     {
         cleanup_current_thing_state(thing);
         initialise_thing_state(thing, CrSt_ManualControl);
@@ -5702,7 +5702,7 @@ short creature_timebomb(struct Thing *creatng)
         ERRORLOG("Invalid creature control; no action");
         return CrStRet_Unchanged;
     }
-    if ((creatng->alloc_flags & TAlF_IsControlled) == 0)
+    if (!creatng->alloc_flags.TAlF_IsControlled)
     {
         struct Thing* trgtng = get_timebomb_target(creatng);
         if (!thing_is_invalid(trgtng))

--- a/src/creature_states_spdig.c
+++ b/src/creature_states_spdig.c
@@ -1224,7 +1224,7 @@ short imp_drops_gold(struct Thing *spdigtng)
         internal_set_thing_state(spdigtng, CrSt_ImpLastDidJob);
         return 1;
     }
-    unsigned char state = ((spdigtng->alloc_flags & TAlF_IsControlled) == 0) ? CrSt_ImpLastDidJob : CrSt_Unused;
+    unsigned char state = !spdigtng->alloc_flags.TAlF_IsControlled ? CrSt_ImpLastDidJob : CrSt_Unused;
     long gold_added = 0;
     TbBool gold_created = false;
     struct Thing* gldtng = find_gold_hoard_at(center_stl_x, center_stl_y);
@@ -1266,7 +1266,7 @@ short imp_drops_gold(struct Thing *spdigtng)
     }
     if ((spdigtng->creature.gold_carried > 0) && (room->used_capacity < room->total_capacity))
     {
-        if ((spdigtng->alloc_flags & TAlF_IsControlled) == 0)
+        if (!spdigtng->alloc_flags.TAlF_IsControlled)
         {
             if (setup_head_for_empty_treasure_space(spdigtng, room)) {
                 spdigtng->continue_state = CrSt_ImpDropsGold;
@@ -1698,7 +1698,7 @@ short creature_picks_up_corpse(struct Thing *creatng)
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     struct Thing* picktng = thing_get(cctrl->pickup_object_id);
     TRACE_THING(picktng);
-    if (!thing_exists(picktng) || (flag_is_set(picktng->alloc_flags,TAlF_IsDragged))
+    if (!thing_exists(picktng) || picktng->alloc_flags.TAlF_IsDragged
         || (get_chessboard_distance(&creatng->mappos, &picktng->mappos) >= subtile_coord(2, 0)))
     {
         set_start_state(creatng);

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -135,7 +135,7 @@ static void draw_creature_view_icons(struct Thing* creatng)
         draw_gui_panel_sprite_left(x, y, ps_units_per_px, spridx);
         x += scale_ui_value_lofi(spr->SWidth);
     }
-    if ( (cctrl->dragtng_idx != 0) && ((creatng->alloc_flags & TAlF_IsDragged) == 0) )
+    if ( (cctrl->dragtng_idx != 0) && !creatng->alloc_flags.TAlF_IsDragged )
     {
         struct Thing* dragtng = thing_get(cctrl->dragtng_idx);
         unsigned long spr_idx;

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1455,7 +1455,7 @@ short get_creature_control_action_inputs(void)
         if (!make_packet)
         {
             TRACE_THING(thing);
-            if ((player->controlled_thing_creatrn != thing->creation_turn) || (!flag_is_set(thing->alloc_flags, TAlF_Exists)) || (thing->active_state == CrSt_CreatureUnconscious))
+            if ((player->controlled_thing_creatrn != thing->creation_turn) || !thing->alloc_flags.TAlF_Exists || (thing->active_state == CrSt_CreatureUnconscious))
             {
                 make_packet = true;
             }

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1853,7 +1853,7 @@ void gui_area_instance_button(struct GuiButton *gbtn)
     {
         long turns_progress;
         long turns_required;
-        if ((ctrltng->alloc_flags & TAlF_IsControlled) != 0) {
+        if (ctrltng->alloc_flags.TAlF_IsControlled) {
             turns_required = inst_inf->fp_reset_time;
         } else {
             turns_required = inst_inf->reset_time;

--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -53,7 +53,7 @@ static int make_thing_zombie (lua_State *L)
     //thing->active_state = CrSt_Disabled;
     //thing->continue_state = CrSt_Disabled;
 
-    thing->alloc_flags |= TAlF_IsControlled;
+    thing->alloc_flags.TAlF_IsControlled = 1;
 
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2508,7 +2508,7 @@ TngUpdateRet damage_creatures_with_physical_force(struct Thing *thing, ModTngFil
         apply_damage_to_thing_and_display_health(thing, param->secondary_number, param->primary_number);
         if ((thing->health >= 0) && !creature_is_leaving_and_cannot_be_stopped(thing))
         {
-            if (((thing->alloc_flags & TAlF_IsControlled) == 0) && !creature_is_kept_in_custody(thing))
+            if (!thing->alloc_flags.TAlF_IsControlled && !creature_is_kept_in_custody(thing))
             {
                 if (get_creature_state_besides_interruptions(thing) != CrSt_CreatureEscapingDeath)
                 {
@@ -3559,7 +3559,7 @@ void keeper_gameplay_loop(void)
 
 TbBool can_thing_be_queried(struct Thing *thing, PlayerNumber plyr_idx)
 {
-    if ( (!thing_is_creature(thing)) || !( (thing->owner == plyr_idx) || (creature_is_kept_in_custody_by_player(thing, plyr_idx)) ) || (thing->alloc_flags & TAlF_IsInLimbo) || (thing->state_flags & TF1_InCtrldLimbo) || (thing->active_state == CrSt_CreatureUnconscious) )
+    if ( (!thing_is_creature(thing)) || !( (thing->owner == plyr_idx) || (creature_is_kept_in_custody_by_player(thing, plyr_idx)) ) || thing->alloc_flags.TAlF_IsInLimbo || (thing->state_flags & TF1_InCtrldLimbo) || (thing->active_state == CrSt_CreatureUnconscious) )
     {
         return false;
     }

--- a/src/packets_misc.c
+++ b/src/packets_misc.c
@@ -191,7 +191,7 @@ TbBigChecksum compute_replay_integrity(void)
     for (long tng_idx = 0; tng_idx < THINGS_COUNT; tng_idx++)
     {
         struct Thing* tng = thing_get(tng_idx);
-        if ((tng->alloc_flags & TAlF_Exists) != 0)
+        if (tng->alloc_flags.TAlF_Exists)
         {
             // It would be nice to completely ignore effects, but since
             // thing indices are used in packets, lack of effect may cause desync too.

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -700,7 +700,7 @@ long computer_place_thing_in_power_hand(struct Computer2 *comp, struct Thing *th
         ERRORLOG("Computer tries to pick up %s index %d which is not pickable", thing_model_name(thing),(int)thing->index);
         return 0;
     }
-    if (flag_is_set(thing->alloc_flags, TAlF_IsControlled)) {
+    if (thing->alloc_flags.TAlF_IsControlled) {
         SYNCDBG(7,"Computer tries to pick up %s index %d which is being controlled", thing_model_name(thing),(int)thing->index);
         return 0;
     }
@@ -2350,7 +2350,7 @@ static struct Thing *find_creature_for_call_to_arms(struct Computer2 *comp, TbBo
     {
         struct CreatureControl *cctrl = creature_control_get_from_thing(i);
 
-        if ( flag_is_set(i->alloc_flags, TAlF_IsInLimbo) )
+        if (i->alloc_flags.TAlF_IsInLimbo)
             continue;
         if (flag_is_set(i->state_flags, TF1_InCtrldLimbo) )
             continue;

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -977,7 +977,7 @@ void leave_creature_as_controller(struct PlayerInfo *player, struct Thing *thing
     if (is_my_player(player)) {
         setup_eye_lens(0);
     }
-    thing->alloc_flags &= ~TAlF_IsControlled;
+    thing->alloc_flags.TAlF_IsControlled = 0;
     thing->rendering_flags &= ~TRF_Invisible;
     player->allocflags &= ~PlaF_CreaturePassengerMode;
     set_engine_view(player, player->view_mode_restore);
@@ -1373,7 +1373,7 @@ TbBool is_thing_directly_controlled_by_player(const struct Thing *thing, PlayerN
             case PI_HeartZoomOut:
             case PI_Drop:
             {
-                if ((thing->alloc_flags & TAlF_IsControlled) != 0)
+                if (thing->alloc_flags.TAlF_IsControlled)
                 {
                     if (player->view_type == PVT_CreatureContrl)
                     {

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -176,12 +176,12 @@ TbBool object_is_pickable_by_hand_to_hold_by_player(const struct Thing* thing, l
   */
 TbBool thing_is_picked_up(const struct Thing *thing)
 {
-    return (((thing->alloc_flags & TAlF_IsInLimbo) != 0) || ((thing->state_flags & TF1_InCtrldLimbo) != 0));
+    return (thing->alloc_flags.TAlF_IsInLimbo || ((thing->state_flags & TF1_InCtrldLimbo) != 0));
 }
 
 TbBool thing_is_picked_up_by_player(const struct Thing *thing, PlayerNumber plyr_idx)
 {
-    if ((thing->alloc_flags & TAlF_IsInLimbo) == 0)
+    if (!thing->alloc_flags.TAlF_IsInLimbo)
         return false;
     if (thing_is_in_power_hand_list(thing, plyr_idx))
         return true;
@@ -190,7 +190,7 @@ TbBool thing_is_picked_up_by_player(const struct Thing *thing, PlayerNumber plyr
 
 TbBool thing_is_picked_up_by_enemy(const struct Thing *thing)
 {
-    if ((thing->alloc_flags & TAlF_IsInLimbo) == 0)
+    if (!thing->alloc_flags.TAlF_IsInLimbo)
         return false;
     return !thing_is_in_power_hand_list(thing, thing->owner) && !thing_is_in_computer_power_hand_list(thing, thing->owner) && ((thing->state_flags & TF1_InCtrldLimbo) == 0);
 }
@@ -251,7 +251,7 @@ TbBool can_thing_be_picked_up2_by_player(const struct Thing *thing, PlayerNumber
     {
         return false;
     }
-    if ( (thing->active_state == CrSt_CreatureUnconscious) || ((thing->alloc_flags & TAlF_IsInLimbo) != 0) || ((thing->state_flags & TF1_InCtrldLimbo) != 0) || (thing->health <= 0) )
+    if ( (thing->active_state == CrSt_CreatureUnconscious) || thing->alloc_flags.TAlF_IsInLimbo || ((thing->state_flags & TF1_InCtrldLimbo) != 0) || (thing->health <= 0) )
     {
         return false;
     }
@@ -515,12 +515,12 @@ void place_thing_in_limbo(struct Thing *thing)
         thing->light_id = 0;
     }
     thing->rendering_flags |= TRF_Invisible;
-    thing->alloc_flags |= TAlF_IsInLimbo;
+    thing->alloc_flags.TAlF_IsInLimbo = 1;
 }
 
 void remove_thing_from_limbo(struct Thing *thing)
 {
-    thing->alloc_flags &= ~TAlF_IsInLimbo;
+    thing->alloc_flags.TAlF_IsInLimbo = 0;
     thing->rendering_flags &= ~TRF_Invisible;
     place_thing_in_mapwho(thing);
 }

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -2965,7 +2965,7 @@ void kill_room_contents_at_subtile(struct Room *room, PlayerNumber plyr_idx, Map
             }
             i = thing->next_on_mapblk;
             // Per thing code start
-            if (thing_is_spellbook(thing) && ((thing->alloc_flags & TAlF_IsDragged) == 0))
+            if (thing_is_spellbook(thing) && !thing->alloc_flags.TAlF_IsDragged)
             {
                 PowerKind spl_idx = book_thing_to_power_kind(thing);
                 dungeon = get_dungeon(plyr_idx);

--- a/src/room_library.c
+++ b/src/room_library.c
@@ -465,7 +465,7 @@ void reposition_all_books_in_room_on_subtile(struct Room *room, MapSubtlCoord st
         {
             ThingModel objkind = thing->model;
             PowerKind spl_idx = book_thing_to_power_kind(thing);
-            if ((spl_idx > 0) && ((thing->alloc_flags & TAlF_IsDragged) == 0))
+            if ((spl_idx > 0) && !thing->alloc_flags.TAlF_IsDragged)
             {
                 if (game.play_gameturn > 10) //Function is used to place books in rooms before dungeons are intialized
                 {
@@ -630,7 +630,7 @@ int check_books_on_subtile_for_reposition_in_room(struct Room *room, MapSubtlCoo
         if (thing_is_spellbook(thing))
         {
             PowerKind spl_idx = book_thing_to_power_kind(thing);
-            if ((spl_idx > 0) && ((thing->alloc_flags & TAlF_IsDragged) == 0) && ((thing->owner == room->owner) || game.play_gameturn < 10))//Function is used to integrate preplaced books at map startup too.
+            if ((spl_idx > 0) && !thing->alloc_flags.TAlF_IsDragged && ((thing->owner == room->owner) || game.play_gameturn < 10))//Function is used to integrate preplaced books at map startup too.
             {
                 // If exceeded capacity of the library
                 if (room->used_capacity > room->total_capacity)

--- a/src/room_workshop.c
+++ b/src/room_workshop.c
@@ -194,7 +194,7 @@ struct Thing *get_workshop_box_thing(PlayerNumber owner, ThingModel objmodel)
             break;
         i = thing->next_of_class;
         // Per-thing code
-        if ( ((thing->alloc_flags & TAlF_Exists) != 0) && (thing->model == objmodel) && (thing->owner == owner) )
+        if ( thing->alloc_flags.TAlF_Exists && (thing->model == objmodel) && (thing->owner == owner) )
         {
             struct Room* room = get_room_thing_is_on(thing);
             if (!thing_is_picked_up(thing) && room_role_matches(room->kind, RoRoF_CratesStorage) && (room->owner == owner))

--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -519,7 +519,7 @@ static TbBool imp_will_soon_be_converting_at_excluding(struct Thing *creatng, Ma
 
     while (!thing_is_invalid(thing))
     {
-        if ((thing->alloc_flags & TAlF_IsInLimbo) == 0 && (thing->state_flags & TF1_InCtrldLimbo) == 0)
+        if (!thing->alloc_flags.TAlF_IsInLimbo && (thing->state_flags & TF1_InCtrldLimbo) == 0)
         {
           if (thing->active_state == CrSt_MoveToPosition)
               continue_state = thing->continue_state;
@@ -730,7 +730,7 @@ long check_place_to_convert_excluding(struct Thing *creatng, MapSlabCoord slb_x,
                     (int)slb_x,(int)slb_y,thing_model_name(thing),(int)thing->index);
                 return 0;
             }
-            else if ((thing->alloc_flags & TAlF_IsControlled) != 0)
+            else if (thing->alloc_flags.TAlF_IsControlled)
             {
                 if (players_are_mutual_allies(thing->owner, creatng->owner))
                 {

--- a/src/thing_corpses.c
+++ b/src/thing_corpses.c
@@ -221,7 +221,7 @@ TngUpdateRet update_dead_creature(struct Thing *thing)
     SYNCDBG(18,"Starting");
     TRACE_THING(thing);
     long corpse_age;
-    if ((thing->alloc_flags & TAlF_IsDragged) == 0)
+    if (!thing->alloc_flags.TAlF_IsDragged)
     {
         if (thing->active_state == DCrSt_Dying)
         {
@@ -274,7 +274,7 @@ TngUpdateRet update_dead_creature(struct Thing *thing)
     if (subtile_has_water_on_top(thing->mappos.x.stl.num, thing->mappos.y.stl.num)) {
         thing->movement_flags |= TMvF_IsOnWater;
     }
-    if ((thing->alloc_flags & TAlF_IsControlled) != 0)
+    if (thing->alloc_flags.TAlF_IsControlled)
     {
         return move_dead_creature(thing);
     }
@@ -491,7 +491,7 @@ struct Thing *create_dead_creature(const struct Coord3d *pos, ThingModel model, 
 struct Thing *destroy_creature_and_create_corpse(struct Thing *thing, long crpscondition)
 {
     ThingModel crmodel = thing->model;
-    TbBool memf1 = ((thing->alloc_flags & TAlF_IsControlled) != 0);
+    TbBool memf1 = thing->alloc_flags.TAlF_IsControlled;
     struct Coord3d pos;
     pos.x.val = thing->mappos.x.val;
     pos.y.val = thing->mappos.y.val;
@@ -511,7 +511,7 @@ struct Thing *destroy_creature_and_create_corpse(struct Thing *thing, long crpsc
         return INVALID_THING;
     }
     deadtng->move_angle_xy = angle;
-    set_flag_value(deadtng->alloc_flags, TAlF_IsControlled, memf1);
+    deadtng->alloc_flags.TAlF_IsControlled = memf1;
     if (owner != game.neutral_player_num)
     {
         // Update thing index inside player struct

--- a/src/thing_data.c
+++ b/src/thing_data.c
@@ -101,7 +101,7 @@ static struct Thing *allocate_thing(enum ThingAllocationPool pool_type, const ch
 
     struct Thing *thing = thing_get(thing_idx);
     memset(thing, 0, sizeof(struct Thing));
-    thing->alloc_flags |= TAlF_Exists;
+    thing->alloc_flags.TAlF_Exists = 1;
     thing->index = thing_idx;
     thing->random_seed = thing->index * 9377 + 9439 + game.play_gameturn;
     TRACE_THING(thing);
@@ -155,7 +155,7 @@ TbBool i_can_allocate_free_thing_structure(unsigned char class_id)
 void delete_thing_structure_f(struct Thing *thing, long a2, const char *func_name)
 {
     TRACE_THING(thing);
-    if ((thing->alloc_flags & TAlF_InDungeonList) != 0) {
+    if (thing->alloc_flags.TAlF_InDungeonList) {
         remove_first_creature(thing);
     }
     if (!a2) {
@@ -230,7 +230,7 @@ TbBool thing_exists(const struct Thing *thing)
 {
     if (thing_is_invalid(thing))
         return false;
-    if ((thing->alloc_flags & TAlF_Exists) == 0)
+    if (!thing->alloc_flags.TAlF_Exists)
         return false;
 #if (BFDEBUG_LEVEL > 0)
     if (thing->index != (thing-thing_get(0)))
@@ -262,17 +262,17 @@ struct Thing* get_parent_thing(const struct Thing* thing)
   */
 TbBool thing_is_in_limbo(const struct Thing* thing)
 {
-    return (thing->alloc_flags & TAlF_IsInLimbo);
+    return thing->alloc_flags.TAlF_IsInLimbo;
 }
 
 TbBool thing_is_dragged_or_pulled(const struct Thing *thing)
 {
-    return ((thing->state_flags & TF1_IsDragged1) != 0) || ((thing->alloc_flags & TAlF_IsDragged) != 0);
+    return ((thing->state_flags & TF1_IsDragged1) != 0) || thing->alloc_flags.TAlF_IsDragged;
 }
 
 struct PlayerInfo *get_player_thing_is_controlled_by(const struct Thing *thing)
 {
-    if ((thing->alloc_flags & TAlF_IsControlled) == 0)
+    if (!thing->alloc_flags.TAlF_IsControlled)
         return INVALID_PLAYER;
     return get_player(thing->owner);
 }

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -19,6 +19,7 @@
 #ifndef DK_THING_DATA_H
 #define DK_THING_DATA_H
 
+#include <assert.h>
 #include "globals.h"
 #include "bflib_basics.h"
 
@@ -36,16 +37,18 @@ typedef unsigned short Thingid;
 
 /******************************************************************************/
 /** Enums for thing->alloc_flags bit fields. */
-enum ThingAllocFlags {
-    TAlF_Exists            = 0x01,
-    TAlF_IsInMapWho        = 0x02,
-    TAlF_IsInStrucList     = 0x04,
-    TAlF_InDungeonList     = 0x08,
-    TAlF_IsInLimbo         = 0x10,
-    TAlF_IsControlled      = 0x20,
-    TAlF_IsFollowingLeader = 0x40,
-    TAlF_IsDragged         = 0x80,
-};
+typedef struct {
+  unsigned char TAlF_Exists : 1;
+  unsigned char TAlF_IsInMapWho : 1;
+  unsigned char TAlF_IsInStrucList : 1;
+  unsigned char TAlF_InDungeonList : 1;
+  unsigned char TAlF_IsInLimbo : 1;
+  unsigned char TAlF_IsControlled : 1;
+  unsigned char TAlF_IsFollowingLeader : 1;
+  unsigned char TAlF_IsDragged : 1;
+} ThingAllocFlags;
+
+static_assert(sizeof(ThingAllocFlags) == 1, "Bit field ThingAllocFlags must be one byte");
 
 /** Enum for specifying thing allocation pool type. */
 enum ThingAllocationPool {
@@ -117,7 +120,7 @@ enum ThingMovementFlags {
 struct Room;
 
 struct Thing {
-    unsigned char alloc_flags;
+    ThingAllocFlags alloc_flags;
     unsigned char state_flags;
     unsigned short next_on_mapblk;
     unsigned short prev_on_mapblk;

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -106,7 +106,7 @@ void set_previous_thing_position(struct Thing *thing) {
  */
 void add_thing_to_list(struct Thing *thing, struct StructureList *list)
 {
-    if ((thing->alloc_flags & TAlF_IsInStrucList) != 0)
+    if (thing->alloc_flags.TAlF_IsInStrucList)
     {
         ERRORLOG("Thing is already in list");
         return;
@@ -116,7 +116,7 @@ void add_thing_to_list(struct Thing *thing, struct StructureList *list)
         prevtng = thing_get(list->index);
     }
     list->count++;
-    thing->alloc_flags |= TAlF_IsInStrucList;
+    thing->alloc_flags.TAlF_IsInStrucList = 1;
     thing->prev_of_class = 0;
     thing->next_of_class = list->index;
     if (!thing_is_invalid(prevtng)) {
@@ -128,7 +128,7 @@ void add_thing_to_list(struct Thing *thing, struct StructureList *list)
 void remove_thing_from_list(struct Thing *thing, struct StructureList *slist)
 {
     struct Thing *sibtng;
-    if ((thing->alloc_flags & TAlF_IsInStrucList) == 0)
+    if (!thing->alloc_flags.TAlF_IsInStrucList)
         return;
     if (thing->index == slist->index)
     {
@@ -164,7 +164,7 @@ void remove_thing_from_list(struct Thing *thing, struct StructureList *slist)
         thing->prev_of_class = 0;
         thing->next_of_class = 0;
     }
-    thing->alloc_flags &= ~TAlF_IsInStrucList;
+    thing->alloc_flags.TAlF_IsInStrucList = 0;
     if (slist->count <= 0) {
         ERRORLOG("List has < 0 structures");
         return;
@@ -993,9 +993,9 @@ void update_things_in_list(struct StructureList *list)
       }
       i = thing->next_of_class;
       // Per-thing code
-      if ((thing->alloc_flags & TAlF_IsFollowingLeader) == 0)
+      if (!thing->alloc_flags.TAlF_IsFollowingLeader)
       {
-          if ((thing->alloc_flags & TAlF_IsInLimbo) != 0) {
+          if (thing->alloc_flags.TAlF_IsInLimbo) {
               update_thing_animation(thing);
           } else {
               update_thing(thing);
@@ -1095,9 +1095,9 @@ unsigned long update_creatures_not_in_list(void)
       ERRORLOG("Some THING has been deleted during the processing of another thing");
       break;
     }
-    if ((thing->alloc_flags & TAlF_IsFollowingLeader) != 0)
+    if (thing->alloc_flags.TAlF_IsFollowingLeader)
     {
-      if ((thing->alloc_flags & TAlF_IsInLimbo) != 0) {
+      if (thing->alloc_flags.TAlF_IsInLimbo) {
         update_thing_animation(thing);
       } else {
         update_thing(thing);
@@ -1354,7 +1354,7 @@ void remove_thing_from_mapwho(struct Thing *thing)
 {
     struct Thing *mwtng;
     SYNCDBG(18,"Starting");
-    if ((thing->alloc_flags & TAlF_IsInMapWho) == 0)
+    if (!thing->alloc_flags.TAlF_IsInMapWho)
         return;
     if (thing->prev_on_mapblk > 0)
     {
@@ -1387,13 +1387,13 @@ void remove_thing_from_mapwho(struct Thing *thing)
     }
     thing->next_on_mapblk = 0;
     thing->prev_on_mapblk = 0;
-    thing->alloc_flags &= ~TAlF_IsInMapWho;
+    thing->alloc_flags.TAlF_IsInMapWho = 0;
 }
 
 void place_thing_in_mapwho(struct Thing *thing)
 {
     SYNCDBG(18,"Starting");
-    if ((thing->alloc_flags & TAlF_IsInMapWho) != 0)
+    if (thing->alloc_flags.TAlF_IsInMapWho)
         return;
     struct Map* mapblk = get_map_block_at(thing->mappos.x.stl.num, thing->mappos.y.stl.num);
     thing->next_on_mapblk = get_mapwho_thing_index(mapblk);
@@ -1409,7 +1409,7 @@ void place_thing_in_mapwho(struct Thing *thing)
     }
     set_mapwho_thing_index(mapblk, thing->index);
     thing->prev_on_mapblk = 0;
-    thing->alloc_flags |= TAlF_IsInMapWho;
+    thing->alloc_flags.TAlF_IsInMapWho = 1;
 }
 
 struct Thing *find_base_thing_on_mapwho(ThingClass oclass, ThingModel model, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
@@ -3100,7 +3100,7 @@ void stop_all_things_playing_samples(void)
     for (long i = 0; i < THINGS_COUNT; i++)
     {
         struct Thing* thing = thing_get(i);
-        if ((thing->alloc_flags & TAlF_Exists) != 0)
+        if (thing->alloc_flags.TAlF_Exists)
         {
             if (thing->snd_emitter_id)
             {
@@ -3176,7 +3176,7 @@ TbBool update_thing(struct Thing *thing)
                 }
                 else
                 {
-                    if (thing_above_flight_altitude(thing) && ((thing->alloc_flags & TAlF_IsControlled) == 0))
+                    if (thing_above_flight_altitude(thing) && !thing->alloc_flags.TAlF_IsControlled)
                     {
                         thing->veloc_push_add.z.val -= thing->fall_acceleration;
                         thing->state_flags |= TF1_PushAdd;

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -1285,7 +1285,7 @@ static TngUpdateRet object_update_dungeon_heart(struct Thing *heartng)
     process_dungeon_destroy(heartng);
 
     SYNCDBG(18,"Beat update");
-    if ((heartng->alloc_flags & TAlF_Exists) == 0)
+    if (!heartng->alloc_flags.TAlF_Exists)
       return TUFRet_Modified;
     if (objst->model_flags & OMF_Beating)
     {


### PR DESCRIPTION
Seems that the use of enum + manual bit operations is an artifact of disassembly, while in the original code they used bitfields.

This commit replaces use of manual masking for ThingAllocFlags.

Since in the original code alloc_flags was 1 byte the commit also includes static assert that sizeof(ThingAllocFlags) still remains one.

However static_assert() might not be available on all compilers and I have no way to check that.

The patch uses 1 and 0 as flag set/reset markers. true/false might be a better choice.

The patch leaves field names as is, however it might be better to replace prefixed names like alloc_flags.TAlF_IsControlled with shorter names like alloc_flags.IsControlled.

The patch assumes the following:
* (a & B) != 0 is a check for flag B raised
* flag_is_set(a, B) same as previous
* a |= B is raising the flag B
* set_flag_value(a, B) as as previous
* a &= ~B is clearing the flag B
* (a & B) == 0 is a check for flag B cleared