### PR TITLE
Multiplayer: Resync cooldown to prevent permanent looping

### DIFF
--- a/src/packets.c
+++ b/src/packets.c
@@ -269,7 +269,6 @@ static TbBool resync_game_allowed(void)
         if ((int32_t)(now - resync_cooldown_end) < 0) {
             if (!resync_cooldown_warned) {
                 show_onscreen_msg(10 * game_num_fps, "Game may be in a desynced state.");
-                NETLOG("Game may be in a desynced state.");
                 resync_cooldown_warned = true;
             }
             return false;

--- a/src/packets.c
+++ b/src/packets.c
@@ -268,8 +268,7 @@ static TbBool resync_game_allowed(void)
     if (resync_attempt_count >= RESYNC_LIMIT_BEFORE_COOLDOWN) {
         if ((int32_t)(now - resync_cooldown_end) < 0) {
             if (!resync_cooldown_warned) {
-                show_onscreen_msg(4 * game_num_fps, "Game may be in a desynced state.");
-                message_add_fmt(MsgType_Blank, 0, "Game may be in a desynced state.");
+                show_onscreen_msg(10 * game_num_fps, "Game may be in a desynced state.");
                 NETLOG("Game may be in a desynced state.");
                 resync_cooldown_warned = true;
             }

--- a/src/packets.c
+++ b/src/packets.c
@@ -55,7 +55,6 @@
 #include "config_crtrmodel.h"
 #include "config_effects.h"
 #include "config_terrain.h"
-#include "config_players.h"
 #include "config_settings.h"
 #include "config_keeperfx.h"
 #include "player_instances.h"
@@ -121,6 +120,9 @@ extern TbBool change_campaign(const char *cmpgn_fname);
 /******************************************************************************/
 TbBool unpausing_in_progress = 0;
 /******************************************************************************/
+#define RESYNC_LIMIT_BEFORE_COOLDOWN 5
+#define RESYNC_COOLDOWN_MS (5 * 60 * 1000)
+
 void set_packet_action(struct Packet *pckt, unsigned char pcktype, long par1, long par2, unsigned short par3, unsigned short par4)
 {
     pckt->actn_par1 = par1;
@@ -245,6 +247,42 @@ TbBool process_dungeon_control_packet_spell_overcharge(long plyr_idx)
         return false;
     }
     return false;
+}
+
+static TbBool resync_game_allowed(void)
+{
+    static int32_t resync_attempt_count = 0;
+    static TbClockMSec resync_cooldown_end = 0;
+    static GameTurn resync_last_turn = 0;
+    static TbBool resync_cooldown_warned = false;
+    TbClockMSec now = LbTimerClock();
+    GameTurn turn = get_gameturn();
+
+    if (turn < resync_last_turn) {
+        resync_attempt_count = 0;
+        resync_cooldown_end = 0;
+        resync_cooldown_warned = false;
+    }
+    resync_last_turn = turn;
+
+    if (resync_attempt_count >= RESYNC_LIMIT_BEFORE_COOLDOWN) {
+        if ((int32_t)(now - resync_cooldown_end) < 0) {
+            if (!resync_cooldown_warned) {
+                show_onscreen_msg(4 * game_num_fps, "Game may be in a desynced state.");
+                message_add_fmt(MsgType_Blank, 0, "Game may be in a desynced state.");
+                NETLOG("Game may be in a desynced state.");
+                resync_cooldown_warned = true;
+            }
+            return false;
+        }
+    }
+
+    if (resync_attempt_count < RESYNC_LIMIT_BEFORE_COOLDOWN) {
+        resync_attempt_count++;
+    }
+    resync_cooldown_end = now + RESYNC_COOLDOWN_MS;
+    resync_cooldown_warned = false;
+    return true;
 }
 
 TbBool player_sell_room_at_subtile(long plyr_idx, long stl_x, long stl_y)
@@ -1789,8 +1827,10 @@ void process_packets(void)
     if (((game.system_flags & GSF_NetworkActive) != 0)
      && ((game.system_flags & (GSF_NetGameNoSync | GSF_NetSeedNoSync)) != 0))
     {
-        SYNCDBG(0,"Resyncing");
-        resync_game();
+        if (resync_game_allowed()) {
+            SYNCDBG(0,"Resyncing");
+            resync_game();
+        }
     }
     get_current_slowdown_percentage();
     MULTIPLAYER_LOG("process_packets: === END turn=%lu ===", (unsigned long)get_gameturn());


### PR DESCRIPTION
Some of these permanent looping resyncs probably aren't the biggest deal in the world and can be played through, but I'm really not sure. Obviously I want to fix them all, but I'm ruining some people's multiplayer games in the process of seeking them out.

So now after 5 resyncs, it goes on cooldown and only allows 1 resync every 5 minutes from then on. Players are notified "Game may be in a desynced state." so you can play on at your own risk.

Worse case scenario is after 5 minutes pass when there's another resync it'll suddenly show you a very different game caused by cascading butterfly-effect differences. Or maybe not, could be fine.