### PR TITLE
fix(md10): md10 shadow crash and restore sprite texture bounds

### DIFF
--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -266,6 +266,15 @@ void get_keepsprite_unscaled_dimensions(long kspr_anim, long angle, long frame, 
 {
     TbBool val_in_range;
     struct KeeperSprite* kspr = sprite_by_frame(kspr_anim);
+    if (kspr == NULL)
+    {
+        ERRORLOG("[md10 crash investigation] NULL sprite returned for anim=%ld angle=%ld frame=%ld", kspr_anim, angle, frame);
+        *orig_w = 0;
+        *orig_h = 0;
+        *unsc_w = 0;
+        *unsc_h = 0;
+        return;
+    }
     if (((angle & ANGLE_MASK) <= DEGREES_202_5) || ((angle & ANGLE_MASK) >= DEGREES_337_5) )
         val_in_range = 0;
     else

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -3896,6 +3896,12 @@ static void create_shadows(struct Thing *thing, struct EngineCoord *ecor, struct
     short dim_th;
     short dim_tw;
     get_keepsprite_unscaled_dimensions(thing->anim_sprite, sprite_angle, thing->current_frame, &dim_ow, &dim_oh, &dim_tw, &dim_th);
+    if (dim_ow <= 0 || dim_oh <= 0 || dim_ow > 256 || dim_oh > 256)
+    {
+        WARNLOG("[md10 crash investigation] Invalid shadow dimensions dim_ow=%d dim_oh=%d for thing %d (anim=%d frame=%d)",
+                dim_ow, dim_oh, thing->index, thing->anim_sprite, thing->current_frame);
+        return;
+    }
     {
         int sh_angle_sin = LbSinL(sh_angle);
         int sh_angle_cos = LbCosL(sh_angle);


### PR DESCRIPTION
Added descriptive headers for functions I know about Added inline comments for explanation of md10 to best of my understanding [md10 crash investigation] guards added to capture root cause if crash recurs