### PR TITLE
Fix Steam API startup for some scenarios 

### DIFF
--- a/src/steam_api.cpp
+++ b/src/steam_api.cpp
@@ -143,11 +143,21 @@ int steam_api_init()
     SteamErrMsg error;
     ESteamAPIInitResult result = SteamAPI_Init(&error);
 
-    // Check if initialization is successful
-    if (result != ESteamAPIInitResult::k_ESteamAPIInitResult_OK)
-    {
-        ERRORLOG("Steam API Failure: %s", error);
+    // Check if initialization was successful
+    if(result == ESteamAPIInitResult::k_ESteamAPIInitResult_OK) {
+        JUSTLOG("Steam API connected");
+    } else {
+        if(result == ESteamAPIInitResult::k_ESteamAPIInitResult_NoSteamClient) {
+            JUSTLOG("Cannot connect to the Steam client. Steam is probably not running");
+        } else if(result == ESteamAPIInitResult::k_ESteamAPIInitResult_VersionMismatch) {
+            WARNLOG("Steam API version mismatch. Steam client appears to be out of date");
+        } else {
+            ERRORLOG("Steam API Failure: %s", error);
+        }
         FreeLibrary(steam_lib);
+        steam_lib = nullptr;
+        SteamAPI_Init = nullptr;
+        SteamAPI_Shutdown = nullptr;
         return 1;
     }
 

--- a/src/steam_api.cpp
+++ b/src/steam_api.cpp
@@ -175,20 +175,15 @@ void steam_api_shutdown()
 {
 #ifdef _WIN32
 
-    JUSTLOG("Shutting down Steam API");
-
     if (SteamAPI_Shutdown != nullptr) {
+        JUSTLOG("Shutting down Steam API");
         SteamAPI_Shutdown();
-    } else {
-        WARNLOG("Steam API could not be shut down. SteamAPI_Shutdown() is a null pointer");
     }
 
     // Unload the Steam DLL
     if (steam_lib != nullptr) {
         FreeLibrary(steam_lib);
         steam_lib = nullptr;
-    } else {
-        WARNLOG("Steam API library could not be unloaded");
     }
 
     // Reset function pointers


### PR DESCRIPTION
Improves the Steam API startup to handle when Steam is not running or when Steam is out of date. 

Also removes the earlier added logs when shutting down because we might have already unloaded the API during startup.