### PR TITLE
Multiplayer: Sync lua seed

### DIFF
--- a/src/lua_base.c
+++ b/src/lua_base.c
@@ -166,7 +166,7 @@ TbBool open_lua_script(LevelNumber lvnum)
 	Lvl_script = luaL_newstate();
 
 	luaL_openlibs(Lvl_script);
-    lua_set_random_seed(game.action_random_seed);
+	lua_set_random_seed(game.action_random_seed);
 
 	reg_host_functions(Lvl_script);
 

--- a/src/lua_base.c
+++ b/src/lua_base.c
@@ -9,6 +9,7 @@
 #include "bflib_basics.h"
 #include "bflib_fileio.h"
 #include "config_keeperfx.h"
+#include "game_legacy.h"
 #include "globals.h"
 #include "gui_msgs.h"
 
@@ -165,6 +166,7 @@ TbBool open_lua_script(LevelNumber lvnum)
 	Lvl_script = luaL_newstate();
 
 	luaL_openlibs(Lvl_script);
+    lua_set_random_seed(game.action_random_seed);
 
 	reg_host_functions(Lvl_script);
 

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -145,6 +145,9 @@ static void init_level(void)
     lens_mode = 0;
     setup_heap_manager();
 
+    init_seeds();
+    sync_various_data();
+
     luascript_loaded = open_lua_script(get_selected_level_number());
     // Load configs which may have per-campaign part, and can even be modified within a level
     recheck_all_mod_exist();
@@ -169,9 +172,6 @@ static void init_level(void)
     setup_panel_colors();
     init_map_size(get_selected_level_number());
     clear_messages();
-    init_seeds();
-    
-    sync_various_data();
     
     // Load the actual level files
     TbBool script_preloaded = preload_script(get_selected_level_number());
@@ -484,6 +484,5 @@ void init_seeds()
         game.player_random_seed = game.action_random_seed * 9473 + 9479;
         
         initial_replay_seed = game.action_random_seed;
-        lua_set_random_seed(game.action_random_seed);
     }
 }

--- a/src/net_resync.cpp
+++ b/src/net_resync.cpp
@@ -29,6 +29,7 @@
 #include "net_game.h"
 #include "game_legacy.h"
 #include "lens_api.h"
+#include "lua_base.h"
 #include "net_input_lag.h"
 #include "net_received_packets.h"
 #include "net_redundant_packets.h"
@@ -355,6 +356,7 @@ void resync_game(void) {
     } else {
         receive_resync_game();
     }
+    lua_set_random_seed(game.action_random_seed);
     recall_localised_game_structure();
     reinit_level_after_load();
 

--- a/src/net_resync.cpp
+++ b/src/net_resync.cpp
@@ -356,7 +356,9 @@ void resync_game(void) {
     } else {
         receive_resync_game();
     }
-    lua_set_random_seed(game.action_random_seed);
+    if (Lvl_script != NULL) {
+        lua_set_random_seed(game.action_random_seed);
+    }
     recall_localised_game_structure();
     reinit_level_after_load();
 


### PR DESCRIPTION
1. `init_seeds()` is now called first which establishes `game.action_random_seed`
2. `sync_various_data();` sends the usual seeds over to the other player.
3. `open_lua_script()` then calls `lua_set_random_seed(game.action_random_seed);`

Whenever there's a resync it calls `lua_set_random_seed(game.action_random_seed);` too.

Haven't tested it yet, I don't even know how to print a lua seed.