### PR TITLE
Player specific Objectives and Information

### DIFF
--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -2102,7 +2102,7 @@ TbBool cmd_string_show(PlayerNumber plyr_idx, char * args)
     long msg_id = pr2str != NULL ? atoi(pr2str) : 0;
     if (msg_id >= 0)
     {
-        set_general_information(msg_id, 0, 0, 0);
+        set_general_information(msg_id, plyr_idx, 0, 0, 0);
     }
     return true;
 }

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -2113,7 +2113,7 @@ TbBool cmd_quick_show(PlayerNumber plyr_idx, char * args)
     long msg_id = pr2str != NULL ? atoi(pr2str) : 0;
     if (msg_id >= 0)
     {
-        set_quick_information(msg_id,my_player_number, 0, 0, 0);
+        set_quick_information(msg_id, plyr_idx, 0, 0, 0);
     }
     return true;
 }

--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -2113,7 +2113,7 @@ TbBool cmd_quick_show(PlayerNumber plyr_idx, char * args)
     long msg_id = pr2str != NULL ? atoi(pr2str) : 0;
     if (msg_id >= 0)
     {
-        set_quick_information(msg_id, 0, 0, 0);
+        set_quick_information(msg_id,my_player_number, 0, 0, 0);
     }
     return true;
 }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -3619,7 +3619,7 @@ void display_objectives(PlayerNumber plyr_idx, MapSubtlCoord x, MapSubtlCoord y)
         event = &game.event[evidx];
         if (event->kind == EvKind_Objective)
         {
-            event_create_event(cor_x, cor_y, EvKind_Objective, plyr_idx, 0);
+            event_create_event_or_update_old_event(cor_x, cor_y, EvKind_Objective, plyr_idx, 0);
             return;
         }
     }
@@ -3631,10 +3631,10 @@ void display_objectives(PlayerNumber plyr_idx, MapSubtlCoord x, MapSubtlCoord y)
             cor_x = creatng->mappos.x.val;
             cor_y = creatng->mappos.y.val;
         }
-        event_create_event(cor_x, cor_y, EvKind_Objective, plyr_idx, creatng->index);
+        event_create_event_or_update_old_event(cor_x, cor_y, EvKind_Objective, plyr_idx, creatng->index);
     } else
     {
-        event_create_event(cor_x, cor_y, EvKind_Objective, plyr_idx, 0);
+        event_create_event_or_update_old_event(cor_x, cor_y, EvKind_Objective, plyr_idx, 0);
     }
 }
 

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -3560,14 +3560,14 @@ void gui_set_autopilot(struct GuiButton *gbtn)
   set_players_packet_action(player, PckA_SetComputerKind, ntype, 0, 0, 0);
 }
 
-void set_level_objective(const char *msg_text)
+void set_level_objective(PlayerNumber plyr_idx, const char *msg_text)
 {
     if (msg_text == NULL)
     {
         ERRORLOG("Invalid message pointer");
         return;
     }
-    snprintf(game.evntbox_text_objective, MESSAGE_TEXT_LEN, "%s", msg_text);
+    snprintf(game.evntbox_text_objective[plyr_idx], MESSAGE_TEXT_LEN, "%s", msg_text);
     new_objective = 1;
 }
 
@@ -3586,13 +3586,11 @@ void update_player_objectives(PlayerNumber plyr_idx)
       switch (player->victory_state)
       {
       case VicS_WonLevel:
-          if (plyr_idx == my_player_number)
-            set_level_objective(get_string(CpgStr_SuccessLandIsYours));
+          set_level_objective(player->id_number,get_string(CpgStr_SuccessLandIsYours));
           display_objectives(player->id_number, 0, 0);
           break;
       case VicS_LostLevel:
-          if (plyr_idx == my_player_number)
-            set_level_objective(get_string(CpgStr_LevelLost));
+          set_level_objective(player->id_number, get_string(CpgStr_LevelLost));
           display_objectives(player->id_number, 0, 0);
           break;
       }
@@ -3621,7 +3619,7 @@ void display_objectives(PlayerNumber plyr_idx, MapSubtlCoord x, MapSubtlCoord y)
         event = &game.event[evidx];
         if (event->kind == EvKind_Objective)
         {
-            event_create_event_or_update_old_event(cor_x, cor_y, EvKind_Objective, plyr_idx, 0);
+            event_create_event(cor_x, cor_y, EvKind_Objective, plyr_idx, 0);
             return;
         }
     }
@@ -3633,10 +3631,10 @@ void display_objectives(PlayerNumber plyr_idx, MapSubtlCoord x, MapSubtlCoord y)
             cor_x = creatng->mappos.x.val;
             cor_y = creatng->mappos.y.val;
         }
-        event_create_event_or_update_nearby_existing_event(cor_x, cor_y, EvKind_Objective, plyr_idx, creatng->index);
+        event_create_event(cor_x, cor_y, EvKind_Objective, plyr_idx, creatng->index);
     } else
     {
-        event_create_event_or_update_nearby_existing_event(cor_x, cor_y, EvKind_Objective, plyr_idx, 0);
+        event_create_event(cor_x, cor_y, EvKind_Objective, plyr_idx, 0);
     }
 }
 

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -427,7 +427,7 @@ TbBool toggle_first_person_menu(TbBool visible);
 void toggle_gui_overlay_map(void);
 
 void update_player_objectives(PlayerNumber plyr_idx);
-void set_level_objective(const char *msg_text);
+void set_level_objective(PlayerNumber plyr_idx, const char *msg_text);
 void display_objectives(PlayerNumber plyr_idx,MapSubtlCoord x,MapSubtlCoord y);
 
 short toggle_main_cheat_menu(void);

--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -324,7 +324,7 @@ struct Game {
     GameTurnDelta pay_day_progress[PLAYERS_COUNT];
     struct SoundSettings sound_settings;
     struct CreatureBattle battles[BATTLES_COUNT];
-    char evntbox_text_objective[MESSAGE_TEXT_LEN];
+    char evntbox_text_objective[PLAYERS_COUNT][MESSAGE_TEXT_LEN];
     char evntbox_text_buffer[MESSAGE_TEXT_LEN];
     struct TextScrollWindow evntbox_scroll_window;
     int32_t flash_button_index; /**< GUI Button Designation ID of a button which is supposed to flash, as part of tutorial. */

--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -233,7 +233,7 @@ void process_dungeon_destroy(struct Thing* heartng)
                 if (is_my_player_number(dungeon->owner))
                 {
                     const char* objective = (game.heart_lost_quick_message) ? game.quick_messages[game.heart_lost_message_id] : get_string(game.heart_lost_message_id);
-                    process_objective(objective, game.heart_lost_message_target, 0, 0);
+                    process_objective(objective,dungeon->owner, game.heart_lost_message_target, 0, 0);
                 }
             }
             // If this is the last heart the player had, finish him

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -274,10 +274,10 @@ short lose_level(struct PlayerInfo *player);
 short resign_level(struct PlayerInfo *player);
 short complete_level(struct PlayerInfo *player);
 void set_general_information(long msg_id, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
-void set_quick_information(long msg_id, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
-void process_objective(const char *msg_text, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
-void set_general_objective(long msg_id, TbMapLocation target, long x, long y);
-void turn_off_power_sight_of_evil(PlayerNumber plridx);
+void set_quick_information(long msg_id, PlayerNumber plyr_idx, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
+void process_objective(const char *msg_text, PlayerNumber plyr_idx, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
+void set_general_objective(long msg_id, PlayerNumber plyr_idx, TbMapLocation target, long x, long y);
+void turn_off_power_sight_of_evil(PlayerNumber plyr_idx);
 void turn_off_power_obey(PlayerNumber plyr_idx);
 
 short dump_first_held_thing_on_map(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool update_hand);

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -273,7 +273,7 @@ short winning_player_quitting(struct PlayerInfo *player, int32_t *plyr_count);
 short lose_level(struct PlayerInfo *player);
 short resign_level(struct PlayerInfo *player);
 short complete_level(struct PlayerInfo *player);
-void set_general_information(long msg_id, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
+void set_general_information(long msg_id, PlayerNumber plyr_idx, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
 void set_quick_information(long msg_id, PlayerNumber plyr_idx, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
 void process_objective(const char *msg_text, PlayerNumber plyr_idx, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y);
 void set_general_objective(long msg_id, PlayerNumber plyr_idx, TbMapLocation target, long x, long y);

--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -549,7 +549,7 @@ static int lua_Display_information(lua_State *L)
     long msg_id    = luaL_checkinteger(L, 1);
     TbMapLocation zoom_location = luaL_optLocation(L,2);
 
-    set_general_information(msg_id,zoom_location,0,0);
+    set_general_information(msg_id,my_player_number,zoom_location,0,0);
     return 0;
 }
 

--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -559,7 +559,7 @@ static int lua_Display_information_with_pos(lua_State *L)
     long stl_x    = luaL_checkstl_x(L, 2);
     long stl_y    = luaL_checkstl_y(L, 3);
 
-    set_general_objective(msg_id, my_player_number, 0,stl_x,stl_y);
+    set_general_information(msg_id, my_player_number, 0,stl_x,stl_y);
     return 0;
 }
 

--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -530,7 +530,7 @@ static int lua_Display_objective(lua_State *L)
     long msg_id    = luaL_checkinteger(L, 1);
     TbMapLocation zoom_location = luaL_optLocation(L,2);
 
-    set_general_objective(msg_id,zoom_location,0,0);
+    set_general_objective(msg_id,my_player_number,zoom_location,0,0);
     return 0;
 }
 
@@ -540,7 +540,7 @@ static int lua_Display_objective_with_pos(lua_State *L)
     long stl_x    = luaL_checkstl_x(L, 2);
     long stl_y    = luaL_checkstl_y(L, 3);
 
-    set_general_objective(msg_id,0,stl_x,stl_y);
+    set_general_objective(msg_id, my_player_number, 0,stl_x,stl_y);
     return 0;
 }
 
@@ -559,7 +559,7 @@ static int lua_Display_information_with_pos(lua_State *L)
     long stl_x    = luaL_checkstl_x(L, 2);
     long stl_y    = luaL_checkstl_y(L, 3);
 
-    set_general_objective(msg_id,0,stl_x,stl_y);
+    set_general_objective(msg_id, my_player_number, 0,stl_x,stl_y);
     return 0;
 }
 
@@ -568,7 +568,7 @@ static int lua_Quick_objective(lua_State *L)
     const char *msg_text = lua_tostring(L, 1);
     TbMapLocation target = luaL_optLocation(L, 2);
 
-    process_objective(msg_text, target, 0, 0);
+    process_objective(msg_text, my_player_number, target, 0, 0);
     return 0;
 }
 
@@ -579,7 +579,7 @@ static int lua_Quick_information(lua_State *L)
     TbMapLocation target = luaL_optLocation(L, 3);
     snprintf(game.quick_messages[slot], MESSAGE_TEXT_LEN, "%s", msg_text);
 
-    set_quick_information(slot, target, 0, 0);
+    set_quick_information(slot,my_player_number, target, 0, 0);
     return 0;
 }
 
@@ -589,7 +589,7 @@ static int lua_Quick_objective_with_pos(lua_State *L)
     MapSubtlCoord stl_x = luaL_checkstl_x(L, 2);
     MapSubtlCoord stl_y = luaL_checkstl_y(L, 3);
 
-    process_objective(msg_text, 0, stl_x, stl_y);
+    process_objective(msg_text, my_player_number, 0, stl_x, stl_y);
     return 0;
 }
 
@@ -601,7 +601,7 @@ static int lua_Quick_information_with_pos(lua_State *L)
     MapSubtlCoord stl_y = luaL_checkstl_y(L, 4);
     snprintf(game.quick_messages[slot], MESSAGE_TEXT_LEN, "%s", msg_text);
 
-    set_quick_information(slot, 0, stl_x, stl_y);
+    set_quick_information(slot,my_player_number, 0, stl_x, stl_y);
     return 0;
 }
 

--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -530,7 +530,10 @@ static int lua_Display_objective(lua_State *L)
     long msg_id    = luaL_checkinteger(L, 1);
     TbMapLocation zoom_location = luaL_optLocation(L,2);
 
-    set_general_objective(msg_id,my_player_number,zoom_location,0,0);
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        set_general_objective(msg_id, plyr_idx, zoom_location, 0, 0);
+    }
     return 0;
 }
 
@@ -540,7 +543,11 @@ static int lua_Display_objective_with_pos(lua_State *L)
     long stl_x    = luaL_checkstl_x(L, 2);
     long stl_y    = luaL_checkstl_y(L, 3);
 
-    set_general_objective(msg_id, my_player_number, 0,stl_x,stl_y);
+
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        set_general_objective(msg_id, plyr_idx, 0, stl_x, stl_y);
+    }
     return 0;
 }
 
@@ -549,7 +556,10 @@ static int lua_Display_information(lua_State *L)
     long msg_id    = luaL_checkinteger(L, 1);
     TbMapLocation zoom_location = luaL_optLocation(L,2);
 
-    set_general_information(msg_id,my_player_number,zoom_location,0,0);
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        set_general_information(msg_id, plyr_idx, zoom_location, 0, 0);
+    }
     return 0;
 }
 
@@ -559,7 +569,10 @@ static int lua_Display_information_with_pos(lua_State *L)
     long stl_x    = luaL_checkstl_x(L, 2);
     long stl_y    = luaL_checkstl_y(L, 3);
 
-    set_general_information(msg_id, my_player_number, 0,stl_x,stl_y);
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        set_general_information(msg_id, plyr_idx, 0, stl_x, stl_y);
+    }
     return 0;
 }
 
@@ -568,7 +581,10 @@ static int lua_Quick_objective(lua_State *L)
     const char *msg_text = lua_tostring(L, 1);
     TbMapLocation target = luaL_optLocation(L, 2);
 
-    process_objective(msg_text, my_player_number, target, 0, 0);
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        process_objective(msg_text, plyr_idx, target, 0, 0);
+    }
     return 0;
 }
 
@@ -579,7 +595,10 @@ static int lua_Quick_information(lua_State *L)
     TbMapLocation target = luaL_optLocation(L, 3);
     snprintf(game.quick_messages[slot], MESSAGE_TEXT_LEN, "%s", msg_text);
 
-    set_quick_information(slot,my_player_number, target, 0, 0);
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        set_quick_information(slot, plyr_idx, target, 0, 0);
+    }
     return 0;
 }
 
@@ -589,7 +608,10 @@ static int lua_Quick_objective_with_pos(lua_State *L)
     MapSubtlCoord stl_x = luaL_checkstl_x(L, 2);
     MapSubtlCoord stl_y = luaL_checkstl_y(L, 3);
 
-    process_objective(msg_text, my_player_number, 0, stl_x, stl_y);
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        process_objective(msg_text, plyr_idx, 0, stl_x, stl_y);
+    }
     return 0;
 }
 
@@ -601,7 +623,10 @@ static int lua_Quick_information_with_pos(lua_State *L)
     MapSubtlCoord stl_y = luaL_checkstl_y(L, 4);
     snprintf(game.quick_messages[slot], MESSAGE_TEXT_LEN, "%s", msg_text);
 
-    set_quick_information(slot,my_player_number, 0, stl_x, stl_y);
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    {
+        set_quick_information(slot, plyr_idx, 0, stl_x, stl_y);
+    }
     return 0;
 }
 

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -831,6 +831,37 @@ static void display_objective_process(struct ScriptContext *context)
     context->value->shorts[4]);
 }
 
+static void display_player_objective_check(const struct ScriptLine* scline)
+{
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[1]);
+    int16_t  msg_num = scline->np[0];
+    MapSubtlCoord x = 0, y = 0;
+    TbMapLocation location = 0;
+    if ((msg_num < 0) || (msg_num >= STRINGS_MAX))
+    {
+        SCRPTERRLOG("Invalid TEXT number");
+        return;
+    }
+    if (scline->command == Cmd_DISPLAY_PLAYER_OBJECTIVE)
+    {
+        const char* where = scline->tp[2];
+        if (!get_map_location_id(where, &location))
+        {
+            return;
+        }
+    }
+    else
+    {
+        x = scline->np[2];
+        y = scline->np[3];
+    }
+    value->shorts[0] = msg_num;
+    value->ulongs[1] = location;
+    value->shorts[3] = x;
+    value->shorts[4] = y;
+    PROCESS_SCRIPT_VALUE(scline->command);
+}
+
 static void quick_objective_check(const struct ScriptLine* scline)
 {
     ALLOCATE_SCRIPT_VALUE(scline->command, ALL_PLAYERS);
@@ -1088,11 +1119,49 @@ static void display_information_check(const struct ScriptLine* scline)
 
 static void display_information_process(struct ScriptContext* context)
 {
-    if (my_player_number == context->player_idx)
+    set_general_information(context->value->shorts[0], context->player_idx,
+        context->value->ulongs[1], context->value->shorts[3], context->value->shorts[4]);
+}
+
+static void display_player_information_check(const struct ScriptLine* scline)
+{
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[1]);
+
+    long msg_num = scline->np[0];
+    if ((msg_num < 0) || (msg_num >= STRINGS_MAX))
     {
-        set_general_information(context->value->shorts[0],
-            context->value->ulongs[1], context->value->shorts[3], context->value->shorts[4]);
+        SCRPTERRLOG("Invalid TEXT number");
+        return;
     }
+
+    MapSubtlCoord x = 0, y = 0;
+    TbMapLocation location = 0;
+    const char* where = "ALL_PLAYERS";
+
+
+    if (scline->command == Cmd_DISPLAY_PLAYER_INFORMATION)
+    {
+        if (scline->tp[2][0] != '\0')
+        {
+            where = scline->tp[2];
+        }
+    }
+    else
+    {
+        x = scline->np[2];
+        y = scline->np[3];
+    }
+    if (!get_map_location_id(where, &location))
+    {
+        SCRPTERRLOG("Invalid location (%s)", scline->tp[2]);
+        return;
+    }
+
+    value->shorts[0] = msg_num;
+    value->ulongs[1] = location;
+    value->shorts[3] = x;
+    value->shorts[4] = y;
+    PROCESS_SCRIPT_VALUE(scline->command);
 }
 
 static void tag_map_rect_check(const struct ScriptLine* scline)
@@ -6620,6 +6689,23 @@ const struct CommandDesc command_desc[] = {
   {"DISPLAY_OBJECTIVE_WITH_POS",        "NNN     ", Cmd_DISPLAY_OBJECTIVE_WITH_POS, &display_objective_check, &display_objective_process},
   {"DISPLAY_INFORMATION",               "Nl      ", Cmd_DISPLAY_INFORMATION, &display_information_check, &display_information_process},
   {"DISPLAY_INFORMATION_WITH_POS",      "NNN     ", Cmd_DISPLAY_INFORMATION_WITH_POS, &display_information_check, &display_information_process},
+  {"DISPLAY_PLAYER_OBJECTIVE",          "NPl     ", Cmd_DISPLAY_PLAYER_OBJECTIVE, &display_player_objective_check, &display_objective_process},
+  {"DISPLAY_PLAYER_OBJECTIVE_WITH_POS", "NPNN    ", Cmd_DISPLAY_PLAYER_OBJECTIVE_WITH_POS, &display_player_objective_check, &display_objective_process},
+  {"DISPLAY_PLAYER_INFORMATION",        "NPl     ", Cmd_DISPLAY_PLAYER_INFORMATION, &display_player_information_check, &display_information_process},
+  {"DISPLAY_PLAYER_INFORMATION_WITH_POS", "NPNN    ", Cmd_DISPLAY_PLAYER_INFORMATION_WITH_POS, &display_player_information_check, &display_information_process},
+  {"QUICK_OBJECTIVE",                   "NAl     ", Cmd_QUICK_OBJECTIVE, &quick_objective_check, &quick_objective_process},
+  {"QUICK_OBJECTIVE_WITH_POS",          "NANN    ", Cmd_QUICK_OBJECTIVE_WITH_POS, &quick_objective_check, &quick_objective_process},
+  {"QUICK_INFORMATION",                 "NAl     ", Cmd_QUICK_INFORMATION, &quick_information_check, &quick_information_process},
+  {"QUICK_INFORMATION_WITH_POS",        "NANN    ", Cmd_QUICK_INFORMATION_WITH_POS, &quick_information_check, &quick_information_process},
+  {"QUICK_PLAYER_OBJECTIVE",            "NPAl    ", Cmd_QUICK_PLAYER_OBJECTIVE, &quick_player_objective_check, &quick_objective_process},
+  {"QUICK_PLAYER_OBJECTIVE_WITH_POS",   "NPANN   ", Cmd_QUICK_PLAYER_OBJECTIVE_WITH_POS, &quick_player_objective_check, &quick_objective_process},
+  {"QUICK_PLAYER_INFORMATION",          "NPAl    ", Cmd_QUICK_PLAYER_INFORMATION, &quick_player_information_check, &quick_information_process},
+  {"QUICK_PLAYER_INFORMATION_WITH_POS", "NPANN   ", Cmd_QUICK_PLAYER_INFORMATION_WITH_POS, &quick_player_information_check, &quick_information_process},
+  {"DISPLAY_MESSAGE",                   "NA      ", Cmd_DISPLAY_MESSAGE, &display_message_check, &display_message_process},
+  {"QUICK_MESSAGE",                     "NAA     ", Cmd_QUICK_MESSAGE, &quick_message_check, &quick_message_process},
+  {"CLEAR_MESSAGE",                     "n       ", Cmd_CLEAR_MESSAGE, &clear_message_check, &clear_message_process},
+  {"HEART_LOST_OBJECTIVE",              "Nl      ", Cmd_HEART_LOST_OBJECTIVE, &heart_lost_objective_check, &heart_lost_objective_process},
+  {"HEART_LOST_QUICK_OBJECTIVE",        "NAl     ", Cmd_HEART_LOST_QUICK_OBJECTIVE, &heart_lost_quick_objective_check, &heart_lost_quick_objective_process},
   {"ADD_TUNNELLER_PARTY_TO_LEVEL",      "PAAANNN ", Cmd_ADD_TUNNELLER_PARTY_TO_LEVEL, NULL, NULL},
   {"ADD_CREATURE_TO_POOL",              "CN      ", Cmd_ADD_CREATURE_TO_POOL, NULL, NULL},
   {"RESET_ACTION_POINT",                "Na      ", Cmd_RESET_ACTION_POINT, &reset_action_point_check, &reset_action_point_process},
@@ -6642,14 +6728,6 @@ const struct CommandDesc command_desc[] = {
   {"ALLY_PLAYERS",                      "PPN     ", Cmd_ALLY_PLAYERS, NULL, NULL},
   {"DEAD_CREATURES_RETURN_TO_POOL",     "B       ", Cmd_DEAD_CREATURES_RETURN_TO_POOL, NULL, NULL},
   {"BONUS_LEVEL_TIME",                  "Nb      ", Cmd_BONUS_LEVEL_TIME, NULL, NULL},
-  {"QUICK_OBJECTIVE",                   "NAl     ", Cmd_QUICK_OBJECTIVE, &quick_objective_check, &quick_objective_process},
-  {"QUICK_INFORMATION",                 "NAl     ", Cmd_QUICK_INFORMATION, &quick_information_check, &quick_information_process},
-  {"QUICK_OBJECTIVE_WITH_POS",          "NANN    ", Cmd_QUICK_OBJECTIVE_WITH_POS, &quick_objective_check, &quick_objective_process},
-  {"QUICK_INFORMATION_WITH_POS",        "NANN    ", Cmd_QUICK_INFORMATION_WITH_POS, &quick_information_check, &quick_information_process},
-  {"QUICK_PLAYER_OBJECTIVE",            "NPAl    ", Cmd_QUICK_PLAYER_OBJECTIVE, &quick_player_objective_check, &quick_objective_process},
-  {"QUICK_PLAYER_INFORMATION",          "NPAl    ", Cmd_QUICK_PLAYER_INFORMATION, &quick_player_information_check, &quick_information_process},
-  {"QUICK_PLAYER_OBJECTIVE_WITH_POS",   "NPANN   ", Cmd_QUICK_PLAYER_OBJECTIVE_WITH_POS, &quick_player_objective_check, &quick_objective_process},
-  {"QUICK_PLAYER_INFORMATION_WITH_POS", "NPANN   ", Cmd_QUICK_PLAYER_INFORMATION_WITH_POS, &quick_player_information_check, &quick_information_process},
   {"SWAP_CREATURE",                     "CC      ", Cmd_SWAP_CREATURE, &swap_creature_check, &swap_creature_process},
   {"PRINT",                             "A       ", Cmd_PRINT, NULL, NULL},
   {"MESSAGE",                           "A       ", Cmd_MESSAGE, NULL, NULL},
@@ -6704,9 +6782,6 @@ const struct CommandDesc command_desc[] = {
   {"CREATE_EFFECTS_LINE",               "LLNNNA  ", Cmd_CREATE_EFFECTS_LINE, &create_effects_line_check, &create_effects_line_process},
   {"IF_SLAB_OWNER",                     "NNP     ", Cmd_IF_SLAB_OWNER, NULL, NULL},
   {"IF_SLAB_TYPE",                      "NNS     ", Cmd_IF_SLAB_TYPE, NULL, NULL},
-  {"QUICK_MESSAGE",                     "NAA     ", Cmd_QUICK_MESSAGE, &quick_message_check, &quick_message_process},
-  {"DISPLAY_MESSAGE",                   "NA      ", Cmd_DISPLAY_MESSAGE, &display_message_check, &display_message_process},
-  {"CLEAR_MESSAGE",                     "n       ", Cmd_CLEAR_MESSAGE, &clear_message_check, &clear_message_process},
   {"USE_SPELL_ON_CREATURE",             "PC!AAn  ", Cmd_USE_SPELL_ON_CREATURE, &use_spell_on_creature_check, &use_spell_on_creature_process},
   {"USE_SPELL_ON_PLAYERS_CREATURES",    "PC!An   ", Cmd_USE_SPELL_ON_PLAYERS_CREATURES, &use_spell_on_players_creatures_check, &use_spell_on_players_creatures_process},
   {"SET_HEART_HEALTH",                  "PN      ", Cmd_SET_HEART_HEALTH, &set_heart_health_check, &set_heart_health_process},
@@ -6724,8 +6799,6 @@ const struct CommandDesc command_desc[] = {
   {"HIDE_VARIABLE",                     "        ", Cmd_HIDE_VARIABLE, &cmd_no_param_check, &hide_variable_process},
   {"CREATE_EFFECT",                     "AAn     ", Cmd_CREATE_EFFECT, &create_effect_check, &create_effect_process},
   {"CREATE_EFFECT_AT_POS",              "ANNn    ", Cmd_CREATE_EFFECT_AT_POS, &create_effect_at_pos_check, &create_effect_at_pos_process},
-  {"HEART_LOST_QUICK_OBJECTIVE",        "NAl     ", Cmd_HEART_LOST_QUICK_OBJECTIVE, &heart_lost_quick_objective_check, &heart_lost_quick_objective_process},
-  {"HEART_LOST_OBJECTIVE",              "Nl      ", Cmd_HEART_LOST_OBJECTIVE, &heart_lost_objective_check, &heart_lost_objective_process},
   {"SET_DOOR",                          "ANN     ", Cmd_SET_DOOR, &set_door_check, &set_door_process},
   {"PLACE_DOOR",                        "PANNb!b!", Cmd_PLACE_DOOR, &place_door_check, &place_door_process},
   {"PLACE_TRAP",                        "PANNb!  ", Cmd_PLACE_TRAP, &place_trap_check, &place_trap_process },

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -1053,7 +1053,7 @@ static void quick_player_information_check(const struct ScriptLine* scline)
 
     if (scline->command == Cmd_QUICK_PLAYER_INFORMATION)
     {
-        if (scline->tp[2][0] != '\0')
+        if (scline->tp[3][0] != '\0')
         {
             where = scline->tp[3];
         }
@@ -1065,7 +1065,7 @@ static void quick_player_information_check(const struct ScriptLine* scline)
     }
     if (!get_map_location_id(where, &location))
     {
-        SCRPTERRLOG("Invalid location (%s)", scline->tp[2]);
+        SCRPTERRLOG("Invalid location (%s)", scline->tp[3]);
         return;
     }
 

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -892,6 +892,58 @@ static void quick_objective_process(struct ScriptContext* context)
     }
 }
 
+
+static void quick_player_objective_check(const struct ScriptLine* scline)
+{
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[1]);
+
+    int16_t idx = scline->np[0];
+    if ((idx < 0) || (idx >= QUICK_MESSAGES_COUNT))
+    {
+        SCRPTERRLOG("Invalid objective ID number (%d)", idx);
+        return;
+    }
+    const char* msgtext = scline->tp[2];
+
+    if (strlen(msgtext) >= MESSAGE_TEXT_LEN)
+    {
+        SCRPTWRNLOG("Objective TEXT too long; truncating to %d characters", MESSAGE_TEXT_LEN - 1);
+    }
+    if ((game.quick_messages[idx][0] != '\0') && (strcmp(game.quick_messages[idx], msgtext) != 0))
+    {
+        SCRPTWRNLOG("Quick Message no %d overwritten by different text", idx);
+    }
+    MapSubtlCoord x = 0, y = 0;
+    TbMapLocation location = 0;
+    const char* where = "ALL_PLAYERS";
+
+    snprintf(game.quick_messages[idx], MESSAGE_TEXT_LEN, "%s", msgtext);
+
+    if (scline->command == Cmd_QUICK_PLAYER_OBJECTIVE)
+    {
+        if (scline->tp[3][0] != '\0')
+        {
+            where = scline->tp[3];
+        }
+    }
+    else
+    {
+        x = scline->np[3];
+        y = scline->np[4];
+    }
+    if (!get_map_location_id(where, &location))
+    {
+        SCRPTERRLOG("Invalid location (%s)", scline->tp[3]);
+        return;
+    }
+
+    value->shorts[0] = idx;
+    value->ulongs[1] = location;
+    value->shorts[3] = x;
+    value->shorts[4] = y;
+    PROCESS_SCRIPT_VALUE(scline->command);
+}
+
 static void quick_information_check(const struct ScriptLine* scline)
 {
     ALLOCATE_SCRIPT_VALUE(scline->command, ALL_PLAYERS);
@@ -6552,6 +6604,7 @@ const struct CommandDesc command_desc[] = {
   {"QUICK_INFORMATION",                 "NAl     ", Cmd_QUICK_INFORMATION, &quick_information_check, &quick_information_process},
   {"QUICK_OBJECTIVE_WITH_POS",          "NANN    ", Cmd_QUICK_OBJECTIVE_WITH_POS, &quick_objective_check, &quick_objective_process},
   {"QUICK_INFORMATION_WITH_POS",        "NANN    ", Cmd_QUICK_INFORMATION_WITH_POS, &quick_information_check, &quick_information_process},
+  {"QUICK_PLAYER_OBJECTIVE",            "NPAl    ", Cmd_QUICK_PLAYER_OBJECTIVE, &quick_player_objective_check, &quick_objective_process},
   {"SWAP_CREATURE",                     "CC      ", Cmd_SWAP_CREATURE, &swap_creature_check, &swap_creature_process},
   {"PRINT",                             "A       ", Cmd_PRINT, NULL, NULL},
   {"MESSAGE",                           "A       ", Cmd_MESSAGE, NULL, NULL},

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -824,13 +824,11 @@ static void display_objective_check(const struct ScriptLine *scline)
 
 static void display_objective_process(struct ScriptContext *context)
 {
-    if (my_player_number == context->player_idx)
-    {
-        set_general_objective(context->value->shorts[0],
-        context->value->ulongs[1],
-        context->value->shorts[3],
-        context->value->shorts[4]);
-    }
+    set_general_objective(context->value->shorts[0],
+    context->player_idx,
+    context->value->ulongs[1],
+    context->value->shorts[3],
+    context->value->shorts[4]);
 }
 
 static void quick_objective_check(const struct ScriptLine* scline)
@@ -886,12 +884,8 @@ static void quick_objective_check(const struct ScriptLine* scline)
 
 static void quick_objective_process(struct ScriptContext* context)
 {
-    if (my_player_number == context->player_idx)
-    {
-        process_objective(game.quick_messages[context->value->shorts[0] % QUICK_MESSAGES_COUNT],context->value->ulongs[1], context->value->shorts[3], context->value->shorts[4]);
-    }
+    process_objective(game.quick_messages[context->value->shorts[0] % QUICK_MESSAGES_COUNT],context->player_idx, context->value->ulongs[1], context->value->shorts[3], context->value->shorts[4]);
 }
-
 
 static void quick_player_objective_check(const struct ScriptLine* scline)
 {
@@ -997,10 +991,58 @@ static void quick_information_check(const struct ScriptLine* scline)
 
 static void quick_information_process(struct ScriptContext* context)
 {
-    if (my_player_number == context->player_idx)
+    set_quick_information(context->value->shorts[0], context->player_idx, context->value->ulongs[1], context->value->shorts[3], context->value->shorts[4]);
+}
+
+static void quick_player_information_check(const struct ScriptLine* scline)
+{
+    ALLOCATE_SCRIPT_VALUE(scline->command, scline->np[1]);
+
+    int16_t idx = scline->np[0];
+    if ((idx < 0) || (idx >= QUICK_MESSAGES_COUNT))
     {
-        set_quick_information(context->value->shorts[0], context->value->ulongs[1], context->value->shorts[3], context->value->shorts[4]);
+        SCRPTERRLOG("Invalid information ID number (%d)", idx);
+        return;
     }
+    const char* msgtext = scline->tp[2];
+
+    if (strlen(msgtext) >= MESSAGE_TEXT_LEN)
+    {
+        SCRPTWRNLOG("Information TEXT too long; truncating to %d characters", MESSAGE_TEXT_LEN - 1);
+    }
+    if ((game.quick_messages[idx][0] != '\0') && (strcmp(game.quick_messages[idx], msgtext) != 0))
+    {
+        SCRPTWRNLOG("Quick Message no %d overwritten by different text", idx);
+    }
+    MapSubtlCoord x = 0, y = 0;
+    TbMapLocation location = 0;
+    const char* where = "ALL_PLAYERS";
+
+    snprintf(game.quick_messages[idx], MESSAGE_TEXT_LEN, "%s", msgtext);
+
+    if (scline->command == Cmd_QUICK_PLAYER_INFORMATION)
+    {
+        if (scline->tp[2][0] != '\0')
+        {
+            where = scline->tp[3];
+        }
+    }
+    else
+    {
+        x = scline->np[3];
+        y = scline->np[4];
+    }
+    if (!get_map_location_id(where, &location))
+    {
+        SCRPTERRLOG("Invalid location (%s)", scline->tp[2]);
+        return;
+    }
+
+    value->shorts[0] = idx;
+    value->ulongs[1] = location;
+    value->shorts[3] = x;
+    value->shorts[4] = y;
+    PROCESS_SCRIPT_VALUE(scline->command);
 }
 
 static void display_information_check(const struct ScriptLine* scline)
@@ -6605,6 +6647,9 @@ const struct CommandDesc command_desc[] = {
   {"QUICK_OBJECTIVE_WITH_POS",          "NANN    ", Cmd_QUICK_OBJECTIVE_WITH_POS, &quick_objective_check, &quick_objective_process},
   {"QUICK_INFORMATION_WITH_POS",        "NANN    ", Cmd_QUICK_INFORMATION_WITH_POS, &quick_information_check, &quick_information_process},
   {"QUICK_PLAYER_OBJECTIVE",            "NPAl    ", Cmd_QUICK_PLAYER_OBJECTIVE, &quick_player_objective_check, &quick_objective_process},
+  {"QUICK_PLAYER_INFORMATION",          "NPAl    ", Cmd_QUICK_PLAYER_INFORMATION, &quick_player_information_check, &quick_information_process},
+  {"QUICK_PLAYER_OBJECTIVE_WITH_POS",   "NPANN   ", Cmd_QUICK_PLAYER_OBJECTIVE_WITH_POS, &quick_player_objective_check, &quick_objective_process},
+  {"QUICK_PLAYER_INFORMATION_WITH_POS", "NPANN   ", Cmd_QUICK_PLAYER_INFORMATION_WITH_POS, &quick_player_information_check, &quick_information_process},
   {"SWAP_CREATURE",                     "CC      ", Cmd_SWAP_CREATURE, &swap_creature_check, &swap_creature_process},
   {"PRINT",                             "A       ", Cmd_PRINT, NULL, NULL},
   {"MESSAGE",                           "A       ", Cmd_MESSAGE, NULL, NULL},

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -197,10 +197,14 @@ enum TbScriptCommands {
     Cmd_SHOW_BONUS_LEVEL                   = 185,
     Cmd_HIDE_BONUS_LEVEL                   = 186,
     Cmd_HIDE_HERO_GATE                     = 187,
-    Cmd_QUICK_PLAYER_OBJECTIVE             = 188,
-    Cmd_QUICK_PLAYER_INFORMATION           = 189,
-    Cmd_QUICK_PLAYER_OBJECTIVE_WITH_POS    = 190,
-    Cmd_QUICK_PLAYER_INFORMATION_WITH_POS  = 191,
+    Cmd_DISPLAY_PLAYER_OBJECTIVE           = 188,
+    Cmd_DISPLAY_PLAYER_INFORMATION         = 189,
+    Cmd_DISPLAY_PLAYER_OBJECTIVE_WITH_POS  = 190,
+    Cmd_DISPLAY_PLAYER_INFORMATION_WITH_POS  = 191,
+    Cmd_QUICK_PLAYER_OBJECTIVE             = 192,
+    Cmd_QUICK_PLAYER_INFORMATION           = 193,
+    Cmd_QUICK_PLAYER_OBJECTIVE_WITH_POS    = 194,
+    Cmd_QUICK_PLAYER_INFORMATION_WITH_POS  = 195,
 };
 
 struct ScriptLine {

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -198,6 +198,9 @@ enum TbScriptCommands {
     Cmd_HIDE_BONUS_LEVEL                   = 186,
     Cmd_HIDE_HERO_GATE                     = 187,
     Cmd_QUICK_PLAYER_OBJECTIVE             = 188,
+    Cmd_QUICK_PLAYER_INFORMATION           = 189,
+    Cmd_QUICK_PLAYER_OBJECTIVE_WITH_POS    = 190,
+    Cmd_QUICK_PLAYER_INFORMATION_WITH_POS  = 191,
 };
 
 struct ScriptLine {

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -197,6 +197,7 @@ enum TbScriptCommands {
     Cmd_SHOW_BONUS_LEVEL                   = 185,
     Cmd_HIDE_BONUS_LEVEL                   = 186,
     Cmd_HIDE_HERO_GATE                     = 187,
+    Cmd_QUICK_PLAYER_OBJECTIVE             = 188,
 };
 
 struct ScriptLine {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1912,15 +1912,12 @@ void set_general_information(long msg_id, TbMapLocation target, MapSubtlCoord x,
     event_create_event(pos_x, pos_y, EvKind_Information, player->id_number, -msg_id);
 }
 
-void set_quick_information(long msg_id, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y)
+void set_quick_information(long msg_id, PlayerNumber plyr_idx, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y)
 {
-    struct PlayerInfo *player;
-    long pos_x;
-    long pos_y;
-    player = get_my_player();
-    find_map_location_coords(target, &x, &y, my_player_number, __func__);
-    pos_x = 0;
-    pos_y = 0;
+    struct PlayerInfo *player = get_player(plyr_idx);
+    long pos_x = 0;
+    long pos_y = 0;
+    find_map_location_coords(target, &x, &y, plyr_idx, __func__);
     if ((x != 0) || (y != 0))
     {
         pos_y = subtile_coord_center(y);
@@ -1929,22 +1926,17 @@ void set_quick_information(long msg_id, TbMapLocation target, MapSubtlCoord x, M
     event_create_event(pos_x, pos_y, EvKind_QuickInformation, player->id_number, -msg_id);
 }
 
-void set_general_objective(long msg_id, TbMapLocation target, long x, long y)
+void set_general_objective(long msg_id, PlayerNumber plyr_idx, TbMapLocation target, long x, long y)
 {
-    process_objective(get_string(msg_id), target, x, y);
+    process_objective(get_string(msg_id), plyr_idx, target, x, y);
 }
 
-void process_objective(const char *msg_text, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y)
+void process_objective(const char *msg_text, PlayerNumber plyr_idx, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y)
 {
-    struct PlayerInfo *player;
-    MapSubtlCoord pos_x;
-    MapSubtlCoord pos_y;
-    player = get_my_player();
-    find_map_location_coords(target, &x, &y, my_player_number, __func__);
-    pos_y = y;
-    pos_x = x;
-    set_level_objective(msg_text);
-    display_objectives(player->id_number, pos_x, pos_y);
+    struct PlayerInfo *player = get_player(plyr_idx);
+    find_map_location_coords(target, &x, &y, plyr_idx, __func__);
+    set_level_objective(player->id_number, msg_text);
+    display_objectives(player->id_number, x, y);
 }
 
 short winning_player_quitting(struct PlayerInfo *player, int32_t *plyr_count)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1895,15 +1895,12 @@ void level_lost_go_first_person(PlayerNumber plyr_idx)
     SYNCDBG(8,"Finished");
 }
 
-void set_general_information(long msg_id, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y)
+void set_general_information(long msg_id, PlayerNumber plyr_idx, TbMapLocation target, MapSubtlCoord x, MapSubtlCoord y)
 {
-    struct PlayerInfo *player;
-    long pos_x;
-    long pos_y;
-    player = get_my_player();
-    find_map_location_coords(target, &x, &y, my_player_number, __func__);
-    pos_x = 0;
-    pos_y = 0;
+    struct PlayerInfo *player = get_player(plyr_idx);
+    long pos_x = 0;
+    long pos_y = 0;
+    find_map_location_coords(target, &x, &y, plyr_idx, __func__);
     if ((x != 0) || (y != 0))
     {
         pos_y = subtile_coord_center(y);

--- a/src/map_events.c
+++ b/src/map_events.c
@@ -409,7 +409,7 @@ void go_on_then_activate_the_event_box(PlayerNumber plyr_idx, EventIndex evidx)
             break;
         case EvKind_Objective:
         {
-            strcpy(game.evntbox_scroll_window.text, game.evntbox_text_objective);
+            strcpy(game.evntbox_scroll_window.text, game.evntbox_text_objective[plyr_idx]);
             int k;
             for (i = EVENT_BUTTONS_COUNT; i >= 0; i--)
             {
@@ -811,7 +811,7 @@ void clear_events(void)
     }
     memset(&game.evntbox_scroll_window, 0, sizeof(struct TextScrollWindow));
     memset(&game.evntbox_text_buffer, 0, MESSAGE_TEXT_LEN);
-    memset(&game.evntbox_text_objective, 0, MESSAGE_TEXT_LEN);
+    memset(&game.evntbox_text_objective, 0, sizeof(game.evntbox_text_objective));
     for (i=0; i < 5; i++)
     {
       memset(&game.bookmark[i], 0, sizeof(struct Bookmark));


### PR DESCRIPTION
Implemented these script commands:

- DISPLAY_PLAYER_OBJECTIVE
- DISPLAY_PLAYER_INFORMATION
- DISPLAY_PLAYER_OBJECTIVE_WITH_POS
- DISPLAY_PLAYER_INFORMATION_WITH_POS 
- QUICK_PLAYER_OBJECTIVE
- QUICK_PLAYER_INFORMATION
- QUICK_PLAYER_OBJECTIVE_WITH_POS
- QUICK_PLAYER_INFORMATION_WITH_POS

Example: 
```
QUICK_PLAYER_OBJECTIVE(1,PLAYER0,"You would do well to target the blue player",PLAYER1)
QUICK_PLAYER_OBJECTIVE(2,PLAYER1,"Red has it out for you, convert the heroes to be unstoppable",-3)
```