### PR TITLE
fix palette issues

### DIFF
--- a/src/vidfade.c
+++ b/src/vidfade.c
@@ -280,10 +280,6 @@ void ProperForcedFadePalette(unsigned char *pal, long fade_steps, enum TbPalette
 
 long PaletteFadePlayer(struct PlayerInfo *player)
 {
-    if (player->main_palette != engine_palette && player->main_palette != player->lens_palette) {
-        ERRORLOG("main_palette (%p) is invalid (engine: %p, lens: %p), resetting", player->main_palette, engine_palette, player->lens_palette);
-        player->main_palette = engine_palette;
-    }
     long i;
     unsigned char palette[PALETTE_SIZE];
     // Find the fade step


### PR DESCRIPTION
Fixes #4487.
But might bring back the multiplayer possession crash. #4423 did three other things for the fix so maybe those edits are all that's required.

I cannot recreate the multiplayer possession crash even after 50 possession tries. But it's probably always been a difficult one to recreate.