### PR TITLE
Lua: fix RegisterObjectDestroyedEvent condition

### DIFF
--- a/config/fxdata/lua/triggers/Builtins.lua
+++ b/config/fxdata/lua/triggers/Builtins.lua
@@ -2,7 +2,7 @@
 -- Entry points for engine-triggered events (e.g. OnPowerCast, OnGameTick).
 -- These functions are called by the C engine and dispatch event data to the Lua trigger system.
 
----@alias event_type "PowerCast"|"Death"|"SpecialActivated"|"GameTick"|"ChatMsg"|"DungeonDestroyed"|"TrapPlaced"|"ApplyDamage"|"LevelUp"|"Rebirth"|"SlabKindChange"|"SlabOwnerChange"|"RoomOwnerChange"|"ShotHitThing"
+---@alias event_type "PowerCast"|"Death"|"SpecialActivated"|"GameTick"|"ChatMsg"|"DungeonDestroyed"|"TrapPlaced"|"ApplyDamage"|"LevelUp"|"Rebirth"|"SlabKindChange"|"SlabOwnerChange"|"RoomOwnerChange"|"ShotHitThing"|"Destroyed"
 
 --- Called when a spell is cast on a unit
 --- @param pwkind power_kind
@@ -31,10 +31,10 @@ function OnCreatureDeath(unit)
 end
 
 --- Called when an object is destroyed
---- @param unit Object The unit that dies
-function OnObjectDestroyed(unit)
+--- @param object Object The object that is destroyed
+function OnObjectDestroyed(object)
     local eventData = {}
-    eventData.unit = unit
+    eventData.object = object
     ProcessEvent("Destroyed",eventData)
 end
 

--- a/config/fxdata/lua/triggers/Events.lua
+++ b/config/fxdata/lua/triggers/Events.lua
@@ -119,10 +119,10 @@ end
 ---@param object? Object the object that triggers the event
 ---@return table
 function RegisterObjectDestroyedEvent(action, object)
-    local trigData = {thing = object}
+    local trigData = {object = object}
 
     local trigger = CreateTrigger("Destroyed",action,trigData)
-    if unit then
+    if object then
         TriggerAddCondition(trigger, function(eventData,triggerData) return eventData.object == triggerData.object end)
     end
     return trigger


### PR DESCRIPTION
bit of inconsistent naming caused the RegisterObjectDestroyedEvent second object param to never add the condition