### PR TITLE
Fixed flash when hovering creatures

### DIFF
--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -785,8 +785,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
           i = player->secondary_cursor_state;
         else
           i = player->primary_cursor_state;
-        if ((player->instance_num == PI_Grab) || (player->instance_num == PI_Drop) || (player->instance_num == PI_Whip) || (player->instance_num == PI_WhipEnd) || (thing_under_hand_local > 0))
-        {
+        if ((player->instance_num == PI_Grab) || (player->instance_num == PI_Drop) || (player->instance_num == PI_Whip) || (player->instance_num == PI_WhipEnd) || (local_thing_under_hand > 0)) {
             i = CSt_PowerHand;
         } else
         if ((i == CSt_PowerHand) && power_hand_is_empty(player))
@@ -805,9 +804,8 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
             break;
         case CSt_PowerHand:
             thing_under_hand = player->thing_under_hand;
-            if (thing_under_hand_local > 0)
-            {
-                thing_under_hand = thing_under_hand_local;
+            if (local_thing_under_hand > 0) {
+                thing_under_hand = local_thing_under_hand;
             }
             thing = thing_get(thing_under_hand);
             TRACE_THING(thing);

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4982,8 +4982,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
         || (thing->class_id == TCls_DeadCreature)
         || (player->work_state == PSt_QueryAll))
     {
-        if ((thing_under_hand_local == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate))
-        {
+        if ((local_thing_under_hand == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate)) {
             lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
             lbSpriteReMapPtr = white_pal;
         } else {
@@ -5307,8 +5306,7 @@ void draw_status_sprites(long scrpos_x, long scrpos_y, struct Thing *thing)
         return;
     if (flag_is_set(game.mode_flags,MFlg_NoHeroHealthFlower))
     {
-        if (thing_under_hand_local != thing->index)
-        {
+        if (local_thing_under_hand != thing->index) {
             cctrl->thought_bubble_last_turn_drawn = get_gameturn();
             if (cctrl->force_health_flower_displayed == false)
             {
@@ -5390,7 +5388,7 @@ void draw_status_sprites(long scrpos_x, long scrpos_y, struct Thing *thing)
     else
     {
         // Determine if the creature is under the player's hand (being hovered over).
-        TbBool is_thing_under_hand = (thing_under_hand_local == thing->index);
+        TbBool is_thing_under_hand = (local_thing_under_hand == thing->index);
         // Check if the creature is an enemy and is visible.
         TbBool is_enemy_and_visible = players_are_enemies(player->id_number, thing->owner) && !creature_is_invisible(thing);
         // Check if the creature belongs to the player, is hurt but not unconscious.
@@ -7994,8 +7992,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
 
     if (!thing_is_invalid(thing))
     {
-        if ((thing_under_hand_local == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate))
-        {
+        if ((local_thing_under_hand == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate)) {
           struct Camera *active_cam = get_player_active_camera(player);
           if ((active_cam != NULL) && (active_cam->view_mode == PVM_IsoWibbleView || active_cam->view_mode == PVM_IsoStraightView))
           {
@@ -8016,7 +8013,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
                   }
                   else if (thing_is_trap_crate(dragtng))
                   {
-                      struct Thing *handthing = thing_get(thing_under_hand_local);
+                      struct Thing *handthing = thing_get(local_thing_under_hand);
                       if (thing_exists(handthing))
                       {
                           if (handthing->class_id == TCls_Trap)

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1939,6 +1939,7 @@ static short get_creature_control_action_inputs(void)
             }
         }
         player->thing_under_hand = 0;
+        local_thing_under_hand = 0;
         struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
         if (cctrl->active_instance_id == CrInst_FIRST_PERSON_DIG)
         {
@@ -1987,6 +1988,7 @@ static short get_creature_control_action_inputs(void)
                     }
                 }
             }
+            local_thing_under_hand = player->thing_under_hand;
             if (player->selected_fp_thing_pickup != player->thing_under_hand)
             {
                 set_players_packet_action(player, PckA_SelectFPPickup, player->thing_under_hand, 0, 0, 0);
@@ -2451,9 +2453,8 @@ static TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *
   if ((*context == CSt_PowerHand) && (!player->one_click_lock_cursor))
   {
     struct Thing* thing = get_nearest_thing_for_hand_or_slap(player->id_number, pos->x.val, pos->y.val);
-    if (!thing_is_invalid(thing))
-    {
-      thing_under_hand_local = thing->index;
+    if (!thing_is_invalid(thing)) {
+      local_thing_under_hand = thing->index;
     } else
     if (hand_is_empty)
     {
@@ -2477,7 +2478,7 @@ static void get_dungeon_control_nonaction_inputs(void)
   my_mouse_y = GetMouseY();
   struct PlayerInfo* player = get_my_player();
   struct Packet* pckt = get_packet(my_player_number);
-  thing_under_hand_local = 0;
+  local_thing_under_hand = 0;
   unset_packet_control(pckt, PCtr_MapCoordsValid);
   if (player->work_state == PSt_CtrlDungeon)
   {
@@ -2492,6 +2493,10 @@ static void get_dungeon_control_nonaction_inputs(void)
     {
         set_players_packet_position(pckt, pos.x.val, pos.y.val, 0);
         pckt->additional_packet_values &= ~PCAdV_ContextMask; // reset cursor states to 0 (CSt_DefaultArrow)
+        struct Thing* thing = get_thing_under_hand(player, pos.x.val, pos.y.val);
+        if (!thing_is_invalid(thing)) {
+            local_thing_under_hand = thing->index;
+        }
     }
   }
   if (is_game_key_pressed(Gkey_ExitGame, true, false))

--- a/src/packets.h
+++ b/src/packets.h
@@ -331,6 +331,7 @@ void unset_players_packet_control(struct PlayerInfo *player, unsigned long flag)
 void set_players_packet_position(struct Packet *pckt, long x, long y, unsigned char context);
 void set_packet_pause_toggle(void);
 void force_application_close(void);
+struct Thing *get_thing_under_hand(struct PlayerInfo *player, MapCoord x, MapCoord y);
 TbBool process_dungeon_control_packet_clicks(long idx);
 TbBool process_players_dungeon_control_packet_action(long idx);
 void process_players_creature_control_packet_control(long idx);

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -80,6 +80,34 @@ void remember_cursor_subtile(struct PlayerInfo *player) {
     player->interpolated_tagging = player->mouse_on_map;
 }
 
+struct Thing *get_thing_under_hand(struct PlayerInfo *player, MapCoord x, MapCoord y)
+{
+    struct Thing *thing;
+
+    switch (player->work_state) {
+    case PSt_Slap:
+        return get_creature_near_to_be_keeper_power_target(x, y, PwrK_SLAP, player->id_number);
+    case PSt_CtrlPassngr:
+        return get_creature_near_and_owned_by(x, y, player->id_number, CREATURE_ANY);
+    case PSt_FreeCtrlPassngr:
+        return get_creature_near_and_owned_by(x, y, -1, CREATURE_ANY);
+    case PSt_CtrlDirect:
+        return get_creature_near_for_controlling(player->id_number, x, y);
+    case PSt_FreeCtrlDirect:
+        return get_creature_near(x, y);
+    case PSt_CreatrQuery:
+    case PSt_CreatrInfo:
+        thing = get_creature_near(x, y);
+        if (thing_is_creature(thing) && can_thing_be_queried(thing, player->id_number)) {
+            return thing;
+        }
+        break;
+    case PST_CastPowerOnTarget:
+        return get_creature_near_to_be_keeper_power_target(x, y, player->chosen_power_kind, player->id_number);
+    }
+    return INVALID_THING;
+}
+
 void set_tag_untag_mode(PlayerNumber plyr_idx)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
@@ -731,6 +759,10 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
     pwkind = player->chosen_power_kind;
+    thing = get_thing_under_hand(player, x, y);
+    if (!thing_is_invalid(thing)) {
+        player->thing_under_hand = thing->index;
+    }
 
     switch (player->work_state)
     {
@@ -752,12 +784,6 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             }
             break;
         case PSt_Slap:
-            thing = get_creature_near_to_be_keeper_power_target(x, y, PwrK_SLAP, plyr_idx);
-            if (thing_is_invalid(thing)) {
-                player->thing_under_hand = 0;
-            } else {
-                player->thing_under_hand = thing->index;
-            }
             if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
             {
                 magic_use_available_power_on_thing(plyr_idx, PwrK_SLAP, 0, stl_x, stl_y, thing, PwMod_Default);
@@ -766,14 +792,6 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             break;
         case PSt_CtrlPassngr:
         case PSt_FreeCtrlPassngr:
-            if (player->work_state == PSt_CtrlPassngr)
-                thing = get_creature_near_and_owned_by(x, y, plyr_idx, CREATURE_ANY);
-            else
-                thing = get_creature_near_and_owned_by(x, y, -1, CREATURE_ANY);
-            if (thing_is_invalid(thing))
-                player->thing_under_hand = 0;
-            else
-                player->thing_under_hand = thing->index;
             if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
             {
                 if (player->thing_under_hand > 0)
@@ -795,14 +813,6 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             break;
         case PSt_CtrlDirect:
         case PSt_FreeCtrlDirect:
-            if (player->work_state == PSt_CtrlDirect)
-                thing = get_creature_near_for_controlling(plyr_idx, x, y);
-            else
-                thing = get_creature_near(x, y);
-            if (thing_is_invalid(thing))
-                player->thing_under_hand = 0;
-            else
-                player->thing_under_hand = thing->index;
             if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
             {
                 if (player->thing_under_hand > 0)
@@ -822,20 +832,6 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             break;
         case PSt_CreatrQuery:
         case PSt_CreatrInfo:
-            thing = get_creature_near(x, y);
-            TbBool CanQuery = false;
-            if (thing_is_creature(thing))
-            {
-                CanQuery = can_thing_be_queried(thing, plyr_idx);
-            }
-            if (!CanQuery)
-            {
-                player->thing_under_hand = 0;
-            }
-            else
-            {
-                player->thing_under_hand = thing->index;
-            }
             if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
             {
                 if (player->thing_under_hand > 0)
@@ -905,13 +901,10 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             break;
         }
         case PST_CastPowerOnTarget:
-            thing = get_creature_near_to_be_keeper_power_target(x, y, pwkind, plyr_idx);
             if (thing_is_invalid(thing))
             {
-                player->thing_under_hand = 0;
                 break;
             }
-            player->thing_under_hand = thing->index;
             if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
             {
                 i = get_power_overcharge_level(player);

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -47,7 +47,7 @@ struct PlayerInfo bad_player;
 
 /** The current player's number. */
 unsigned char my_player_number;
-short thing_under_hand_local;
+short local_thing_under_hand;
 /******************************************************************************/
 
 struct Camera *get_player_active_camera(const struct PlayerInfo *player)

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -266,7 +266,7 @@ struct PlayerInfo {
 /******************************************************************************/
 
 extern unsigned char my_player_number;
-extern short thing_under_hand_local;
+extern short local_thing_under_hand;
 
 #pragma pack()
 /******************************************************************************/

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -581,8 +581,7 @@ void draw_power_hand(void)
     thing = thing_get(player->hand_thing_idx);
     if (!thing_exists(thing))
     {
-        if (thing_under_hand_local > 0)
-        {
+        if ((local_thing_under_hand > 0) && (player->work_state == PSt_CtrlDungeon)) {
             process_keeper_sprite(GetMouseX()+scale_ui_value(60*global_hand_scale), GetMouseY()+scale_ui_value(40*global_hand_scale),
               game.conf.power_hand_conf.pwrhnd_cfg_stats[player->hand_idx].anim_idx[HndA_Hover], 0, 0, scale_ui_value(64*global_hand_scale));
         }
@@ -604,7 +603,7 @@ void draw_power_hand(void)
     }
     if (player->work_state != PSt_HoldInHand)
     {
-      TbBool draw_hand = (thing_under_hand_local > 0);
+      TbBool draw_hand = (local_thing_under_hand > 0);
       if ((player->work_state == PSt_CtrlDungeon) && !power_hand_is_empty(player))
       {
         draw_hand = (player->secondary_cursor_state == CSt_PowerHand) || ((player->secondary_cursor_state == CSt_DefaultArrow) && (player->primary_cursor_state == CSt_PowerHand));


### PR DESCRIPTION
I made a mistake by not considering/testing all the other ways creatures can flash white. I've refactored it so both the authoritative thing_under_hand and local one both use the same new function: `get_thing_under_hand()`

Fixes #4828