### PR TITLE
Multiplayer: Smooth lobby/landview/torture screen at high ping

### DIFF
--- a/src/bflib_enet.cpp
+++ b/src/bflib_enet.cpp
@@ -31,7 +31,6 @@
 #include "post_inc.h"
 
 #define NUM_CHANNELS 2
-#define CONNECT_TIMEOUT 3000
 #define DEFAULT_PORT 5556
 
 namespace
@@ -175,7 +174,7 @@ namespace
         {
             return Lb_FAIL;
         }
-        if (wait_for_connect(CONNECT_TIMEOUT))
+        if (wait_for_connect(TIMEOUT_ENET_CONNECT))
         {
             host_destroy();
             return Lb_FAIL;

--- a/src/bflib_mshandler.cpp
+++ b/src/bflib_mshandler.cpp
@@ -26,6 +26,7 @@
 #include "bflib_basics.h"
 #include "bflib_mouse.h"
 #include "bflib_sprite.h"
+#include <SDL2/SDL.h>
 
 #include "keeperfx.hpp"
 #include "post_inc.h"
@@ -265,5 +266,18 @@ bool MouseStateHandler::PointerEndSwap(void)
       }
     }
     return true;
+}
+
+void MouseStateHandler::UpdateMouseFromSDL(void)
+{
+    int host_cursor_x;
+    int host_cursor_y;
+    std::lock_guard<std::mutex> guard(lock);
+    SDL_PumpEvents();
+    SDL_GetMouseState(&host_cursor_x, &host_cursor_y);
+    if (SetPosition(host_cursor_x, host_cursor_y)) {
+        lbDisplay.MMouseX = mspos.x;
+        lbDisplay.MMouseY = mspos.y;
+    }
 }
 /******************************************************************************/

--- a/src/bflib_mshandler.hpp
+++ b/src/bflib_mshandler.hpp
@@ -45,6 +45,7 @@ class MouseStateHandler {
     bool SetMouseWindow(long x, long y,long width, long height);
     bool PointerBeginSwap(void);
     bool PointerEndSwap(void);
+    void UpdateMouseFromSDL(void);
  protected:
     bool SetPointer(const struct TbSprite *spr, struct TbPoint *pt);
     // Properties

--- a/src/bflib_network.cpp
+++ b/src/bflib_network.cpp
@@ -36,7 +36,7 @@
 
 #ifdef __cplusplus
 void gameplay_loop_draw();
-extern "C" void network_yield_draw();
+extern "C" void network_yield_draw_gameplay();
 #endif
 
 #ifdef __cplusplus

--- a/src/bflib_network.h
+++ b/src/bflib_network.h
@@ -29,6 +29,11 @@ extern "C" {
 /******************************************************************************/
 
 #define CLIENT_TABLE_LEN 32
+
+#define TIMEOUT_ENET_CONNECT 2000
+#define TIMEOUT_JOIN_LOBBY 2000
+#define TIMEOUT_LOBBY_EXCHANGE 3000
+#define TIMEOUT_GAMEPLAY_MISSING_PACKET 8000
 /******************************************************************************/
 #pragma pack(1)
 

--- a/src/front_landview.h
+++ b/src/front_landview.h
@@ -45,21 +45,21 @@ enum MapLevelInfoFlags {
 
 struct MapLevelInfo { // sizeof = 56
   unsigned char fadeflags;
-  long fade_step;
-  long fade_pos;
-  long hotspot_imgpos_x; /**< Position of the chosen level ensign zoom area, which is either being zoomed in to or zoomed out from. Stored as land view background bitmap coordinate. */
-  long hotspot_imgpos_y;
+  float fade_step;
+  float fade_pos;
+  float hotspot_imgpos_x; /**< Position of the chosen level ensign zoom area, which is either being zoomed in to or zoomed out from. Stored as land view background bitmap coordinate. */
+  float hotspot_imgpos_y;
   long state_trigger;
-  long screen_shift_x; /**< Shift X coordinate for top left corner of the visible land picture area. Acts as the final shift in both zoom and non-zoom modes. */
-  long screen_shift_y; /**< Shift Y coordinate for top left corner of the visible land picture area. */
-  long precise_scrshift_x; /**< Precise shift X for top left corner of the visible land picture area. Extended precision version, used as source for scrshift_x while zooming. */
-  long precise_scrshift_y; /**< Precise shift Y for top left corner of the visible land picture area. */
-  long velocity_x; /**< Velocity at which screen_shift_x is being changed. */
-  long velocity_y; /**< Velocity at which screen_shift_y is being changed. */
-  long hotspot_shift_x; /**< Position of the chosen level ensign zoom area, which is either being zoomed in to or zoomed out from. Set to top left corner of an area which would have the ensign in center. */
-  long hotspot_shift_y;
-  long screen_shift_aimed_x; /**< Shift X coordinate at which the screen_shift is aiming towards zooming. */
-  long screen_shift_aimed_y;
+  float screen_shift_x; /**< Shift X coordinate for top left corner of the visible land picture area. Acts as the final shift in both zoom and non-zoom modes. */
+  float screen_shift_y; /**< Shift Y coordinate for top left corner of the visible land picture area. */
+  float precise_scrshift_x; /**< Precise shift X for top left corner of the visible land picture area. Extended precision version, used as source for scrshift_x while zooming. */
+  float precise_scrshift_y; /**< Precise shift Y for top left corner of the visible land picture area. */
+  float velocity_x; /**< Velocity at which screen_shift_x is being changed. */
+  float velocity_y; /**< Velocity at which screen_shift_y is being changed. */
+  float hotspot_shift_x; /**< Position of the chosen level ensign zoom area, which is either being zoomed in to or zoomed out from. Set to top left corner of an area which would have the ensign in center. */
+  float hotspot_shift_y;
+  float screen_shift_aimed_x; /**< Shift X coordinate at which the screen_shift is aiming towards zooming. */
+  float screen_shift_aimed_y;
 };
 
 struct ScreenPacket {

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -89,6 +89,7 @@
 #include "sprites.h"
 #include "moonphase.h"
 #include "config_keeperfx.h"
+#include "bflib_mshandler.hpp"
 #include "post_inc.h"
 
 #ifdef __cplusplus
@@ -96,6 +97,8 @@ extern "C" {
 #endif
 
 extern void enum_sessions_callback(struct TbNetworkCallbackData *netcdat, void *ptr);
+extern long double last_draw_completed_time;
+long double get_time_tick_ns();
 /******************************************************************************/
 TbClockMSec gui_message_timeout = 0;
 char gui_message_text[TEXT_BUFFER_LENGTH];
@@ -3400,6 +3403,7 @@ void draw_debug_messages() {
  */
 short frontend_draw(void)
 {
+    pointerHandler.UpdateMouseFromSDL();
     short result;
     switch (frontend_menu_state)
     {
@@ -3476,6 +3480,7 @@ short frontend_draw(void)
     draw_debug_messages();
     perform_any_screen_capturing();
     LbScreenUnlock();
+    last_draw_completed_time = get_time_tick_ns();
     return result;
 }
 


### PR DESCRIPTION
This one was really tricky to discover the correct approach for, it took me quite a while. It looks very simple and obvious in hindsight though.

The chat box still hasn't received the treatment (it'll still feel the same as before), but everything else has been made smoother. It shouldn't be too difficult to do the chat box too, because I've already done the in-game chat, but that can be a separate PR.

Known issue: in the landview you see your own hand move smoothly but you don't see your opponent's hand move smoothly, and vice versa for what the other player sees. To fix this I'd need to interpolate hand positions.