### PR TITLE
Multiplayer: Fixed replacing players with AI

### DIFF
--- a/src/bflib_network_exchange.cpp
+++ b/src/bflib_network_exchange.cpp
@@ -56,6 +56,12 @@ char* InitMessageBuffer(enum NetMessageType msg_type) {
     return ptr + 1;
 }
 
+static TbBool can_exchange_with_peer(NetUserId peer_id) {
+    return (peer_id != netstate.my_id) &&
+        (netstate.users[peer_id].progress != USER_UNUSED) &&
+        (my_player_number == get_host_player_id() || peer_id == SERVER_ID);
+}
+
 void SendMessage(NetUserId dest, const char* end_ptr) {
     netstate.sp->sendmsg_single(dest, netstate.msg_buffer, end_ptr - netstate.msg_buffer);
 }
@@ -281,23 +287,26 @@ void LbNetwork_WaitForMissingPackets(void* server_buf, size_t client_frame_size)
         TbClockMSec start = LbTimerClock();
         while (true) {
             int elapsed = LbTimerClock() - start;
+            TbBool has_remote_peer = false;
             if (elapsed >= TIMEOUT_GAMEPLAY_MISSING_PACKET) {
                 MULTIPLAYER_LOG("LbNetwork_WaitForMissingPackets: Timeout waiting for turn=%lu packets", (unsigned long)historical_turn);
                 break;
             }
 
-            NetUserId id;
-            for (id = 0; id < netstate.max_players; id += 1) {
-                if (id == netstate.my_id) { continue; }
-                if (netstate.users[id].progress == USER_UNUSED) { continue; }
-                if (my_player_number != get_host_player_id() && id != SERVER_ID) { continue; }
+            netstate.sp->update(OnNewUser);
+            const int wait_time = min(TIMEOUT_GAMEPLAY_MISSING_PACKET - elapsed, 100);
+            for (NetUserId peer_id = 0; peer_id < netstate.max_players; peer_id += 1) {
+                if (!can_exchange_with_peer(peer_id)) { continue; }
 
-                int wait_time = TIMEOUT_GAMEPLAY_MISSING_PACKET - elapsed;
-                if (netstate.sp->msgready(id, wait_time)) {
-                    while (netstate.sp->msgready(id, 0)) {
-                        ProcessMessage(id, server_buf, client_frame_size);
+                has_remote_peer = true;
+                if (netstate.sp->msgready(peer_id, wait_time)) {
+                    while (netstate.sp->msgready(peer_id, 0)) {
+                        ProcessMessage(peer_id, server_buf, client_frame_size);
                     }
                 }
+            }
+            if (!has_remote_peer) {
+                break;
             }
 
             received_packets = get_received_packets_for_turn(historical_turn);
@@ -329,11 +338,8 @@ TbError LbNetwork_Exchange(enum NetMessageType msg_type, void *send_buf, void *s
         timeout_max = (1000 / game_num_fps);
     }
 
-    NetUserId id;
-    for (id = 0; id < netstate.max_players; id += 1) {
-        if (id == netstate.my_id) { continue; }
-        if (netstate.users[id].progress == USER_UNUSED) { continue; }
-        if (my_player_number != get_host_player_id() && id != SERVER_ID) { continue; }
+    for (NetUserId peer_id = 0; peer_id < netstate.max_players; peer_id += 1) {
+        if (!can_exchange_with_peer(peer_id)) { continue; }
 
         TbClockMSec start = LbTimerClock();
         while (true) {
@@ -341,7 +347,7 @@ TbError LbNetwork_Exchange(enum NetMessageType msg_type, void *send_buf, void *s
             if (elapsed >= timeout_max) {
                 break;
             }
-            if (netstate.users[id].progress == USER_UNUSED) {
+            if (netstate.users[peer_id].progress == USER_UNUSED) {
                 break;
             }
 
@@ -350,14 +356,14 @@ TbError LbNetwork_Exchange(enum NetMessageType msg_type, void *send_buf, void *s
             if (remaining_time_until_draw < 0) {remaining_time_until_draw = 0;}
             int wait = min(timeout_max - elapsed, remaining_time_until_draw);
 
-            if (netstate.sp->msgready(id, wait)) {
-                ProcessMessage(id, server_buf, client_frame_size);
+            if (netstate.sp->msgready(peer_id, wait)) {
+                ProcessMessage(peer_id, server_buf, client_frame_size);
                 if (msg_type != NETMSG_GAMEPLAY) {
                     break;
                 }
                 TbBool received_gameplay_msg = (netstate.msg_buffer[0] == NETMSG_GAMEPLAY);
-                while (netstate.sp->msgready(id, 0)) {
-                    ProcessMessage(id, server_buf, client_frame_size);
+                while (netstate.sp->msgready(peer_id, 0)) {
+                    ProcessMessage(peer_id, server_buf, client_frame_size);
                     if (netstate.msg_buffer[0] == NETMSG_GAMEPLAY) {
                         received_gameplay_msg = true;
                     }

--- a/src/packets.c
+++ b/src/packets.c
@@ -1575,29 +1575,43 @@ void process_players_creature_control_packet_action(long plyr_idx)
   }
 }
 
-static void replace_with_ai(int old_active_players)
-{
-    int k = 0;
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++)
-    {
-        if (network_player_active(i))
-            k++;
+static void replace_disconnected_players_with_ai(void) {
+    if ((game.system_flags & GSF_NetworkActive) == 0) {
+        return;
     }
-    if (old_active_players != k)
-    {
-        for (int i = 0; i < NET_PLAYERS_COUNT; i++)
-        {
-            struct PlayerInfo *player = get_player(i);
-            if (!network_player_active(player->packet_num))
-            {
-                message_add(MsgType_Player, player->id_number, "I am the computer now!");
-                JUSTLOG("p:%d I am the computer now!", player->id_number);
-
-                player->allocflags |= PlaF_CompCtrl;
-                toggle_computer_player(i);
-            }
+    TbBool host_disconnected = (netstate.my_id != SERVER_ID && netstate.users[SERVER_ID].progress == USER_UNUSED);
+    for (int player_index = 0; player_index < NET_PLAYERS_COUNT; player_index++) {
+        struct PlayerInfo* player = get_player(player_index);
+        if (!player_exists(player) || ((player->allocflags & PlaF_CompCtrl) != 0)) {
+            continue;
         }
+        if (host_disconnected && player_index == my_player_number) {
+            continue;
+        }
+        if (!host_disconnected && network_player_active(player_index)) {
+            continue;
+        }
+        if (player->victory_state != VicS_Undecided) {
+            player->allocflags &= ~PlaF_Allocated;
+            continue;
+        }
+        message_add(MsgType_Player, player->id_number, "I am the computer now!");
+        JUSTLOG("p:%d I am the computer now!", player->id_number);
+        player->allocflags |= PlaF_CompCtrl;
+        toggle_computer_player(player->id_number);
     }
+    if (!host_disconnected) {
+        return;
+    }
+    message_add(MsgType_Player, my_player_number, "Network connection to host lost");
+    game.input_lag_turns = 0;
+    game.skip_initial_input_turns = 0;
+    LbNetwork_Stop();
+    memset(net_player_info, 0, sizeof(net_player_info));
+    clear_flag(game.system_flags, GSF_NetworkActive);
+    fe_network_active = 0;
+    game.game_kind = GKind_LocalGame;
+    setup_count_players();
 }
 
 static void load_old_packets(PlayerNumber my_packet_num) {
@@ -1672,27 +1686,19 @@ void process_packets(void)
 
     if (game.game_kind != GKind_LocalGame)
     {
-        int old_active_players = 0;
-        for (i = 0; i < NET_PLAYERS_COUNT; i++)
-        {
-            if (network_player_active(i))
-                old_active_players++;
-        }
-        MULTIPLAYER_LOG("process_packets: About to send/receive packets, active_players=%d", old_active_players);
-
         if (!game.packet_load_enable || game.packet_load_initialized)
         {
-            struct Packet* my_pckt = get_packet_direct(player->packet_num);
+            struct Packet* my_packet = get_packet_direct(player->packet_num);
             const char* player_name;
             if (player->packet_num == 0) {player_name = "Host";} else {player_name = "Client";}
-            MULTIPLAYER_LOG("process_packets: SENDING packet[%s] turn=%lu checksum=%08lx", player_name, (unsigned long)my_pckt->turn, (unsigned long)my_pckt->checksum);
-            TbError exchange_result = LbNetwork_Exchange(NETMSG_GAMEPLAY, my_pckt, game.packets, sizeof(struct Packet));
+            MULTIPLAYER_LOG("process_packets: SENDING packet[%s] turn=%lu checksum=%08lx", player_name, (unsigned long)my_packet->turn, (unsigned long)my_packet->checksum);
+            TbError exchange_result = LbNetwork_Exchange(NETMSG_GAMEPLAY, my_packet, game.packets, sizeof(struct Packet));
             if (exchange_result != Lb_OK) {
                 ERRORLOG("LbNetwork_Exchange failed");
             }
             LbNetwork_WaitForMissingPackets(game.packets, sizeof(struct Packet));
         }
-        replace_with_ai(old_active_players);
+        replace_disconnected_players_with_ai();
     }
 
     MULTIPLAYER_LOG("process_packets: Loading packets from input lag queue");
@@ -1704,8 +1710,7 @@ void process_packets(void)
         return;
     }
 
-    if (checksums_different()) { //Should be called directly after LbNetwork_Exchange, to see if there's anything wrong with the received packet
-        // Setting checksum problem flags
+    if ((game.system_flags & GSF_NetworkActive) != 0 && checksums_different()) {
         set_flag(game.system_flags, GSF_NetGameNoSync);
         clear_flag(game.system_flags, GSF_NetSeedNoSync);
     } else {
@@ -1714,8 +1719,9 @@ void process_packets(void)
     }
 
     // Write packets into file, if requested
-    if ((game.packet_save_enable) && (game.packet_fopened))
+    if ((game.packet_save_enable) && (game.packet_fopened)) {
         save_packets();
+    }
     //Debug code, to find packet errors
     #if DEBUG_NETWORK_PACKETS
     write_debug_packets();
@@ -1723,14 +1729,15 @@ void process_packets(void)
     // Process the packets
     for (i=0; i<PACKETS_COUNT; i++)
     {
-        player = get_player(i);
-        if (player_exists(player) && ((player->allocflags & PlaF_CompCtrl) == 0))
-        process_players_packet(i);
+        struct PlayerInfo* packet_player = get_player(i);
+        if (player_exists(packet_player) && ((packet_player->allocflags & PlaF_CompCtrl) == 0)) {
+            process_players_packet(i);
+        }
     }
     // Clear all packets
     clear_packets();
-    if (((game.system_flags & GSF_NetGameNoSync) != 0)
-    || ((game.system_flags & GSF_NetSeedNoSync) != 0))
+    if (((game.system_flags & GSF_NetworkActive) != 0)
+     && ((game.system_flags & (GSF_NetGameNoSync | GSF_NetSeedNoSync)) != 0))
     {
         SYNCDBG(0,"Resyncing");
         resync_game();


### PR DESCRIPTION
Fixes this bug:
1. Start two KeeperFX processes in a LAN multiplayer game. (and start the game)
2. Open Task Manager --> Go to Details Tab --> End one of the keeperfx.exe processes (must be in details tab)
3. Doing this caused a freeze previously, but now it correctly replaces the player with AI.

Most likely also fixes other disconnection freezes.