### PR TITLE
Prevent queued left-click when opening game

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3783,6 +3783,9 @@ static TbBool wait_at_frontend(void)
     frontend_set_state(get_startup_menu_state());
     try_restore_frontend_error_box();
 
+    LbWindowsControl();
+    clear_mouse_pressed_lrbutton();
+
     short finish_menu = 0;
     clear_flag(game.mode_flags, MFlg_DemoMode);
     // TODO move to separate function


### PR DESCRIPTION
When you run the executable, there's the red disc loading screen and if you click during this loading screen then your click will carry over to the main menu and then automatically click on one of the menu options.

This issue was introduced at some point when I made the mouse smoother.