### PR TITLE
Multiplayer: local Hand of Evil creature hover

### DIFF
--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -777,6 +777,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
         return;
     }
     long i;
+    short thing_under_hand;
     switch (plrst_cfg_stat->pointer_group)
     {
     case PsPg_CtrlDungeon:
@@ -784,6 +785,14 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
           i = player->secondary_cursor_state;
         else
           i = player->primary_cursor_state;
+        if ((player->instance_num == PI_Grab) || (player->instance_num == PI_Drop) || (player->instance_num == PI_Whip) || (player->instance_num == PI_WhipEnd) || (thing_under_hand_local > 0))
+        {
+            i = CSt_PowerHand;
+        } else
+        if ((i == CSt_PowerHand) && power_hand_is_empty(player))
+        {
+            i = CSt_DefaultArrow;
+        }
         switch (i)
         {
         case CSt_PickAxe:
@@ -795,10 +804,15 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
             set_pointer_graphic(MousePG_LockMark);
             break;
         case CSt_PowerHand:
-            thing = thing_get(player->thing_under_hand);
+            thing_under_hand = player->thing_under_hand;
+            if (thing_under_hand_local > 0)
+            {
+                thing_under_hand = thing_under_hand_local;
+            }
+            thing = thing_get(thing_under_hand);
             TRACE_THING(thing);
             TbBool can_cast = false;
-            if ((player->input_crtr_control) && (thing_exists(thing)) && (dungeon->things_in_hand[0] != player->thing_under_hand))
+            if ((player->input_crtr_control) && (thing_exists(thing)) && (dungeon->things_in_hand[0] != thing_under_hand))
             {
                 PowerKind pwkind = PwrK_POSSESS;
                 if (can_cast_spell(player->id_number, pwkind, thing->mappos.x.stl.num, thing->mappos.y.stl.num, thing, CastChk_Default))
@@ -829,7 +843,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
 
                 player->display_flags |= PlaF6_DisplayNeedsUpdate;
             } else
-            if (((player->input_crtr_query) && !thing_is_invalid(thing)) && (dungeon->things_in_hand[0] != player->thing_under_hand)
+            if (((player->input_crtr_query) && !thing_is_invalid(thing)) && (dungeon->things_in_hand[0] != thing_under_hand)
                 && can_thing_be_queried(thing, player->id_number))
             {
                 set_pointer_graphic(MousePG_Query);

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4982,7 +4982,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
         || (thing->class_id == TCls_DeadCreature)
         || (player->work_state == PSt_QueryAll))
     {
-        if ((player->thing_under_hand == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate))
+        if ((thing_under_hand_local == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate))
         {
             lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
             lbSpriteReMapPtr = white_pal;
@@ -5307,7 +5307,7 @@ void draw_status_sprites(long scrpos_x, long scrpos_y, struct Thing *thing)
         return;
     if (flag_is_set(game.mode_flags,MFlg_NoHeroHealthFlower))
     {
-        if (player->thing_under_hand != thing->index)
+        if (thing_under_hand_local != thing->index)
         {
             cctrl->thought_bubble_last_turn_drawn = get_gameturn();
             if (cctrl->force_health_flower_displayed == false)
@@ -5390,7 +5390,7 @@ void draw_status_sprites(long scrpos_x, long scrpos_y, struct Thing *thing)
     else
     {
         // Determine if the creature is under the player's hand (being hovered over).
-        TbBool is_thing_under_hand = (player->thing_under_hand == thing->index);
+        TbBool is_thing_under_hand = (thing_under_hand_local == thing->index);
         // Check if the creature is an enemy and is visible.
         TbBool is_enemy_and_visible = players_are_enemies(player->id_number, thing->owner) && !creature_is_invisible(thing);
         // Check if the creature belongs to the player, is hurt but not unconscious.
@@ -7994,7 +7994,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
 
     if (!thing_is_invalid(thing))
     {
-        if ((player->thing_under_hand == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate))
+        if ((thing_under_hand_local == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate))
         {
           struct Camera *active_cam = get_player_active_camera(player);
           if ((active_cam != NULL) && (active_cam->view_mode == PVM_IsoWibbleView || active_cam->view_mode == PVM_IsoStraightView))
@@ -8016,7 +8016,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
                   }
                   else if (thing_is_trap_crate(dragtng))
                   {
-                      struct Thing *handthing = thing_get(player->thing_under_hand);
+                      struct Thing *handthing = thing_get(thing_under_hand_local);
                       if (thing_exists(handthing))
                       {
                           if (handthing->class_id == TCls_Trap)

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -2391,6 +2391,7 @@ static TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *
   unsigned long x;
   unsigned long y;
   struct PlayerInfo* player = get_my_player();
+  TbBool hand_is_empty = power_hand_is_empty(player);
   if ((pointer_x < 0) || (pointer_y < 0)
    || (pointer_x >= player->engine_window_width/pixel_size)
    || (pointer_y >= player->engine_window_height/pixel_size))
@@ -2414,7 +2415,7 @@ static TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *
     pos->x.val = (x<<8) + top_pointed_at_frac_x;
     pos->y.val = (y<<8) + top_pointed_at_frac_y;
   } else
-  if (!power_hand_is_empty(player))
+  if (!hand_is_empty)
   {
     *context = CSt_PowerHand;
     pos->x.val = (x<<8) + top_pointed_at_frac_x;
@@ -2441,11 +2442,19 @@ static TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *
   {
     pos->x.val = (block_pointed_at_x<<8) + pointed_at_frac_x;
     pos->y.val = (block_pointed_at_y<<8) + pointed_at_frac_y;
+    *context = CSt_PowerHand;
+  }
+  if ((*context == CSt_PowerHand) && (!player->one_click_lock_cursor))
+  {
     struct Thing* thing = get_nearest_thing_for_hand_or_slap(player->id_number, pos->x.val, pos->y.val);
     if (!thing_is_invalid(thing))
-      *context = CSt_PowerHand;
-    else
+    {
+      thing_under_hand_local = thing->index;
+    } else
+    if (hand_is_empty)
+    {
       *context = CSt_DefaultArrow;
+    }
   }
   if (pos->x.val >= (game.map_subtiles_x << 8))
     pos->x.val = (game.map_subtiles_x << 8)-1;
@@ -2464,6 +2473,7 @@ static void get_dungeon_control_nonaction_inputs(void)
   my_mouse_y = GetMouseY();
   struct PlayerInfo* player = get_my_player();
   struct Packet* pckt = get_packet(my_player_number);
+  thing_under_hand_local = 0;
   unset_packet_control(pckt, PCtr_MapCoordsValid);
   if (player->work_state == PSt_CtrlDungeon)
   {
@@ -2473,10 +2483,12 @@ static void get_dungeon_control_nonaction_inputs(void)
           set_players_packet_position(pckt, pos.x.val, pos.y.val, context);
     }
   } else
-    if (screen_to_map(get_local_camera(get_player_active_camera(player)), my_mouse_x, my_mouse_y, &pos))
   {
-      set_players_packet_position(pckt, pos.x.val, pos.y.val, 0);
-      pckt->additional_packet_values &= ~PCAdV_ContextMask; // reset cursor states to 0 (CSt_DefaultArrow)
+    if (screen_to_map(get_local_camera(get_player_active_camera(player)), my_mouse_x, my_mouse_y, &pos))
+    {
+        set_players_packet_position(pckt, pos.x.val, pos.y.val, 0);
+        pckt->additional_packet_values &= ~PCAdV_ContextMask; // reset cursor states to 0 (CSt_DefaultArrow)
+    }
   }
   if (is_game_key_pressed(Gkey_ExitGame, true, false))
   {

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -47,6 +47,7 @@ struct PlayerInfo bad_player;
 
 /** The current player's number. */
 unsigned char my_player_number;
+short thing_under_hand_local;
 /******************************************************************************/
 
 struct Camera *get_player_active_camera(const struct PlayerInfo *player)

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -266,6 +266,7 @@ struct PlayerInfo {
 /******************************************************************************/
 
 extern unsigned char my_player_number;
+extern short thing_under_hand_local;
 
 #pragma pack()
 /******************************************************************************/

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -580,7 +580,14 @@ void draw_power_hand(void)
     }
     thing = thing_get(player->hand_thing_idx);
     if (!thing_exists(thing))
+    {
+        if (thing_under_hand_local > 0)
+        {
+            process_keeper_sprite(GetMouseX()+scale_ui_value(60*global_hand_scale), GetMouseY()+scale_ui_value(40*global_hand_scale),
+              game.conf.power_hand_conf.pwrhnd_cfg_stats[player->hand_idx].anim_idx[HndA_Hover], 0, 0, scale_ui_value(64*global_hand_scale));
+        }
         return;
+    }
     if (player->hand_busy_until_turn > get_gameturn())
     {
         SYNCDBG(7,"Drawing hand %s index %d, busy state", thing_model_name(thing), (int)thing->index);
@@ -597,10 +604,14 @@ void draw_power_hand(void)
     }
     if (player->work_state != PSt_HoldInHand)
     {
-      if ( (player->work_state != PSt_CtrlDungeon)
-        || ((player->secondary_cursor_state != CSt_PowerHand) && ((player->work_state != PSt_CtrlDungeon) || (player->secondary_cursor_state != CSt_DefaultArrow) || (player->primary_cursor_state != CSt_PowerHand))) )
+      TbBool draw_hand = (thing_under_hand_local > 0);
+      if ((player->work_state == PSt_CtrlDungeon) && !power_hand_is_empty(player))
       {
-        if ((player->instance_num != PI_Grab) && (player->instance_num != PI_Drop))
+        draw_hand = (player->secondary_cursor_state == CSt_PowerHand) || ((player->secondary_cursor_state == CSt_DefaultArrow) && (player->primary_cursor_state == CSt_PowerHand));
+      }
+      if ((player->work_state != PSt_CtrlDungeon) || !draw_hand)
+      {
+        if ((player->instance_num != PI_Grab) && (player->instance_num != PI_Drop) && (player->instance_num != PI_Whip) && (player->instance_num != PI_WhipEnd))
         {
           if (player->work_state == PSt_Slap)
           {


### PR DESCRIPTION
Adds local creature hovering (white flashing and hand sprite) so creatures are easier to pick up while `input_lag_turns` is high.
This does not make picking up creatures as easy as singleplayer, but it does feel like an improvement.

This also fixes a tiny animation bug in singleplayer where when you slapped a creature if you moved your cursor away really fast from the creature, the animation would end early. Now it plays out the full slap animation even if you move your cursor away.