### PR TITLE
Multiplayer: Request new lobby list after failing to join

### DIFF
--- a/src/net_game.c
+++ b/src/net_game.c
@@ -208,8 +208,14 @@ long network_session_join(void)
     if (LbNetwork_Join(net_session[net_session_index_active], net_player_name, &plyr_num, NULL) == 0)
         return plyr_num;
     join_lobby_id[0] = '\0';
-    if (!attempting_to_join_cancel_requested())
+    if (!attempting_to_join_cancel_requested()) {
+        if (frontnet_service_selected(FrontendNetSvc_Online)) {
+            net_session_index_active = -1;
+            net_session_index_active_id = -1;
+            matchmaking_request_list();
+        }
         process_network_error(-802);
+    }
     return -1;
 }
 

--- a/src/net_matchmaking.c
+++ b/src/net_matchmaking.c
@@ -222,6 +222,19 @@ static int websocket_exchange(const char *request, char *response_buffer, size_t
     return websocket_receive(response_buffer, buffer_size, WEBSOCKET_RECEIVE_TIMEOUT_MS);
 }
 
+int matchmaking_request_list(void)
+{
+    SDL_LockMutex(mutex);
+    if (!curl_handle) {
+        SDL_UnlockMutex(mutex);
+        return -1;
+    }
+    matchmaking_session_count = 0;
+    int result = websocket_send("{\"action\":\"list\",\"version\":\"" MATCHMAKING_VERSION "\"}");
+    SDL_UnlockMutex(mutex);
+    return result;
+}
+
 static const char *json_parse_string(const char *json, const char *key, char *output, size_t output_buffer_size)
 {
     char key_pattern[JSON_KEY_PATTERN_SIZE];
@@ -333,9 +346,8 @@ int matchmaking_connect(void)
         return -1;
     }
     LbNetLog("Matchmaking: connected\n");
-    websocket_send("{\"action\":\"list\",\"version\":\"" MATCHMAKING_VERSION "\"}");
     SDL_UnlockMutex(mutex);
-    return 0;
+    return matchmaking_request_list();
 }
 
 void matchmaking_disconnect(void)

--- a/src/net_matchmaking.h
+++ b/src/net_matchmaking.h
@@ -46,6 +46,7 @@ extern char join_lobby_id[MATCHMAKING_ID_MAX];
 
 void matchmaking_connect_async(void);
 int matchmaking_connect(void);
+int matchmaking_request_list(void);
 void matchmaking_disconnect(void);
 void matchmaking_refresh_sessions(void);
 int matchmaking_create(const char *name, int udp_ipv4_port, int udp_ipv6_port);


### PR DESCRIPTION
I've tested this by having two keeperfx processes running, one hosting a lobby and one viewing the lobby list. Then I close the lobby one with Task Manager-->Details. The 2nd player viewing the lobby list will be seeing an unjoinable lobby listed which just stays there until you exit out to the main menu. But now with this PR after the first join attempt the lobby list will be refreshed and the stale lobby removed.

I've also applied a server-side fix for stale lobbies which should be a bigger deal than this little client-side fix.