### PR TITLE
Removed BREAK_IN script variable

### DIFF
--- a/src/dungeon_data.h
+++ b/src/dungeon_data.h
@@ -206,7 +206,6 @@ struct Dungeon {
     int manage_score;
     int total_score;
     uint32_t max_gameplay_score;
-    short times_breached_dungeon;
     short highest_task_number;
     GoldAmount total_money_owned;
     GoldAmount offmap_money_owned;

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -309,8 +309,6 @@ const struct NamedCommand script_boolean_desc[] = {
 const struct NamedCommand variable_desc[] = {
     {"MONEY",                       SVar_MONEY},
     {"GAME_TURN",                   SVar_GAME_TURN},
-    {"BREAK_IN",                    SVar_BREAK_IN},
-    //{"CREATURE_NUM",              SVar_CREATURE_NUM},
     {"TOTAL_DIGGERS",               SVar_TOTAL_DIGGERS},
     {"TOTAL_CREATURES",             SVar_TOTAL_CREATURES},
     {"TOTAL_RESEARCH",              SVar_TOTAL_RESEARCH},
@@ -378,8 +376,6 @@ const struct NamedCommand variable_desc[] = {
 const struct NamedCommand dk1_variable_desc[] = {
     {"MONEY",                       SVar_MONEY},
     {"GAME_TURN",                   SVar_GAME_TURN},
-    {"BREAK_IN",                    SVar_BREAK_IN},
-    //{"CREATURE_NUM",                SVar_CREATURE_NUM},
     {"TOTAL_IMPS",                  SVar_TOTAL_DIGGERS},
     {"TOTAL_CREATURES",             SVar_CONTROLS_TOTAL_CREATURES},
     {"TOTAL_RESEARCH",              SVar_TOTAL_RESEARCH},

--- a/src/lvl_script_conditions.c
+++ b/src/lvl_script_conditions.c
@@ -52,9 +52,6 @@ long get_condition_value(PlayerNumber plyr_idx, unsigned char valtype, short val
         return dungeon->total_money_owned;
     case SVar_GAME_TURN:
         return get_gameturn();
-    case SVar_BREAK_IN:
-        dungeon = get_dungeon(plyr_idx);
-        return dungeon->times_breached_dungeon;
     case SVar_CREATURE_NUM:
         return count_player_creatures_of_model(plyr_idx, validx);
     case SVar_TOTAL_DIGGERS:

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -216,7 +216,6 @@ struct CommandDesc { // sizeof = 14 // originally was 13
 enum ScriptVariables {
   SVar_MONEY                           =  1,
   SVar_GAME_TURN                       =  5,
-  SVar_BREAK_IN                        =  6,
   SVar_CREATURE_NUM                    =  7,
   SVar_TOTAL_DIGGERS                   =  8,
   SVar_TOTAL_CREATURES                 =  9,


### PR DESCRIPTION
- It did nothing
- It cannot be reliably made to do anything

Not to be confused with 'times broken into', which is the amount of times tunnellers (not imps), broke into your dungeon.