### PR TITLE
fix(audio): clean up buffer use properly on stream and shutdown

### DIFF
--- a/src/bflib_sndlib.cpp
+++ b/src/bflib_sndlib.cpp
@@ -470,11 +470,52 @@ void SDLCALL on_music_finished() {
 } // local
 
 extern "C" void FreeAudio() {
+	SYNCDBG(6, "Starting audio cleanup");
+
+	// Check if SDL_mixer audio device is open before attempting to halt playback
+	int frequency = 0;
+	int channels = 0;
+	unsigned short format = 0;
+	int audio_opened = Mix_QuerySpec(&frequency, &format, &channels);
+
+	if (audio_opened > 0) {
+		SYNCDBG(7, "SDL_mixer audio device is open, halting playback");
+		// Stop all SDL_mixer playback first
+		Mix_HaltMusic();
+		Mix_HaltChannel(-1);
+	} else {
+		SYNCDBG(7, "SDL_mixer audio device already closed, skipping Mix_Halt calls");
+	}
+
+	// Free SDL_mixer resources before OpenAL cleanup
+	{
+		std::lock_guard<std::mutex> guard(g_mix_mutex);
+		if (auto music = g_mix_music.exchange(nullptr)) {
+			Mix_FreeMusic(music);
+			SYNCDBG(8, "Freed SDL_mixer music");
+		}
+		if (g_streamed_sample) {
+			Mix_FreeChunk(g_streamed_sample);
+			g_streamed_sample = nullptr;
+			SYNCDBG(8, "Freed SDL_mixer streamed sample");
+		}
+	}
+
+	// Properly shutdown SDL_mixer before clearing OpenAL resources
+	ShutDownSDLAudio();
+	SYNCDBG(7, "SDL_mixer shutdown complete");
+
+	// Clear OpenAL sources and buffers while context is still current
+	// The unique_ptr destructors will handle proper OpenAL cleanup
 	g_sources.clear();
 	g_banks[0].clear();
 	g_banks[1].clear();
+	SYNCDBG(7, "Cleared OpenAL sources and sound banks");
+
+	// Now destroy OpenAL context and device (unique_ptr handles proper cleanup)
 	g_openal_context = nullptr;
 	g_openal_device = nullptr;
+	SYNCDBG(6, "Audio cleanup complete");
 }
 
 extern "C" void SetSoundMasterVolume(SoundVolume volume) {

--- a/src/bflib_sndlib.cpp
+++ b/src/bflib_sndlib.cpp
@@ -479,15 +479,13 @@ extern "C" void FreeAudio() {
 	int audio_opened = Mix_QuerySpec(&frequency, &format, &channels);
 
 	if (audio_opened > 0) {
+		// Stop playback before freeing chunks, so the audio thread isn't reading them
 		SYNCDBG(7, "SDL_mixer audio device is open, halting playback");
-		// Stop all SDL_mixer playback first
 		Mix_HaltMusic();
 		Mix_HaltChannel(-1);
-	} else {
-		SYNCDBG(7, "SDL_mixer audio device already closed, skipping Mix_Halt calls");
 	}
 
-	// Free SDL_mixer resources before OpenAL cleanup
+	// Free SDL_mixer resources
 	{
 		std::lock_guard<std::mutex> guard(g_mix_mutex);
 		if (auto music = g_mix_music.exchange(nullptr)) {
@@ -501,12 +499,19 @@ extern "C" void FreeAudio() {
 		}
 	}
 
-	// Properly shutdown SDL_mixer before clearing OpenAL resources
-	ShutDownSDLAudio();
-	SYNCDBG(7, "SDL_mixer shutdown complete");
+    // Sanity check again to see if the audio device is still open. If it is, then shut it down. If not, then it was already closed by SDL's inner workings or elsewhere and we can skip the shutdown to avoid double-freeing resources.
+    audio_opened = Mix_QuerySpec(&frequency, &format, &channels);
+	if (audio_opened > 0) {
+		ShutDownSDLAudio();
+		SYNCDBG(7, "SDL_mixer shutdown complete");
+	} else {
+		while (Mix_Init(0) != 0) {
+			Mix_Quit();
+		}
+		SYNCDBG(7, "SDL_mixer audio device already closed, skipped duplicate shutdown");
+	}
 
 	// Clear OpenAL sources and buffers while context is still current
-	// The unique_ptr destructors will handle proper OpenAL cleanup
 	g_sources.clear();
 	g_banks[0].clear();
 	g_banks[1].clear();
@@ -901,7 +906,7 @@ extern "C" void stop_streamed_samples()
 	std::lock_guard<std::mutex> guard(g_mix_mutex);
 	const auto old_sample = std::exchange(g_streamed_sample, nullptr);
 	if (old_sample) {
-		Mix_FreeChunk(g_streamed_sample);
+		Mix_FreeChunk(old_sample);
 	}
 }
 

--- a/src/front_easter.c
+++ b/src/front_easter.c
@@ -55,8 +55,6 @@ const struct TbBirthday team_birthdays[] = {
     {13,11,"Alex Peters"},
     { 1,12,"Dene Carter"},
     {25, 5,"Tomasz Lis"},
-    {29,11,"Michael Chateauneuf"},
-    {23, 4, "Peter Lockett"},
     {0,0,NULL},
     };
 

--- a/src/front_easter.c
+++ b/src/front_easter.c
@@ -56,6 +56,7 @@ const struct TbBirthday team_birthdays[] = {
     { 1,12,"Dene Carter"},
     {25, 5,"Tomasz Lis"},
     {29,11,"Michael Chateauneuf"},
+    {23, 4, "Peter Lockett"},
     {0,0,NULL},
     };
 


### PR DESCRIPTION
**Audio cleanup improvements:**

* Added checks to determine if the SDL_mixer audio device is open before attempting to halt playback, preventing unnecessary calls if already closed.
* Added thread-safe cleanup of SDL_mixer resources
* Ensured SDL_mixer is properly shut down before proceeding to OpenAL cleanup, maintaining correct resource release order.

**Debug logging enhancements:**

* Introduced detailed debug logs at each step of the cleanup process to aid in troubleshooting and verifying correct behavior.