### PR TITLE
Reset game kind after gameplay loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3580,6 +3580,10 @@ void keeper_gameplay_loop(void)
         frametime_end_measurement(Frametime_FullFrame);
     } // end while
     SYNCDBG(0,"Gameplay loop finished after %lu turns",(unsigned long)game.play_gameturn);
+
+    // Reset the game kind because we are not in a game anymore at this point
+    game.game_kind = GKind_Unset;
+
     api_event("GAME_ENDED");
 }
 


### PR DESCRIPTION
Fixes https://github.com/dkfans/keeperfx/issues/4553

Reason for not resetting the full game struct data is that it also seems to reset other stuff like what campaign we are in. 