### PR TITLE
New mappack/campaign launch arguments

### DIFF
--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -1126,46 +1126,52 @@ TbBool load_campaign(const char *cmpgn_fname,struct GameCampaign *campgn,unsigne
     return result;
 }
 
+uint8_t prepare_campaign_file_name(const char *cmpgn_fname, char *cmpgn_file, int cmpgn_file_len)
+{
+    cmpgn_file[0] = '\0';
+    if (cmpgn_fname == NULL)
+        return CampgnT_Default;
+    uint8_t pack = CampgnT_Default;
+    if (strncasecmp(cmpgn_fname, "campgns/", 8) == 0) {
+        pack = CampgnT_Campaign;
+        cmpgn_fname += 8;
+    } else if (strncasecmp(cmpgn_fname, "levels/", 7) == 0) {
+        pack = CampgnT_Mappack;
+        cmpgn_fname += 7;
+    } else if (strncasecmp(cmpgn_fname, "multiplayer/", 12) == 0) {
+        pack = CampgnT_MultiplayerMappack;
+        cmpgn_fname += 12;
+    }
+    snprintf(cmpgn_file, cmpgn_file_len, "%s", cmpgn_fname);
+    int len = strlen(cmpgn_file);
+    if ((len > 0) && ((len < 4) || (strcasecmp(cmpgn_file + len - 4, ".cfg") != 0)))
+        str_append(cmpgn_file, cmpgn_file_len, ".cfg");
+    return pack;
+}
+
 TbBool change_campaign(uint8_t pack, const char *cmpgn_fname)
 {
     static short campaign_fgroup = FGrp_None;
     SYNCDBG(8,"Starting");
+    char cmpgn_file[DISKPATH_SIZE];
+    uint8_t prefix_pack = prepare_campaign_file_name(cmpgn_fname, cmpgn_file, sizeof(cmpgn_file));
+    if (prefix_pack != CampgnT_Default)
+        pack = prefix_pack;
     short fgroup = FGrp_None;
-    switch (pack) {
-    case CampgnT_Mappack:
-        if (is_campaign_in_list(cmpgn_fname, &mappacks_list)) {
-            fgroup = FGrp_VarLevels;
-        }
-        break;
-    case CampgnT_Campaign:
-        if (is_campaign_in_list(cmpgn_fname, &campaigns_list)) {
-            fgroup = FGrp_Campgn;
-        }
-        break;
-    case CampgnT_MultiplayerMappack:
-        if (is_campaign_in_list(cmpgn_fname, &mp_mappacks_list)) {
-            fgroup = FGrp_MpLevels;
-        }
-        break;
-    case CampgnT_Default:
-    default:
-        if (is_campaign_in_list(cmpgn_fname, &campaigns_list)) {
-            fgroup = FGrp_Campgn;
-        } else if (is_campaign_in_list(cmpgn_fname, &mappacks_list)) {
-            fgroup = FGrp_VarLevels;
-        } else if (is_campaign_in_list(cmpgn_fname, &mp_mappacks_list)) {
-            fgroup = FGrp_MpLevels;
-        }
-        break;
-    }
-    if ((fgroup != FGrp_None) && (campaign_fgroup == fgroup) && (strcasecmp(campaign.fname,cmpgn_fname) == 0)) {
+    if (((pack == CampgnT_Campaign) || (pack == CampgnT_Default)) && is_campaign_in_list(cmpgn_file, &campaigns_list))
+        fgroup = FGrp_Campgn;
+    else if (((pack == CampgnT_Mappack) || (pack == CampgnT_Default)) && is_campaign_in_list(cmpgn_file, &mappacks_list))
+        fgroup = FGrp_VarLevels;
+    else if (((pack == CampgnT_MultiplayerMappack) || (pack == CampgnT_Default)) && is_campaign_in_list(cmpgn_file, &mp_mappacks_list))
+        fgroup = FGrp_MpLevels;
+    if ((fgroup != FGrp_None) && (campaign_fgroup == fgroup) && (strcasecmp(campaign.fname,cmpgn_file) == 0)) {
         return true;
     }
     free_campaign(&campaign);
     campaign_fgroup = FGrp_None;
-    TbBool result = (fgroup != FGrp_None) && load_campaign(cmpgn_fname,&campaign,CnfLd_Standard, fgroup);
+    TbBool result = (fgroup != FGrp_None) && load_campaign(cmpgn_file,&campaign,CnfLd_Standard, fgroup);
     if (!result) {
-        WARNMSG("Loading campaign file \"%s\" failed falling back to default campaign.", cmpgn_fname);
+        WARNMSG("Loading campaign file \"%s\" failed falling back to default campaign.", cmpgn_file);
         fgroup = FGrp_Campgn;
         result = load_campaign(keeper_campaign_file,&campaign,CnfLd_Standard, fgroup);
     }

--- a/src/config_campaigns.h
+++ b/src/config_campaigns.h
@@ -191,6 +191,7 @@ TbBool load_campaigns_list(struct CampaignsList *clist, short fgroup, const char
 TbBool change_campaign(uint8_t pack, const char *cmpgn_fname);
 TbBool is_campaign_loaded(void);
 TbBool is_campaign_in_list(const char *cmpgn_fname, struct CampaignsList *clist);
+uint8_t prepare_campaign_file_name(const char *cmpgn_fname, char *cmpgn_file, int cmpgn_file_len);
 TbBool is_map_pack(void);
 void set_default_mp_mappack(void);
 /******************************************************************************/

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -113,9 +113,6 @@ static TbBool try_starting_level_from_chat(const char *message, int32_t player_i
     }
     char campaign_filename[80];
     snprintf(campaign_filename, sizeof(campaign_filename), "%.*s", campaign_len, message);
-    if ((campaign_len < 4) || (strncasecmp(message + campaign_len - 4, ".cfg", 4) != 0)) {
-        strcat(campaign_filename, ".cfg");
-    }
     return frontnet_start_level(campaign_filename, level_num);
 }
 
@@ -124,14 +121,13 @@ TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
     if (campaign_fname == NULL || campaign_fname[0] == '\0') {
         return false;
     }
-    TbBool campaign_loaded;
-    if ((lvnum <= 0) || is_campaign_in_list(campaign_fname, &mp_mappacks_list)) {
-        campaign_loaded = change_campaign(CampgnT_MultiplayerMappack, campaign_fname);
-    } else {
-        campaign_loaded = change_campaign(CampgnT_Default, campaign_fname);
+    char campaign_file[DISKPATH_SIZE];
+    uint8_t pack = prepare_campaign_file_name(campaign_fname, campaign_file, sizeof(campaign_file));
+    if ((pack == CampgnT_Default) && ((lvnum <= 0) || is_campaign_in_list(campaign_file, &mp_mappacks_list))) {
+        pack = CampgnT_MultiplayerMappack;
     }
-    if (!campaign_loaded
-     || (strcasecmp(campaign.fname, campaign_fname) != 0)) {
+    if (!change_campaign(pack, campaign_file)
+     || (strcasecmp(campaign.fname, campaign_file) != 0)) {
         ERRORLOG("Unable to load campaign '%s' for level %d", campaign_fname, (int)lvnum);
         return false;
     }

--- a/src/ftests/ftest.c
+++ b/src/ftests/ftest.c
@@ -296,7 +296,6 @@ TbBool ftest_setup_test(struct FTestConfig* const test_config)
     strcpy(start_params.selected_campaign, test_config->level_file);
     LevelNumber selected_level = test_config->level;
 
-    str_append(start_params.selected_campaign, sizeof(start_params.selected_campaign), ".cfg");
     TbBool result = change_campaign(CampgnT_Default, start_params.selected_campaign);
     if(!result)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3707,7 +3707,6 @@ static TbBool wait_at_frontend(void)
         TbBool result = false;
         if (start_params.selected_campaign[0] != '\0')
         {
-            str_append(start_params.selected_campaign, sizeof(start_params.selected_campaign), ".cfg");
             result = change_campaign(CampgnT_Default, start_params.selected_campaign);
         }
         if (!result) {


### PR DESCRIPTION
You can now specify the directory like so:
```
-campaign campgns/keeporig -level 1
-campaign levels/classic -level 1
-campaign multiplayer/classic -level 1
```
And also use the old style as well:
```
-campaign keeporig -level 1
-campaign classic -level 1
```