### PR TITLE
Fixed game not starting with -timer command line

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4246,12 +4246,13 @@ short process_command_line(unsigned short argc, char *argv[])
           if (strcasecmp(pr2str, "game") == 0)
           {
               TimerGame = true;
+              narg++;
           }
           else if (strcasecmp(pr2str, "continuous") == 0)
           {
               TimerNoReset = true;
+              narg++;
           }
-          narg++;
       }
       else if ( strcasecmp(parstr,"config") == 0 )
       {


### PR DESCRIPTION
Run the game with these command line options in this order: `keeperfx.exe -nointro -alex -timer -sessions localhost`

Notice the game fails to start.