### PR TITLE
Multiplayer: Split front_landview.c into two files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ obj/front_fmvids.o \
 obj/front_highscore.o \
 obj/front_input.o \
 obj/front_landview.o \
+obj/front_landview_multiplayer.o \
 obj/front_lvlstats.o \
 obj/front_lvlstats_data.o \
 obj/front_network.o \

--- a/keeperfx_vs2010.vcxproj
+++ b/keeperfx_vs2010.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="src\front_highscore.c" />
     <ClCompile Include="src\front_input.c" />
     <ClCompile Include="src\front_landview.c" />
+    <ClCompile Include="src\front_landview_multiplayer.c" />
     <ClCompile Include="src\front_lvlstats.c" />
     <ClCompile Include="src\front_lvlstats_data.cpp" />
     <ClCompile Include="src\front_network.c" />

--- a/keeperfx_vs2010.vcxproj.filters
+++ b/keeperfx_vs2010.vcxproj.filters
@@ -288,6 +288,9 @@
     <ClCompile Include="src\front_landview.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\front_landview_multiplayer.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\front_lvlstats.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/linux.mk
+++ b/linux.mk
@@ -123,6 +123,7 @@ src/front_fmvids.c \
 src/front_highscore.c \
 src/front_input.c \
 src/front_landview.c \
+src/front_landview_multiplayer.c \
 src/front_lvlstats.c \
 src/front_lvlstats_data.cpp \
 src/front_network.c \

--- a/src/front_landview.c
+++ b/src/front_landview.c
@@ -63,33 +63,14 @@
 extern "C" {
 #endif
 /******************************************************************************/
-struct NetMapPlayersState {
-    int32_t unselected_players;
-    LevelNumber selected_level_number;
-    TbBool is_selected;
-};
-
-/******************************************************************************/
 #define WINDOW_X_SIZE 960
 #define WINDOW_Y_SIZE 720
 #define LANDVIEW_ZOOM_STEP (2 * 3.3f)
 #define LANDVIEW_PAN_ACCEL (4 * 3.3f)
 #define LANDVIEW_PAN_DECEL (1 * 3.3f)
 #define LANDVIEW_PAN_MAX_SPEED (24 * 3.3f)
-
-enum NetMapSlapFrame {
-    NetMapSlap_StartFrame = 9,
-    NetMapSlap_HitFrame = 13,
-    NetMapSlap_EndFrame = 16,
-};
-
-TbPixel net_player_colours[] = { 251, 58, 182, 11};
-const long hand_limp_xoffset[] = { 32,  31,  30,  29,  28,  27,  26,  24,  22,  19,  15,  9, };
-const long hand_limp_yoffset[] = {-11, -10,  -9,  -8,  -7,  -6,  -5,  -4,  -3,  -2,  -1,  0, };
 struct TbSprite dummy_sprite = {0, 0, 0};
 
-long limp_hand_x = 0;
-long limp_hand_y = 0;
 LevelNumber mouse_over_lvnum;
 LevelNumber playing_speech_lvnum;
 struct TbHugeSprite map_window;
@@ -103,9 +84,6 @@ struct TbSpriteSheet * map_font = NULL;
 struct TbSpriteSheet * map_hand = NULL;
 long map_sound_fade;
 unsigned char *map_screen;
-long fe_net_level_selected;
-long net_map_limp_time;
-struct ScreenPacket net_screen_packet[NET_PLAYERS_COUNT];
 /******************************************************************************/
 #ifdef __cplusplus
 }
@@ -222,20 +200,6 @@ void update_ensigns_visibility(void)
   lvinfo = get_level_info(lvnum);
   if (lvinfo != NULL)
       lvinfo->state = get_extra_level_kind_visibility(ExLv_NewMoon);
-}
-
-void update_net_ensigns_visibility(void)
-{
-    SYNCDBG(18, "Starting");
-    set_all_ensigns_state(LvSt_Hidden);
-    long lvnum = first_multiplayer_level();
-    while (lvnum > 0)
-    {
-        struct LevelInformation* lvinfo = get_level_info(lvnum);
-        if (lvinfo != NULL)
-            lvinfo->state = LvSt_Visible;
-        lvnum = next_multiplayer_level(lvnum);
-    }
 }
 
 int compute_sound_good_to_bad_factor(void)
@@ -982,37 +946,7 @@ TbBool load_map_and_window(LevelNumber lvnum)
     return true;
 }
 
-void frontnet_init_level_descriptions(void)
-{
-    //TODO NETWORK Don't allow campaigns besides original - we don't have per-campaign MP yet
-    //if (!is_campaign_loaded())
-    {
-        if (!change_campaign("")) {
-            return;
-        }
-    }
-}
-
-void frontnetmap_unload(void)
-{
-    clear_light_system(&game.lish);
-    clear_mapmap();
-    clear_things_and_persons_data();
-    clear_computer();
-    clear_rooms();
-    clear_dungeons();
-    clear_slabs();
-    memcpy(&frontend_palette, frontend_backup_palette, PALETTE_SIZE);
-    free_font(&map_font);
-    free_spritesheet(&map_flag);
-    free_spritesheet(&map_hand);
-    memcpy(&frontend_palette, frontend_backup_palette, PALETTE_SIZE);
-    fe_network_active = 0;
-    stop_music();
-    set_music_volume(settings.music_volume);
-}
-
-static void frontmap_start_music(void)
+void frontmap_start_music(void)
 {
     if (strlen(campaign.soundtrack_fname) > 0) {
         const int track = atoi(campaign.soundtrack_fname);
@@ -1025,70 +959,6 @@ static void frontmap_start_music(void)
     } else {
         play_music_track(2);
     }
-}
-
-TbBool frontnetmap_load(void)
-{
-    SYNCDBG(8,"Starting");
-    if (fe_network_active)
-    {
-      if (LbNetwork_EnableNewPlayers(0))
-        ERRORLOG("Unable to prohibit new players joining exchange");
-    }
-    frontend_load_data_from_cd();
-    game.selected_level_number = 0;
-    if (!load_map_and_window(0))
-    {
-        frontend_load_data_reset();
-        return false;
-    }
-    switch (campaign.land_markers)
-    {
-    case LndMk_PINPOINTS:
-        map_flag = load_spritesheet("ldata/netflag_pin.dat", "ldata/netflag_pin.tab");
-        break;
-    default:
-        ERRORLOG("Unsupported land markers type %d",(int)campaign.land_markers);
-        // Fall Through
-    case LndMk_ENSIGNS:
-        map_flag = load_spritesheet("ldata/netflag_ens.dat", "ldata/netflag_ens.tab");
-        break;
-    }
-    map_font = load_spritesheet("ldata/netfont.dat", "ldata/netfont.tab");
-    map_hand = load_spritesheet("ldata/maphand.dat", "ldata/maphand.tab");
-    if (!map_flag || !map_font || !map_hand)
-    {
-      ERRORLOG("Unable to load MAP SCREEN sprites");
-      return false;
-    }
-    frontend_load_data_reset();
-    frontnet_init_level_descriptions();
-    frontmap_zoom_skip_init(SINGLEPLAYER_NOTSTARTED);
-    fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
-    net_level_hilighted = SINGLEPLAYER_NOTSTARTED;
-    set_pointer_graphic_none();
-    LbMouseSetPosition(lbDisplay.PhysicalScreenWidth/2, lbDisplay.PhysicalScreenHeight/2);
-    map_sound_fade = FULL_LOUDNESS;
-    lbDisplay.DrawFlags = 0;
-    set_music_volume(settings.music_volume);
-    frontmap_start_music();
-    if (fe_network_active)
-    {
-        net_number_of_players = 0;
-        for (long i = 0; i < NET_PLAYERS_COUNT; i++)
-        {
-            struct ScreenPacket* nspck = &net_screen_packet[i];
-            if ((nspck->networkstatus_flags & NetStat_PlayerConnected) != 0)
-              net_number_of_players++;
-        }
-    } else
-    {
-      net_number_of_players = 1;
-    }
-    net_map_slap_frame = 0;
-    net_map_limp_time = 0;
-    update_net_ensigns_visibility();
-    return true;
 }
 
 void process_map_zoom_in(void)
@@ -1216,66 +1086,6 @@ TbBool frontmap_load(void)
     return true;
 }
 
-TbBool rectangle_intersects(struct TbRect *rcta, struct TbRect *rctb)
-{
-    long left = rcta->left;
-    if (rcta->left <= rctb->left)
-      left = rctb->left;
-    long top = rcta->top;
-    if (top <= rctb->top)
-      top = rctb->top;
-    long right = rcta->right;
-    if (right >= rctb->right)
-      right = rctb->right;
-    long bottom = rcta->bottom;
-    if (bottom >= rctb->bottom)
-      bottom = rctb->bottom;
-    return (left < right) && (top < bottom);
-}
-
-TbBool test_hand_slap_collides(PlayerNumber plyr_idx)
-{
-  struct TbRect rctb;
-  if (is_my_player_number(plyr_idx))
-    return false;
-  struct ScreenPacket* nspck = &net_screen_packet[my_player_number];
-  if (screen_packet_action(nspck) == NetAct_Limping)
-    return false;
-  // Rectangle of given player
-  nspck = &net_screen_packet[(int)plyr_idx];
-  struct TbRect rcta;
-  rcta.left = nspck->stored_data1 - 7;
-  rcta.top = nspck->stored_data2 - 13;
-  rcta.right = rcta.left + 30;
-  rcta.bottom = rcta.top + 20;
-  // Rectangle of local player
-  nspck = &net_screen_packet[my_player_number];
-  if (screen_packet_action(nspck) == NetAct_Slapping)
-  {
-    rctb.left = nspck->stored_data1 - 31;
-    rctb.top = nspck->stored_data2 - 27;
-    rctb.right = get_sprite(map_hand, 9)->SWidth + rctb.left;
-    rctb.bottom = rctb.top + get_sprite(map_hand, 9)->SHeight;
-  } else
-  if (nspck->action_par1 != SINGLEPLAYER_NOTSTARTED)
-  {
-    rctb.left = nspck->stored_data1 - 20;
-    rctb.top = nspck->stored_data2 - 14;
-    rctb.right = get_sprite(map_hand, 17)->SWidth + rctb.left;
-    rctb.bottom = rctb.top + get_sprite(map_hand, 17)->SHeight;
-  } else
-  {
-    rctb.left = nspck->stored_data1 - 19;
-    rctb.top = nspck->stored_data2 - 25;
-    rctb.right = get_sprite(map_hand, 1)->SWidth + rctb.left;
-    rctb.bottom = rctb.top + get_sprite(map_hand, 1)->SHeight;
-  }
-  // Return if the rectangles are intersecting
-  if (rectangle_intersects(&rcta, &rctb))
-    return true;
-  return false;
-}
-
 void frontmap_draw(void)
 {
     SYNCDBG(8,"Starting");
@@ -1373,76 +1183,20 @@ void update_velocity(void)
 }
 
 /**
- * Draws player's hands.
+ * Sets the level name text for active level display.
  */
-void draw_netmap_players_hands(void)
+void set_level_name_text(LevelNumber lvnum, const char *lv_name)
 {
-  struct ScreenPacket *nspck;
-  const char *plyr_nam;
-  const struct TbSprite *spr;
-  TbPixel colr;
-  long x;
-  long y;
-  long w;
-  long h;
-  long i;
-  long k;
-  unsigned char action;
-  for (i=0; i < NET_PLAYERS_COUNT; i++)
-  {
-      nspck = &net_screen_packet[i];
-      plyr_nam = network_player_name(i);
-      colr = net_player_colours[i];
-      if ((nspck->networkstatus_flags & NetStat_PlayerConnected) != 0)
-      {
-        x = 0;
-        y = 0;
-        action = screen_packet_action(nspck);
-        if (action == NetAct_Slapping)
-        {
-          k = (unsigned char)nspck->action_par1;
-          spr = get_sprite(map_hand, k);
-        } else
-        if (action == NetAct_Limping)
-        {
-          k = nspck->action_par2;
-          if (k > 11)
-            k = 11;
-          if (k < 0)
-            k = 0;
-          x = hand_limp_xoffset[k];
-          y = hand_limp_yoffset[k];
-          spr = get_sprite(map_hand, 21);
-        } else
-        if (nspck->action_par1 == SINGLEPLAYER_NOTSTARTED)
-        {
-            k = LbTimerClock() / 150;
-            spr = get_sprite(map_hand, 1 + (k%8));
-        } else
-        {
-            k = LbTimerClock() / 150;
-            spr = get_sprite(map_hand, 17 + (k%4));
-        }
-        if (i == my_player_number && action == NetAct_None && nspck->action_par1 == SINGLEPLAYER_NOTSTARTED) {
-            x += GetMouseX()*16/units_per_pixel_landview - 18;
-            y += GetMouseY()*16/units_per_pixel_landview - 25;
-        } else {
-            x += nspck->stored_data1 - (long)map_info.screen_shift_x - 18;
-            y += nspck->stored_data2 - (long)map_info.screen_shift_y - 25;
-        }
-        LbSpriteDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, spr);
-        w = LbTextStringWidth(plyr_nam);
-        if (w > 0)
-        {
-          lbDisplay.DrawFlags = 0;
-          h = LbTextHeight(level_name);
-          y += 32;
-          x += 32;
-          LbDrawBox(scale_value_landview(x-4), scale_value_landview(y), scale_value_landview(w+8), scale_value_landview(h), colr);
-          LbTextDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, plyr_nam);
-        }
-      }
-  }
+    struct LevelInformation *lvinfo = get_level_info(lvnum);
+    if (lvinfo == NULL) {
+        snprintf(level_name, sizeof(level_name), "%s", get_string(GUIStr_MnuLevel));
+        return;
+    }
+    if ((lv_name != NULL) && (strlen(lv_name) > 0)) {
+        snprintf(level_name, sizeof(level_name), "%s %d: %s", get_string(GUIStr_MnuLevel), (int)lvinfo->lvnum, lv_name);
+        return;
+    }
+    snprintf(level_name, sizeof(level_name), "%s %d", get_string(GUIStr_MnuLevel), (int)lvinfo->lvnum);
 }
 
 /**
@@ -1464,11 +1218,7 @@ void draw_map_level_descriptions(void)
         lv_name = get_string(lvinfo->name_stridx);
     else
       lv_name = lvinfo->name;
-    if ((lv_name != NULL) && (strlen(lv_name) > 0)) {
-      snprintf(level_name, sizeof(level_name), "%s %d: %s", get_string(GUIStr_MnuLevel), (int)lvinfo->lvnum, lv_name);
-    } else {
-      snprintf(level_name, sizeof(level_name), "%s %d", get_string(GUIStr_MnuLevel), (int)lvinfo->lvnum);
-    }
+    set_level_name_text(lvnum, lv_name);
     long w = LbTextStringWidth(level_name);
     long x = lvinfo->ensign_x - (long)map_info.screen_shift_x;
     long y = lvinfo->ensign_y - (long)map_info.screen_shift_y - 8;
@@ -1476,25 +1226,6 @@ void draw_map_level_descriptions(void)
     LbDrawBox(scale_value_landview(x-4), scale_value_landview(y), scale_value_landview(w+8), scale_value_landview(h), 0);
     LbTextDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, level_name);
   }
-}
-
-void frontnetmap_draw(void)
-{
-    SYNCDBG(8,"Starting");
-    LbTextSetFont(map_font);
-    LbTextSetWindow(0, 0, lbDisplay.PhysicalScreenWidth, lbDisplay.PhysicalScreenHeight);
-    if ((map_info.fadeflags & MLInfoFlg_Zooming) != 0)
-    {
-        frontzoom_to_point(map_info.hotspot_imgpos_x, map_info.hotspot_imgpos_y, map_info.fade_pos);
-        compressed_window_draw();
-    } else
-    {
-        draw_map_screen();
-        draw_map_level_ensigns();
-        draw_netmap_players_hands();
-        draw_map_level_descriptions();
-        compressed_window_draw();
-    }
 }
 
 void frontmap_input(void)
@@ -1572,69 +1303,6 @@ void frontmap_input(void)
     update_velocity();
 }
 
-void frontnetmap_input(void)
-{
-  if (lbKeyOn[KC_ESCAPE])
-  {
-      fe_net_level_selected = LEVELNUMBER_ERROR;
-      lbKeyOn[KC_ESCAPE] = 0;
-      SYNCLOG("Escaped from level selection");
-      return;
-  }
-
-  if (net_map_limp_time == 0)
-  {
-      struct LevelInformation* lvinfo;
-      if (right_button_clicked)
-      {
-          right_button_clicked = 0;
-          if (fe_net_level_selected == SINGLEPLAYER_NOTSTARTED)
-          {
-              if ((!net_map_slap_frame) && (!net_map_limp_time))
-              {
-                  net_map_slap_frame = NetMapSlap_StartFrame;
-              }
-          } else
-        {
-            lvinfo = get_level_info(fe_net_level_selected);
-            if (lvinfo != NULL) {
-              LbMouseSetPosition(scale_value_landview(lvinfo->ensign_x - (long)map_info.screen_shift_x),
-                  scale_value_landview(lvinfo->ensign_y - (long)map_info.screen_shift_y));
-            }
-            fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
-        }
-    }
-
-    if (fe_net_level_selected == SINGLEPLAYER_NOTSTARTED)
-    {
-      net_level_hilighted = SINGLEPLAYER_NOTSTARTED;
-      frontmap_input_active_ensign(GetMouseX(), GetMouseY());
-      if (mouse_over_lvnum > 0)
-        net_level_hilighted = mouse_over_lvnum;
-      if (net_level_hilighted > 0)
-      {
-        if ((net_map_slap_frame == 0) && (net_map_limp_time == 0))
-        {
-          if (left_button_clicked)
-          {
-              fe_net_level_selected = net_level_hilighted;
-              left_button_clicked = 0;
-              lvinfo = get_level_info(fe_net_level_selected);
-              if (lvinfo != NULL) {
-                snprintf(level_name, sizeof(level_name), "%s %d", get_string(GUIStr_MnuLevel), (int)lvinfo->lvnum);
-              } else {
-                snprintf(level_name, sizeof(level_name), "%s", get_string(GUIStr_MnuLevel));
-              }
-              SYNCLOG("Selected level %d with description \"%s\"",(int)fe_net_level_selected,level_name);
-          }
-        }
-      }
-      check_mouse_scroll();
-      update_velocity();
-    }
-  }
-}
-
 void frontmap_unload(void)
 {
     SYNCDBG(8,"Starting");
@@ -1681,166 +1349,5 @@ long frontmap_update(void)
   SYNCDBG(8,"Finished");
   return 0;
 }
-
-TbBool frontmap_exchange_screen_packet(void)
-{
-    struct ScreenPacket* nspck = &net_screen_packet[my_player_number];
-    memset(nspck, 0, sizeof(struct ScreenPacket));
-    nspck->networkstatus_flags |= NetStat_PlayerConnected;
-    nspck->action_par1 = fe_net_level_selected;
-    if (net_map_limp_time > 0)
-    {
-      screen_packet_set_action(nspck, NetAct_Limping);
-      nspck->stored_data1 = limp_hand_x;
-      nspck->stored_data2 = limp_hand_y;
-      net_map_limp_time--;
-      nspck->action_par2 = net_map_limp_time;
-      if (net_map_limp_time == 1)
-      {
-          LbMouseSetPosition(
-            limp_hand_x + hand_limp_xoffset[0] - map_info.screen_shift_x,
-            limp_hand_y + hand_limp_yoffset[0] - map_info.screen_shift_y);
-      }
-    } else
-    if (fe_net_level_selected > 0)
-    {
-        const struct TbSprite* spr = get_map_ensign(1);
-        struct LevelInformation* lvinfo = get_level_info(fe_net_level_selected);
-        if (lvinfo != NULL)
-        {
-            nspck->stored_data1 = lvinfo->ensign_x + my_player_number * ((long)spr->SWidth);
-            nspck->stored_data2 = lvinfo->ensign_y - 48;
-        }
-    } else
-    if (net_map_slap_frame > 0)
-    {
-        nspck->stored_data1 = GetMouseX()*16/units_per_pixel_landview + map_info.screen_shift_x;
-        nspck->stored_data2 = GetMouseY()*16/units_per_pixel_landview + map_info.screen_shift_y;
-        if (net_map_slap_frame <= NetMapSlap_EndFrame)
-        {
-          screen_packet_set_action(nspck, NetAct_Slapping);
-          nspck->action_par1 = net_map_slap_frame;
-          net_map_slap_frame++;
-        } else
-        {
-          net_map_slap_frame = 0;
-        }
-    } else
-    {
-        nspck->stored_data1 = GetMouseX()*16/units_per_pixel_landview + map_info.screen_shift_x;
-        nspck->stored_data2 = GetMouseY()*16/units_per_pixel_landview + map_info.screen_shift_y;
-    }
-    if (fe_network_active)
-    {
-      if (LbNetwork_Exchange(NETMSG_FRONTEND, nspck, &net_screen_packet, sizeof(struct ScreenPacket)))
-      {
-          ERRORLOG("LbNetwork_Exchange failed");
-          return false;
-      }
-    }
-    return true;
-}
-
-TbBool frontnetmap_update_players(struct NetMapPlayersState * nmps)
-{
-    memset(scratch, 0, PALETTE_SIZE);
-    int32_t leading_votes = -1;
-    for (long i = 0; i < NET_PLAYERS_COUNT; i++)
-    {
-        struct ScreenPacket* nspck = &net_screen_packet[i];
-        if ((nspck->networkstatus_flags & NetStat_PlayerConnected) == 0)
-          continue;
-        if (i != my_player_number && !network_player_active(i))
-        {
-            LbNetwork_EnableNewPlayers(1);
-            frontend_set_state(FeSt_NET_START);
-            return false;
-        }
-        if (nspck->action_par1 == LEVELNUMBER_ERROR)
-        {
-            if (fe_network_active)
-            {
-              if (LbNetwork_EnableNewPlayers(1))
-                ERRORLOG("Unable to enable new players joining exchange");
-              frontend_set_state(FeSt_NET_START);
-            } else
-            {
-              frontend_set_state(FeSt_MAIN_MENU);
-            }
-            return false;
-        }
-        if ((nspck->action_par1 == SINGLEPLAYER_NOTSTARTED) || (screen_packet_action(nspck) == NetAct_Slapping))
-        {
-            nmps->unselected_players++;
-        } else
-        {
-            LevelNumber pckt_lvnum = nspck->action_par1;
-            scratch[pckt_lvnum]++;
-            if (scratch[pckt_lvnum] == leading_votes)
-            {
-                nmps->is_selected = false;
-            } else
-            if (scratch[pckt_lvnum] > leading_votes)
-            {
-                nmps->selected_level_number = pckt_lvnum;
-                leading_votes = scratch[pckt_lvnum];
-                nmps->is_selected = true;
-            }
-        }
-        if ((screen_packet_action(nspck) == NetAct_Slapping) && (nspck->action_par1 == NetMapSlap_HitFrame))
-        {
-            if ( test_hand_slap_collides(i) )
-            {
-                net_map_limp_time = 12;
-                fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
-                net_map_slap_frame = 0;
-                limp_hand_x = nspck->stored_data1;
-                limp_hand_y = nspck->stored_data2;
-                screen_packet_set_action(nspck, NetAct_Limping);
-                SYNCLOG("Slapped out of level");
-            }
-        }
-    }
-    return true;
-}
-
-TbBool frontnetmap_update(void)
-{
-    SYNCDBG(8,"Starting");
-    set_music_volume((map_sound_fade * settings.music_volume) / FULL_LOUDNESS);
-
-    struct NetMapPlayersState nmps;
-    nmps.unselected_players = 0;
-    nmps.selected_level_number = SINGLEPLAYER_NOTSTARTED;
-    nmps.is_selected = false;
-    if ((map_info.fadeflags & MLInfoFlg_Zooming) != 0)
-    {
-        if (frontmap_update_zoom())
-        {
-          SYNCDBG(8,"Zoom end");
-          return true;
-        }
-    } else
-    {
-        frontmap_exchange_screen_packet();
-        frontnetmap_update_players(&nmps);
-    }
-    if ((!nmps.unselected_players) && (nmps.selected_level_number > 0) && (nmps.is_selected))
-    {
-        set_selected_level_number(nmps.selected_level_number);
-        snprintf(level_name, sizeof(level_name), "%s %d", get_string(GUIStr_MnuLevel), (int)nmps.selected_level_number);
-        if (fe_network_active < 1) {
-            map_info.state_trigger = FeSt_START_KPRLEVEL;
-        } else {
-            map_info.state_trigger = FeSt_START_MPLEVEL;
-        }
-        frontmap_zoom_in_init(nmps.selected_level_number);
-        if (!fe_network_active)
-            fe_computer_players = 1;
-    }
-    SYNCDBG(8,"Normal end");
-    return false;
-}
-
 
 /******************************************************************************/

--- a/src/front_landview.h
+++ b/src/front_landview.h
@@ -106,7 +106,6 @@ extern struct TbSpriteSheet *map_hand;
 extern long map_sound_fade;
 extern unsigned char *map_screen;
 extern long fe_net_level_selected;
-extern long net_map_limp_time;
 extern struct ScreenPacket net_screen_packet[NET_PLAYERS_COUNT];
 
 #pragma pack()
@@ -127,8 +126,9 @@ void frontmap_unload(void);
 long frontmap_update(void);
 void frontzoom_to_point(long a1, long a2, long a3);
 void compressed_window_draw(void);
-void frontnet_init_level_descriptions(void);
 const struct TbSprite *get_ensign_sprite_for_level(struct LevelInformation *lvinfo, int anim_frame);
+void set_level_name_text(LevelNumber lvnum, const char *lv_name);
+void draw_map_level_descriptions(void);
 
 TbBool initialize_description_speech(void);
 TbBool play_current_description_speech(short play_good);

--- a/src/front_landview_multiplayer.c
+++ b/src/front_landview_multiplayer.c
@@ -1,0 +1,594 @@
+/******************************************************************************/
+// Free implementation of Bullfrog's Dungeon Keeper strategy game.
+/******************************************************************************/
+/** @file front_landview_multiplayer.c
+ *     Network land view, where the user can select map for multiplayer.
+ * @par Purpose:
+ *     Functions for displaying and maintaining the network land view.
+ * @par Comment:
+ *     Split from front_landview.c to isolate multiplayer-specific behavior.
+ * @author   KeeperFX Team
+ * @date     05 May 2026
+ * @par  Copying and copyrights:
+ *     This program is free software; you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation; either version 2 of the License, or
+ *     (at your option) any later version.
+ */
+/******************************************************************************/
+#include "pre_inc.h"
+#include "front_landview.h"
+
+#include "globals.h"
+#include "bflib_basics.h"
+#include "bflib_datetm.h"
+#include "bflib_mouse.h"
+#include "bflib_network.h"
+#include "bflib_network_exchange.h"
+#include "bflib_sndlib.h"
+#include "bflib_sound.h"
+#include "bflib_sprite.h"
+#include "bflib_sprfnt.h"
+#include "bflib_video.h"
+#include "bflib_vidraw.h"
+
+#include "config_campaigns.h"
+#include "config_settings.h"
+#include "front_network.h"
+#include "front_simple.h"
+#include "frontend.h"
+#include "game_legacy.h"
+#include "kjm_input.h"
+#include "keeperfx.hpp"
+#include "room_list.h"
+#include "vidfade.h"
+#include "vidmode.h"
+#include "post_inc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/******************************************************************************/
+/* Keep network landview animation and slap timing local to this unit. */
+#define NETLAND_SLAP_SOUND 75
+#define NETLAND_SLAP_MISS_SOUND 26
+#define NETLAND_SLAP_MISS_SOUND_VARIANTS 6
+#define NETLAND_HAND_ANIM_SPEED 20
+#define NETLAND_HAND_LIMP_FRAME_COUNT ((int32_t)(sizeof(hand_limp_xoffset) / sizeof(hand_limp_xoffset[0])))
+
+struct NetLandPlayersState {
+    int32_t unselected_players;
+    LevelNumber selected_level_number;
+    TbBool is_selected;
+};
+
+enum NetLandSlapFrame {
+    NetLandSlap_StartFrame = 9,
+    NetLandSlap_HitFrame = 13,
+    NetLandSlap_EndFrame = 16,
+};
+
+struct NetLandRemoteSlap {
+    TbClockMSec start;
+    int32_t x;
+    int32_t y;
+    TbBool active;
+};
+
+struct NetLandLocalState {
+    TbClockMSec limp_start;
+    TbClockMSec local_slap_anim_start;
+    int32_t limp_x;
+    int32_t limp_y;
+    int32_t local_slap_send_frame;
+    int32_t slap_miss_wait;
+};
+
+extern LevelNumber mouse_over_lvnum;
+void draw_map_screen(void);
+void draw_map_level_ensigns(void);
+const struct TbSprite * get_map_ensign(long idx);
+void set_all_ensigns_state(unsigned short nstate);
+void unload_map_and_window(void);
+TbBool load_map_and_window(LevelNumber lvnum);
+void frontmap_start_music(void);
+void frontmap_zoom_skip_init(LevelNumber lvnum);
+void frontmap_zoom_in_init(LevelNumber lvnum);
+TbBool frontmap_input_active_ensign(long curr_mx, long curr_my);
+TbBool frontmap_update_zoom(void);
+
+TbPixel net_player_colours[] = { 251, 58, 182, 11 };
+const int32_t hand_limp_xoffset[] = { 32, 31, 30, 29, 28, 27, 26, 24, 22, 19, 15, 9 };
+const int32_t hand_limp_yoffset[] = { -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0 };
+
+long fe_net_level_selected;
+static struct NetLandLocalState net_map_local;
+static struct NetLandRemoteSlap net_map_remote_slap[NET_PLAYERS_COUNT];
+struct ScreenPacket net_screen_packet[NET_PLAYERS_COUNT];
+/******************************************************************************/
+#ifdef __cplusplus
+}
+#endif
+/******************************************************************************/
+static void update_net_ensigns_visibility(void)
+{
+    SYNCDBG(18, "Starting");
+    set_all_ensigns_state(LvSt_Hidden);
+    long lvnum = first_multiplayer_level();
+    while (lvnum > 0) {
+        struct LevelInformation* lvinfo = get_level_info(lvnum);
+        if (lvinfo != NULL) {
+            lvinfo->state = LvSt_Visible;
+        }
+        lvnum = next_multiplayer_level(lvnum);
+    }
+}
+
+static TbBool is_connected_screen_packet(const struct ScreenPacket *nspck)
+{
+    return (nspck->networkstatus_flags & NetStat_PlayerConnected) != 0;
+}
+
+static void set_screen_packet_position(struct ScreenPacket *nspck, int32_t x, int32_t y)
+{
+    nspck->stored_data1 = x;
+    nspck->stored_data2 = y;
+}
+
+static void set_remote_slap_position(struct NetLandRemoteSlap *remote_slap, const struct ScreenPacket *nspck)
+{
+    remote_slap->x = nspck->stored_data1;
+    remote_slap->y = nspck->stored_data2;
+}
+
+static void set_packet_slap_frame(struct ScreenPacket *nspck, int32_t slap_frame)
+{
+    screen_packet_set_action(nspck, NetAct_Slapping);
+    nspck->action_par1 = slap_frame;
+}
+
+void frontnetmap_unload(void)
+{
+    unload_map_and_window();
+    free_font(&map_font);
+    free_spritesheet(&map_flag);
+    free_spritesheet(&map_hand);
+    fe_network_active = 0;
+    stop_music();
+    set_music_volume(settings.music_volume);
+}
+
+static int32_t get_hand_limp_frame(TbClockMSec now)
+{
+    return NETLAND_HAND_LIMP_FRAME_COUNT - 1 - ((now - net_map_local.limp_start) * NETLAND_HAND_ANIM_SPEED) / 1000;
+}
+
+static void stop_hand_limp(void)
+{
+    LbMouseSetPosition(net_map_local.limp_x + hand_limp_xoffset[0] - map_info.screen_shift_x, net_map_local.limp_y + hand_limp_yoffset[0] - map_info.screen_shift_y);
+    net_map_local.limp_start = 0;
+}
+
+static int32_t get_local_hand_limp_frame(TbClockMSec now)
+{
+    if (net_map_local.limp_start == 0) {
+        return -1;
+    }
+    int32_t frame = get_hand_limp_frame(now);
+    if (frame >= 0) {
+        return frame;
+    }
+    stop_hand_limp();
+    return -1;
+}
+
+static int32_t get_slap_anim_frame(TbClockMSec slap_anim_start, TbClockMSec now)
+{
+    if (slap_anim_start == 0) {
+        return 0;
+    }
+    int32_t frame = NetLandSlap_StartFrame + ((now - slap_anim_start) * NETLAND_HAND_ANIM_SPEED) / 1000;
+    if (frame > NetLandSlap_EndFrame) {
+        return 0;
+    }
+    return frame;
+}
+
+static const struct TbSprite *get_hand_sprite_for_packet(const struct ScreenPacket *nspck, int32_t anim_frame, int32_t *x, int32_t *y)
+{
+    int32_t frame;
+    switch (screen_packet_action(nspck)) {
+    case NetAct_Limping:
+        frame = clamp(nspck->action_par2, 0, NETLAND_HAND_LIMP_FRAME_COUNT - 1);
+        *x = nspck->stored_data1 + hand_limp_xoffset[frame];
+        *y = nspck->stored_data2 + hand_limp_yoffset[frame];
+        return get_sprite(map_hand, 21);
+    case NetAct_Slapping:
+        *x = nspck->stored_data1 - 31;
+        *y = nspck->stored_data2 - 27;
+        return get_sprite(map_hand, nspck->action_par1);
+    default:
+        if (nspck->action_par1 == SINGLEPLAYER_NOTSTARTED) {
+            *x = nspck->stored_data1 - 19;
+            *y = nspck->stored_data2 - 25;
+            return get_sprite(map_hand, 1 + (anim_frame % 8));
+        }
+        *x = nspck->stored_data1 - 20;
+        *y = nspck->stored_data2 - 14;
+        return get_sprite(map_hand, 17 + (anim_frame % 4));
+    }
+}
+
+static void get_hand_packet(PlayerNumber plyr_idx, struct ScreenPacket *nspck, int32_t slap_frame, TbClockMSec now)
+{
+    if (!is_my_player_number(plyr_idx)) {
+        struct NetLandRemoteSlap *remote_slap = &net_map_remote_slap[(int32_t)plyr_idx];
+        *nspck = net_screen_packet[(int32_t)plyr_idx];
+        TbBool packet_slap = screen_packet_action(nspck) == NetAct_Slapping;
+        if (packet_slap) {
+            // Hold onto a remote slap until the sender clears it, so network delay doesn't accidentally turn one slap into multiple.
+            if (!remote_slap->active) {
+                remote_slap->start = now;
+                remote_slap->active = true;
+            }
+            set_remote_slap_position(remote_slap, nspck);
+        } else {
+            remote_slap->active = false;
+        }
+        if (remote_slap->start != 0) {
+            int32_t display_frame = get_slap_anim_frame(remote_slap->start, now);
+            if (display_frame != 0) {
+                if (!packet_slap && nspck->action_par1 == SINGLEPLAYER_NOTSTARTED) {
+                    set_remote_slap_position(remote_slap, nspck);
+                }
+                set_packet_slap_frame(nspck, display_frame);
+                set_screen_packet_position(nspck, remote_slap->x, remote_slap->y);
+                return;
+            }
+            remote_slap->start = 0;
+        }
+        if (packet_slap && remote_slap->active) {
+            screen_packet_set_action(nspck, NetAct_None);
+            nspck->action_par1 = SINGLEPLAYER_NOTSTARTED;
+        }
+        return;
+    }
+    memset(nspck, 0, sizeof(struct ScreenPacket));
+    nspck->networkstatus_flags = NetStat_PlayerConnected;
+    nspck->action_par1 = fe_net_level_selected;
+    set_screen_packet_position(nspck, GetMouseX()*16/units_per_pixel_landview + map_info.screen_shift_x, GetMouseY()*16/units_per_pixel_landview + map_info.screen_shift_y);
+    int32_t frame = get_local_hand_limp_frame(now);
+    if (frame >= 0) {
+        screen_packet_set_action(nspck, NetAct_Limping);
+        nspck->action_par2 = frame;
+        set_screen_packet_position(nspck, net_map_local.limp_x, net_map_local.limp_y);
+        return;
+    }
+    if (slap_frame > 0) {
+        set_packet_slap_frame(nspck, slap_frame);
+        return;
+    }
+    if (nspck->action_par1 > 0) {
+        const struct TbSprite* spr = get_map_ensign(1);
+        struct LevelInformation* lvinfo = get_level_info(nspck->action_par1);
+        if (lvinfo != NULL) {
+            set_screen_packet_position(nspck, lvinfo->ensign_x + my_player_number * ((int32_t)spr->SWidth), lvinfo->ensign_y - 48);
+        }
+    }
+}
+
+static void draw_netmap_players_hands(void)
+{
+  struct ScreenPacket nspck;
+  const char *plyr_nam;
+  const struct TbSprite *spr;
+  TbPixel colr;
+  TbClockMSec now;
+  int32_t x, y;
+  int32_t w;
+  int32_t h;
+  int32_t i;
+  int32_t anim_frame;
+
+  now = LbTimerClock();
+  anim_frame = now / 150;
+  for (i=0; i < NET_PLAYERS_COUNT; i++) {
+      int32_t slap_frame;
+
+      if (!is_connected_screen_packet(&net_screen_packet[i])) {
+        continue;
+      }
+      slap_frame = 0;
+      if (i == my_player_number) {
+          slap_frame = get_slap_anim_frame(net_map_local.local_slap_anim_start, now);
+      }
+      get_hand_packet(i, &nspck, slap_frame, now);
+      plyr_nam = network_player_name(i);
+      colr = net_player_colours[i];
+      spr = get_hand_sprite_for_packet(&nspck, anim_frame, &x, &y);
+      x -= (long)map_info.screen_shift_x;
+      y -= (long)map_info.screen_shift_y;
+      LbSpriteDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, spr);
+      w = LbTextStringWidth(plyr_nam);
+      if (w > 0) {
+        lbDisplay.DrawFlags = 0;
+        h = LbTextHeight(level_name);
+        y += 32;
+        x += 32;
+        LbDrawBox(scale_value_landview(x-4), scale_value_landview(y), scale_value_landview(w+8), scale_value_landview(h), colr);
+        LbTextDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, plyr_nam);
+      }
+  }
+}
+
+void frontnetmap_draw(void)
+{
+    SYNCDBG(8,"Starting");
+    LbTextSetFont(map_font);
+    LbTextSetWindow(0, 0, lbDisplay.PhysicalScreenWidth, lbDisplay.PhysicalScreenHeight);
+    if ((map_info.fadeflags & MLInfoFlg_Zooming) != 0) {
+        frontzoom_to_point(map_info.hotspot_imgpos_x, map_info.hotspot_imgpos_y, map_info.fade_pos);
+        compressed_window_draw();
+    } else {
+        draw_map_screen();
+        draw_map_level_ensigns();
+        draw_netmap_players_hands();
+        draw_map_level_descriptions();
+        compressed_window_draw();
+    }
+}
+
+void frontnetmap_input(void)
+{
+  TbBool can_select;
+  TbClockMSec now;
+  struct LevelInformation* lvinfo;
+
+  if (lbKeyOn[KC_ESCAPE]) {
+      fe_net_level_selected = LEVELNUMBER_ERROR;
+      lbKeyOn[KC_ESCAPE] = 0;
+      SYNCLOG("Escaped from level selection");
+      return;
+  }
+
+  now = LbTimerClock();
+  if (get_local_hand_limp_frame(now) >= 0) {
+      return;
+  }
+  can_select = (get_slap_anim_frame(net_map_local.local_slap_anim_start, now) == 0) && (net_map_local.local_slap_send_frame == 0);
+
+  if (right_button_clicked) {
+      right_button_clicked = 0;
+      if (fe_net_level_selected != SINGLEPLAYER_NOTSTARTED) {
+        lvinfo = get_level_info(fe_net_level_selected);
+        if (lvinfo != NULL) {
+          LbMouseSetPosition(scale_value_landview(lvinfo->ensign_x - (int32_t)map_info.screen_shift_x),
+              scale_value_landview(lvinfo->ensign_y - (int32_t)map_info.screen_shift_y));
+        }
+        fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
+      } else if (can_select) {
+          net_map_local.local_slap_anim_start = now;
+          net_map_local.local_slap_send_frame = NetLandSlap_StartFrame;
+          can_select = false;
+      }
+  }
+
+  if (fe_net_level_selected != SINGLEPLAYER_NOTSTARTED) {
+      return;
+  }
+
+  net_level_hilighted = SINGLEPLAYER_NOTSTARTED;
+  frontmap_input_active_ensign(GetMouseX(), GetMouseY());
+  if (mouse_over_lvnum > 0) {
+    net_level_hilighted = mouse_over_lvnum;
+  }
+  if ((net_level_hilighted > 0) && can_select && left_button_clicked) {
+      fe_net_level_selected = net_level_hilighted;
+      left_button_clicked = 0;
+      set_level_name_text(fe_net_level_selected, NULL);
+      SYNCLOG("Selected level %d with description \"%s\"",(int)fe_net_level_selected,level_name);
+  }
+  check_mouse_scroll();
+  update_velocity();
+}
+
+TbBool frontnetmap_load(void)
+{
+    SYNCDBG(8,"Starting");
+    if (fe_network_active) {
+      if (LbNetwork_EnableNewPlayers(0)) {
+        ERRORLOG("Unable to prohibit new players joining exchange");
+      }
+    }
+    frontend_load_data_from_cd();
+    game.selected_level_number = 0;
+    if (!load_map_and_window(0)) {
+        frontend_load_data_reset();
+        return false;
+    }
+    switch (campaign.land_markers) {
+    case LndMk_PINPOINTS:
+        map_flag = load_spritesheet("ldata/netflag_pin.dat", "ldata/netflag_pin.tab");
+        break;
+    default:
+        ERRORLOG("Unsupported land markers type %d",(int)campaign.land_markers);
+        // Fall Through
+    case LndMk_ENSIGNS:
+        map_flag = load_spritesheet("ldata/netflag_ens.dat", "ldata/netflag_ens.tab");
+        break;
+    }
+    map_font = load_spritesheet("ldata/netfont.dat", "ldata/netfont.tab");
+    map_hand = load_spritesheet("ldata/maphand.dat", "ldata/maphand.tab");
+    if (!map_flag || !map_font || !map_hand) {
+      ERRORLOG("Unable to load MAP SCREEN sprites");
+      return false;
+    }
+    frontend_load_data_reset();
+    //TODO NETWORK Don't allow campaigns besides original - we don't have per-campaign MP yet
+    change_campaign("");
+    frontmap_zoom_skip_init(SINGLEPLAYER_NOTSTARTED);
+    fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
+    net_level_hilighted = SINGLEPLAYER_NOTSTARTED;
+    set_pointer_graphic_none();
+    LbMouseSetPosition(lbDisplay.PhysicalScreenWidth/2, lbDisplay.PhysicalScreenHeight/2);
+    map_sound_fade = FULL_LOUDNESS;
+    lbDisplay.DrawFlags = 0;
+    set_music_volume(settings.music_volume);
+    frontmap_start_music();
+    if (fe_network_active) {
+        net_number_of_players = 0;
+        for (long i = 0; i < NET_PLAYERS_COUNT; i++) {
+            struct ScreenPacket* nspck = &net_screen_packet[i];
+            if (is_connected_screen_packet(nspck)) {
+              net_number_of_players++;
+            }
+        }
+    } else {
+      net_number_of_players = 1;
+    }
+    memset(&net_map_local, 0, sizeof(net_map_local));
+    memset(net_map_remote_slap, 0, sizeof(net_map_remote_slap));
+    update_net_ensigns_visibility();
+    return true;
+}
+
+static TbBool frontmap_exchange_screen_packet(void)
+{
+    struct ScreenPacket* nspck = &net_screen_packet[my_player_number];
+    TbClockMSec now = LbTimerClock();
+    if (net_map_local.local_slap_send_frame > NetLandSlap_EndFrame) {
+        net_map_local.local_slap_send_frame = 0;
+    }
+    get_hand_packet(my_player_number, nspck, net_map_local.local_slap_send_frame, now);
+    if (screen_packet_action(nspck) == NetAct_Slapping) {
+        if (net_map_local.local_slap_send_frame == NetLandSlap_HitFrame) {
+            net_map_local.slap_miss_wait = 2;
+        }
+        net_map_local.local_slap_send_frame++;
+    }
+    if (fe_network_active) {
+      if (LbNetwork_Exchange(NETMSG_FRONTEND, nspck, &net_screen_packet, sizeof(struct ScreenPacket))) {
+          ERRORLOG("LbNetwork_Exchange failed");
+          return false;
+      }
+    }
+    return true;
+}
+
+static TbBool frontnetmap_update_players(struct NetLandPlayersState * nmps)
+{
+    memset(scratch, 0, PALETTE_SIZE);
+    struct ScreenPacket* my_nspck = &net_screen_packet[my_player_number];
+    TbBool slap_hit_confirmed = false;
+    int32_t leading_votes = -1;
+    for (int32_t i = 0; i < NET_PLAYERS_COUNT; i++) {
+        struct ScreenPacket* nspck = &net_screen_packet[i];
+        unsigned char action;
+        TbBool remote_player;
+        if (!is_connected_screen_packet(nspck)) {
+          continue;
+        }
+        remote_player = i != my_player_number;
+        if (remote_player && !network_player_active(i)) {
+            LbNetwork_EnableNewPlayers(1);
+            frontend_set_state(FeSt_NET_START);
+            return false;
+        }
+        if (nspck->action_par1 == LEVELNUMBER_ERROR) {
+            if (fe_network_active) {
+              if (LbNetwork_EnableNewPlayers(1)) {
+                ERRORLOG("Unable to enable new players joining exchange");
+              }
+              frontend_set_state(FeSt_NET_START);
+            } else {
+              frontend_set_state(FeSt_MAIN_MENU);
+            }
+            return false;
+        }
+        action = screen_packet_action(nspck);
+        if ((nspck->action_par1 == SINGLEPLAYER_NOTSTARTED) || (action == NetAct_Slapping)) {
+            nmps->unselected_players++;
+        } else {
+            LevelNumber pckt_lvnum = nspck->action_par1;
+            scratch[pckt_lvnum]++;
+            if (scratch[pckt_lvnum] == leading_votes) {
+                nmps->is_selected = false;
+            } else if (scratch[pckt_lvnum] > leading_votes) {
+                nmps->selected_level_number = pckt_lvnum;
+                leading_votes = scratch[pckt_lvnum];
+                nmps->is_selected = true;
+            }
+        }
+        if ((action == NetAct_Slapping) && (nspck->action_par1 == NetLandSlap_HitFrame) && remote_player && (screen_packet_action(my_nspck) != NetAct_Limping)) {
+            int32_t hand_x;
+            int32_t hand_y;
+            const struct TbSprite *spr = get_hand_sprite_for_packet(nspck, 0, &hand_x, &hand_y);
+            if ((my_nspck->stored_data1 - 7 < hand_x + spr->SWidth) && (hand_x < my_nspck->stored_data1 + 23)
+              && (my_nspck->stored_data2 - 13 < hand_y + spr->SHeight) && (hand_y < my_nspck->stored_data2 + 7)) {
+                net_map_local.limp_start = LbTimerClock();
+                fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
+                net_map_local.local_slap_anim_start = 0;
+                net_map_local.local_slap_send_frame = 0;
+                net_map_local.slap_miss_wait = 0;
+                net_map_local.limp_x = nspck->stored_data1;
+                net_map_local.limp_y = nspck->stored_data2;
+                play_non_3d_sample(NETLAND_SLAP_SOUND);
+                SYNCLOG("Slapped out of level");
+            }
+        }
+        if (remote_player && (net_map_local.slap_miss_wait > 0) && (screen_packet_action(my_nspck) == NetAct_Slapping)) {
+            int32_t hand_x;
+            int32_t hand_y;
+            const struct TbSprite *spr = get_hand_sprite_for_packet(my_nspck, 0, &hand_x, &hand_y);
+            if ((nspck->stored_data1 - 7 < hand_x + spr->SWidth) && (hand_x < nspck->stored_data1 + 23)
+              && (nspck->stored_data2 - 13 < hand_y + spr->SHeight) && (hand_y < nspck->stored_data2 + 7)) {
+                slap_hit_confirmed = true;
+            }
+        }
+    }
+    if (net_map_local.slap_miss_wait > 0) {
+        if (slap_hit_confirmed) {
+            net_map_local.slap_miss_wait = 0;
+        } else {
+            net_map_local.slap_miss_wait--;
+            if (net_map_local.slap_miss_wait == 0) {
+                play_non_3d_sample(NETLAND_SLAP_MISS_SOUND + SOUND_RANDOM(NETLAND_SLAP_MISS_SOUND_VARIANTS));
+            }
+        }
+    }
+    return true;
+}
+
+TbBool frontnetmap_update(void)
+{
+    SYNCDBG(8,"Starting");
+    set_music_volume((map_sound_fade * settings.music_volume) / FULL_LOUDNESS);
+
+    struct NetLandPlayersState nmps = { 0, SINGLEPLAYER_NOTSTARTED, false };
+    if ((map_info.fadeflags & MLInfoFlg_Zooming) != 0) {
+        if (frontmap_update_zoom()) {
+          SYNCDBG(8,"Zoom end");
+          return true;
+        }
+    } else {
+        frontmap_exchange_screen_packet();
+        frontnetmap_update_players(&nmps);
+    }
+    if ((!nmps.unselected_players) && (nmps.selected_level_number > 0) && (nmps.is_selected)) {
+        set_selected_level_number(nmps.selected_level_number);
+        set_level_name_text(nmps.selected_level_number, NULL);
+        if (fe_network_active < 1) {
+            map_info.state_trigger = FeSt_START_KPRLEVEL;
+        } else {
+            map_info.state_trigger = FeSt_START_MPLEVEL;
+        }
+        frontmap_zoom_in_init(nmps.selected_level_number);
+        if (!fe_network_active) {
+            fe_computer_players = 1;
+        }
+    }
+    SYNCDBG(8,"Normal end");
+    return false;
+}
+
+/******************************************************************************/

--- a/src/front_landview_multiplayer.c
+++ b/src/front_landview_multiplayer.c
@@ -279,46 +279,46 @@ static void get_hand_packet(PlayerNumber plyr_idx, struct ScreenPacket *nspck, i
 
 static void draw_netmap_players_hands(void)
 {
-  struct ScreenPacket nspck;
-  const char *plyr_nam;
-  const struct TbSprite *spr;
-  TbPixel colr;
-  TbClockMSec now;
-  int32_t x, y;
-  int32_t w;
-  int32_t h;
-  int32_t i;
-  int32_t anim_frame;
+    struct ScreenPacket nspck;
+    const char *plyr_nam;
+    const struct TbSprite *spr;
+    TbPixel colr;
+    TbClockMSec now;
+    int32_t x, y;
+    int32_t w;
+    int32_t h;
+    int32_t i;
+    int32_t anim_frame;
 
-  now = LbTimerClock();
-  anim_frame = now / 150;
-  for (i=0; i < NET_PLAYERS_COUNT; i++) {
-      int32_t slap_frame;
+    now = LbTimerClock();
+    anim_frame = now / 150;
+    for (i=0; i < NET_PLAYERS_COUNT; i++) {
+        int32_t slap_frame;
 
-      if (!is_connected_screen_packet(&net_screen_packet[i])) {
-        continue;
-      }
-      slap_frame = 0;
-      if (i == my_player_number) {
-          slap_frame = get_slap_anim_frame(net_map_local.local_slap_anim_start, now);
-      }
-      get_hand_packet(i, &nspck, slap_frame, now);
-      plyr_nam = network_player_name(i);
-      colr = net_player_colours[i];
-      spr = get_hand_sprite_for_packet(&nspck, anim_frame, &x, &y);
-      x -= (long)map_info.screen_shift_x;
-      y -= (long)map_info.screen_shift_y;
-      LbSpriteDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, spr);
-      w = LbTextStringWidth(plyr_nam);
-      if (w > 0) {
-        lbDisplay.DrawFlags = 0;
-        h = LbTextHeight(level_name);
-        y += 32;
-        x += 32;
-        LbDrawBox(scale_value_landview(x-4), scale_value_landview(y), scale_value_landview(w+8), scale_value_landview(h), colr);
-        LbTextDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, plyr_nam);
-      }
-  }
+        if (!is_connected_screen_packet(&net_screen_packet[i])) {
+            continue;
+        }
+        slap_frame = 0;
+        if (i == my_player_number) {
+            slap_frame = get_slap_anim_frame(net_map_local.local_slap_anim_start, now);
+        }
+        get_hand_packet(i, &nspck, slap_frame, now);
+        plyr_nam = network_player_name(i);
+        colr = net_player_colours[i];
+        spr = get_hand_sprite_for_packet(&nspck, anim_frame, &x, &y);
+        x -= (long)map_info.screen_shift_x;
+        y -= (long)map_info.screen_shift_y;
+        LbSpriteDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, spr);
+        w = LbTextStringWidth(plyr_nam);
+        if (w > 0) {
+            lbDisplay.DrawFlags = 0;
+            h = LbTextHeight(level_name);
+            y += 32;
+            x += 32;
+            LbDrawBox(scale_value_landview(x-4), scale_value_landview(y), scale_value_landview(w+8), scale_value_landview(h), colr);
+            LbTextDrawResized(scale_value_landview(x), scale_value_landview(y), units_per_pixel_landview, plyr_nam);
+        }
+    }
 }
 
 void frontnetmap_draw(void)
@@ -340,65 +340,65 @@ void frontnetmap_draw(void)
 
 void frontnetmap_input(void)
 {
-  TbBool can_select;
-  TbClockMSec now;
-  struct LevelInformation* lvinfo;
+    TbBool can_select;
+    TbClockMSec now;
+    struct LevelInformation* lvinfo;
 
-  if (lbKeyOn[KC_ESCAPE]) {
-      fe_net_level_selected = LEVELNUMBER_ERROR;
-      lbKeyOn[KC_ESCAPE] = 0;
-      SYNCLOG("Escaped from level selection");
-      return;
-  }
+    if (lbKeyOn[KC_ESCAPE]) {
+        fe_net_level_selected = LEVELNUMBER_ERROR;
+        lbKeyOn[KC_ESCAPE] = 0;
+        SYNCLOG("Escaped from level selection");
+        return;
+    }
 
-  now = LbTimerClock();
-  if (get_local_hand_limp_frame(now) >= 0) {
-      return;
-  }
-  can_select = (get_slap_anim_frame(net_map_local.local_slap_anim_start, now) == 0) && (net_map_local.local_slap_send_frame == 0);
+    now = LbTimerClock();
+    if (get_local_hand_limp_frame(now) >= 0) {
+        return;
+    }
+    can_select = (get_slap_anim_frame(net_map_local.local_slap_anim_start, now) == 0) && (net_map_local.local_slap_send_frame == 0);
 
-  if (right_button_clicked) {
-      right_button_clicked = 0;
-      if (fe_net_level_selected != SINGLEPLAYER_NOTSTARTED) {
-        lvinfo = get_level_info(fe_net_level_selected);
-        if (lvinfo != NULL) {
-          LbMouseSetPosition(scale_value_landview(lvinfo->ensign_x - (int32_t)map_info.screen_shift_x),
-              scale_value_landview(lvinfo->ensign_y - (int32_t)map_info.screen_shift_y));
+    if (right_button_clicked) {
+        right_button_clicked = 0;
+        if (fe_net_level_selected != SINGLEPLAYER_NOTSTARTED) {
+            lvinfo = get_level_info(fe_net_level_selected);
+            if (lvinfo != NULL) {
+                LbMouseSetPosition(scale_value_landview(lvinfo->ensign_x - (int32_t)map_info.screen_shift_x),
+                    scale_value_landview(lvinfo->ensign_y - (int32_t)map_info.screen_shift_y));
+            }
+            fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
+        } else if (can_select) {
+            net_map_local.local_slap_anim_start = now;
+            net_map_local.local_slap_send_frame = NetLandSlap_StartFrame;
+            can_select = false;
         }
-        fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
-      } else if (can_select) {
-          net_map_local.local_slap_anim_start = now;
-          net_map_local.local_slap_send_frame = NetLandSlap_StartFrame;
-          can_select = false;
-      }
-  }
+    }
 
-  if (fe_net_level_selected != SINGLEPLAYER_NOTSTARTED) {
-      return;
-  }
+    if (fe_net_level_selected != SINGLEPLAYER_NOTSTARTED) {
+        return;
+    }
 
-  net_level_hilighted = SINGLEPLAYER_NOTSTARTED;
-  frontmap_input_active_ensign(GetMouseX(), GetMouseY());
-  if (mouse_over_lvnum > 0) {
-    net_level_hilighted = mouse_over_lvnum;
-  }
-  if ((net_level_hilighted > 0) && can_select && left_button_clicked) {
-      fe_net_level_selected = net_level_hilighted;
-      left_button_clicked = 0;
-      set_level_name_text(fe_net_level_selected, NULL);
-      SYNCLOG("Selected level %d with description \"%s\"",(int)fe_net_level_selected,level_name);
-  }
-  check_mouse_scroll();
-  update_velocity();
+    net_level_hilighted = SINGLEPLAYER_NOTSTARTED;
+    frontmap_input_active_ensign(GetMouseX(), GetMouseY());
+    if (mouse_over_lvnum > 0) {
+        net_level_hilighted = mouse_over_lvnum;
+    }
+    if ((net_level_hilighted > 0) && can_select && left_button_clicked) {
+        fe_net_level_selected = net_level_hilighted;
+        left_button_clicked = 0;
+        set_level_name_text(fe_net_level_selected, NULL);
+        SYNCLOG("Selected level %d with description \"%s\"",(int)fe_net_level_selected,level_name);
+    }
+    check_mouse_scroll();
+    update_velocity();
 }
 
 TbBool frontnetmap_load(void)
 {
     SYNCDBG(8,"Starting");
     if (fe_network_active) {
-      if (LbNetwork_EnableNewPlayers(0)) {
-        ERRORLOG("Unable to prohibit new players joining exchange");
-      }
+        if (LbNetwork_EnableNewPlayers(0)) {
+            ERRORLOG("Unable to prohibit new players joining exchange");
+        }
     }
     frontend_load_data_from_cd();
     game.selected_level_number = 0;
@@ -420,8 +420,8 @@ TbBool frontnetmap_load(void)
     map_font = load_spritesheet("ldata/netfont.dat", "ldata/netfont.tab");
     map_hand = load_spritesheet("ldata/maphand.dat", "ldata/maphand.tab");
     if (!map_flag || !map_font || !map_hand) {
-      ERRORLOG("Unable to load MAP SCREEN sprites");
-      return false;
+        ERRORLOG("Unable to load MAP SCREEN sprites");
+        return false;
     }
     frontend_load_data_reset();
     //TODO NETWORK Don't allow campaigns besides original - we don't have per-campaign MP yet
@@ -440,12 +440,12 @@ TbBool frontnetmap_load(void)
         for (long i = 0; i < NET_PLAYERS_COUNT; i++) {
             struct ScreenPacket* nspck = &net_screen_packet[i];
             if (is_connected_screen_packet(nspck)) {
-              net_number_of_players++;
+                net_number_of_players++;
             }
         }
     } else {
-      memset(net_screen_packet, 0, sizeof(net_screen_packet));
-      net_number_of_players = 1;
+        memset(net_screen_packet, 0, sizeof(net_screen_packet));
+        net_number_of_players = 1;
     }
     memset(&net_map_local, 0, sizeof(net_map_local));
     memset(net_map_remote_slap, 0, sizeof(net_map_remote_slap));
@@ -468,10 +468,10 @@ static TbBool frontmap_exchange_screen_packet(void)
         net_map_local.local_slap_send_frame++;
     }
     if (fe_network_active) {
-      if (LbNetwork_Exchange(NETMSG_FRONTEND, nspck, &net_screen_packet, sizeof(struct ScreenPacket))) {
-          ERRORLOG("LbNetwork_Exchange failed");
-          return false;
-      }
+        if (LbNetwork_Exchange(NETMSG_FRONTEND, nspck, &net_screen_packet, sizeof(struct ScreenPacket))) {
+            ERRORLOG("LbNetwork_Exchange failed");
+            return false;
+        }
     }
     return true;
 }
@@ -487,7 +487,7 @@ static TbBool frontnetmap_update_players(struct NetLandPlayersState * nmps)
         unsigned char action;
         TbBool remote_player;
         if (!is_connected_screen_packet(nspck)) {
-          continue;
+            continue;
         }
         remote_player = i != my_player_number;
         if (remote_player && !network_player_active(i)) {
@@ -497,12 +497,12 @@ static TbBool frontnetmap_update_players(struct NetLandPlayersState * nmps)
         }
         if (nspck->action_par1 == LEVELNUMBER_ERROR) {
             if (fe_network_active) {
-              if (LbNetwork_EnableNewPlayers(1)) {
-                ERRORLOG("Unable to enable new players joining exchange");
-              }
-              frontend_set_state(FeSt_NET_START);
+                if (LbNetwork_EnableNewPlayers(1)) {
+                    ERRORLOG("Unable to enable new players joining exchange");
+                }
+                frontend_set_state(FeSt_NET_START);
             } else {
-              frontend_set_state(FeSt_MAIN_MENU);
+                frontend_set_state(FeSt_MAIN_MENU);
             }
             return false;
         }
@@ -568,8 +568,8 @@ TbBool frontnetmap_update(void)
     struct NetLandPlayersState nmps = { 0, SINGLEPLAYER_NOTSTARTED, false };
     if ((map_info.fadeflags & MLInfoFlg_Zooming) != 0) {
         if (frontmap_update_zoom()) {
-          SYNCDBG(8,"Zoom end");
-          return true;
+            SYNCDBG(8,"Zoom end");
+            return true;
         }
     } else {
         frontmap_exchange_screen_packet();

--- a/src/front_landview_multiplayer.c
+++ b/src/front_landview_multiplayer.c
@@ -444,6 +444,7 @@ TbBool frontnetmap_load(void)
             }
         }
     } else {
+      memset(net_screen_packet, 0, sizeof(net_screen_packet));
       net_number_of_players = 1;
     }
     memset(&net_map_local, 0, sizeof(net_map_local));

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -399,7 +399,6 @@ long net_comport_index_active;
 long net_speed_index_active;
 long net_number_of_players;
 long net_number_of_enum_players;
-long net_map_slap_frame;
 long net_level_hilighted;
 struct NetMessage net_message[NET_MESSAGES_COUNT];
 long net_number_of_messages;
@@ -2853,7 +2852,8 @@ FrontendMenuState frontend_setup_state(FrontendMenuState nstate)
           break;
       case FeSt_NETLAND_VIEW:
           set_pointer_graphic_none();
-          frontnet_init_level_descriptions();
+          //TODO NETWORK Don't allow campaigns besides original - we don't have per-campaign MP yet
+          change_campaign("");
           frontnetmap_load();
           break;
       case FeSt_FEDEFINE_KEYS:

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -258,7 +258,6 @@ extern long net_service_scroll_offset;
 extern long net_number_of_services;
 extern long net_number_of_players;
 extern long net_number_of_enum_players;
-extern long net_map_slap_frame;
 extern long net_level_hilighted;
 extern struct NetMessage net_message[NET_MESSAGES_COUNT];
 extern long net_number_of_messages;

--- a/src/frontmenu_net.c
+++ b/src/frontmenu_net.c
@@ -693,6 +693,7 @@ void frontnet_service_select(struct GuiButton *gbtn)
   if ( ((game.system_flags & GSF_AllowOnePlayer) != 0)
      && (srvidx+1 >= net_number_of_services) )
   {
+      frontend_set_player_number(default_loc_player);
       fe_network_active = 0;
       frontend_set_state(FeSt_NETLAND_VIEW);
   } else


### PR DESCRIPTION
One of the reasons landview netcode has been difficult to deal with is because it's been entangled with regular landview, an almost 2000 line file. So to reduce complexity I've extracted out a new file: `front_landview_multiplayer.c`.

The code already treated `FeSt_NETLAND_VIEW` as something distinct from `FeSt_LAND_VIEW` and there was already a bunch of `frontnetmap_*()` and `frontmap_*()` alternate versions of functions, so the split seems like a natural fit.

I also fixed #4709, #4715, #4665 and added sound effects.