### PR TITLE
Fixed navigating around pillars

### DIFF
--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -3083,7 +3083,6 @@ AriadneReturn ariadne_update_state_wallhug(struct Thing *thing, struct Ariadne *
             pos.x.val = arid->endpos.x.val;
             pos.y.val = arid->endpos.y.val;
             pos.z.val = arid->endpos.z.val;
-            JUSTLOG("RECOMPUTE PATH");
             if (ariadne_initialise_creature_route(thing, &pos, arid->move_speed, arid->route_flags) == AridRet_OK) {
                 return AridRet_OK;
             }


### PR DESCRIPTION
Basically: Recompute the route whenever a wall hugging creature's required hug_angle changes. It sounds pretty expensive but I think it might be OK. It's not quite "every time the creature changes direction", the `if (hug_angle != thing->move_angle_xy)` seems to be doing some heavy lifting where they align most of the time.

I've attached a `JUSTLOG` to the recompute line so you can press `~` to see how often it fires off and it seems like it's usually only running it to unstuck itself. I haven't seen any FPS drops yet, I've tested a wide open map with hundreds of creatures and I'm only seeing one recompute every 5 seconds or so. I also tested a maze map with imps scattered throughout and it wasn't firing much there either.

Fixes this map:
[map27444.zip](https://github.com/user-attachments/files/26346386/map27444.zip)
Tag the gems and the imp will get stuck after a while (use Fast Forward), but with this PR it won't get stuck.