### PR TITLE
Optimize annoyance processing for Eat Food

### DIFF
--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -160,7 +160,7 @@ TortureTime = 50
 
 [annoyance]
 ; How many anger points are generated while doing various tasks. Use negative value to reduce annoyance.
-; Whenever the creature eats. As food(It means <0), happiness can only be obtained when a creature is hungry. But for those who dislike it(It means >0), every time is torture.
+; Whenever the creature eats. Negative values(getting happy) only apply when the creature is actually hungry when eating.
 EatFood = 0
 ; Whenever the creature is dropped on a room if the job is defined in 'NotDoJobs'.
 WillNotDoJob = 0

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -160,7 +160,7 @@ TortureTime = 50
 
 [annoyance]
 ; How many anger points are generated while doing various tasks. Use negative value to reduce annoyance.
-; Whenever the creature eats.
+; Whenever the creature eats. As food(It means <0), happiness can only be obtained when a creature is hungry. But for those who dislike it(It means >0), every time is torture.
 EatFood = 0
 ; Whenever the creature is dropped on a room if the job is defined in 'NotDoJobs'.
 WillNotDoJob = 0

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -837,8 +837,12 @@ long instf_eat(struct Thing *creatng, int32_t *param)
 {
     TRACE_THING(creatng);
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
-    if (cctrl->hunger_amount > 0)
+    if (cctrl->hunger_amount > 0) {
         cctrl->hunger_amount--;
+    } else
+    if (cctrl->hunger_loss < 255) {
+        cctrl->hunger_loss++;
+    }
     apply_health_to_thing_and_display_health(creatng, game.conf.rules[creatng->owner].health.food_health_gain);
     cctrl->hunger_level = 0;
     return 1;

--- a/src/creature_states_gardn.c
+++ b/src/creature_states_gardn.c
@@ -83,11 +83,10 @@ void person_eat_food(struct Thing *creatng, struct Thing *foodtng, struct Room *
     creatng->continue_state = CrSt_CreatureToGarden;
     {
         // TODO ANGER Maybe better either zero the hunger anger or apply annoy_eat_food points, based on the annoy_eat_food value?
-        /*struct CreatureModelConfig *crconf;
-        crconf = creature_stats_get_from_thing(creatng);
-        anger_apply_anger_to_creature(creatng, crconf->annoy_eat_food, AngR_Other, 1);*/
         struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
-        anger_apply_anger_to_creature(creatng, -cctrl->annoyance_level[AngR_Hungry], AngR_Hungry, 1);
+        anger_apply_anger_to_creature(creatng, -cctrl->annoyance_level[AngR_Hungry], AngR_Hungry, 0); // `annoyance_level[AngR_Hungry]` value may be large, so no extend other
+        struct CreatureModelConfig *crconf = creature_stats_get_from_thing(creatng);
+        anger_apply_anger_to_creature(creatng, crconf->annoy_eat_food, AngR_Other, 1);
     }
     if (thing_is_creature(foodtng))
     {

--- a/src/creature_states_gardn.c
+++ b/src/creature_states_gardn.c
@@ -29,6 +29,7 @@
 #include "creature_instances.h"
 #include "creature_states.h"
 #include "creature_states_prisn.h"
+#include "creature_states_mood.h"
 #include "game_legacy.h"
 #include "gui_soundmsgs.h"
 #include "lua_triggers.h"
@@ -75,18 +76,24 @@ TbBool hunger_is_creature_hungry(const struct Thing *creatng)
     return ((crconf->hunger_rate != 0) && (cctrl->hunger_level > crconf->hunger_rate));
 }
 
+/*
+ * Creatures actively feeding in the Hatchery
+ */
 void person_eat_food(struct Thing *creatng, struct Thing *foodtng, struct Room *room)
 {
+    struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
+    long old_hunger_level = cctrl->hunger_level;
     thing_play_sample(creatng, 112+SOUND_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
     internal_set_thing_state(creatng, CrSt_CreatureEat);
     set_creature_instance(creatng, CrInst_EAT, 0, 0);
     creatng->continue_state = CrSt_CreatureToGarden;
     {
-        // TODO ANGER Maybe better either zero the hunger anger or apply annoy_eat_food points, based on the annoy_eat_food value?
-        struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
-        anger_apply_anger_to_creature(creatng, -cctrl->annoyance_level[AngR_Hungry], AngR_Hungry, 0); // `annoyance_level[AngR_Hungry]` value may be large, so no extend other
+        anger_set_creature_anger(creatng, 0, AngR_Hungry);
         struct CreatureModelConfig *crconf = creature_stats_get_from_thing(creatng);
-        anger_apply_anger_to_creature(creatng, crconf->annoy_eat_food, AngR_Other, 1);
+        if (crconf->annoy_eat_food > 0 || old_hunger_level > (long)crconf->hunger_rate) {
+            // As food(It means <0), happiness can only be obtained when a creature is hungry. But for those who dislike it(It means >0), every time is torture.
+            anger_apply_anger_to_creature(creatng, crconf->annoy_eat_food, AngR_Other, 1);
+        }
     }
     if (thing_is_creature(foodtng))
     {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -628,8 +628,11 @@ void food_eaten_by_creature(struct Thing *foodtng, struct Thing *creatng)
     }
     // Food is destroyed just below, so the sound must be made by creature
     thing_play_sample(creatng, 112+SOUND_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+
+    anger_apply_anger_to_creature(creatng, -cctrl->annoyance_level[AngR_Hungry], AngR_Hungry, 0); // `annoyance_level[AngR_Hungry]` value may be large, so no extend other
     struct CreatureModelConfig* crconf = creature_stats_get_from_thing(creatng);
-    anger_apply_anger_to_creature(creatng, crconf->annoy_eat_food, AngR_Hungry, 1);
+    anger_apply_anger_to_creature(creatng, crconf->annoy_eat_food, AngR_Other, 1);
+
     struct Dungeon* dungeon = get_players_num_dungeon(creatng->owner);
     if (!dungeon_invalid(dungeon)) {
         dungeon->lvstats.chickens_eaten++;
@@ -643,7 +646,7 @@ void food_eaten_by_creature(struct Thing *foodtng, struct Thing *creatng)
     }
 }
 
-void anger_apply_anger_to_creature_f(struct Thing *creatng, long anger, AnnoyMotive reason, long a3, const char *func_name)
+void anger_apply_anger_to_creature_f(struct Thing *creatng, long anger, AnnoyMotive reason, long should_extend_other, const char *func_name)
 {
     SYNCDBG(17,"The %s index %d owner %d will be applied with %d anger",
         thing_model_name(creatng),(int)creatng->index,(int)creatng->owner,(int)anger);
@@ -653,7 +656,7 @@ void anger_apply_anger_to_creature_f(struct Thing *creatng, long anger, AnnoyMot
     if (anger > 0)
     {
         anger_increase_creature_anger_f(creatng, anger, reason, func_name);
-        if (reason != AngR_Other)
+        if (reason != AngR_Other && should_extend_other != 0)
         {
             if (anger_free_for_anger_increase(creatng))
             {
@@ -665,7 +668,7 @@ void anger_apply_anger_to_creature_f(struct Thing *creatng, long anger, AnnoyMot
     if (anger < 0)
     {
         anger_reduce_creature_anger_f(creatng, anger, reason, func_name);
-        if (reason == AngR_Other)
+        if (reason == AngR_Other && should_extend_other != 0)
         {
             long angrpart = 32 * anger / 256;
             for (AnnoyMotive reaspart = 1; reaspart < AngR_Other; reaspart++)

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -609,9 +609,13 @@ TbBool set_creature_door_combat(struct Thing *creatng, struct Thing *obthing)
     return true;
 }
 
+/*
+ * hand-feeding, or creatures picking up nearby food randomly
+ */
 void food_eaten_by_creature(struct Thing *foodtng, struct Thing *creatng)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
+    long old_hunger_level = cctrl->hunger_level;
     if (cctrl->instance_id == CrInst_NULL)
     {
         set_creature_instance(creatng, CrInst_EAT, 0, 0);
@@ -629,9 +633,12 @@ void food_eaten_by_creature(struct Thing *foodtng, struct Thing *creatng)
     // Food is destroyed just below, so the sound must be made by creature
     thing_play_sample(creatng, 112+SOUND_RANDOM(3), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
 
-    anger_apply_anger_to_creature(creatng, -cctrl->annoyance_level[AngR_Hungry], AngR_Hungry, 0); // `annoyance_level[AngR_Hungry]` value may be large, so no extend other
+    anger_set_creature_anger(creatng, 0, AngR_Hungry);
     struct CreatureModelConfig* crconf = creature_stats_get_from_thing(creatng);
-    anger_apply_anger_to_creature(creatng, crconf->annoy_eat_food, AngR_Other, 1);
+    if (crconf->annoy_eat_food > 0 || old_hunger_level > (long)crconf->hunger_rate) {
+        // As food(It means <0), happiness can only be obtained when a creature is hungry. But for those who dislike it(It means >0), every time is torture.
+        anger_apply_anger_to_creature(creatng, crconf->annoy_eat_food, AngR_Other, 1);
+    }
 
     struct Dungeon* dungeon = get_players_num_dungeon(creatng->owner);
     if (!dungeon_invalid(dungeon)) {
@@ -646,7 +653,7 @@ void food_eaten_by_creature(struct Thing *foodtng, struct Thing *creatng)
     }
 }
 
-void anger_apply_anger_to_creature_f(struct Thing *creatng, long anger, AnnoyMotive reason, long should_extend_other, const char *func_name)
+void anger_apply_anger_to_creature_f(struct Thing *creatng, long anger, AnnoyMotive reason, long a3, const char *func_name)
 {
     SYNCDBG(17,"The %s index %d owner %d will be applied with %d anger",
         thing_model_name(creatng),(int)creatng->index,(int)creatng->owner,(int)anger);
@@ -656,7 +663,7 @@ void anger_apply_anger_to_creature_f(struct Thing *creatng, long anger, AnnoyMot
     if (anger > 0)
     {
         anger_increase_creature_anger_f(creatng, anger, reason, func_name);
-        if (reason != AngR_Other && should_extend_other != 0)
+        if (reason != AngR_Other)
         {
             if (anger_free_for_anger_increase(creatng))
             {
@@ -668,7 +675,7 @@ void anger_apply_anger_to_creature_f(struct Thing *creatng, long anger, AnnoyMot
     if (anger < 0)
     {
         anger_reduce_creature_anger_f(creatng, anger, reason, func_name);
-        if (reason == AngR_Other && should_extend_other != 0)
+        if (reason == AngR_Other)
         {
             long angrpart = 32 * anger / 256;
             for (AnnoyMotive reaspart = 1; reaspart < AngR_Other; reaspart++)

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -123,8 +123,8 @@ unsigned int get_creature_blocked_flags_at(struct Thing *thing, struct Coord3d *
 struct Thing *get_enemy_soul_container_creature_can_see(struct Thing *thing);
 TbBool thing_can_be_eaten(struct Thing *thing);
 void food_eaten_by_creature(struct Thing *foodtng, struct Thing *creatng);
-void anger_apply_anger_to_creature_f(struct Thing *thing, long anger, AnnoyMotive reason, long should_extend_other, const char *func_name);
-#define anger_apply_anger_to_creature(thing, anger, reason, should_extend_other) anger_apply_anger_to_creature_f(thing, anger, reason, should_extend_other, __func__)
+void anger_apply_anger_to_creature_f(struct Thing *thing, long anger, AnnoyMotive reason, long a3, const char *func_name);
+#define anger_apply_anger_to_creature(thing, anger, reason, a3) anger_apply_anger_to_creature_f(thing, anger, reason, a3, __func__)
 HitPoints apply_damage_to_thing_and_display_health(struct Thing *thing, HitPoints dmg, PlayerNumber inflicting_plyr_idx);
 void process_creature_standing_on_corpses_at(struct Thing *thing, struct Coord3d *pos);
 long creature_instance_has_reset(const struct Thing *thing, long a2);

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -123,8 +123,8 @@ unsigned int get_creature_blocked_flags_at(struct Thing *thing, struct Coord3d *
 struct Thing *get_enemy_soul_container_creature_can_see(struct Thing *thing);
 TbBool thing_can_be_eaten(struct Thing *thing);
 void food_eaten_by_creature(struct Thing *foodtng, struct Thing *creatng);
-void anger_apply_anger_to_creature_f(struct Thing *thing, long anger, AnnoyMotive reason, long a3, const char *func_name);
-#define anger_apply_anger_to_creature(thing, anger, reason, a3) anger_apply_anger_to_creature_f(thing, anger, reason, a3, __func__)
+void anger_apply_anger_to_creature_f(struct Thing *thing, long anger, AnnoyMotive reason, long should_extend_other, const char *func_name);
+#define anger_apply_anger_to_creature(thing, anger, reason, should_extend_other) anger_apply_anger_to_creature_f(thing, anger, reason, should_extend_other, __func__)
 HitPoints apply_damage_to_thing_and_display_health(struct Thing *thing, HitPoints dmg, PlayerNumber inflicting_plyr_idx);
 void process_creature_standing_on_corpses_at(struct Thing *thing, struct Coord3d *pos);
 long creature_instance_has_reset(const struct Thing *thing, long a2);


### PR DESCRIPTION
1. Fix: Feeding 40 chicks to Horny incorrectly triggers `Your creatures are upset because they are hungry`.
2. Prevent hungry-angry creatures from receiving significant recovery in other annoyance categories after being fed.