### PR TITLE
No mystery flag on Ctrl+F11

### DIFF
--- a/src/front_landview.c
+++ b/src/front_landview.c
@@ -158,7 +158,10 @@ void set_all_ensigns_state(unsigned short nstate)
     struct LevelInformation* lvinfo = get_first_level_info();
     while (lvinfo != NULL)
     {
-        lvinfo->state = nstate;
+        if (lvinfo->lvnum != 0)
+        {
+            lvinfo->state = nstate;
+        }
         lvinfo = get_next_level_info(lvinfo);
     }
 }


### PR DESCRIPTION
Fixes #4521

The function new_level_info_entry makes sure that there is 'LEVEL_INFO_GROW_DELTA' number of levels initialized beyond the lvinfos_count. This means that checks if checking if `lvinfo != NULL` to know if a level exist does not work, because it only checks if it is initialized.

As a result the Ctrl+F11 cheat made 31 levels visible which were otherwise zeroed out.