### PR TITLE
Fix Steam API shutdown

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4418,8 +4418,8 @@ int LbBullfrogMain(unsigned short argc, char *argv[])
         SYNCDBG(0,"finished properly");
     }
 
-    LbErrorLogClose();
     steam_api_shutdown();
+    LbErrorLogClose();
     return 0;
 }
 

--- a/src/steam_api.cpp
+++ b/src/steam_api.cpp
@@ -146,7 +146,7 @@ int steam_api_init()
     // Check if initialization is successful
     if (result != ESteamAPIInitResult::k_ESteamAPIInitResult_OK)
     {
-        JUSTLOG("Steam API Failure: %s", error);
+        ERRORLOG("Steam API Failure: %s", error);
         FreeLibrary(steam_lib);
         return 1;
     }

--- a/src/steam_api.cpp
+++ b/src/steam_api.cpp
@@ -52,8 +52,8 @@ union SteamApiInitUnion
 };
 
 // Variables
-SteamApiInitFunc SteamAPI_Init;
-SteamApiShutdownFunc SteamAPI_Shutdown;
+SteamApiInitFunc SteamAPI_Init = nullptr;
+SteamApiShutdownFunc SteamAPI_Shutdown = nullptr;
 
 /**
  * @brief Initializes the Steam API in KeeperFX.
@@ -151,7 +151,6 @@ int steam_api_init()
         return 1;
     }
 
-    FreeLibrary(steam_lib);
     return 0;
 
 #endif
@@ -165,10 +164,26 @@ int steam_api_init()
 void steam_api_shutdown()
 {
 #ifdef _WIN32
-    if (SteamAPI_Shutdown != NULL) {
+
+    JUSTLOG("Shutting down Steam API");
+
+    if (SteamAPI_Shutdown != nullptr) {
         SteamAPI_Shutdown();
     } else {
-        WARNLOG("Steam API could not be shut down. SteamAPI_Shutdown() is NULL");
+        WARNLOG("Steam API could not be shut down. SteamAPI_Shutdown() is a null pointer");
     }
+
+    // Unload the Steam DLL
+    if (steam_lib != nullptr) {
+        FreeLibrary(steam_lib);
+        steam_lib = nullptr;
+    } else {
+        WARNLOG("Steam API library could not be unloaded");
+    }
+
+    // Reset function pointers
+    SteamAPI_Init = nullptr;
+    SteamAPI_Shutdown = nullptr;
+
 #endif
 }

--- a/src/steam_api.cpp
+++ b/src/steam_api.cpp
@@ -165,18 +165,10 @@ int steam_api_init()
 void steam_api_shutdown()
 {
 #ifdef _WIN32
-    if (SteamAPI_Shutdown != NULL)
-    {
+    if (SteamAPI_Shutdown != NULL) {
         SteamAPI_Shutdown();
-    }
-
-    SteamAPI_Shutdown = NULL;
-    SteamAPI_Init = NULL;
-
-    if (steam_lib != NULL)
-    {
-        FreeLibrary(steam_lib);
-        steam_lib = NULL;
+    } else {
+        WARNLOG("Steam API could not be shut down. SteamAPI_Shutdown() is NULL");
     }
 #endif
 }


### PR DESCRIPTION
Fixes wrongful crash reports in the launcher because of the Steam API incorrectly shutting down.

Mistake was checking for `NULL` instead of `nullptr`.

Also moved the closing of the error log behind the Steam API shutdown because I also improved logging. 