### PR TITLE
Fix disease crash on portmaster

### DIFF
--- a/src/vidmode.h
+++ b/src/vidmode.h
@@ -131,7 +131,7 @@ struct TbAlphaTables {
     unsigned char black[8*256];
     unsigned char orange[8*256];
     // This is to force the array to have 256x256 size
-    //unsigned char unused[191*256];
+    unsigned char unused[191*256];
 };
 
 /******************************************************************************/


### PR DESCRIPTION
when casting disease on my handheld, I crash
this fixed the crash

```
Error: Failure signal: Segmentation violation (ANSI) (11).
Error: Signal code: 1 (address not mapped to object).
Error: Fault address: 0x555e515d61.
Error: Context PC=0x5555d86cd0 SP=0x7fd9184940.
[#0 ] ./keeperfx.aarch64   : ./keeperfx.aarch64(+0xb52f8) [0x5555d692f8] [0x5555d692f8+0x0]
[#1 ] ./keeperfx.aarch64   : ./keeperfx.aarch64(+0xb5570) [0x5555d69570] [0x5555d69570+0x0]
[#2 ] linux-vdso.so.1      : __kernel_rt_sigreturn                [0x7f827eb6c0+0x0]
[#3 ] ./keeperfx.aarch64   : LbSpriteDrawUsingScalingUpDataTrans1LR [0x5555d86cd0+0x188]
[#4 ] ./keeperfx.aarch64   : DrawAlphaSpriteUsingScalingData      [0x5555d87d00+0xf8]
[#5 ] ./keeperfx.aarch64   : ./keeperfx.aarch64(+0x15b1f4) [0x5555e0f1f4] [0x5555e0f1f4+0x0]
[#6 ] ./keeperfx.aarch64   : process_keeper_sprite                [0x5555e17cb8+0x1c8]
[#7 ] ./keeperfx.aarch64   : ./keeperfx.aarch64(+0x1645ec) [0x5555e185ec] [0x5555e185ec+0x0]
[#8 ] ./keeperfx.aarch64   : draw_view                            [0x5555e19128+0x868]
[#9 ] ./keeperfx.aarch64   : engine                               [0x5555f856e0+0x178]
[#10] ./keeperfx.aarch64   : redraw_isometric_view                [0x5555e09d0c+0x7c]
[#11] ./keeperfx.aarch64   : redraw_display                       [0x5555e0af3c+0x424]
[#12] ./keeperfx.aarch64   : keeper_screen_redraw                 [0x5555e0b658+0x138]
[#13] ./keeperfx.aarch64   : gameplay_loop_draw                   [0x5555f861a4+0x5c]
[#14] ./keeperfx.aarch64   : keeper_gameplay_loop                 [0x5555f86770+0xa8]
[#15] ./keeperfx.aarch64   : game_loop                            [0x5555f87104+0x5c4]

```