### PR TITLE
Multiplayer: Various disconnection fixes

### DIFF
--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -6922,9 +6922,9 @@ msgid "%s has disconnected."
 msgstr "%s 已断开连接。"
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "对手已断开连接"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6918,9 +6918,9 @@ msgid "%s has disconnected."
 msgstr "%s 已中斷連線。"
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "對手已中斷連線"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -7293,9 +7293,9 @@ msgid "%s has disconnected."
 msgstr "%s se odpojil."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Soupeř se odpojil"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -7294,9 +7294,9 @@ msgid "%s has disconnected."
 msgstr "%s is losgekoppeld."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Tegenstander is losgekoppeld"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -5903,8 +5903,8 @@ msgid "%s has disconnected."
 msgstr ""
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
+msgctxt "Unused"
+msgid "unused"
 msgstr ""
 
 #: guitext:1119

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -7551,9 +7551,9 @@ msgid "%s has disconnected."
 msgstr "%s s'est déconnecté."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Adversaire déconnecté"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7580,9 +7580,9 @@ msgid "%s has disconnected."
 msgstr "%s wurde getrennt."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Gegner getrennt"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -7413,9 +7413,9 @@ msgid "%s has disconnected."
 msgstr "%s si è disconnesso."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Avversario disconnesso"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -7257,9 +7257,9 @@ msgid "%s has disconnected."
 msgstr "%s の接続が切断されました。"
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "対戦相手の接続が切断されました"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -7301,9 +7301,9 @@ msgid "%s has disconnected."
 msgstr "%s 님의 연결이 끊겼습니다."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "상대의 연결이 끊겼습니다"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -7324,9 +7324,9 @@ msgid "%s has disconnected."
 msgstr "%s disiunctus est."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Adversarius disiunctus est"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -7401,9 +7401,9 @@ msgid "%s has disconnected."
 msgstr "%s rozłączył się."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Przeciwnik rozłączył się"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_por.po
+++ b/lang/gtext_por.po
@@ -7525,9 +7525,9 @@ msgid "%s has disconnected."
 msgstr "%s desconectou-se."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Oponente desconectado"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -6704,9 +6704,9 @@ msgid "%s has disconnected."
 msgstr "%s отключился."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Противник отключился"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -7556,9 +7556,9 @@ msgid "%s has disconnected."
 msgstr "%s se ha desconectado."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Oponente desconectado"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -7320,9 +7320,9 @@ msgid "%s has disconnected."
 msgstr "%s har kopplats från."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Motståndare frånkopplad"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/lang/gtext_ukr.po
+++ b/lang/gtext_ukr.po
@@ -7375,9 +7375,9 @@ msgid "%s has disconnected."
 msgstr "%s від'єднався."
 
 #: guitext:1118
-msgctxt "Network game message"
-msgid "Opponent disconnected"
-msgstr "Суперник від'єднався"
+msgctxt "Unused"
+msgid "unused"
+msgstr "unused"
 
 #: guitext:1119
 msgctxt "Network game message"

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -466,7 +466,7 @@ enum GUIStrings {
     GUIStr_NetAiTookOver,
     GUIStr_NetPlayerLeftGame,
     GUIStr_NetPlayerDisconnected,
-    GUIStr_NetOpponentDisconnected,
+    GUIStr_NetUnused,
     GUIStr_NetHostConnectionLost,
     GuiStrEnd
 };

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -843,7 +843,7 @@ static short get_global_inputs(void)
             SYNCMSG("Finished level %d. Total turns taken: %u (%02u:%02u:%02u at %d fps). Real time elapsed: %02u:%02u:%02u:%03u.",
                 game.loaded_level_number, get_gameturn(), GameT.Hours, GameT.Minutes, GameT.Seconds, turns_per_second, Timer.Hours, Timer.Minutes, Timer.Seconds, Timer.MSeconds);
         }
-        set_players_packet_action(player, PckA_FinishGame, 0, 0, 0, 0);
+        set_players_packet_action(player, PckA_FinishGame, player->victory_state, 0, 0, 0);
         return true;
   }
   if ( is_game_key_pressed(Gkey_DumpToOldPos, true, false) )
@@ -884,7 +884,7 @@ static TbBool get_level_lost_inputs(void)
         return true;
     if (is_game_key_pressed(Gkey_FinishLevel, true, false))
     {
-        set_players_packet_action(player, PckA_FinishGame, 0,0,0,0);
+        set_players_packet_action(player, PckA_FinishGame, player->victory_state, 0, 0, 0);
     }
     if (player->view_type == PVT_MapScreen)
     {

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -330,7 +330,7 @@ static TbBool replace_network_player_with_ai(struct PlayerInfo *player, const ch
         message_add(MsgType_Player, player->id_number, get_string(GUIStr_NetAiTookOver));
         JUSTLOG("p:%d computer took over", player->id_number);
     }
-    if (departure_message_format != NULL && player->player_name[0] != '\0') {
+    if (departure_message_format != NULL && player->id_number != get_host_player_id() && player->player_name[0] != '\0') {
         message_add_fmt(MsgType_Blank, 0, departure_message_format, player->player_name);
         JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);
     }

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -384,7 +384,7 @@ void process_quit_packet(struct PlayerInfo *player, short complete_quit)
 
     int32_t plyr_count = 0;
     short winning_quit = winning_player_quitting(player, &plyr_count);
-    TbBool replaced_with_ai = replace_network_player_with_ai(player, get_string(GUIStr_NetPlayerLeftGame));
+    TbBool replaced_with_ai = replace_network_player_with_ai(player, get_string(GUIStr_NetPlayerDisconnected));
     if (player != myplyr) {
         OnDroppedUser(player->packet_num, NETDROP_MANUAL);
     }

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -294,7 +294,7 @@ static void resolve_network_quit_outcome(struct PlayerInfo *player)
     set_player_as_won_level(player);
 }
 
-static TbBool network_has_connected_human_opponents(void)
+static TbBool network_has_connected_enemies_to_defeat(void)
 {
     struct PlayerInfo *myplyr = get_my_player();
     for (int i = 0; i < PLAYERS_COUNT; i++) {
@@ -302,6 +302,16 @@ static TbBool network_has_connected_human_opponents(void)
         if (player_exists(player) && !is_my_player(player) && player->is_active == 1 && (player->allocflags & PlaF_CompCtrl) == 0
          && !player_cannot_win(player->id_number) && network_player_active(player->packet_num)
          && players_are_enemies(myplyr->id_number, player->id_number)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static TbBool network_has_connected_remote_users(void)
+{
+    for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_players; user_id += 1) {
+        if (user_id != netstate.my_id && netstate.users[user_id].progress != USER_UNUSED) {
             return true;
         }
     }
@@ -375,8 +385,8 @@ void process_quit_packet(struct PlayerInfo *player, short complete_quit)
     if (player != myplyr) {
         OnDroppedUser(player->packet_num, NETDROP_MANUAL);
     }
-    TbBool has_human_opponents = network_has_connected_human_opponents();
-    if (has_human_opponents && replaced_with_ai) {
+    TbBool has_enemies_to_defeat = network_has_connected_enemies_to_defeat();
+    if (has_enemies_to_defeat && replaced_with_ai) {
         return;
     }
 
@@ -388,18 +398,19 @@ void process_quit_packet(struct PlayerInfo *player, short complete_quit)
             }
         }
     }
-
-    if (player == myplyr || player->id_number == get_host_player_id() || !has_human_opponents) {
+    if (player == myplyr || player->id_number == get_host_player_id() || !has_enemies_to_defeat) {
         if (player != myplyr) {
             resolve_network_quit_outcome(myplyr);
         }
         if (winning_quit && (plyr_count > 1)) {
             myplyr->additional_flags |= PlaAF_UnlockedLordTorture;
         }
-        if ((player != myplyr) && (myplyr->victory_state != VicS_Undecided)) {
-            stop_network_game_and_continue_locally();
-        } else {
-            stop_network_game_and_quit(complete_quit);
+        if (player == myplyr || has_enemies_to_defeat || !network_has_connected_remote_users()) {
+            if ((player != myplyr) && (myplyr->victory_state != VicS_Undecided)) {
+                stop_network_game_and_continue_locally();
+            } else {
+                stop_network_game_and_quit(complete_quit);
+            }
         }
     }
 
@@ -418,21 +429,26 @@ void process_disconnected_network_players(void)
     if (host_disconnected) {
         departure_message_format = NULL;
     }
+    TbBool disconnected = host_disconnected;
     for (int player_index = 0; player_index < MAX_NET_USERS; player_index++) {
         struct PlayerInfo *player = get_player(player_index);
         if (!player_exists(player) || is_my_player(player) || (!host_disconnected && network_player_active(player->packet_num))) {
             continue;
         }
+        disconnected = true;
         if (!replace_network_player_with_ai(player, departure_message_format) && player->victory_state != VicS_Undecided) {
             player->allocflags &= ~PlaF_Allocated;
         }
     }
 
-    if (!host_disconnected && network_has_connected_human_opponents()) {
+    if (!disconnected || (!host_disconnected && network_has_connected_enemies_to_defeat())) {
         return;
     }
     struct PlayerInfo *myplyr = get_my_player();
     resolve_network_quit_outcome(myplyr);
+    if (!host_disconnected && network_has_connected_remote_users()) {
+        return;
+    }
     const char *message = get_string(GUIStr_NetOpponentDisconnected);
     if (host_disconnected) {
         message = get_string(GUIStr_NetHostConnectionLost);

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -320,18 +320,21 @@ static TbBool network_has_connected_remote_users(void)
 
 static TbBool replace_network_player_with_ai(struct PlayerInfo *player, const char *departure_message_format)
 {
-    if (is_my_player(player) || (player->allocflags & PlaF_CompCtrl) != 0 || player->victory_state != VicS_Undecided) {
+    if (is_my_player(player) || (player->allocflags & PlaF_CompCtrl) != 0) {
         return false;
     }
-    player->allocflags |= PlaF_CompCtrl;
-    toggle_computer_player(player->id_number);
-    message_add(MsgType_Player, player->id_number, get_string(GUIStr_NetAiTookOver));
-    JUSTLOG("p:%d computer took over", player->id_number);
+    TbBool replaced_with_ai = (player->victory_state == VicS_Undecided);
+    if (replaced_with_ai) {
+        player->allocflags |= PlaF_CompCtrl;
+        toggle_computer_player(player->id_number);
+        message_add(MsgType_Player, player->id_number, get_string(GUIStr_NetAiTookOver));
+        JUSTLOG("p:%d computer took over", player->id_number);
+    }
     if (departure_message_format != NULL && player->player_name[0] != '\0') {
         message_add_fmt(MsgType_Blank, 0, departure_message_format, player->player_name);
         JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);
     }
-    return true;
+    return replaced_with_ai;
 }
 
 static void stop_network_game_state(void)

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -42,6 +42,7 @@
 #include "dungeon_data.h"
 #include "game_legacy.h"
 #include "gui_msgs.h"
+#include "net_exchange_gameplay.h"
 #include "net_input_lag.h"
 #include "net_checksums.h"
 #include "keeperfx.hpp"
@@ -435,6 +436,18 @@ void process_disconnected_network_players(void)
     const char *departure_message_format = get_string(GUIStr_NetPlayerDisconnected);
     if (host_disconnected) {
         departure_message_format = NULL;
+        GameTurn newest_turn = get_gameturn();
+        for (GameTurnDelta offset = 0; offset <= game.input_lag_turns; offset += 1) {
+            if ((GameTurn)offset > newest_turn) {
+                break;
+            }
+            const struct Packet *host_packet = get_history_packet(get_host_player_id(), newest_turn - offset);
+            if (host_packet != NULL && host_packet->action == PckA_FinishGame && host_packet->actn_par1 == VicS_WonLevel) {
+                get_my_player()->additional_flags &= ~PlaAF_UnlockedLordTorture;
+                quit_game = 1;
+                return;
+            }
+        }
     }
     TbBool disconnected = host_disconnected;
     for (int player_index = 0; player_index < MAX_NET_USERS; player_index++) {

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -323,18 +323,18 @@ static TbBool replace_network_player_with_ai(struct PlayerInfo *player, const ch
     if (is_my_player(player) || (player->allocflags & PlaF_CompCtrl) != 0) {
         return false;
     }
-    TbBool replaced_with_ai = (player->victory_state == VicS_Undecided);
-    if (replaced_with_ai) {
-        player->allocflags |= PlaF_CompCtrl;
-        toggle_computer_player(player->id_number);
-        message_add(MsgType_Player, player->id_number, get_string(GUIStr_NetAiTookOver));
-        JUSTLOG("p:%d computer took over", player->id_number);
-    }
     if (departure_message_format != NULL && player->id_number != get_host_player_id() && player->player_name[0] != '\0') {
         message_add_fmt(MsgType_Blank, 0, departure_message_format, player->player_name);
         JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);
     }
-    return replaced_with_ai;
+    if (player->victory_state != VicS_Undecided) {
+        return false;
+    }
+    player->allocflags |= PlaF_CompCtrl;
+    toggle_computer_player(player->id_number);
+    message_add(MsgType_Player, player->id_number, get_string(GUIStr_NetAiTookOver));
+    JUSTLOG("p:%d computer took over", player->id_number);
+    return true;
 }
 
 static void stop_network_game_state(void)

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -452,11 +452,9 @@ void process_disconnected_network_players(void)
     if (!host_disconnected && network_has_connected_remote_users()) {
         return;
     }
-    const char *message = get_string(GUIStr_NetOpponentDisconnected);
     if (host_disconnected) {
-        message = get_string(GUIStr_NetHostConnectionLost);
+        message_add(MsgType_Blank, 0, get_string(GUIStr_NetHostConnectionLost));
     }
-    message_add(MsgType_Blank, 0, message);
     if (myplyr->victory_state != VicS_Undecided) {
         stop_network_game_and_continue_locally();
     } else {

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -382,17 +382,21 @@ void process_quit_packet(struct PlayerInfo *player, short complete_quit)
         return;
     }
 
-    int32_t plyr_count = 0;
-    short winning_quit = winning_player_quitting(player, &plyr_count);
     TbBool replaced_with_ai = replace_network_player_with_ai(player, get_string(GUIStr_NetPlayerDisconnected));
     if (player != myplyr) {
         OnDroppedUser(player->packet_num, NETDROP_MANUAL);
+        if (player->id_number == get_host_player_id()) {
+            process_disconnected_network_players();
+            return;
+        }
     }
     TbBool has_enemies_to_defeat = network_has_connected_enemies_to_defeat();
     if (has_enemies_to_defeat && replaced_with_ai) {
         return;
     }
 
+    int32_t plyr_count = 0;
+    short winning_quit = winning_player_quitting(player, &plyr_count);
     if (winning_quit) {
         for (int i = 0; i < PLAYERS_COUNT; i++) {
             struct PlayerInfo *swplyr = get_player(i);

--- a/src/packets.c
+++ b/src/packets.c
@@ -652,9 +652,19 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         turn_off_all_menus();
         free_swipe_graphic();
       }
-      if ((game.system_flags & GSF_NetworkActive) != 0 && (!my_player
-       || ((player->victory_state == VicS_LostLevel) && (player->id_number == get_host_player_id())))) {
-        return 0;
+      if ((game.system_flags & GSF_NetworkActive) != 0) {
+        TbBool host_packet = player->packet_num == get_host_player_id();
+        if (!my_player) {
+          if (host_packet && (player->victory_state != VicS_LostLevel)) {
+            get_my_player()->additional_flags &= ~PlaAF_UnlockedLordTorture;
+            quit_game = 1;
+          }
+          return 0;
+        } else if (host_packet && (player->victory_state == VicS_LostLevel)) {
+          return 0;
+        } else if (host_packet && (player->victory_state == VicS_WonLevel)) {
+          player->additional_flags &= ~PlaAF_UnlockedLordTorture;
+        }
       }
       switch (player->victory_state)
       {

--- a/src/packets.c
+++ b/src/packets.c
@@ -648,6 +648,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
   case PckA_FinishGame:
       {
       TbBool my_player = is_my_player(player);
+      int32_t victory_state = pckt->actn_par1;
       if (my_player) {
         turn_off_all_menus();
         free_swipe_graphic();
@@ -655,18 +656,18 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       if ((game.system_flags & GSF_NetworkActive) != 0) {
         TbBool host_packet = player->packet_num == get_host_player_id();
         if (!my_player) {
-          if (host_packet && (player->victory_state != VicS_LostLevel)) {
+          if ((victory_state == VicS_WonLevel) || (host_packet && (player->victory_state != VicS_LostLevel))) {
             get_my_player()->additional_flags &= ~PlaAF_UnlockedLordTorture;
             quit_game = 1;
           }
           return 0;
-        } else if (host_packet && (player->victory_state == VicS_LostLevel)) {
+        } else if (host_packet && (victory_state == VicS_LostLevel)) {
           return 0;
-        } else if (host_packet && (player->victory_state == VicS_WonLevel)) {
+        } else if (host_packet && (victory_state == VicS_WonLevel)) {
           player->additional_flags &= ~PlaAF_UnlockedLordTorture;
         }
       }
-      switch (player->victory_state)
+      switch (victory_state)
       {
       case VicS_WonLevel:
           complete_level(player);
@@ -1621,6 +1622,10 @@ void process_packets(void)
             }
         }
         process_disconnected_network_players();
+        if (quit_game || exit_keeper) {
+            clear_packets();
+            return;
+        }
     }
     MULTIPLAYER_LOG("process_packets: Loading packets from packet history");
     load_old_packets();
@@ -1657,6 +1662,9 @@ void process_packets(void)
     }
     // Clear all packets
     clear_packets();
+    if (quit_game || exit_keeper) {
+        return;
+    }
     if (((game.system_flags & GSF_NetworkActive) != 0)
      && ((game.system_flags & (GSF_NetGameNoSync | GSF_NetSeedNoSync)) != 0))
     {

--- a/src/packets.c
+++ b/src/packets.c
@@ -646,6 +646,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
   case PckA_NoOperation:
       return 1;
   case PckA_FinishGame:
+      {
       TbBool my_player = is_my_player(player);
       if (my_player) {
         turn_off_all_menus();
@@ -672,6 +673,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         frontend_save_continue_game(false);
       }
       return 0;
+      }
   case PckA_PlyrMsgEnd:
       process_gameplay_chat_message(player->id_number, player->mp_pending_message);
       player->mp_pending_message[0] = '\0';

--- a/src/packets.c
+++ b/src/packets.c
@@ -646,18 +646,13 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
   case PckA_NoOperation:
       return 1;
   case PckA_FinishGame:
-      if ((player->victory_state == VicS_LostLevel) && ((game.system_flags & GSF_NetworkActive) != 0) && (player->id_number == get_host_player_id()))
-      {
-        return 0;
-      }
-      if (is_my_player(player))
-      {
+      TbBool my_player = is_my_player(player);
+      if (my_player) {
         turn_off_all_menus();
         free_swipe_graphic();
       }
-      if ((game.system_flags & GSF_NetworkActive) != 0)
-      {
-        process_quit_packet(player, 0);
+      if ((game.system_flags & GSF_NetworkActive) != 0 && (!my_player
+       || ((player->victory_state == VicS_LostLevel) && (player->id_number == get_host_player_id())))) {
         return 0;
       }
       switch (player->victory_state)
@@ -673,8 +668,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
           break;
       }
       player->allocflags &= ~PlaF_Allocated;
-      if (is_my_player(player))
-      {
+      if (my_player) {
         frontend_save_continue_game(false);
       }
       return 0;


### PR DESCRIPTION
Also removed a generic "Opponent disconnected" message, can't remember why we had that. "PlayerName has disconnected." is better.