### PR TITLE
Multiplayer: Separate synced animation state from local rendering state

### DIFF
--- a/src/creature_graphics.c
+++ b/src/creature_graphics.c
@@ -275,6 +275,19 @@ void get_keepsprite_unscaled_dimensions(long kspr_anim, long angle, long frame, 
         *unsc_h = 0;
         return;
     }
+    int32_t frames = kspr->FramesCount;
+    if (frames <= 0) {
+        *orig_w = 0;
+        *orig_h = 0;
+        *unsc_w = 0;
+        *unsc_h = 0;
+        return;
+    }
+    if (frame < 0) {
+        frame = 0;
+    } else if (frame >= frames) {
+        frame = frames - 1;
+    }
     if (((angle & ANGLE_MASK) <= DEGREES_202_5) || ((angle & ANGLE_MASK) >= DEGREES_337_5) )
         val_in_range = 0;
     else
@@ -361,7 +374,7 @@ void set_creature_model_graphics(long crmodel, unsigned short seq_idx, unsigned 
 short get_creature_anim(struct Thing *thing, unsigned short seq_idx)
 {
     short idx = get_creature_model_graphics(thing->model, seq_idx);
-    return get_anim_for_current_view(idx);
+    return get_td_animation_sprite(idx);
 }
 
 void untint_thing(struct Thing *thing)
@@ -395,7 +408,7 @@ TbBool update_creature_anim(struct Thing *thing, long speed, long seq_idx)
 
 TbBool update_creature_animation_by_sprite(struct Thing *thing, long speed, long anim_idx)
 {
-    unsigned long i = get_anim_for_current_view(anim_idx);
+    unsigned long i = get_td_animation_sprite(anim_idx);
     // Only update when it's a different sprite, or a different animation speed.
     if ((i != thing->anim_sprite) || ((speed != thing->anim_speed) && (speed != -1)))
     {

--- a/src/creature_graphics.h
+++ b/src/creature_graphics.h
@@ -69,7 +69,7 @@ enum FrameFlags {
     FFL_NoShadows = 1,
 };
 
-struct KeeperSprite { // sizeof = 26
+struct KeeperSprite {
   uint32_t DataOffset;
 
   unsigned short SWidth;

--- a/src/creature_graphics.h
+++ b/src/creature_graphics.h
@@ -69,7 +69,7 @@ enum FrameFlags {
     FFL_NoShadows = 1,
 };
 
-struct KeeperSprite { // sizeof = 16
+struct KeeperSprite { // sizeof = 26
   uint32_t DataOffset;
 
   unsigned short SWidth;

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -55,7 +55,6 @@
 #include "power_hand.h"
 #include "gui_topmsg.h"
 #include "gui_soundmsgs.h"
-#include "engine_arrays.h"
 #include "player_utils.h"
 #include "player_instances.h"
 #include "player_computer.h"
@@ -1776,8 +1775,7 @@ short creature_change_to_chicken(struct Thing *creatng)
         struct Thing *efftng = create_effect_element(&creatng->mappos, TngEffElm_Chicken, creatng->owner);
         if (!thing_is_invalid(efftng))
         {
-            unsigned long k = get_anim_for_current_view(819);
-            set_thing_draw(efftng, k, 0, 1200 * cctrl->countdown / 10 + game.conf.crtr_conf.sprite_size, -1, 0, ODC_Default);
+            set_thing_draw(efftng, 819, 0, 1200 * cctrl->countdown / 10 + game.conf.crtr_conf.sprite_size, -1, 0, ODC_Default);
             clear_flag(efftng->rendering_flags, TRF_Transpar_Flags);
             set_flag(efftng->rendering_flags, TRF_Transpar_8);
         }

--- a/src/creature_states_lair.c
+++ b/src/creature_states_lair.c
@@ -41,7 +41,6 @@
 #include "room_lair.h"
 #include "room_util.h"
 #include "map_utils.h"
-#include "engine_arrays.h"
 #include "game_legacy.h"
 
 #include "keeperfx.hpp"
@@ -266,8 +265,7 @@ CrStateRet creature_add_lair_to_room(struct Thing *creatng, struct Room *room)
     lairtng->lair.spr_size = game.conf.crtr_conf.sprite_size + (game.conf.crtr_conf.sprite_size * game.conf.crtr_conf.exp.size_increase_on_exp * cctrl->exp_level) / 100;
     lairtng->move_angle_xy = THING_RANDOM(creatng, DEGREES_360);
     struct ObjectConfigStats* objst = get_object_model_stats(lairtng->model);
-    unsigned long i = get_anim_for_current_view(objst->sprite_anim_idx);
-    set_thing_draw(lairtng, i, objst->anim_speed, lairtng->lair.cssize, 0, -1, objst->draw_class);
+    set_thing_draw(lairtng, objst->sprite_anim_idx, objst->anim_speed, lairtng->lair.cssize, 0, -1, objst->draw_class);
     thing_play_sample(creatng, 158, NORMAL_PITCH, 0, 3, 1, 2, FULL_LOUDNESS);
     create_effect(&pos, imp_spangle_effects[get_player_color_idx(creatng->owner)], creatng->owner);
     anger_set_creature_anger(creatng, 0, AngR_NoLair);

--- a/src/engine_arrays.c
+++ b/src/engine_arrays.c
@@ -48,48 +48,37 @@ long lintel_bottom_height[256];
 }
 #endif
 /******************************************************************************/
-short get_anim_for_current_view(short n)
+short get_td_animation_sprite(short animation_sprite)
 {
-    if ((lens_mode == 2) || (lens_mode == 3))
-    {
-        if ((n < FP_TD_ANIMATION_COUNT) && (td_to_fp_animation[n] >= 0))
-          return td_to_fp_animation[n];
-        else if ((n >= KEEPERSPRITE_ADD_OFFSET) && (n < KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM))
-        {
-            return td_to_fp_sprite_add[n - KEEPERSPRITE_ADD_OFFSET];
-        }
-    } else
-    {
-        if ((n < FP_TD_ANIMATION_COUNT) && (fp_to_td_animation[n] >= 0))
-          return fp_to_td_animation[n];
-        else if ((n >= KEEPERSPRITE_ADD_OFFSET) && (n < KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM))
-        {
-            return fp_to_td_sprite_add[n - KEEPERSPRITE_ADD_OFFSET];
+    if ((animation_sprite >= 0) && (animation_sprite < FP_TD_ANIMATION_COUNT) && (fp_to_td_animation[animation_sprite] >= 0)) {
+        return fp_to_td_animation[animation_sprite];
+    }
+    if ((animation_sprite >= KEEPERSPRITE_ADD_OFFSET) && (animation_sprite < KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM)) {
+        short td_sprite = fp_to_td_sprite_add[animation_sprite - KEEPERSPRITE_ADD_OFFSET];
+        if (td_sprite > 0) {
+            return td_sprite;
         }
     }
-    return n;
+    return animation_sprite;
 }
 
-short convert_fp_to_td_animation(short n)
+unsigned short get_render_animation_sprite(unsigned short animation_sprite)
 {
-    if (n < FP_TD_ANIMATION_COUNT)
-        return fp_to_td_animation[n];
-    else if ((n >= KEEPERSPRITE_ADD_OFFSET) && (n < KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM))
-    {
-        return fp_to_td_sprite_add[n - KEEPERSPRITE_ADD_OFFSET];
+    if ((lens_mode == 2) || (lens_mode == 3)) {
+        if (animation_sprite < FP_TD_ANIMATION_COUNT) {
+            short fp_sprite = td_to_fp_animation[animation_sprite];
+            if (fp_sprite >= 0) {
+                return (unsigned short)fp_sprite;
+            }
+        }
+        if ((animation_sprite >= KEEPERSPRITE_ADD_OFFSET) && (animation_sprite < KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM)) {
+            short fp_sprite = td_to_fp_sprite_add[animation_sprite - KEEPERSPRITE_ADD_OFFSET];
+            if (fp_sprite > 0) {
+                return (unsigned short)fp_sprite;
+            }
+        }
     }
-    return n;
-}
-
-short convert_td_to_fp_animation(short n)
-{
-    if (n < FP_TD_ANIMATION_COUNT)
-        return td_to_fp_animation[n];
-    else if ((n >= KEEPERSPRITE_ADD_OFFSET) && (n < KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM))
-    {
-        return td_to_fp_sprite_add[n - KEEPERSPRITE_ADD_OFFSET];
-    }
-    return n;
+    return animation_sprite;
 }
 
 void init_fp_td_animation_conversion_tables(void)

--- a/src/engine_arrays.h
+++ b/src/engine_arrays.h
@@ -61,9 +61,8 @@ extern short fp_to_td_sprite_add[KEEPERSPRITE_ADD_NUM];
 extern unsigned short floor_to_ceiling_map[TEXTURE_BLOCKS_COUNT];
 extern struct WibbleTable blank_wibble_table[WIBBLE_TABLE_SIZE];
 /******************************************************************************/
-short get_anim_for_current_view(short n);
-short convert_fp_to_td_animation(short n);
-short convert_td_to_fp_animation(short n);
+short get_td_animation_sprite(short animation_sprite);
+unsigned short get_render_animation_sprite(unsigned short animation_sprite);
 
 void init_fp_td_animation_conversion_tables(void);
 void setup_mesh_randomizers(void);

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -27,7 +27,6 @@
 #include "bflib_mouse.h"
 #include "bflib_dernc.h"
 #include "lvl_script.h"
-#include "engine_arrays.h"
 #include "player_data.h"
 #include "dungeon_data.h"
 #include "player_instances.h"
@@ -440,68 +439,6 @@ long map_fade_out(long palette_fade_step)
     return get_my_player()->instance_remain_turns * 4;
 }
 
-void set_sprite_view_3d(void)
-{
-    for (long i = 1; i < THINGS_COUNT; i++)
-    {
-        struct Thing* thing = thing_get(i);
-        if (thing_exists(thing))
-        {
-            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Invisible) == 0))
-            {
-                int n = convert_td_to_fp_animation(thing->anim_sprite);
-                if (n >= 0)
-                {
-                    thing->anim_sprite = n;
-                    long nframes = keepersprite_frames(thing->anim_sprite);
-                    if (nframes != thing->max_frames)
-                    {
-                        ERRORLOG("No frames different between views C%u, M%d, A%u, B%ld",thing->class_id,thing->model,thing->max_frames,nframes);
-                        thing->max_frames = nframes;
-                        n = thing->max_frames - 1;
-                        if (n > thing->current_frame) {
-                            n = thing->current_frame;
-                        }
-                        thing->current_frame = n;
-                        thing->anim_time = n << 8;
-                    }
-                }
-            }
-        }
-    }
-}
-
-void set_sprite_view_isometric(void)
-{
-    for (long i = 1; i < THINGS_COUNT; i++)
-    {
-        struct Thing* thing = thing_get(i);
-        if (thing_exists(thing))
-        {
-            if (thing_is_creature(thing) || ((thing->rendering_flags & TRF_Invisible) == 0))
-            {
-                int n = convert_fp_to_td_animation(thing->anim_sprite);
-                if (n >= 0)
-                {
-                    thing->anim_sprite = n;
-                    long nframes = keepersprite_frames(thing->anim_sprite);
-                    if (nframes != thing->max_frames)
-                    {
-                        ERRORLOG("No frames different between views C%u, M%d, A%u, B%ld",thing->class_id,thing->model,thing->max_frames,nframes);
-                        thing->max_frames = nframes;
-                        n = thing->max_frames - 1;
-                        if (n > thing->current_frame) {
-                            n = thing->current_frame;
-                        }
-                        thing->current_frame = n;
-                        thing->anim_time = n << 8;
-                    }
-                }
-            }
-        }
-    }
-}
-
 long dummy_sound_line_of_sight(long a1, long a2, long a3, long a4, long a5, long a6)
 {
     return 1;
@@ -528,7 +465,6 @@ void set_engine_view(struct PlayerInfo *player, long val)
         if (!is_my_player(player))
             break;
         lens_mode = 2;
-        set_sprite_view_3d();
         S3DSetLineOfSightFunction(dummy_sound_line_of_sight);
         S3DSetDeadzoneRadius(0);
         LbMouseSetPosition((MyScreenWidth/pixel_size) >> 1,(MyScreenHeight/pixel_size) >> 1);
@@ -544,7 +480,6 @@ void set_engine_view(struct PlayerInfo *player, long val)
             break;
         lens_mode = 0;
         // no need to set temp_cluedo_mode here; it's done in update_engine_settings
-        set_sprite_view_isometric();
         S3DSetLineOfSightFunction(dummy_sound_line_of_sight);
         S3DSetDeadzoneRadius(1280);
         break;
@@ -568,7 +503,6 @@ void set_engine_view(struct PlayerInfo *player, long val)
             break;
         lens_mode = 0;
         temp_cluedo_mode = 0;
-        set_sprite_view_isometric();
         S3DSetLineOfSightFunction(dummy_sound_line_of_sight);
         S3DSetDeadzoneRadius(1280);
         break;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -493,6 +493,12 @@ static void (*render_sprite_debug_fn) (struct Thing*, long scrpos_x, long scrpos
 static int render_sprite_debug_level = 0;
 static void draw_keepsprite_unscaled_in_buffer(unsigned short kspr_n, short angle, unsigned char current_frame, unsigned char *outbuf);
 static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr);
+
+static TbBool animation_sprite_id_invalid(unsigned short animation_sprite)
+{
+    return ((animation_sprite >= CREATURE_FRAMELIST_LENGTH) && (animation_sprite < KEEPERSPRITE_ADD_OFFSET))
+        || (animation_sprite >= KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM);
+}
 /******************************************************************************/
 
 static void calculate_hud_scale(struct Camera *cam) {
@@ -3870,6 +3876,8 @@ static long find_fade_S(struct EngineCoord *ecor)
 
 static void create_shadows(struct Thing *thing, struct EngineCoord *ecor, struct Coord3d *pos)
 {
+    unsigned short animation_sprite;
+    unsigned char current_frame;
     short mv_angle;
     short sh_angle;
     short sprite_angle;
@@ -3879,7 +3887,12 @@ static void create_shadows(struct Thing *thing, struct EngineCoord *ecor, struct
     struct EngineCoord ecor3;
     struct EngineCoord ecor4;
 
-    struct KeeperSprite *spr = keepersprite_array(thing->anim_sprite);
+    animation_sprite = get_render_animation_sprite(thing->anim_sprite);
+    current_frame = thing->current_frame;
+    struct KeeperSprite *spr = keepersprite_array(animation_sprite);
+    if (spr == NULL) {
+        return;
+    }
 
     mv_angle = thing->move_angle_xy;
     sh_angle = get_angle_xy_to(pos, &thing->mappos);
@@ -3895,11 +3908,11 @@ static void create_shadows(struct Thing *thing, struct EngineCoord *ecor, struct
     short dim_oh;
     short dim_th;
     short dim_tw;
-    get_keepsprite_unscaled_dimensions(thing->anim_sprite, sprite_angle, thing->current_frame, &dim_ow, &dim_oh, &dim_tw, &dim_th);
+    get_keepsprite_unscaled_dimensions(animation_sprite, sprite_angle, current_frame, &dim_ow, &dim_oh, &dim_tw, &dim_th);
     if (dim_ow <= 0 || dim_oh <= 0 || dim_ow > 256 || dim_oh > 256)
     {
         WARNLOG("[md10 crash investigation] Invalid shadow dimensions dim_ow=%d dim_oh=%d for thing %d (anim=%d frame=%d)",
-                dim_ow, dim_oh, thing->index, thing->anim_sprite, thing->current_frame);
+                dim_ow, dim_oh, thing->index, animation_sprite, current_frame);
         return;
     }
     {
@@ -3988,8 +4001,8 @@ static void create_shadows(struct Thing *thing, struct EngineCoord *ecor, struct
     // overall
     kspr->vertex_first.S = dist_sq;
     kspr->angle = sprite_angle;
-    kspr->anim_sprite = thing->anim_sprite;
-    kspr->current_frame = thing->current_frame;
+    kspr->anim_sprite = animation_sprite;
+    kspr->current_frame = current_frame;
 }
 
 // Creature status flower above head in isometric view
@@ -4820,6 +4833,8 @@ static void process_keeper_flame_on_sprite(struct BucketKindJontySprite* jspr, l
     struct ObjectConfigStats* objst;
     struct TrapConfigStats* trapst;
     struct FlameProperties flame;
+    unsigned short animation_sprite;
+    unsigned char current_frame;
     unsigned long nframe;
     long add_x, add_y;
     long scale = 0;
@@ -4863,7 +4878,9 @@ static void process_keeper_flame_on_sprite(struct BucketKindJontySprite* jspr, l
         lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR4;
     if (flag_is_set(thing->rendering_flags, TRF_Transpar_Alpha))
         EngineSpriteDrawUsingAlpha = 1;
-    process_keeper_sprite(jspr->scr_x, jspr->scr_y, thing->anim_sprite, angle, thing->current_frame, base_sprite_size);
+    animation_sprite = get_render_animation_sprite(thing->anim_sprite);
+    current_frame = thing->current_frame;
+    process_keeper_sprite(jspr->scr_x, jspr->scr_y, animation_sprite, angle, current_frame, base_sprite_size);
 
     //Flame
     lbDisplay.DrawFlags = 0;
@@ -4880,8 +4897,12 @@ static void process_keeper_flame_on_sprite(struct BucketKindJontySprite* jspr, l
     {
         EngineSpriteDrawUsingAlpha = 1;
     }
-    nframe = (thing->index + get_gameturn() * flame.anim_speed / 256) % keepersprite_frames(flame.animation_id);
-    process_keeper_sprite(jspr->scr_x + add_x, jspr->scr_y + add_y, flame.animation_id, angle, nframe, scale);
+    unsigned short flame_sprite = get_render_animation_sprite(flame.animation_id);
+    unsigned char flame_frames = keepersprite_frames(flame_sprite);
+    if (flame_frames > 0) {
+        nframe = (thing->index + get_gameturn() * flame.anim_speed / 256) % flame_frames;
+        process_keeper_sprite(jspr->scr_x + add_x, jspr->scr_y + add_y, flame_sprite, angle, nframe, scale);
+    }
 }
 
 static unsigned short get_thing_shade(struct Thing* thing);
@@ -4892,10 +4913,14 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
     struct PlayerInfo *player = get_my_player();
     struct ObjectConfigStats* objst;
     struct Thing *thing = jspr->thing;
+    unsigned short animation_sprite;
+    unsigned char current_frame;
     short angle;
     flg_mem = lbDisplay.DrawFlags;
     alpha_mem = EngineSpriteDrawUsingAlpha;
-    if (keepersprite_rotable(thing->anim_sprite))
+    animation_sprite = get_render_animation_sprite(thing->anim_sprite);
+    current_frame = thing->current_frame;
+    if (keepersprite_rotable(animation_sprite))
     {
         angle = thing->move_angle_xy - cam->rotation_angle_x; // rotation_angle_x maybe short
     }
@@ -4982,12 +5007,9 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
         thing_being_displayed = NULL;
     }
 
-    if (
-            ((thing->anim_sprite >= CREATURE_FRAMELIST_LENGTH) && (thing->anim_sprite < KEEPERSPRITE_ADD_OFFSET))
-            || (thing->anim_sprite >= KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM)
-            )
+    if (animation_sprite_id_invalid(animation_sprite))
     {
-        ERRORLOG("Invalid graphic Id %d from model %d, class %d", (int)thing->anim_sprite, (int)thing->model, (int)thing->class_id);
+        ERRORLOG("Invalid graphic Id %d from model %d, class %d", (int)animation_sprite, (int)thing->model, (int)thing->class_id);
         lbDisplay.DrawFlags = flg_mem;
         EngineSpriteDrawUsingAlpha = alpha_mem;
         return;
@@ -5027,7 +5049,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
     {
         if (is_shown || get_my_player()->id_number == thing->owner || thing->trap.revealed)
         {
-            process_keeper_sprite(jspr->scr_x, jspr->scr_y, thing->anim_sprite, angle, thing->current_frame, size_on_screen);
+            process_keeper_sprite(jspr->scr_x, jspr->scr_y, animation_sprite, angle, current_frame, size_on_screen);
         }
     }
     lbDisplay.DrawFlags = flg_mem;
@@ -7736,6 +7758,15 @@ void process_keeper_sprite(short x, short y, unsigned short kspr_base, short ksp
     SYNCDBG(17, "At (%d,%d) opts %d %d %d %d", (int)x, (int)y, (int)kspr_base, (int)kspr_angle, (int)sprgroup, (int)scale);
     player = get_my_player();
     creature_sprites = keepersprite_array(kspr_base);
+    if (creature_sprites == NULL) {
+        return;
+    }
+    if (creature_sprites->FramesCount == 0) {
+        return;
+    }
+    if (sprgroup >= creature_sprites->FramesCount) {
+        sprgroup = creature_sprites->FramesCount - 1;
+    }
 
     if (((kspr_angle & ANGLE_MASK) <= 1151) || ((kspr_angle & ANGLE_MASK) >= 1919) || (creature_sprites->Rotable != 2) )
         needs_xflip = 0;
@@ -7779,7 +7810,7 @@ void process_keeper_sprite(short x, short y, unsigned short kspr_base, short ksp
         }
         if ( (thing_being_displayed->movement_flags & TMvF_BeingSacrificed) != 0 )
         {
-            get_keepsprite_unscaled_dimensions(thing_being_displayed->anim_sprite, thing_being_displayed->move_angle_xy, thing_being_displayed->current_frame, &dim_ow, &dim_oh, &dim_tw, &dim_th);
+            get_keepsprite_unscaled_dimensions(kspr_base, thing_being_displayed->move_angle_xy, sprgroup, &dim_ow, &dim_oh, &dim_tw, &dim_th);
             cctrl = creature_control_get_from_thing(thing_being_displayed);
             lltemp = dim_oh * (48 - (long)cctrl->sacrifice.animation_counter);
             cutoff = ((((lltemp >> 24) & 0x1F) + (long)lltemp) >> 5) / 2;
@@ -7928,12 +7959,16 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
     unsigned char alpha_mem;
     struct PlayerInfo *player = get_my_player();
     struct Thing *thing = jspr->thing;
+    unsigned short animation_sprite;
+    unsigned char current_frame;
     long angle;
     int32_t scaled_size;
     struct ObjectConfigStats* objst;
     flg_mem = lbDisplay.DrawFlags;
     alpha_mem = EngineSpriteDrawUsingAlpha;
-    if (keepersprite_rotable(thing->anim_sprite))
+    animation_sprite = get_render_animation_sprite(thing->anim_sprite);
+    current_frame = thing->current_frame;
+    if (keepersprite_rotable(animation_sprite))
     {
       angle = thing->move_angle_xy - spr_map_angle;
       angle += DEGREES_45 * (long)((thing->flags & TAF_ROTATED_MASK) >> TAF_ROTATED_SHIFT);
@@ -8018,12 +8053,9 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
         render_sprite_debug_fn(thing, jspr->scr_x, jspr->scr_y);
     }
 
-    if (
-        ((thing->anim_sprite >= CREATURE_FRAMELIST_LENGTH) && (thing->anim_sprite < KEEPERSPRITE_ADD_OFFSET))
-        || (thing->anim_sprite >= KEEPERSPRITE_ADD_OFFSET + KEEPERSPRITE_ADD_NUM)
-    )
+    if (animation_sprite_id_invalid(animation_sprite))
     {
-        ERRORLOG("Invalid graphic Id %d from model %d, class %d", (int)thing->anim_sprite, (int)thing->model, (int)thing->class_id);
+        ERRORLOG("Invalid graphic Id %d from model %d, class %d", (int)animation_sprite, (int)thing->model, (int)thing->class_id);
     } else
     {
         struct TrapConfigStats *trapst;
@@ -8036,7 +8068,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
                 process_keeper_flame_on_sprite(jspr, angle, scaled_size);
                 break;
             }
-            process_keeper_sprite(jspr->scr_x, jspr->scr_y, thing->anim_sprite, angle, thing->current_frame, scaled_size);
+            process_keeper_sprite(jspr->scr_x, jspr->scr_y, animation_sprite, angle, current_frame, scaled_size);
             break;
         case TCls_Trap:
             trapst = get_trap_model_stats(thing->model);
@@ -8049,10 +8081,10 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
                 process_keeper_flame_on_sprite(jspr, angle, scaled_size);
                 break;
             }
-            process_keeper_sprite(jspr->scr_x, jspr->scr_y, thing->anim_sprite, angle, thing->current_frame, scaled_size);
+            process_keeper_sprite(jspr->scr_x, jspr->scr_y, animation_sprite, angle, current_frame, scaled_size);
             break;
         default:
-            process_keeper_sprite(jspr->scr_x, jspr->scr_y, thing->anim_sprite, angle, thing->current_frame, scaled_size);
+            process_keeper_sprite(jspr->scr_x, jspr->scr_y, animation_sprite, angle, current_frame, scaled_size);
             break;
         }
     }
@@ -8213,8 +8245,17 @@ static void draw_keepsprite_unscaled_in_buffer(unsigned short kspr_n, short angl
         flip_range = true;
     i = ((angle + DEGREES_22_5) & ANGLE_MASK);
     quarter = abs(4 - (i >> 8)); // i is restricted by "&" so (i>>8) is 0..7
-    kspr_idx = keepersprite_index(kspr_n);
     kspr_arr = keepersprite_array(kspr_n);
+    if (kspr_arr == NULL) {
+        return;
+    }
+    if (kspr_arr->FramesCount == 0) {
+        return;
+    }
+    if (current_frame >= kspr_arr->FramesCount) {
+        current_frame = kspr_arr->FramesCount - 1;
+    }
+    kspr_idx = keepersprite_index(kspr_n);
 
     if (kspr_arr->Rotable == 0)
     {
@@ -8707,8 +8748,9 @@ static void do_map_who_for_thing(struct Thing *thing)
             int count;
             int i;
 
-            struct KeeperSprite *spr = keepersprite_array(thing->anim_sprite);
-            if ((spr->frame_flags & FFL_NoShadows) == 0)
+            unsigned short animation_sprite = get_render_animation_sprite(thing->anim_sprite);
+            struct KeeperSprite *spr = keepersprite_array(animation_sprite);
+            if ((spr != NULL) && ((spr->frame_flags & FFL_NoShadows) == 0))
             {
                 count = find_closest_lights(&thing->mappos, &nearlgt);
                 for (i = 0; i < count; i++)

--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -136,6 +136,9 @@ struct LogThingDesyncInfo {
     HitPoints health;
     GameTurn creation_turn;
     uint32_t random_seed;
+    unsigned short anim_sprite;
+    short anim_speed;
+    int32_t anim_time;
     unsigned char current_frame;
     unsigned char max_frames;
     unsigned char active_state;

--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -255,8 +255,7 @@ static int thing_set_field(lua_State *L) {
         move_thing_in_map(thing, &pos);
     } else if (strcmp(key, "anim_sprite") == 0)
     {
-        thing->anim_sprite = luaL_checkAnimationId(L, 3);
-        thing->max_frames = keepersprite_frames(thing->anim_sprite);
+        set_thing_animation(thing, luaL_checkAnimationId(L, 3), -1);
     } else if (strcmp(key, "anim_speed") == 0)
     {
         thing->anim_speed = luaL_checkinteger(L, 3);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,7 +311,7 @@ long get_foot_creature_has_down(struct Thing *thing)
         return 0;
     unsigned short frame = (creature_is_dragging_something(thing)) ? CGI_Drag : CGI_Ambulate;
     n = get_creature_model_graphics(thing->model, frame);
-    i = get_anim_for_current_view(n);
+    i = get_td_animation_sprite(n);
     if (i != thing->anim_sprite)
         return 0;
     if (val == 1)
@@ -867,7 +867,7 @@ void update_thing_animation(struct Thing *thing)
             thing->anim_time %= i;
           }
         }
-        thing->current_frame = (thing->anim_time >> 8) & 0xFF;
+        thing->current_frame = thing->anim_time >> 8;
     }
     if (thing->transformation_speed != 0)
     {

--- a/src/net_checksums.c
+++ b/src/net_checksums.c
@@ -67,6 +67,9 @@ TbBigChecksum get_thing_checksum(const struct Thing* thing) {
     CHECKSUM_ADD(checksum, thing->mappos.y.val);
     CHECKSUM_ADD(checksum, thing->mappos.z.val);
     CHECKSUM_ADD(checksum, thing->health);
+    CHECKSUM_ADD(checksum, thing->anim_sprite);
+    CHECKSUM_ADD(checksum, thing->anim_speed);
+    CHECKSUM_ADD(checksum, thing->anim_time);
     CHECKSUM_ADD(checksum, thing->current_frame);
     CHECKSUM_ADD(checksum, thing->max_frames);
     CHECKSUM_ADD(checksum, thing->active_state);
@@ -242,6 +245,9 @@ void update_turn_checksums(void) {
             thing_snapshot->health = thing->health;
             thing_snapshot->creation_turn = thing->creation_turn;
             thing_snapshot->random_seed = thing->random_seed;
+            thing_snapshot->anim_sprite = thing->anim_sprite;
+            thing_snapshot->anim_speed = thing->anim_speed;
+            thing_snapshot->anim_time = thing->anim_time;
             thing_snapshot->current_frame = thing->current_frame;
             thing_snapshot->max_frames = thing->max_frames;
             thing_snapshot->active_state = thing->active_state;
@@ -361,10 +367,11 @@ static void log_thing_differences(struct LogDetailedSnapshot* client, const char
         }
         if (host_thing == NULL || client_thing->checksum != host_thing->checksum) {
             if (host_thing != NULL) {
-                ERRORLOG("    [Host] Thing[%d] class_id=%d model=%d owner=%d mappos=(%ld,%ld,%ld) health=%ld creation_turn=%lu random_seed=%08x current_frame=%u max_frames=%u active_state=%u continue_state=%u movement_flags=%04x move_angle_xy=%d move_angle_z=%d holding_player=%d parent_idx=%d fall_acceleration=%u veloc_base=(%ld,%ld,%ld) veloc_push_once=(%ld,%ld,%ld) veloc_push_add=(%ld,%ld,%ld)",
+                ERRORLOG("    [Host] Thing[%d] class_id=%d model=%d owner=%d mappos=(%ld,%ld,%ld) health=%ld creation_turn=%lu random_seed=%08x anim_sprite=%u anim_speed=%d anim_time=%ld current_frame=%u max_frames=%u active_state=%u continue_state=%u movement_flags=%04x move_angle_xy=%d move_angle_z=%d holding_player=%d parent_idx=%d fall_acceleration=%u veloc_base=(%ld,%ld,%ld) veloc_push_once=(%ld,%ld,%ld) veloc_push_add=(%ld,%ld,%ld)",
                     host_thing->index, host_thing->class_id, host_thing->model, host_thing->owner,
                     (long)host_thing->mappos.x.val, (long)host_thing->mappos.y.val, (long)host_thing->mappos.z.val,
                     (long)host_thing->health, (unsigned long)host_thing->creation_turn, host_thing->random_seed,
+                    (unsigned)host_thing->anim_sprite, (int)host_thing->anim_speed, (long)host_thing->anim_time,
                     (unsigned)host_thing->current_frame, (unsigned)host_thing->max_frames,
                     (unsigned)host_thing->active_state, (unsigned)host_thing->continue_state,
                     (unsigned)host_thing->movement_flags,
@@ -376,10 +383,11 @@ static void log_thing_differences(struct LogDetailedSnapshot* client, const char
             } else {
                 ERRORLOG("    [Host] Thing[%d] missing", client_thing->index);
             }
-            ERRORLOG("    [Client] Thing[%d] class_id=%d model=%d owner=%d mappos=(%ld,%ld,%ld) health=%ld creation_turn=%lu random_seed=%08x current_frame=%u max_frames=%u active_state=%u continue_state=%u movement_flags=%04x move_angle_xy=%d move_angle_z=%d holding_player=%d parent_idx=%d fall_acceleration=%u veloc_base=(%ld,%ld,%ld) veloc_push_once=(%ld,%ld,%ld) veloc_push_add=(%ld,%ld,%ld)",
+            ERRORLOG("    [Client] Thing[%d] class_id=%d model=%d owner=%d mappos=(%ld,%ld,%ld) health=%ld creation_turn=%lu random_seed=%08x anim_sprite=%u anim_speed=%d anim_time=%ld current_frame=%u max_frames=%u active_state=%u continue_state=%u movement_flags=%04x move_angle_xy=%d move_angle_z=%d holding_player=%d parent_idx=%d fall_acceleration=%u veloc_base=(%ld,%ld,%ld) veloc_push_once=(%ld,%ld,%ld) veloc_push_add=(%ld,%ld,%ld)",
                 client_thing->index, client_thing->class_id, client_thing->model, client_thing->owner,
                 (long)client_thing->mappos.x.val, (long)client_thing->mappos.y.val, (long)client_thing->mappos.z.val,
                 (long)client_thing->health, (unsigned long)client_thing->creation_turn, client_thing->random_seed,
+                (unsigned)client_thing->anim_sprite, (int)client_thing->anim_speed, (long)client_thing->anim_time,
                 (unsigned)client_thing->current_frame, (unsigned)client_thing->max_frames,
                 (unsigned)client_thing->active_state, (unsigned)client_thing->continue_state,
                 (unsigned)client_thing->movement_flags,

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -56,7 +56,6 @@
 #include "frontend.h"
 #include "gui_draw.h"
 #include "engine_render.h"
-#include "engine_arrays.h"
 #include "sounds.h"
 #include "game_legacy.h"
 #include "sprites.h"
@@ -302,8 +301,7 @@ struct Thing *process_object_being_picked_up(struct Thing *thing, long plyr_idx)
         i = UNSYNC_RANDOM(3);
         powerst = get_power_model_stats(PwrK_PICKUPFOOD);
         thing_play_sample(thing, powerst->select_sound_idx + i, NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
-        i = get_anim_for_current_view(122);
-        set_thing_draw(thing, i, 256, -1, -1, 0, ODC_Default);
+        set_thing_draw(thing, 122, 256, -1, -1, 0, ODC_Default);
         remove_food_from_food_room_if_possible(thing);
         picktng = thing;
     }
@@ -951,7 +949,7 @@ void drop_held_thing_on_ground(struct Dungeon *dungeon, struct Thing *droptng, c
     if (thing_is_object(droptng))
     {
         if (object_is_mature_food(droptng)) {
-            set_thing_draw(droptng, get_anim_for_current_view(819), 256, -1, -1, 0, ODC_Default);
+            set_thing_draw(droptng, 819, 256, -1, -1, 0, ODC_Default);
         }
         else
         {
@@ -1389,7 +1387,7 @@ TbBool place_thing_in_power_hand(struct Thing *thing, PlayerNumber plyr_idx)
         //Removing combat is called in insert_thing_into_power_hand_list(), so we don't have to do it here
         if (creature_under_spell_effect(thing, CSAfF_Chicken))
         {
-            i = get_anim_for_current_view(122); // Hardcoded value, 122 is grabbed chicken.
+            i = 122; // Hardcoded value, 122 is grabbed chicken.
         }
         else
         {
@@ -1405,7 +1403,7 @@ TbBool place_thing_in_power_hand(struct Thing *thing, PlayerNumber plyr_idx)
         }
         struct ObjectConfigStats* objst = get_object_model_stats(thing->model);
         if (objst->sprite_anim_idx_in_hand != 0)
-            i = get_anim_for_current_view(objst->sprite_anim_idx_in_hand);
+            i = objst->sprite_anim_idx_in_hand;
         else
             i = objst->sprite_anim_idx;
         set_thing_draw(thing, i, objst->anim_speed, -1, -1, 0, ODC_Default);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -2598,7 +2598,7 @@ TbBool update_kills_counters(struct Thing *victim, struct Thing *killer,
 long creature_is_ambulating(struct Thing *thing)
 {
     int n = get_creature_model_graphics(thing->model, CGI_Ambulate);
-    int i = get_anim_for_current_view(n);
+    int i = get_td_animation_sprite(n);
     if (i != thing->anim_sprite)
         return 0;
     return 1;

--- a/src/thing_data.c
+++ b/src/thing_data.c
@@ -279,15 +279,20 @@ struct PlayerInfo *get_player_thing_is_controlled_by(const struct Thing *thing)
     return get_player(thing->owner);
 }
 
-void set_thing_draw(struct Thing *thing, long anim, long speed, long scale, char animate_once, char start_frame, unsigned char draw_class)
+void set_thing_animation(struct Thing *thing, long animation_index, long speed)
 {
-    unsigned long i;
-    thing->anim_sprite = get_anim_for_current_view(anim);
-    thing->draw_class = draw_class;
+    thing->anim_sprite = get_td_animation_sprite(animation_index);
     thing->max_frames = keepersprite_frames(thing->anim_sprite);
     if (speed != -1) {
         thing->anim_speed = speed;
     }
+}
+
+void set_thing_draw(struct Thing *thing, long anim, long speed, long scale, char animate_once, char start_frame, unsigned char draw_class)
+{
+    unsigned char current_frame;
+    set_thing_animation(thing, anim, speed);
+    thing->draw_class = draw_class;
     if (scale != -1)
     {
         thing->sprite_size = scale;
@@ -299,23 +304,21 @@ void set_thing_draw(struct Thing *thing, long anim, long speed, long scale, char
     if (animate_once != -1) {
         set_flag_value(thing->rendering_flags, TRF_AnimateOnce, animate_once);
     }
-    if (start_frame == -2)
-    {
-      i = keepersprite_frames(thing->anim_sprite) - 1;
-      thing->current_frame = i;
-      thing->anim_time = i << 8;
-    } else
-    if (start_frame == -1)
-    {
-      i = THING_RANDOM(thing, thing->max_frames);
-      thing->current_frame = i;
-      thing->anim_time = i << 8;
-    } else
-    {
-      i = start_frame;
-      thing->current_frame = i;
-      thing->anim_time = i << 8;
+    if (start_frame == -2) {
+        current_frame = 0;
+        if (thing->max_frames > 0) {
+            current_frame = thing->max_frames - 1;
+        }
+    } else if (start_frame == -1) {
+        current_frame = 0;
+        if (thing->max_frames > 0) {
+            current_frame = THING_RANDOM(thing, thing->max_frames);
+        }
+    } else {
+        current_frame = start_frame;
     }
+    thing->current_frame = current_frame;
+    thing->anim_time = current_frame << 8;
 }
 
 void query_thing(struct Thing *thing)

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -352,6 +352,7 @@ TbBool thing_is_in_limbo(const struct Thing* thing);
 TbBool thing_is_dragged_or_pulled(const struct Thing *thing);
 struct PlayerInfo *get_player_thing_is_controlled_by(const struct Thing *thing);
 
+void set_thing_animation(struct Thing *thing, long animation_index, long speed);
 void set_thing_draw(struct Thing *thing, long anim, long speed, long scale, char animate_once, char start_frame, unsigned char draw_class);
 
 void query_thing(struct Thing *thing);

--- a/src/thing_effects.c
+++ b/src/thing_effects.c
@@ -201,9 +201,9 @@ void process_spells_affected_by_effect_elements(struct Thing *thing)
         MapCoord cor_z_max = thing->clipbox_size_z + (thing->clipbox_size_z * game.conf.crtr_conf.exp.size_increase_on_exp * cctrl->exp_level) / 80; //effect is 25% larger than unit
 
         struct EffectElementConfigStats* eestat = get_effect_element_model_stats(TngEffElm_FlashBall1);
-        unsigned short nframes = keepersprite_frames(eestat->sprite_idx);
+        unsigned char nframes = keepersprite_frames(eestat->sprite_idx);
         GameTurnDelta dtadd = 0;
-        unsigned short cframe = get_gameturn() % nframes;
+        unsigned char cframe = get_gameturn() % nframes;
         pos.z.val = thing->mappos.z.val;
         int radius = diamtr / 2;
         while (pos.z.val < cor_z_max + thing->mappos.z.val)

--- a/src/thing_objects.c
+++ b/src/thing_objects.c
@@ -33,7 +33,6 @@
 #include "config_strings.h"
 #include "config_terrain.h"
 #include "creature_states_pray.h"
-#include "engine_arrays.h"
 #include "game_legacy.h"
 #include "game_loop.h"
 #include "gui_soundmsgs.h"
@@ -52,6 +51,7 @@
 #include "room_garden.h"
 #include "sounds.h"
 #include "thing_effects.h"
+#include "thing_data.h"
 #include "thing_navigate.h"
 #include "thing_physics.h"
 #include "thing_stats.h"
@@ -113,8 +113,7 @@ struct CallToArmsGraphics call_to_arms_graphics[10];
 /******************************************************************************/
 struct Thing *create_object(const struct Coord3d *pos, ThingModel model, unsigned short owner, long parent_idx)
 {
-    long i;
-    long start_frame;
+    char start_frame;
 
     if (!i_can_allocate_free_thing_structure(TCls_Object))
     {
@@ -140,8 +139,6 @@ struct Thing *create_object(const struct Coord3d *pos, ThingModel model, unsigne
     thing->clipbox_size_z = objst->size_z;
     thing->solid_size_xy = objst->size_xy;
     thing->solid_size_z = objst->size_z;
-    thing->anim_speed = objst->anim_speed;
-    thing->anim_sprite = objst->sprite_anim_idx;
     thing->health = saturate_set_signed(objst->health,32);
     thing->fall_acceleration = objst->fall_acceleration;
     thing->inertia_floor = 204;
@@ -153,16 +150,11 @@ struct Thing *create_object(const struct Coord3d *pos, ThingModel model, unsigne
     thing->owner = owner;
     thing->creation_turn = get_gameturn();
 
-    if (!objst->random_start_frame)
-    {
-      i = get_anim_for_current_view(objst->sprite_anim_idx);
-      start_frame = 0;
-    } else
-    {
-      i = get_anim_for_current_view(objst->sprite_anim_idx);
-      start_frame = -1;
+    start_frame = 0;
+    if (objst->random_start_frame) {
+        start_frame = -1;
     }
-    set_thing_draw(thing, i, objst->anim_speed, objst->sprite_size_max, 0, start_frame, objst->draw_class);
+    set_thing_draw(thing, objst->sprite_anim_idx, objst->anim_speed, objst->sprite_size_max, 0, start_frame, objst->draw_class);
     set_flag_value(thing->rendering_flags, TRF_Unshaded, objst->light_unaffected);
 
     set_flag(thing->rendering_flags, objst->transparency_flags);
@@ -213,7 +205,7 @@ struct Thing *create_object(const struct Coord3d *pos, ThingModel model, unsigne
     }
     if (objst->genre == OCtg_HeroGate)
     {
-        i = get_free_hero_gate_number();
+        int32_t i = get_free_hero_gate_number();
         if (i > 0)
         {
             thing->hero_gate.number = i;
@@ -1177,7 +1169,7 @@ void update_dungeon_heart_beat(struct Thing *heartng)
             }
         }
         k = (((unsigned long long)heartng->anim_time >> 32) & 0xFF) + heartng->anim_time;
-        heartng->current_frame = (k >> 8) & 0xFF;
+        heartng->current_frame = k >> 8;
         if (LbIsFrozenOrPaused())
         {
             stop_thing_playing_sample(heartng, 93);
@@ -1484,7 +1476,7 @@ static TngUpdateRet object_update_object_scale(struct Thing *objtng)
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     struct ObjectConfigStats* objst = get_object_model_stats(objtng->model);
     int spr_size;
-    int start_frame = objtng->current_frame;
+    unsigned char start_frame = objtng->current_frame;
     if (objtng->lair.belongs_to) {
         spr_size = game.conf.crtr_conf.sprite_size + (game.conf.crtr_conf.sprite_size * cctrl->exp_level * game.conf.crtr_conf.exp.size_increase_on_exp) / 100;
     } else {
@@ -1492,25 +1484,18 @@ static TngUpdateRet object_update_object_scale(struct Thing *objtng)
     }
     int cssize = objtng->lair.cssize;
     objtng->lair.spr_size = spr_size;
-    long i;
     if (cssize+32 < spr_size)
     {
         objtng->lair.cssize = cssize+32;
-        i = get_anim_for_current_view(objst->sprite_anim_idx);
     } else
     if (cssize-32 > spr_size)
     {
         objtng->lair.cssize = cssize-32;
-        i = get_anim_for_current_view(objst->sprite_anim_idx);
     } else
     {
         objtng->lair.cssize = spr_size;
-        i = get_anim_for_current_view(objst->sprite_anim_idx);
     }
-    if ((i & 0x8000u) != 0) {
-        i = objst->sprite_anim_idx;
-    }
-    set_thing_draw(objtng, i, objst->anim_speed, objtng->lair.cssize, 0, start_frame, objst->draw_class);
+    set_thing_draw(objtng, objst->sprite_anim_idx, objst->anim_speed, objtng->lair.cssize, 0, start_frame, objst->draw_class);
     return TUFRet_Modified;
 }
 
@@ -1994,12 +1979,7 @@ GoldAmount add_gold_to_hoarde(struct Thing *gldtng, struct Room *room, GoldAmoun
     gldtng->model = gold_hoard_objects[wealth_size-1];
     // Set visual appearance
     struct ObjectConfigStats* objst = get_object_model_stats(gldtng->model);
-    unsigned short i = objst->sprite_anim_idx;
-    unsigned short n = get_anim_for_current_view(i);
-    if ((n & 0x8000u) == 0) {
-      i = n;
-    }
-    set_thing_draw(gldtng, i, objst->anim_speed, objst->sprite_size_max, 0, 0, objst->draw_class);
+    set_thing_draw(gldtng, objst->sprite_anim_idx, objst->anim_speed, objst->sprite_size_max, 0, 0, objst->draw_class);
     return amount;
 }
 
@@ -2046,12 +2026,7 @@ GoldAmount remove_gold_from_hoarde(struct Thing *gldtng, struct Room *room, Gold
     gldtng->model = gold_hoard_objects[wealth_size-1];
     // Set visual appearance
     struct ObjectConfigStats* objst = get_object_model_stats(gldtng->model);
-    unsigned short i = objst->sprite_anim_idx;
-    unsigned short n = get_anim_for_current_view(i);
-    if ((n & 0x8000u) == 0) {
-      i = n;
-    }
-    set_thing_draw(gldtng, i, objst->anim_speed, objst->sprite_size_max, 0, 0, objst->draw_class);
+    set_thing_draw(gldtng, objst->sprite_anim_idx, objst->anim_speed, objst->sprite_size_max, 0, 0, objst->draw_class);
     return amount;
 }
 

--- a/src/thing_traps.c
+++ b/src/thing_traps.c
@@ -28,6 +28,7 @@
 #include "thing_data.h"
 #include "creature_states_combt.h"
 #include "config_creature.h"
+#include "config_trapdoor.h"
 #include "config_terrain.h"
 #include "creature_states.h"
 #include "thing_effects.h"
@@ -949,7 +950,7 @@ TngUpdateRet update_trap(struct Thing *traptng)
         if ((traptng->trap.rearm_turn <= get_gameturn())) // Recharge complete, rearm.
         {
             // Back to regular anim.
-            traptng->anim_sprite = get_anim_for_current_view(trapst->sprite_anim_idx);
+            traptng->anim_sprite = get_td_animation_sprite(trapst->sprite_anim_idx);
             traptng->max_frames = keepersprite_frames(traptng->anim_sprite);
             traptng->trap.wait_for_rearm = false;
         }
@@ -957,7 +958,7 @@ TngUpdateRet update_trap(struct Thing *traptng)
         {
             if (trapst->attack_sprite_anim_idx != 0)
             {
-                traptng->anim_sprite = get_anim_for_current_view(trapst->attack_sprite_anim_idx);
+                traptng->anim_sprite = get_td_animation_sprite(trapst->attack_sprite_anim_idx);
                 traptng->anim_speed = trapst->attack_anim_speed;
                 traptng->max_frames = keepersprite_frames(traptng->anim_sprite);
             }
@@ -966,12 +967,12 @@ TngUpdateRet update_trap(struct Thing *traptng)
         {
             if (trapst->recharge_sprite_anim_idx != 0)
             {
-                traptng->anim_sprite = get_anim_for_current_view(trapst->recharge_sprite_anim_idx);
+                traptng->anim_sprite = get_td_animation_sprite(trapst->recharge_sprite_anim_idx);
                 traptng->anim_speed = trapst->recharge_anim_speed;
             }
             else
             {
-                traptng->anim_sprite = get_anim_for_current_view(trapst->sprite_anim_idx);
+                traptng->anim_sprite = get_td_animation_sprite(trapst->sprite_anim_idx);
                 traptng->anim_speed = trapst->anim_speed;
             }
             traptng->max_frames = keepersprite_frames(traptng->anim_sprite);


### PR DESCRIPTION
There's an issue with the animation variables on an individual creature being treated as local variables, while they're actually supposed to be synced. They're being shared between players, because there's only one creature with one set of variables.

I'll just lead with the obvious here: animation variables need to be synced because there's a lot of gameplay stuff tied to them.

They changed locally whenever you switched views. So in multiplayer when a resync happens they get copied from the host machine, which apparently can cause a permanent resync loop. When you switch between first person view and top down view, the `current_frame` and `max_frames` inside creatures change, which might have you wondering: Which player's current view owns the `thing->current_frame`? In multiplayer each machine can have a different local view (someone can be in first person and someone can be in top down view), but they are still utilizing these same shared variables on the same creature which isn't very safe.

One partial solution would be to simply not checksum `current_frame` and `max_frames`, which is what we've mostly been doing, but I'm pretty sure that's just hiding the issue away and results in obscure butterfly-effect desyncs down the line.

Anyway what I've done here: Inside a Thing/creature, the anim_sprite/anim_speed/anim_time/current_frame/max_frames variables now all consistently refer to the top down values, but during render time this is converted to the first-person values (if player is in first person view). This "conversion" doesn't mean setting the values, it's just local to the rendering code.