### PR TITLE
Fix: Restore missing default values for roomflags_on and video_detail_level

### DIFF
--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -250,6 +250,7 @@ void setup_default_settings(void)
     settings.video_cluedo_mode             = 0;
     settings.sound_volume                  = 127;
     settings.music_volume                  = 90;
+    settings.roomflags_on                  = 1;
     settings.gamma_correction              = 0;
     settings.switching_vidmodes_index      = Lb_SCREEN_MODE_INVALID;
     settings.tooltips_on                   = true;

--- a/src/config_settings.c
+++ b/src/config_settings.c
@@ -243,6 +243,7 @@ static unsigned char name_to_kmod(const char *name)
 /******************************************************************************/
 void setup_default_settings(void)
 {
+    settings.video_detail_level            = 0;
     settings.video_shadows                 = 4;
     settings.view_distance                 = 3;
     settings.video_rotate_mode             = 0;


### PR DESCRIPTION
The default initialization for `video_detail` and `roomflags_on` were probably accidentally dropped here https://github.com/dkfans/keeperfx/commit/56766c2917177e58de07639b7079bd4fbe3e030e#diff-0cf9e21c97eebd2642effdf233c5da0e4fc9039aa10cf6d91d1cf7067bcc2523L303.
 These settings were referred to as `unusedfield_0` and `unusedfield_8` respectively prior.

This fixes the intended default behavior of room flag display and explictly sets video detail.
