### PR TITLE
Multiplayer: Refactor enet message queues

### DIFF
--- a/src/bflib_enet.cpp
+++ b/src/bflib_enet.cpp
@@ -16,6 +16,7 @@
 #include "bflib_enet.h"
 #include "bflib_datetm.h"
 #include "bflib_network.h"
+#include "bflib_network_internal.h"
 #include "front_network.h"
 #include "bflib_math.h"
 #include "net_portforward.h"
@@ -34,14 +35,13 @@
 #include "post_inc.h"
 
 #define NUM_CHANNELS 2
-#define MAX_PEERS 2
-#define PEER_TIMEOUT_MIN_MS 4000
-#define PEER_TIMEOUT_MAX_MS 10000
 #define HOLEPUNCH_CONNECT_DELAY_MS 1000
 #define HOLEPUNCH_PRE_CONNECT_DELAY_MS 500
 #define HAPPY_EYEBALLS_DELAY_MS 250
 #define JOIN_CONNECT_POLL_DELAY_MS 16
 #define ENET_ADDRESS_BUFFER_SIZE 128
+#define INCOMING_QUEUE_WARNING_THRESHOLD 200
+#define INCOMING_QUEUE_WARNING_INTERVAL 100
 
 uint16_t external_ipv4_port = 0;
 int skip_holepunch = 0;
@@ -61,9 +61,11 @@ namespace
     TransferRateTracker upload_rate_tracker = {0, 0};
 
     // List
-    ENetPacket *oldest_packet = nullptr;
-    ENetPacket *newest_packet = nullptr;
+    ENetPacket *oldest_packet[MAX_NET_USERS] = {nullptr};
+    ENetPacket *newest_packet[MAX_NET_USERS] = {nullptr};
     int incoming_queue_size = 0;
+
+    TbBool not_expected_user(NetUserId *);
 
     unsigned int sample_transfer_bytes_per_second(TransferRateTracker *tracker, enet_uint32 *total)
     {
@@ -86,12 +88,51 @@ namespace
         return tracker->bytes_per_second;
     }
 
+    void enqueue_incoming_packet(ENetPacket *packet, NetUserId source)
+    {
+        packet->userData = nullptr;
+        if (oldest_packet[source] == nullptr) {
+            newest_packet[source] = packet;
+            oldest_packet[source] = packet;
+        } else {
+            newest_packet[source]->userData = packet;
+            newest_packet[source] = packet;
+        }
+        incoming_queue_size += 1;
+        if (incoming_queue_size == INCOMING_QUEUE_WARNING_THRESHOLD) {
+            fprintf(stderr, "Too many packets %d\n", incoming_queue_size);
+            WARNLOG("Too many packets %d", incoming_queue_size);
+        } else if (incoming_queue_size > INCOMING_QUEUE_WARNING_THRESHOLD && (incoming_queue_size % INCOMING_QUEUE_WARNING_INTERVAL) == 0) {
+            fprintf(stderr, "Too many packets %d\n", incoming_queue_size);
+            WARNLOG("Too many packets %d", incoming_queue_size);
+        }
+    }
+
+    void destroy_incoming_queue(NetUserId source)
+    {
+        for (ENetPacket *packet = oldest_packet[source]; packet != nullptr;) {
+            ENetPacket *current_packet = packet;
+            packet = static_cast<ENetPacket *>(packet->userData);
+            enet_packet_destroy(current_packet);
+            incoming_queue_size -= 1;
+        }
+        oldest_packet[source] = nullptr;
+        newest_packet[source] = nullptr;
+    }
+
+    void destroy_incoming_queue()
+    {
+        for (NetUserId source = 0; source < MAX_NET_USERS; source++) {
+            destroy_incoming_queue(source);
+        }
+    }
+
     ENetHost *create_ipv6_host(enet_uint16 port)
     {
         ENetAddress bind_address;
         enet_address_build_any(&bind_address, ENET_ADDRESS_TYPE_IPV6);
         bind_address.port = port;
-        return enet_host_create(ENET_ADDRESS_TYPE_IPV6, &bind_address, MAX_PEERS, NUM_CHANNELS, 0, 0);
+        return enet_host_create(ENET_ADDRESS_TYPE_IPV6, &bind_address, MAX_NET_PEERS, NUM_CHANNELS, 0, 0);
     }
 
     TbError bf_enet_init(NetDropCallback drop_callback)
@@ -104,19 +145,7 @@ namespace
 
     void host_destroy()
     {
-        if (oldest_packet)
-        {
-            for (ENetPacket *packet = oldest_packet; packet != nullptr;)
-            {
-                ENetPacket *current_packet = packet;
-                packet = static_cast<ENetPacket *>(packet->userData);
-                enet_packet_destroy(current_packet);
-            }
-
-            oldest_packet = nullptr;
-            newest_packet = nullptr;
-            incoming_queue_size = 0;
-        }
+        destroy_incoming_queue();
         download_rate_tracker = TransferRateTracker();
         upload_rate_tracker = TransferRateTracker();
         client_peer = nullptr;
@@ -163,7 +192,7 @@ namespace
         ENetAddress address;
         enet_address_build_any(&address, ENET_ADDRESS_TYPE_IPV6);
         address.port = actual_port;
-        host = enet_host_create(ENET_ADDRESS_TYPE_ANY, &address, MAX_PEERS, NUM_CHANNELS, 0, 0);
+        host = enet_host_create(ENET_ADDRESS_TYPE_ANY, &address, MAX_NET_PEERS, NUM_CHANNELS, 0, 0);
         if (host) {
             host_is_dual_stack = 1;
             address = host->address;
@@ -172,7 +201,7 @@ namespace
             LbNetLog("ENet: dual-stack host creation failed, falling back to IPv4-only\n");
             enet_address_build_any(&address, ENET_ADDRESS_TYPE_IPV4);
             address.port = actual_port;
-            host = enet_host_create(ENET_ADDRESS_TYPE_IPV4, &address, MAX_PEERS, NUM_CHANNELS, 0, 0);
+            host = enet_host_create(ENET_ADDRESS_TYPE_IPV4, &address, MAX_NET_PEERS, NUM_CHANNELS, 0, 0);
             if (!host)
                 return Lb_FAIL;
             host_is_dual_stack = 0;
@@ -256,7 +285,7 @@ namespace
     TbError finish_join(ENetHost *next_host, ENetPeer *next_peer, ENetHost *old_host, ENetPeer *old_peer,
         const char *join_type, const char *ip_version) {
         LbNetLog("Join: connected successfully via %s (%s)\n", join_type, ip_version);
-        enet_peer_timeout(next_peer, 0, PEER_TIMEOUT_MIN_MS, PEER_TIMEOUT_MAX_MS);
+        enet_peer_timeout(next_peer, PEER_TIMEOUT_LIMIT, PEER_TIMEOUT_MIN_MS, PEER_TIMEOUT_MAX_MS);
         cleanup_join_host(old_host, old_peer);
         host = next_host;
         client_peer = next_peer;
@@ -266,7 +295,7 @@ namespace
     TbError create_join_host(ENetAddressType address_type)
     {
         host_destroy();
-        host = enet_host_create(address_type, NULL, MAX_PEERS, NUM_CHANNELS, 0, 0);
+        host = enet_host_create(address_type, NULL, MAX_NET_PEERS, NUM_CHANNELS, 0, 0);
         if (!host) {
             LbNetLog("Join: failed to create ENet host\n");
             return Lb_FAIL;
@@ -292,7 +321,7 @@ namespace
             int service_result = enet_host_service(host, &enet_event, 0);
             if (service_result > 0 && enet_event.type == ENET_EVENT_TYPE_CONNECT) {
                 LbNetLog("Join: connected successfully via %s\n", join_type);
-                enet_peer_timeout(client_peer, 0, PEER_TIMEOUT_MIN_MS, PEER_TIMEOUT_MAX_MS);
+                enet_peer_timeout(client_peer, PEER_TIMEOUT_LIMIT, PEER_TIMEOUT_MIN_MS, PEER_TIMEOUT_MAX_MS);
                 return Lb_OK;
             }
             if (service_result > 0 && (enet_event.type == ENET_EVENT_TYPE_DISCONNECT || enet_event.type == ENET_EVENT_TYPE_DISCONNECT_TIMEOUT)) {
@@ -523,7 +552,7 @@ namespace
             case ENET_EVENT_TYPE_CONNECT:
                 LbNetLog("ENet: incoming connection accepted\n");
                 if (new_user(&user_id)) {
-                    enet_peer_timeout(enet_event.peer, 0, PEER_TIMEOUT_MIN_MS, PEER_TIMEOUT_MAX_MS);
+                    enet_peer_timeout(enet_event.peer, PEER_TIMEOUT_LIMIT, PEER_TIMEOUT_MIN_MS, PEER_TIMEOUT_MAX_MS);
                     enet_event.peer->data = reinterpret_cast<void *>(user_id);
                 } else {
                     LbNetLog("ENet: rejecting peer, no user slot available\n");
@@ -532,34 +561,27 @@ namespace
                 break;
             case ENET_EVENT_TYPE_DISCONNECT:
             case ENET_EVENT_TYPE_DISCONNECT_TIMEOUT: {
-                user_id = NetUserId(reinterpret_cast<ptrdiff_t>(enet_event.peer->data));
+                if (client_peer && client_peer == enet_event.peer) {
+                    user_id = SERVER_ID;
+                } else {
+                    user_id = NetUserId(reinterpret_cast<ptrdiff_t>(enet_event.peer->data));
+                }
                 const char *disconnect_reason = "timed out";
                 if (enet_event.type == ENET_EVENT_TYPE_DISCONNECT)
                     disconnect_reason = "disconnected (clean)";
+                destroy_incoming_queue(user_id);
                 LbNetLog("ENet: peer %d %s\n", (int)user_id, disconnect_reason);
                 g_drop_callback(user_id, NETDROP_ERROR);
                 break;
             }
-            case ENET_EVENT_TYPE_RECEIVE:
-                enet_event.packet->userData = nullptr;
-                if (oldest_packet == nullptr)
-                {
-                    newest_packet = enet_event.packet;
-                    oldest_packet = newest_packet;
-                    incoming_queue_size = 1;
+            case ENET_EVENT_TYPE_RECEIVE: {
+                user_id = SERVER_ID;
+                if (!client_peer) {
+                    user_id = NetUserId(reinterpret_cast<ptrdiff_t>(enet_event.peer->data));
                 }
-                else
-                {
-                    newest_packet->userData = enet_event.packet;
-                    newest_packet = enet_event.packet;
-                    incoming_queue_size += 1;
-                    if (incoming_queue_size > 50)
-                    {
-                        fprintf(stderr, "Too many packets %d\n", incoming_queue_size);
-                        WARNLOG("Too many packets %d", incoming_queue_size);
-                    }
-                }
+                enqueue_incoming_packet(enet_event.packet, user_id);
                 return 1;
+            }
             case ENET_EVENT_TYPE_NONE:
                 break;
         }
@@ -572,6 +594,9 @@ namespace
      */
     void bf_enet_update(NetNewUserCallback new_user)
     {
+        if (new_user == nullptr) {
+            new_user = not_expected_user;
+        }
         int packets_read = 0;
         const int MAX_PACKETS_PER_UPDATE = 100;
         while (packets_read < MAX_PACKETS_PER_UPDATE && bf_enet_read_event(new_user, 0))
@@ -655,6 +680,43 @@ namespace
         return false;
     }
 
+    bool wait_for_incoming_packet(NetUserId source, unsigned timeout)
+    {
+        if (oldest_packet[source] != nullptr) {
+            return true;
+        }
+
+        TbClockMSec start = LbTimerClock();
+        while (true)
+        {
+            unsigned wait_ms = 0;
+            if (timeout > 0)
+            {
+                TbClockMSec elapsed = LbTimerClock() - start;
+                if (elapsed >= timeout) {
+                    return false;
+                }
+                wait_ms = (unsigned)(timeout - elapsed);
+            }
+
+            NetNewUserCallback new_user_callback;
+            if (!client_peer) {
+                new_user_callback = OnNewUser;
+            } else {
+                new_user_callback = not_expected_user;
+            }
+            if (bf_enet_read_event(new_user_callback, wait_ms) <= 0) {
+                return false;
+            }
+            if (oldest_packet[source] != nullptr) {
+                return true;
+            }
+            if (timeout == 0) {
+                return false;
+            }
+        }
+    }
+
     /**
      * Completely reads a message. Blocks until entire message has been read.
      * Will not block if msgready has returned > 0.
@@ -664,16 +726,17 @@ namespace
      * @return The actual size of the message received, <= max_size. If 0, an
      *  error occurred.
      */
-    size_t bf_enet_readmsg(NetUserId, char *buffer, size_t max_size)
+    size_t bf_enet_readmsg(NetUserId source, char *buffer, size_t max_size)
     {
-        while (!oldest_packet)
-        {
-            bf_enet_read_event(not_expected_user, 0);
+        if (oldest_packet[source] == nullptr) {
+            if (!wait_for_incoming_packet(source, 0)) {
+                return 0;
+            }
         }
-        ENetPacket *packet = oldest_packet;
-        oldest_packet = static_cast<ENetPacket *>(oldest_packet->userData);
-        if (oldest_packet == nullptr) {
-            newest_packet = nullptr;
+        ENetPacket *packet = oldest_packet[source];
+        oldest_packet[source] = static_cast<ENetPacket *>(oldest_packet[source]->userData);
+        if (oldest_packet[source] == nullptr) {
+            newest_packet[source] = nullptr;
         }
         incoming_queue_size--;
 
@@ -694,15 +757,12 @@ namespace
      *  for a message to arrive before returning.
      * @return The size of the message waiting if there is a message, otherwise 0.
      */
-    size_t bf_enet_msgready(NetUserId, unsigned timeout)
+    size_t bf_enet_msgready(NetUserId source, unsigned timeout)
     {
-        if (!oldest_packet)
-        {
-            bf_enet_read_event(not_expected_user, timeout);
+        if (!wait_for_incoming_packet(source, timeout)) {
+            return 0;
         }
-        if (oldest_packet)
-            return oldest_packet->dataLength;
-        return 0;
+        return oldest_packet[source]->dataLength;
     }
 
     /**

--- a/src/bflib_enet.cpp
+++ b/src/bflib_enet.cpp
@@ -718,13 +718,11 @@ namespace
     }
 
     /**
-     * Completely reads a message. Blocks until entire message has been read.
-     * Will not block if msgready has returned > 0.
+     * Reads and removes the oldest queued message from a user.
      * @param source The source user.
-     * @param buffer
-     * @param max_size The maximum size of the message to be received.
-     * @return The actual size of the message received, <= max_size. If 0, an
-     *  error occurred.
+     * @param buffer Output buffer for the received message.
+     * @param max_size Maximum number of bytes copied into the buffer.
+     * @return Number of bytes copied, or 0 if no message is queued.
      */
     size_t bf_enet_readmsg(NetUserId source, char *buffer, size_t max_size)
     {

--- a/src/bflib_network.cpp
+++ b/src/bflib_network.cpp
@@ -30,7 +30,6 @@
 #include "net_game.h"
 #include "front_landview.h"
 #include "front_network.h"
-#include "net_received_packets.h"
 #include "net_matchmaking.h"
 #include "net_lan.h"
 #include "keeperfx.hpp"
@@ -68,15 +67,45 @@ void UpdateLocalPlayerInfo(NetUserId id) {
     strcpy(localPlayerInfoPtr[id].name, netstate.users[id].name);
 }
 
+char* begin_net_message(enum NetMessageType msg_type) {
+    char *ptr = netstate.msg_buffer;
+    *ptr = msg_type;
+    return ptr + 1;
+}
+
+void send_message_buffer(NetUserId dest, const char* end_ptr) {
+    netstate.sp->sendmsg_single(dest, netstate.msg_buffer, end_ptr - netstate.msg_buffer);
+}
+
 void SendUserUpdate(NetUserId dest, NetUserId updated_user) {
-    char * ptr = InitMessageBuffer(NETMSG_USERUPDATE);
+    char * ptr = begin_net_message(NETMSG_USERUPDATE);
     *ptr = updated_user;
     ptr += 1;
     *ptr = netstate.users[updated_user].progress;
     ptr += 1;
     strcpy(ptr, netstate.users[updated_user].name);
     ptr += strlen(netstate.users[updated_user].name) + 1;
-    SendMessage(dest, ptr);
+    send_message_buffer(dest, ptr);
+}
+
+void LbNetwork_SendChatMessageImmediate(int player_id, const char *message) {
+    char *ptr = begin_net_message(NETMSG_CHATMESSAGE);
+    *ptr = player_id;
+    ptr += 1;
+    strcpy(ptr, message);
+    ptr += strlen(message) + 1;
+    if (netstate.my_id != SERVER_ID) {
+        if (IsUserActive(SERVER_ID)) {
+            send_message_buffer(SERVER_ID, ptr);
+        }
+        return;
+    }
+    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+        if (id == netstate.my_id || !IsUserActive(id)) {
+            continue;
+        }
+        send_message_buffer(id, ptr);
+    }
 }
 
 void LbNetwork_SetServerPort(int port) {

--- a/src/bflib_network.h
+++ b/src/bflib_network.h
@@ -36,14 +36,17 @@ extern "C" {
 #define TIMEOUT_JOIN_LOBBY 2000
 #define TIMEOUT_LOBBY_EXCHANGE 3000
 #define TIMEOUT_GAMEPLAY_MISSING_PACKET 8000
+#define PEER_TIMEOUT_LIMIT 0
+#define PEER_TIMEOUT_MIN_MS 5000
+#define PEER_TIMEOUT_MAX_MS 30000
 /******************************************************************************/
 #pragma pack(1)
 
 // New Declarations Here ======================================================
 
-#define MAX_N_USERS 4
-#define MAX_N_PEERS (MAX_N_USERS - 1)
-#define SERVER_ID   0
+#define MAX_NET_USERS 2
+#define MAX_NET_PEERS (MAX_NET_USERS - 1)
+#define SERVER_ID     0
 
 typedef int NetUserId;
 
@@ -255,6 +258,7 @@ TbError LbNetwork_EnableNewPlayers(TbBool allow);
 TbError LbNetwork_EnumeratePlayers(struct TbNetworkSessionNameEntry *sesn, TbNetworkCallbackFunc callback, void *user_data);
 TbError LbNetwork_EnumerateSessions(TbNetworkCallbackFunc callback, void *ptr);
 TbError LbNetwork_Stop(void);
+void    LbNetwork_SendChatMessageImmediate(int player_id, const char *message);
 void    LbNetwork_UpdateInputLagIfHost(void);
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/bflib_network_exchange.cpp
+++ b/src/bflib_network_exchange.cpp
@@ -50,24 +50,14 @@ extern "C" {
 
 #define NETWORK_FPS 60
 
-char* InitMessageBuffer(enum NetMessageType msg_type) {
-    char* ptr = netstate.msg_buffer;
-    *ptr = msg_type;
-    return ptr + 1;
-}
-
 static TbBool can_exchange_with_peer(NetUserId peer_id) {
     return (peer_id != netstate.my_id) &&
         (netstate.users[peer_id].progress != USER_UNUSED) &&
         (my_player_number == get_host_player_id() || peer_id == SERVER_ID);
 }
 
-void SendMessage(NetUserId dest, const char* end_ptr) {
-    netstate.sp->sendmsg_single(dest, netstate.msg_buffer, end_ptr - netstate.msg_buffer);
-}
-
 void SendFrameToPeers(NetUserId source_id, const void * send_buf, size_t buf_size, int seq_nbr, enum NetMessageType msg_type) {
-    char * ptr = InitMessageBuffer(msg_type);
+    char * ptr = begin_net_message(msg_type);
     *ptr = source_id;
     ptr += 1;
     *(int *) ptr = seq_nbr;
@@ -87,7 +77,7 @@ void SendFrameToPeers(NetUserId source_id, const void * send_buf, size_t buf_siz
             netstate.sp->sendmsg_single_unsequenced(id, netstate.msg_buffer, ptr - netstate.msg_buffer);
             netstate.sp->sendmsg_single(id, netstate.msg_buffer, ptr - netstate.msg_buffer);
         } else {
-            SendMessage(id, ptr);
+            send_message_buffer(id, ptr);
         }
     }
     if (msg_type == NETMSG_GAMEPLAY) {
@@ -96,7 +86,8 @@ void SendFrameToPeers(NetUserId source_id, const void * send_buf, size_t buf_siz
 }
 
 TbError ProcessMessage(NetUserId source, void* server_buf, size_t frame_size) {
-    if (netstate.sp->readmsg(source, netstate.msg_buffer, sizeof(netstate.msg_buffer)) <= 0) {
+    size_t message_size = netstate.sp->readmsg(source, netstate.msg_buffer, sizeof(netstate.msg_buffer));
+    if (message_size <= 0) {
         ERRORLOG("Problem reading message from %u", source);
         return Lb_FAIL;
     }
@@ -146,12 +137,12 @@ TbError ProcessMessage(NetUserId source, void* server_buf, size_t frame_size) {
         NETMSG("User %s successfully logged in", netstate.users[source].name);
         netstate.users[source].progress = USER_LOGGEDIN;
         play_non_3d_sample(76);
-        char * msg_ptr = InitMessageBuffer(NETMSG_LOGIN);
+        char * msg_ptr = begin_net_message(NETMSG_LOGIN);
         *msg_ptr = source;
         msg_ptr += 1;
         memcpy(msg_ptr, &netstate.users[SERVER_ID].version, sizeof(netstate.users[SERVER_ID].version));
         msg_ptr += sizeof(netstate.users[SERVER_ID].version);
-        SendMessage(source, msg_ptr);
+        send_message_buffer(source, msg_ptr);
         NetUserId uid;
         for (uid = 0; uid < netstate.max_players; uid += 1) {
             if (netstate.users[uid].progress == USER_UNUSED) {
@@ -236,6 +227,14 @@ TbError ProcessMessage(NetUserId source, void* server_buf, size_t frame_size) {
             return Lb_OK;
         }
         process_chat_message_end(player_id, ptr);
+        if (netstate.my_id == SERVER_ID && source != SERVER_ID) {
+            for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+                if (id == netstate.my_id || id == source || !IsUserActive(id)) {
+                    continue;
+                }
+                netstate.sp->sendmsg_single(id, netstate.msg_buffer, message_size);
+            }
+        }
         return Lb_OK;
     }
     return Lb_OK;
@@ -247,14 +246,14 @@ TbError LbNetwork_ExchangeLogin(char *plyr_name) {
         ERRORLOG("Login credentials too long");
         return Lb_FAIL;
     }
-    char * ptr = InitMessageBuffer(NETMSG_LOGIN);
+    char * ptr = begin_net_message(NETMSG_LOGIN);
     strcpy(ptr, netstate.password);
     ptr += strlen(netstate.password) + 1;
     strcpy(ptr, plyr_name);
     ptr += strlen(plyr_name) + 1;
     memcpy(ptr, &net_current_version, sizeof(net_current_version));
     ptr += sizeof(net_current_version);
-    SendMessage(SERVER_ID, ptr);
+    send_message_buffer(SERVER_ID, ptr);
     TbClockMSec start = LbTimerClock();
     while (true) {
         TbClockMSec elapsed = LbTimerClock() - start;
@@ -402,21 +401,9 @@ TbError LbNetwork_Exchange(enum NetMessageType msg_type, void *send_buf, void *s
     return Lb_OK;
 }
 
-void LbNetwork_SendChatMessageImmediate(int player_id, const char *message) {
-    char* ptr = InitMessageBuffer(NETMSG_CHATMESSAGE);
-    *ptr = player_id;
-    ptr += 1;
-    strcpy(ptr, message);
-    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
-        if (id != netstate.my_id && IsUserActive(id)) {
-            netstate.sp->sendmsg_single(id, netstate.msg_buffer, 3 + strlen(message));
-        }
-    }
-}
-
 void LbNetwork_BroadcastUnpauseTimesync(void) {
     MULTIPLAYER_LOG("LbNetwork_BroadcastUnpauseTimesync");
-    InitMessageBuffer(NETMSG_UNPAUSE);
+    begin_net_message(NETMSG_UNPAUSE);
     for (NetUserId id = 0; id < netstate.max_players; id += 1) {
         if (id != netstate.my_id && IsUserActive(id)) {
             netstate.sp->sendmsg_single(id, netstate.msg_buffer, 1);

--- a/src/bflib_network_exchange.h
+++ b/src/bflib_network_exchange.h
@@ -29,7 +29,6 @@ extern "C" {
 TbError LbNetwork_Exchange(enum NetMessageType msg_type, void *send_buf, void *server_buf, size_t buf_size);
 TbError LbNetwork_ExchangeLogin(char *plyr_name);
 void LbNetwork_WaitForMissingPackets(void* server_buf, size_t client_frame_size);
-void LbNetwork_SendChatMessageImmediate(int player_id, const char *message);
 void LbNetwork_BroadcastUnpauseTimesync(void);
 
 #ifdef __cplusplus

--- a/src/bflib_network_internal.h
+++ b/src/bflib_network_internal.h
@@ -60,7 +60,7 @@ struct NetFrame {
 
 struct NetState {
     const struct NetSP *sp;
-    struct NetUser users[MAX_N_USERS];
+    struct NetUser users[MAX_NET_USERS];
     struct NetFrame *exchg_queue;
     char password[32];
     NetUserId my_id;
@@ -87,8 +87,8 @@ TbBool OnNewUser(NetUserId *assigned_id);
 void OnDroppedUser(NetUserId id, enum NetDropReason reason);
 TbBool IsUserActive(NetUserId id);
 void UpdateLocalPlayerInfo(NetUserId id);
-char* InitMessageBuffer(enum NetMessageType msg_type);
-void SendMessage(NetUserId dest, const char* end_ptr);
+char* begin_net_message(enum NetMessageType msg_type);
+void send_message_buffer(NetUserId dest, const char* end_ptr);
 void SendUserUpdate(NetUserId dest, NetUserId updated_user);
 
 #ifdef __cplusplus

--- a/src/front_landview.h
+++ b/src/front_landview.h
@@ -106,7 +106,7 @@ extern struct TbSpriteSheet *map_hand;
 extern long map_sound_fade;
 extern unsigned char *map_screen;
 extern long fe_net_level_selected;
-extern struct ScreenPacket net_screen_packet[NET_PLAYERS_COUNT];
+extern struct ScreenPacket net_screen_packet[MAX_NET_USERS];
 
 #pragma pack()
 /******************************************************************************/

--- a/src/front_landview_multiplayer.c
+++ b/src/front_landview_multiplayer.c
@@ -103,8 +103,8 @@ const int32_t hand_limp_yoffset[] = { -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, 
 
 long fe_net_level_selected;
 static struct NetLandLocalState net_map_local;
-static struct NetLandRemoteSlap net_map_remote_slap[NET_PLAYERS_COUNT];
-struct ScreenPacket net_screen_packet[NET_PLAYERS_COUNT];
+static struct NetLandRemoteSlap net_map_remote_slap[MAX_NET_USERS];
+struct ScreenPacket net_screen_packet[MAX_NET_USERS];
 /******************************************************************************/
 #ifdef __cplusplus
 }
@@ -298,7 +298,7 @@ static void draw_netmap_players_hands(void)
 
     now = LbTimerClock();
     anim_frame = now / 150;
-    for (i=0; i < NET_PLAYERS_COUNT; i++) {
+    for (i=0; i < MAX_NET_USERS; i++) {
         int32_t slap_frame;
 
         if (!is_connected_screen_packet(&net_screen_packet[i])) {
@@ -450,7 +450,7 @@ TbBool frontnetmap_load(void)
     frontmap_start_music();
     if (fe_network_active) {
         net_number_of_players = 0;
-        for (long i = 0; i < NET_PLAYERS_COUNT; i++) {
+        for (long i = 0; i < MAX_NET_USERS; i++) {
             struct ScreenPacket* nspck = &net_screen_packet[i];
             if (is_connected_screen_packet(nspck)) {
                 net_number_of_players++;
@@ -495,7 +495,7 @@ static TbBool frontnetmap_update_players(struct NetLandPlayersState * nmps)
     struct ScreenPacket* my_nspck = &net_screen_packet[my_player_number];
     TbBool slap_hit_confirmed = false;
     int32_t leading_votes = -1;
-    for (int32_t i = 0; i < NET_PLAYERS_COUNT; i++) {
+    for (int32_t i = 0; i < MAX_NET_USERS; i++) {
         struct ScreenPacket* nspck = &net_screen_packet[i];
         unsigned char action;
         TbBool remote_player;

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -338,7 +338,7 @@ static TbBool check_frontend_version_mismatch(void)
   if (netstate.my_id != SERVER_ID) {
     remote_id = my_player_number;
   }
-  for (int32_t i = 0; i < NET_PLAYERS_COUNT; i++) {
+  for (int32_t i = 0; i < MAX_NET_USERS; i++) {
     if (!network_player_active(i)) {
       continue;
     }
@@ -371,7 +371,7 @@ static TbBool check_frontend_version_mismatch(void)
 static void process_frontend_packets(void)
 {
   int32_t i;
-  for (i = 0; i < NET_PLAYERS_COUNT; i++) {
+  for (i = 0; i < MAX_NET_USERS; i++) {
     net_screen_packet[i].networkstatus_flags &= ~NetStat_PlayerConnected;
   }
   struct ScreenPacket* nspckt = &net_screen_packet[my_player_number];
@@ -394,7 +394,7 @@ static void process_frontend_packets(void)
   write_debug_screenpackets();
 #endif
   TbBool version_mismatch_found = check_frontend_version_mismatch();
-  for (i = 0; i < NET_PLAYERS_COUNT; i++) {
+  for (i = 0; i < MAX_NET_USERS; i++) {
     nspckt = &net_screen_packet[i];
     if ((nspckt->networkstatus_flags & NetStat_PlayerConnected) != 0) {
         switch (screen_packet_action(nspckt)) {
@@ -435,7 +435,7 @@ static void process_frontend_packets(void)
   if (frontend_alliances == -1) {
     frontend_alliances = 0;
   }
-  for (i = 0; i < NET_PLAYERS_COUNT; i++) {
+  for (i = 0; i < MAX_NET_USERS; i++) {
     nspckt = &net_screen_packet[i];
     if ((nspckt->networkstatus_flags & NetStat_PlayerConnected) == 0) {
       if (frontend_is_player_allied(my_player_number, i)) {

--- a/src/frontmenu_net.c
+++ b/src/frontmenu_net.c
@@ -353,7 +353,7 @@ void frontnet_draw_net_start_players(struct GuiButton *gbtn)
         long subplyr_idx;
         for (subplyr_idx = 0; subplyr_idx < net_number_of_enum_players; subplyr_idx++)
         {
-            if (subplyr_idx >= NET_PLAYERS_COUNT)
+            if (subplyr_idx >= MAX_NET_USERS)
                 break;
             if (net_player_info[subplyr_idx].network_user_active)
             {
@@ -414,7 +414,7 @@ void frontnet_draw_alliance_grid(struct GuiButton *gbtn)
 
     pos_x = gbtn->scr_pos_x;
     spr = get_frontend_sprite(GFS_slidrect_indicator_std0);
-    for (netplyr_idx=0; netplyr_idx < NET_PLAYERS_COUNT; netplyr_idx++)
+    for (netplyr_idx=0; netplyr_idx < MAX_NET_USERS; netplyr_idx++)
     {
         LbSpriteDrawResized(pos_x / pixel_size, pos_y / pixel_size, units_per_px, spr);
         pos_x += spr->SWidth * units_per_px / 16;
@@ -423,7 +423,7 @@ void frontnet_draw_alliance_grid(struct GuiButton *gbtn)
 
     pos_x = gbtn->scr_pos_x;
     spr = get_frontend_sprite(GFS_slidrect_indicator_std1);
-    for (netplyr_idx=0; netplyr_idx < NET_PLAYERS_COUNT; netplyr_idx++)
+    for (netplyr_idx=0; netplyr_idx < MAX_NET_USERS; netplyr_idx++)
     {
         LbSpriteDrawResized(pos_x / pixel_size, pos_y / pixel_size, units_per_px, spr);
         pos_x += spr->SWidth * units_per_px / 16;
@@ -432,7 +432,7 @@ void frontnet_draw_alliance_grid(struct GuiButton *gbtn)
 
     pos_x = gbtn->scr_pos_x;
     spr = get_frontend_sprite(GFS_slidrect_indicator_std2);
-    for (netplyr_idx=0; netplyr_idx < NET_PLAYERS_COUNT; netplyr_idx++)
+    for (netplyr_idx=0; netplyr_idx < MAX_NET_USERS; netplyr_idx++)
     {
         LbSpriteDrawResized(pos_x / pixel_size, pos_y / pixel_size, units_per_px, spr);
         pos_x += spr->SWidth * units_per_px / 16;
@@ -441,7 +441,7 @@ void frontnet_draw_alliance_grid(struct GuiButton *gbtn)
 
     pos_x = gbtn->scr_pos_x;
     spr = get_frontend_sprite(GFS_slidrect_indicator_std2);
-    for (netplyr_idx=0; netplyr_idx < NET_PLAYERS_COUNT; netplyr_idx++)
+    for (netplyr_idx=0; netplyr_idx < MAX_NET_USERS; netplyr_idx++)
     {
         LbSpriteDrawResized(pos_x / pixel_size, pos_y / pixel_size, units_per_px, spr);
         pos_x += spr->SWidth * units_per_px / 16;

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -49,11 +49,11 @@
 extern "C" {
 #endif
 /******************************************************************************/
-struct TbNetworkPlayerInfo net_player_info[NET_PLAYERS_COUNT];
+struct TbNetworkPlayerInfo net_player_info[MAX_NET_USERS];
 struct TbNetworkSessionNameEntry *net_session[32];
 long net_number_of_sessions;
 long net_session_index_active;
-struct TbNetworkPlayerName net_player[NET_PLAYERS_COUNT];
+struct TbNetworkPlayerName net_player[MAX_NET_USERS];
 struct ConfigInfo net_config_info;
 char net_service[16][NET_SERVICE_LEN];
 char net_player_name[20];
@@ -76,13 +76,13 @@ struct StartupSyncPacket {
 short setup_network_service(enum FrontendNetService service)
 {
   struct ServiceInitData *init_data = NULL;
-  SYNCMSG("Initializing 4-players type %d network", service);
+  SYNCMSG("Initializing %d-players type %d network", MAX_NET_USERS, service);
   memset(net_player_info, 0, sizeof(net_player_info));
   if (service != FrontendNetSvc_Online && service != FrontendNetSvc_LAN) {
     process_network_error(-800);
     return 0;
   }
-  if ( LbNetwork_Init(NS_ENET_UDP, NET_PLAYERS_COUNT, &net_player_info[0], init_data) )
+  if ( LbNetwork_Init(NS_ENET_UDP, MAX_NET_USERS, &net_player_info[0], init_data) )
   {
     process_network_error(-800);
     return 0;
@@ -109,10 +109,10 @@ int setup_old_network_service(void)
 }
 
 
-static void setup_players_from_startup_packets(const struct StartupSyncPacket startup_sync_packets[NET_PLAYERS_COUNT])
+static void setup_players_from_startup_packets(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
     int k = 0;
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++) {
+    for (int i = 0; i < MAX_NET_USERS; i++) {
         const struct StartupSyncPacket *sync = &startup_sync_packets[i];
         if (!net_player_info[i].network_user_active) {
             continue;
@@ -144,23 +144,23 @@ static void setup_players_from_startup_packets(const struct StartupSyncPacket st
     }
 }
 
-static void sync_startup_input_lag(const struct StartupSyncPacket startup_sync_packets[NET_PLAYERS_COUNT])
+static void sync_startup_input_lag(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
     game.input_lag_turns = startup_sync_packets[get_host_player_id()].input_lag_turns;
     game.skip_initial_input_turns = calculate_skip_input();
     NETLOG("Startup input lag synced: input_lag=%d", game.input_lag_turns);
 }
 
-static void sync_startup_zoom_distance(const struct StartupSyncPacket startup_sync_packets[NET_PLAYERS_COUNT])
+static void sync_startup_zoom_distance(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
     zoom_distance_setting = startup_sync_packets[get_host_player_id()].zoom_distance_setting;
     frontview_zoom_distance_setting = startup_sync_packets[get_host_player_id()].frontview_zoom_distance_setting;
 }
 
-static TbBool verify_map_checksums(const struct StartupSyncPacket startup_sync_packets[NET_PLAYERS_COUNT])
+static TbBool verify_map_checksums(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
     const TbBigChecksum host_checksum = startup_sync_packets[get_host_player_id()].map_checksum;
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++) {
+    for (int i = 0; i < MAX_NET_USERS; i++) {
         if (net_player_info[i].network_user_active && startup_sync_packets[i].map_checksum != host_checksum) {
             ERRORLOG("Level checksums %08x(Host) != %08x(Client) for player %d", host_checksum, startup_sync_packets[i].map_checksum, i);
             return false;
@@ -170,9 +170,9 @@ static TbBool verify_map_checksums(const struct StartupSyncPacket startup_sync_p
     return true;
 }
 
-static void verify_startup_sprite_zip_checksums(const struct StartupSyncPacket startup_sync_packets[NET_PLAYERS_COUNT])
+static void verify_startup_sprite_zip_checksums(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++) {
+    for (int i = 0; i < MAX_NET_USERS; i++) {
         if (net_player_info[i].network_user_active && startup_sync_packets[i].sprite_zip_checksum != sprite_zip_combined_checksum) {
             message_add_fmt(MsgType_Player, 0, "Verify /fxdata/ is the same across all PCs.");
             message_add_fmt(MsgType_Player, 0, "WARNING: Custom sprite mismatch with %s!", network_player_name(i));
@@ -181,7 +181,7 @@ static void verify_startup_sprite_zip_checksums(const struct StartupSyncPacket s
 }
 
 static struct StartupSyncPacket s_local_startup_sync;
-static struct StartupSyncPacket s_startup_sync_packets[NET_PLAYERS_COUNT];
+static struct StartupSyncPacket s_startup_sync_packets[MAX_NET_USERS];
 
 static void build_local_startup_sync(void)
 {
@@ -203,7 +203,7 @@ static void build_local_startup_sync(void)
 
 static TbBool all_human_players_sent_startup_sync(void)
 {
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++) {
+    for (int i = 0; i < MAX_NET_USERS; i++) {
         if (net_player_info[i].network_user_active && !s_startup_sync_packets[i].startup_sync_packet_valid) {
             return false;
         }
@@ -241,7 +241,7 @@ static void setup_network_player_numbers(void)
     TbBool is_set = false;
     int k = 0;
     SYNCDBG(6, "Starting");
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++)
+    for (int i = 0; i < MAX_NET_USERS; i++)
     {
         struct PlayerInfo* player = get_player(i);
         if (net_player_info[i].network_user_active)
@@ -268,7 +268,7 @@ void setup_count_players(void)
   } else
   {
     game.active_players_count = 0;
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++)
+    for (int i = 0; i < MAX_NET_USERS; i++)
     {
       if (net_player_info[i].network_user_active)
         game.active_players_count++;
@@ -292,14 +292,14 @@ void init_players_network_game(CoroutineLoop *context)
  */
 TbBool network_player_active(int plyr_idx)
 {
-    if ((plyr_idx < 0) || (plyr_idx >= NET_PLAYERS_COUNT))
+    if ((plyr_idx < 0) || (plyr_idx >= MAX_NET_USERS))
         return false;
     return (net_player_info[plyr_idx].network_user_active != 0);
 }
 
 const char *network_player_name(int plyr_idx)
 {
-    if ((plyr_idx < 0) || (plyr_idx >= NET_PLAYERS_COUNT))
+    if ((plyr_idx < 0) || (plyr_idx >= MAX_NET_USERS))
         return NULL;
     return net_player_info[plyr_idx].name;
 }

--- a/src/net_game.h
+++ b/src/net_game.h
@@ -29,7 +29,6 @@
 extern "C" {
 #endif
 
-#define NET_PLAYERS_COUNT       4
 #define NET_SERVICE_LEN        64
 #define PACKETS_COUNT           9
 
@@ -39,11 +38,11 @@ extern "C" {
 struct TbNetworkSessionNameEntry;
 
 /******************************************************************************/
-extern struct TbNetworkPlayerInfo net_player_info[NET_PLAYERS_COUNT];
+extern struct TbNetworkPlayerInfo net_player_info[MAX_NET_USERS];
 extern struct TbNetworkSessionNameEntry *net_session[32];
 extern long net_number_of_sessions;
 extern long net_session_index_active;
-extern struct TbNetworkPlayerName net_player[NET_PLAYERS_COUNT];
+extern struct TbNetworkPlayerName net_player[MAX_NET_USERS];
 extern struct ConfigInfo net_config_info;
 extern char net_service[16][NET_SERVICE_LEN];
 extern char net_player_name[20];

--- a/src/net_redundant_packets.c
+++ b/src/net_redundant_packets.c
@@ -37,7 +37,7 @@ struct PacketHistory {
     unsigned char valid_count;
 };
 
-static struct PacketHistory packet_history[MAX_N_USERS];
+static struct PacketHistory packet_history[MAX_NET_USERS];
 
 /******************************************************************************/
 
@@ -50,7 +50,7 @@ void clear_redundant_packets(void) {
 }
 
 void store_sent_packet(PlayerNumber player, const struct Packet* packet) {
-    if (player < 0 || player >= MAX_N_USERS) {
+    if (player < 0 || player >= MAX_NET_USERS) {
         return;
     }
     struct PacketHistory* history = &packet_history[player];
@@ -62,7 +62,7 @@ void store_sent_packet(PlayerNumber player, const struct Packet* packet) {
 }
 
 size_t bundle_packets(PlayerNumber player, const struct Packet* current_packet, char* out_buffer) {
-    if (player < 0 || player >= MAX_N_USERS) {
+    if (player < 0 || player >= MAX_NET_USERS) {
         return 0;
     }
     struct PacketHistory* history = &packet_history[player];
@@ -84,7 +84,7 @@ size_t bundle_packets(PlayerNumber player, const struct Packet* current_packet, 
 }
 
 void unbundle_packets(const char* bundled_buffer, PlayerNumber source_player) {
-    if (source_player < 0 || source_player >= MAX_N_USERS) {
+    if (source_player < 0 || source_player >= MAX_NET_USERS) {
         return;
     }
     struct BundledPacket bundled;

--- a/src/net_resync.cpp
+++ b/src/net_resync.cpp
@@ -198,7 +198,7 @@ static TbBool send_resync_data(const void * buffer, size_t total_length) {
     memcpy(message_buffer + sizeof(ResyncHeader), compressed_buffer, compressed_size);
 
     NETLOG("Host: Sending resync data to all clients");
-    for (NetUserId user_index = 0; user_index < MAX_N_USERS; ++user_index) {
+    for (NetUserId user_index = 0; user_index < MAX_NET_USERS; ++user_index) {
         if (netstate.users[user_index].progress != USER_LOGGEDIN) {
             continue;
         }
@@ -379,8 +379,8 @@ void LbNetwork_TimesyncBarrier(void) {
     const TbBool is_host = (my_player_number == get_host_player_id());
     if (is_host) {
         MULTIPLAYER_LOG("Host: Handling any pending timesync requests");
-        TbBool timesynced[MAX_N_USERS];
-        for (NetUserId i = 0; i < MAX_N_USERS; ++i) {
+        TbBool timesynced[MAX_NET_USERS];
+        for (NetUserId i = 0; i < MAX_NET_USERS; ++i) {
             if (i == netstate.my_id) {
                 timesynced[i] = 1;
             } else if (netstate.users[i].progress == USER_LOGGEDIN) {
@@ -394,7 +394,7 @@ void LbNetwork_TimesyncBarrier(void) {
         TbClockMSec last_anim_time = wait_start;
         while (LbTimerClock() - wait_start < RESYNC_TIMESYNC_TIMEOUT_MS) {
             netstate.sp->update(OnNewUser);
-            for (NetUserId id = 0; id < MAX_N_USERS; ++id) {
+            for (NetUserId id = 0; id < MAX_NET_USERS; ++id) {
                 if (id == netstate.my_id) continue;
                 if (netstate.users[id].progress != USER_LOGGEDIN) continue;
                 while (netstate.sp->msgready(id, 0)) {
@@ -419,7 +419,7 @@ void LbNetwork_TimesyncBarrier(void) {
                 }
             }
             TbBool all_done = 1;
-            for (NetUserId id = 0; id < MAX_N_USERS; ++id) {
+            for (NetUserId id = 0; id < MAX_NET_USERS; ++id) {
                 if (!timesynced[id]) {
                     all_done = 0;
                     break;
@@ -435,7 +435,7 @@ void LbNetwork_TimesyncBarrier(void) {
             }
         }
         LbSleepFor(100);
-        for (NetUserId id = 0; id < MAX_N_USERS; ++id) {
+        for (NetUserId id = 0; id < MAX_NET_USERS; ++id) {
             if (id == netstate.my_id) continue;
             if (netstate.users[id].progress != USER_LOGGEDIN) continue;
             if (!timesynced[id]) {
@@ -459,7 +459,7 @@ void LbNetwork_TimesyncBarrier(void) {
         message.message_type = NETMSG_RESYNC_RESUME;
         message.resume_time = resume_time;
         MULTIPLAYER_LOG("Host: Broadcasting RESUME to all clients (current=%lu, resume=%lu, delay=%lu, client_rtt=%lu)", (unsigned long)current_time, (unsigned long)resume_time, (unsigned long)delay, (unsigned long)g_client_rtt_ms);
-        for (NetUserId user_index = 0; user_index < MAX_N_USERS; ++user_index) {
+        for (NetUserId user_index = 0; user_index < MAX_NET_USERS; ++user_index) {
             if (netstate.users[user_index].progress != USER_LOGGEDIN) {
                 continue;
             }

--- a/src/packets.c
+++ b/src/packets.c
@@ -1666,7 +1666,7 @@ static void replace_disconnected_players_with_ai(void) {
         return;
     }
     TbBool host_disconnected = (netstate.my_id != SERVER_ID && netstate.users[SERVER_ID].progress == USER_UNUSED);
-    for (int player_index = 0; player_index < NET_PLAYERS_COUNT; player_index++) {
+    for (int player_index = 0; player_index < MAX_NET_USERS; player_index++) {
         struct PlayerInfo* player = get_player(player_index);
         if (!player_exists(player) || ((player->allocflags & PlaF_CompCtrl) != 0)) {
             continue;

--- a/src/packets_misc.c
+++ b/src/packets_misc.c
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 /******************************************************************************/
-#define PACKET_TURN_SIZE (NET_PLAYERS_COUNT*sizeof(struct PacketEx) + sizeof(TbBigChecksum))
+#define PACKET_TURN_SIZE (MAX_NET_USERS*sizeof(struct PacketEx) + sizeof(TbBigChecksum))
 #define MULTIPLAYER_PAUSE_COOLDOWN_MS 500
 struct Packet bad_packet;
 unsigned long initial_replay_seed;
@@ -224,15 +224,15 @@ short save_packets(void)
         chksum = 0;
     LbFileSeek(game.packet_save_fp, 0, Lb_FILE_SEEK_END);
     // Prepare data in the buffer
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++)
+    for (int i = 0; i < MAX_NET_USERS; i++)
         memcpy(&pckt_buf[i*sizeof(struct Packet)], &game.packets[i], sizeof(struct Packet));
-    memcpy(&pckt_buf[NET_PLAYERS_COUNT*sizeof(struct Packet)], &chksum, sizeof(TbBigChecksum));
+    memcpy(&pckt_buf[MAX_NET_USERS*sizeof(struct Packet)], &chksum, sizeof(TbBigChecksum));
     // Write buffer into file
     if (LbFileWrite(game.packet_save_fp, &pckt_buf, turn_data_size) != turn_data_size)
     {
         ERRORLOG("Packet file write error");
     }
-    for (int i = 0; i < NET_PLAYERS_COUNT; i++) {
+    for (int i = 0; i < MAX_NET_USERS; i++) {
         if (game.packets[i].action == PckA_PlyrMsgEnd) {
             if (LbFileWrite(game.packet_save_fp, get_player(i)->mp_pending_message, PLAYER_MP_MESSAGE_LEN) != PLAYER_MP_MESSAGE_LEN) {
                 ERRORLOG("Chat message file write error");
@@ -362,9 +362,9 @@ void load_packets_for_turn(GameTurn nturn)
         return;
     }
     game.packet_file_pos += turn_data_size;
-    for (long i = 0; i < NET_PLAYERS_COUNT; i++)
+    for (long i = 0; i < MAX_NET_USERS; i++)
         memcpy(&game.packets[i], &pckt_buf[i * sizeof(struct Packet)], sizeof(struct Packet));
-    for (long i = 0; i < NET_PLAYERS_COUNT; i++) {
+    for (long i = 0; i < MAX_NET_USERS; i++) {
         if (game.packets[i].action == PckA_PlyrMsgEnd) {
             if (LbFileRead(game.packet_save_fp, get_player(i)->mp_pending_message, PLAYER_MP_MESSAGE_LEN) == PLAYER_MP_MESSAGE_LEN) {
                 game.packet_file_pos += PLAYER_MP_MESSAGE_LEN;
@@ -373,7 +373,7 @@ void load_packets_for_turn(GameTurn nturn)
             }
         }
     }
-    TbBigChecksum tot_chksum = llong(&pckt_buf[NET_PLAYERS_COUNT * sizeof(struct Packet)]);
+    TbBigChecksum tot_chksum = llong(&pckt_buf[MAX_NET_USERS * sizeof(struct Packet)]);
     if (game.turns_fastforward > 0)
         game.turns_fastforward--;
     if (game.packet_checksum_verify)

--- a/src/packets_misc.c
+++ b/src/packets_misc.c
@@ -36,7 +36,7 @@
 extern "C" {
 #endif
 /******************************************************************************/
-#define PACKET_TURN_SIZE (MAX_NET_USERS*sizeof(struct PacketEx) + sizeof(TbBigChecksum))
+#define PACKET_TURN_SIZE (PACKETS_COUNT*sizeof(struct Packet) + sizeof(TbBigChecksum))
 #define MULTIPLAYER_PAUSE_COOLDOWN_MS 500
 struct Packet bad_packet;
 unsigned long initial_replay_seed;
@@ -224,15 +224,15 @@ short save_packets(void)
         chksum = 0;
     LbFileSeek(game.packet_save_fp, 0, Lb_FILE_SEEK_END);
     // Prepare data in the buffer
-    for (int i = 0; i < MAX_NET_USERS; i++)
+    for (int i = 0; i < PACKETS_COUNT; i++)
         memcpy(&pckt_buf[i*sizeof(struct Packet)], &game.packets[i], sizeof(struct Packet));
-    memcpy(&pckt_buf[MAX_NET_USERS*sizeof(struct Packet)], &chksum, sizeof(TbBigChecksum));
+    memcpy(&pckt_buf[PACKETS_COUNT*sizeof(struct Packet)], &chksum, sizeof(TbBigChecksum));
     // Write buffer into file
     if (LbFileWrite(game.packet_save_fp, &pckt_buf, turn_data_size) != turn_data_size)
     {
         ERRORLOG("Packet file write error");
     }
-    for (int i = 0; i < MAX_NET_USERS; i++) {
+    for (int i = 0; i < PACKETS_COUNT; i++) {
         if (game.packets[i].action == PckA_PlyrMsgEnd) {
             if (LbFileWrite(game.packet_save_fp, get_player(i)->mp_pending_message, PLAYER_MP_MESSAGE_LEN) != PLAYER_MP_MESSAGE_LEN) {
                 ERRORLOG("Chat message file write error");
@@ -362,9 +362,9 @@ void load_packets_for_turn(GameTurn nturn)
         return;
     }
     game.packet_file_pos += turn_data_size;
-    for (long i = 0; i < MAX_NET_USERS; i++)
+    for (long i = 0; i < PACKETS_COUNT; i++)
         memcpy(&game.packets[i], &pckt_buf[i * sizeof(struct Packet)], sizeof(struct Packet));
-    for (long i = 0; i < MAX_NET_USERS; i++) {
+    for (long i = 0; i < PACKETS_COUNT; i++) {
         if (game.packets[i].action == PckA_PlyrMsgEnd) {
             if (LbFileRead(game.packet_save_fp, get_player(i)->mp_pending_message, PLAYER_MP_MESSAGE_LEN) == PLAYER_MP_MESSAGE_LEN) {
                 game.packet_file_pos += PLAYER_MP_MESSAGE_LEN;
@@ -373,7 +373,7 @@ void load_packets_for_turn(GameTurn nturn)
             }
         }
     }
-    TbBigChecksum tot_chksum = llong(&pckt_buf[MAX_NET_USERS * sizeof(struct Packet)]);
+    TbBigChecksum tot_chksum = llong(&pckt_buf[PACKETS_COUNT * sizeof(struct Packet)]);
     if (game.turns_fastforward > 0)
         game.turns_fastforward--;
     if (game.packet_checksum_verify)


### PR DESCRIPTION
- Use per-user queues instead of a shared queue
- Some simple renames
- Moved some code around

`MAX_NET_USERS` has been set to 2 until 4-players is done.