### PR TITLE
Display a Coop flag on Coop multiplayer maps

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -93,6 +93,7 @@ enum Ensigns {
     EnsDisMulti2    = 46,
     EnsDisMulti3    = 47,
     EnsDisMulti4    = 48,
+    EnsCoop         = 49,
 };
 
 enum TbLevelState {

--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -94,6 +94,7 @@ const struct NamedCommand cmpgn_map_ensign_flag_options[] = {
   {"BONUS",           EnsBonus},
   {"FULL_MOON",       EnsFullMoon},
   {"NEW_MOON",        EnsNewMoon},
+  {"COOP",            EnsCoop},
   {NULL,              0},
   };
 

--- a/src/front_landview.c
+++ b/src/front_landview.c
@@ -395,6 +395,10 @@ const struct TbSprite *get_ensign_sprite_for_level(struct LevelInformation *lvin
             }
             if ((fe_net_level_selected == lvinfo->lvnum) || (net_level_hilighted == lvinfo->lvnum))
                 ensign_sprite_index++;
+            if (lvinfo->ensign_type == EnsCoop)
+            {
+                ensign_sprite_index = ensign_sprite_index + 6;
+            }
         }
         else
         {


### PR DESCRIPTION
Goes with https://github.com/dkfans/FXGraphics/pull/114
To display it, have `ENSIGN = COOP` in the .lof file of the map.