### PR TITLE
Fix crash in trig rasteriser from 16.16 fixed-point overflow

### DIFF
--- a/src/bflib_render_trig.c
+++ b/src/bflib_render_trig.c
@@ -3114,6 +3114,18 @@ void trig_render_md10(struct TrigLocalRend *tlr)
             colM = ((colH & 0xFF) << 8) + (colL & 0xFF);
         }
 
+        // Scanline OOB check — skip if any pixel would land outside the framebuffer
+        {
+            unsigned char *fb_start = poly_screen + vec_screen_width;
+            unsigned char *fb_end   = poly_screen + vec_screen_width * (vec_window_height + 1);
+            if (o < fb_start || o + point_y_a > fb_end)
+            {
+                ERRORLOG("[md10] scanline ptr %p..%p out of bounds (%p..%p)",
+                         o, o + point_y_a, fb_start, fb_end);
+                continue;
+            }
+        }
+
         // Per-pixel scanline loop
         for (; point_y_a > 0; point_y_a--, o++)
         {
@@ -4454,6 +4466,24 @@ void trig(struct PolyPoint *point_a, struct PolyPoint *point_b, struct PolyPoint
     opt_a = point_a;
     opt_b = point_b;
     opt_c = point_c;
+
+    // Reject triangles whose coords would overflow 16.16 fixed-point
+    {
+        long max_x = max(max(point_a->X, point_b->X), point_c->X);
+        long min_x = min(min(point_a->X, point_b->X), point_c->X);
+        long max_y = max(max(point_a->Y, point_b->Y), point_c->Y);
+        long min_y = min(min(point_a->Y, point_b->Y), point_c->Y);
+        if ((max_x - min_x > 32767) || (max_y - min_y > 32767) ||
+            (max_x > 32767) || (min_x < -32767) ||
+            (max_y > 32767) || (min_y < -32767))
+        {
+            SYNCDBG(8, "Triangle coords exceed 16.16 fixed-point range: "
+                    "X[%ld..%ld] Y[%ld..%ld], skipping",
+                    min_x, max_x, min_y, max_y);
+            return;
+        }
+    }
+
     start_type = trig_reorder_input_points(&opt_a, &opt_b, &opt_c);
 
     NOLOG("start type %d",(int)start_type);


### PR DESCRIPTION
## Problem

At high resolutions (2560×1440, 3440×1440), the software triangle rasteriser crashes with `EXCEPTION_ACCESS_VIOLATION` in `trig_render_md10` — the translucent shadow rendering path.

## Root Cause

The triangle setup functions (`trig_ll_start`, `trig_rl_start`, etc.) compute `(delta_x << 16)` and `(X << 16)` using 16.16 fixed-point arithmetic in signed 32-bit integers. When vertex screen coordinates exceed ±32767 — which happens when `rotpers()` projects near-camera geometry at high resolutions — the left-shift silently overflows, corrupting the `polyscans` array and producing out-of-bounds framebuffer writes.

This overflow was always latent in the original Bullfrog x86 assembly (`shll $0x10` wraps silently on x86) and was faithfully preserved in the ASM-to-C conversion (PR #1973). It simply never triggered at the original 640×480 resolution.

## Fix

- **Coordinate guard in `trig()`**: Rejects triangles where any vertex X/Y exceeds ±32767 or where the X or Y span exceeds 32767, preventing overflow before it reaches the setup functions. Covers all ~25 rendering modes.
- **OOB safety net in `trig_render_md10()`**: Bounds-checks the output pointer against the `poly_screen` buffer and logs an error if triggered, preventing the access violation as a defence-in-depth measure.