### PR TITLE
Fixed directional keyboard controls in Forced Perspective

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -2195,47 +2195,19 @@ void get_isometric_view_nonaction_inputs(void)
             set_packet_control(packet, PCtr_ViewTiltReset);
         if ( is_game_key_pressed(Gkey_MoveLeft, NULL, no_mods) || is_key_pressed(KC_LEFT,KMod_DONTCARE) )
         {
-            if(player->work_state == PSt_FreeCtrlDirect || player->work_state == PSt_CtrlDirect)
-            {
-                set_packet_control(packet, PCtr_MoveLeft);
-            }
-            else
-            {
-                 movement_accum_x = -1.0f;
-            }
+            movement_accum_x = -1.0f;
         }
         if ( is_game_key_pressed(Gkey_MoveRight, NULL, no_mods) || is_key_pressed(KC_RIGHT,KMod_DONTCARE) )
         {
-            if(player->work_state == PSt_FreeCtrlDirect || player->work_state == PSt_CtrlDirect)
-            {
-                set_packet_control(packet, PCtr_MoveRight);
-            }
-            else
-            {
-                 movement_accum_x = 1.0f;
-            }
+            movement_accum_x = 1.0f;
         }
         if ( is_game_key_pressed(Gkey_MoveUp, NULL, no_mods) || is_key_pressed(KC_UP,KMod_DONTCARE) )
         {
-            if(player->work_state == PSt_FreeCtrlDirect || player->work_state == PSt_CtrlDirect)
-            {
-                set_packet_control(packet, PCtr_MoveUp);
-            }
-            else
-            {
-                 movement_accum_y = -1.0f;
-            }
+            movement_accum_y = -1.0f;
         }
         if ( is_game_key_pressed(Gkey_MoveDown, NULL, no_mods) || is_key_pressed(KC_DOWN,KMod_DONTCARE) )
         {
-            if(player->work_state == PSt_FreeCtrlDirect || player->work_state == PSt_CtrlDirect)
-            {
-                set_packet_control(packet, PCtr_MoveDown);
-            }
-            else
-            {
-                 movement_accum_y = 1.0f;
-            }
+            movement_accum_y = 1.0f;
         }
         // Packets will be sent by send_camera_catchup_packets() based on position difference
     }
@@ -2331,13 +2303,21 @@ void get_front_view_nonaction_inputs(void)
           }
         }
         if ( is_game_key_pressed(Gkey_MoveLeft, NULL, no_mods) || is_key_pressed(KC_LEFT,KMod_DONTCARE) )
-            set_packet_control(pckt, PCtr_MoveLeft);
+        {
+            movement_accum_x = -1.0f;
+        }
         if ( is_game_key_pressed(Gkey_MoveRight, NULL, no_mods) || is_key_pressed(KC_RIGHT,KMod_DONTCARE) )
-            set_packet_control(pckt, PCtr_MoveRight);
+        {
+             movement_accum_x = 1.0f;
+        }
         if ( is_game_key_pressed(Gkey_MoveUp, NULL, no_mods) || is_key_pressed(KC_UP,KMod_DONTCARE) )
-            set_packet_control(pckt, PCtr_MoveUp);
+        {
+             movement_accum_y = -1.0f;
+        }
         if ( is_game_key_pressed(Gkey_MoveDown, NULL, no_mods) || is_key_pressed(KC_DOWN,KMod_DONTCARE) )
-            set_packet_control(pckt, PCtr_MoveDown);
+        {
+             movement_accum_y = 1.0f;
+        }
     }
     if ( is_game_key_pressed(Gkey_ZoomIn, NULL, false) )
         set_packet_control(pckt, PCtr_ViewZoomIn);


### PR DESCRIPTION
Fixes #4479

Also fixed being unable to use the keyboard to navigate with Possess Creature selected.