### PR TITLE
Multiplayer: set input lag 0 requirement to <25ms

### DIFF
--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -132,7 +132,7 @@ void LbNetwork_UpdateInputLagIfHost(void) {
     int combined_time = turn_time_ms + extra_turn_processing_time;
     input_lag = max(1, average_ping / combined_time);
     
-    if (average_ping <= 40) {
+    if (average_ping < 25) {
         input_lag = 0;
     }
 


### PR DESCRIPTION
Going with the theory that half-a-turn (half of 50ms) should provide the smoothest experience when choosing between input lag 0 and input lag 1.