### PR TITLE
Multiplayer: Add client-side build/sell previews and fix various issues

### DIFF
--- a/src/cursor_tag.c
+++ b/src/cursor_tag.c
@@ -24,7 +24,6 @@
 #include "dungeon_data.h"
 #include "game_legacy.h"
 #include "roomspace.h"
-#include "roomspace_prediction.h"
 #include "engine_render.h"
 #include "slab_data.h"
 #include "power_hand.h"
@@ -44,21 +43,18 @@ extern "C" {
 }
 #endif
 /******************************************************************************/
-unsigned char tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab)
+unsigned char tag_cursor_blocks_dig(struct PlayerInfo *player, const struct Packet *pckt, struct RoomSpace *render_roomspace, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab)
 {
-    SYNCDBG(7,"Starting for player %d at subtile (%d,%d)",(int)plyr_idx,(int)stl_x,(int)stl_y);
-    struct PlayerInfo* player = get_player(plyr_idx);
-    struct RoomSpace *render_roomspace = get_local_dig_prediction_render_roomspace(&player->render_roomspace);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    SYNCDBG(7,"Starting for player %d at subtile (%d,%d)",(int)player->id_number,(int)stl_x,(int)stl_y);
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
-    int floor_height_z = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
+    int floor_height_z = floor_height_for_volume_box(player->id_number, slb_x, slb_y);
     TbBool allowed = false;
     if (render_roomspace->slab_count > 0 && full_slab) // if roomspace is not empty
     {
         allowed = true;
     }
-    else if (subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false)) // else if not using roomspace, is current slab diggable
+    else if (subtile_is_diggable_for_player(player->id_number, stl_x, stl_y, false)) // else if not using roomspace, is current slab diggable
     {
         allowed = true;
     }
@@ -86,7 +82,7 @@ unsigned char tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
             }
         }
     }
-    if (is_my_player_number(plyr_idx) && !game_is_busy_doing_gui() && (game.small_map_state != 2) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
+    if (is_my_player_number(player->id_number) && !game_is_busy_doing_gui() && (game.small_map_state != 2) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
     {
         map_volume_box.visible = 1;
         map_volume_box.color = line_color;

--- a/src/cursor_tag.h
+++ b/src/cursor_tag.h
@@ -28,7 +28,10 @@ extern "C" {
 
 #pragma pack()
 /******************************************************************************/
-unsigned char tag_cursor_blocks_dig(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab);
+struct PlayerInfo;
+struct Packet;
+struct RoomSpace;
+unsigned char tag_cursor_blocks_dig(struct PlayerInfo *player, const struct Packet *pckt, struct RoomSpace *render_roomspace, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab);
 void tag_cursor_blocks_thing_in_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool is_special_digger, TbBool full_slab);
 TbBool tag_cursor_blocks_sell_area(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab);
 TbBool tag_cursor_blocks_place_door(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -796,7 +796,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
         {
         case CSt_PickAxe:
         {
-            set_pointer_graphic((player->roomspace_highlight_mode == 1) ? MousePG_Pickaxe2 : MousePG_Pickaxe);
+            set_pointer_graphic((player->roomspace_highlight_mode == drag_placement_mode) ? MousePG_Pickaxe2 : MousePG_Pickaxe);
             break;
         }
         case CSt_DoorKey:
@@ -849,7 +849,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
             } else
             {
                 if ((player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0) {
-                  set_pointer_graphic((player->roomspace_highlight_mode == 1) ? MousePG_Pickaxe2 : MousePG_Pickaxe);
+                  set_pointer_graphic((player->roomspace_highlight_mode == drag_placement_mode) ? MousePG_Pickaxe2 : MousePG_Pickaxe);
                 } else {
                   set_pointer_graphic(MousePG_Invisible);
                 }

--- a/src/packets.c
+++ b/src/packets.c
@@ -1043,7 +1043,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
     case PckA_SetRoomspaceHighlight:
     {
         player->roomspace_mode = pckt->actn_par1;
-        if ( (pckt->actn_par2 == 1) || (pckt->actn_par1 == 2) )
+        if ( (pckt->actn_par2 == 1) || (pckt->actn_par1 == roomspace_detection_mode) )
         {
             // exit out of click and drag mode
             if (player->render_roomspace.drag_mode)
@@ -1060,13 +1060,13 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         player->roomspace_highlight_mode = pckt->actn_par1;
         switch (pckt->actn_par1)
         {
-            case 0:
+            case box_placement_mode:
             {
                 reset_dungeon_build_room_ui_variables(plyr_idx);
                 player->roomspace_width = player->roomspace_height = pckt->actn_par2;
                 break;
             }
-            case 1: // drag
+            case drag_placement_mode: // drag
             {
                 if (pckt->actn_par2 == 1)
                 {

--- a/src/packets.c
+++ b/src/packets.c
@@ -970,62 +970,15 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       set_player_mode(player, pckt->actn_par1);
       set_engine_view(player, player->view_mode_restore);
       return false;
-  case PckA_SetRoomspaceAuto:
-    {
-        player->roomspace_detection_looseness = (unsigned char)pckt->actn_par1;
-        player->roomspace_mode = roomspace_detection_mode;
-        player->one_click_mode_exclusive = false;
-        player->render_roomspace.highlight_mode = false;
-        return false;
-    }
-   case PckA_SetRoomspaceMan:
-    {
-        player->user_defined_roomspace_width = pckt->actn_par1;
-        player->roomspace_width = pckt->actn_par1;
-        player->roomspace_height = pckt->actn_par1;
-        player->roomspace_mode = box_placement_mode;
-        player->one_click_mode_exclusive = false;
-        player->render_roomspace.highlight_mode = false;
-        player->roomspace_no_default = true;
-        return false;
-    }
+    case PckA_SetRoomspaceAuto:
+    case PckA_SetRoomspaceMan:
     case PckA_SetRoomspaceDragPaint:
-    {
-        player->roomspace_height = 1;
-        player->roomspace_width = 1;
-    }
-    // fall through
     case PckA_SetRoomspaceDrag:
-    {
-        player->roomspace_detection_looseness = DEFAULT_USER_ROOMSPACE_DETECTION_LOOSENESS;
-        player->user_defined_roomspace_width = DEFAULT_USER_ROOMSPACE_WIDTH;
-        player->roomspace_mode = drag_placement_mode;
-        player->one_click_mode_exclusive = true; // Enable GuiLayer_OneClickBridgeBuild layer
-        player->render_roomspace.highlight_mode = false;
-        player->roomspace_no_default = false;
-        player->roomspace_drag_paint_mode = (pckt->action == PckA_SetRoomspaceDragPaint);
-        return false;
-    }
     case PckA_SetRoomspaceDefault:
-    {
-        player->roomspace_detection_looseness = DEFAULT_USER_ROOMSPACE_DETECTION_LOOSENESS;
-        player->user_defined_roomspace_width = DEFAULT_USER_ROOMSPACE_WIDTH;
-        player->roomspace_width = player->roomspace_height = pckt->actn_par1;
-        player->roomspace_mode = box_placement_mode;
-        player->one_click_mode_exclusive = false;
-        player->roomspace_no_default = false;
-        return false;
-    }
     case PckA_SetRoomspaceWholeRoom:
-    {
-        player->render_roomspace.highlight_mode = false;
-        player->roomspace_mode = roomspace_detection_mode;
-        return false;
-    }
     case PckA_SetRoomspaceSubtile:
     {
-        player->render_roomspace.highlight_mode = false;
-        player->roomspace_mode = single_subtile_mode;
+        apply_roomspace_packet_action(player, pckt);
         return false;
     }
     case PckA_RoomspaceHighlightToggle:

--- a/src/packets.h
+++ b/src/packets.h
@@ -357,7 +357,6 @@ void close_packet_file(void);
 TbBool reinit_packets_after_load(void);
 struct Room *keeper_build_room(long stl_x,long stl_y,long plyr_idx,long rkind);
 TbBool player_sell_room_at_subtile(long plyr_idx, long stl_x, long stl_y);
-void set_tag_untag_mode(PlayerNumber plyr_idx);
 TbBool packets_process_cheats(PlayerNumber plyr_idx, MapCoord x, MapCoord y,
     struct Packet* pckt, MapSubtlCoord stl_x, MapSubtlCoord stl_y, MapSlabCoord slb_x, MapSlabCoord slb_y);
 void disable_packet_mode(void);

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -125,13 +125,7 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
         }
         return false;
     }
-    player->full_slab_cursor = 1; // always use full slabs, not single subtiles
-    if (is_my_player(player))
-    {
-        gui_room_type_highlighted = player->chosen_room_kind;
-    }
-    get_dungeon_build_user_roomspace(&player->render_roomspace, player->id_number, player->chosen_room_kind, stl_x, stl_y, player->roomspace_mode);
-    long i = tag_cursor_blocks_place_room(player->id_number, stl_x, stl_y, player->full_slab_cursor);
+    TbBool can_place_room = update_dungeon_build_roomspace_preview(plyr_idx, stl_x, stl_y);
     if ( (player->roomspace_mode == drag_placement_mode) && (player->roomspace_drag_paint_mode == false) )
     {
        if ((pckt->control_flags & PCtr_LBtnRelease) != PCtr_LBtnRelease)
@@ -158,7 +152,7 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
             return false; //stops attempts at invalid rooms, if left mouse button held (i.e. don't repeat failure sound repeatedly in paint mode)
         }
     }
-    if (i == 0)
+    if (!can_place_room)
     {
         if (can_build_room_at_slab(player->id_number, player->chosen_room_kind, subtile_slab(stl_x), subtile_slab(stl_y)))
         {
@@ -560,9 +554,7 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
     MapCoord y = (pckt->pos_y);
     MapSubtlCoord stl_x = coord_subtile(x);
     MapSubtlCoord stl_y = coord_subtile(y);
-    player->full_slab_cursor = (player->roomspace_mode != single_subtile_mode);
-    get_dungeon_sell_user_roomspace(&player->render_roomspace, player->id_number, stl_x, stl_y);
-    tag_cursor_blocks_sell_area(plyr_idx, stl_x, stl_y, player->full_slab_cursor);
+    update_dungeon_sell_roomspace_preview(plyr_idx, stl_x, stl_y);
     if (player->roomspace_mode == drag_placement_mode)
     {
        if ((pckt->control_flags & PCtr_LBtnRelease) != PCtr_LBtnRelease)

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -108,24 +108,6 @@ struct Thing *get_thing_under_hand(struct PlayerInfo *player, MapCoord x, MapCoo
     return INVALID_THING;
 }
 
-void set_tag_untag_mode(PlayerNumber plyr_idx)
-{
-    struct PlayerInfo* player = get_player(plyr_idx);
-    // The commented out section is the old way, this check is now performed as part of keeper_highlight_roomspace() in roomspace.cabs
-    // which sets render_roomspace.untag_mode
-    /*long i;
-    i = get_subtile_number(stl_slab_center_subtile(stl_x),stl_slab_center_subtile(stl_y));
-    if (find_from_task_list(plyr_idx,i) != -1)
-        player->allocflags |= PlaF_ChosenSlabHasActiveTask;
-    else
-        player->allocflags &= ~PlaF_ChosenSlabHasActiveTask;*/
-
-    if (player->render_roomspace.untag_mode)
-        player->allocflags |= PlaF_ChosenSlabHasActiveTask;
-    else
-        player->allocflags &= ~PlaF_ChosenSlabHasActiveTask;
-}
-
 TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
@@ -256,8 +238,8 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
         } else
         {
             player->additional_flags |= PlaAF_ChosenSubTileIsHigh;
-            get_dungeon_highlight_user_roomspace(&player->render_roomspace, player->id_number, stl_x, stl_y);
-            tag_cursor_blocks_dig(player->id_number, stl_x, stl_y, player->full_slab_cursor);
+            get_dungeon_highlight_user_roomspace(&player->render_roomspace, player, pckt, stl_x, stl_y, NULL);
+            tag_cursor_blocks_dig(player, pckt, &player->render_roomspace, stl_x, stl_y, player->full_slab_cursor);
             player->thing_under_hand = 0;
         }
     }
@@ -311,8 +293,8 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         if ( (player->primary_cursor_state == CSt_PickAxe) || ( (player->primary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0) ) )
         {
             player->thing_under_hand = 0;
-            get_dungeon_highlight_user_roomspace(&player->render_roomspace, player->id_number, stl_x, stl_y);
-            box_colour = tag_cursor_blocks_dig(player->id_number, stl_x, stl_y, player->full_slab_cursor);
+            get_dungeon_highlight_user_roomspace(&player->render_roomspace, player, pckt, stl_x, stl_y, NULL);
+            box_colour = tag_cursor_blocks_dig(player, pckt, &player->render_roomspace, stl_x, stl_y, player->full_slab_cursor);
             at_limit = (box_colour == SLC_REDYELLOW) || (box_colour == SLC_REDFLASH);
         }
         if ((pckt->control_flags & PCtr_LBtnClick) != 0)
@@ -324,7 +306,6 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
             switch (player->primary_cursor_state)
             {
                 case CSt_PickAxe:
-                    set_tag_untag_mode(plyr_idx);
                     if (!player->render_roomspace.drag_mode)
                     {
                         if (at_limit)
@@ -352,7 +333,6 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
                 case CSt_PowerHand:
                     if (player->thing_under_hand == 0)
                     {
-                        set_tag_untag_mode(plyr_idx);
                         if (!player->render_roomspace.drag_mode)
                         {
                             if (at_limit)
@@ -384,10 +364,6 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         if (player->secondary_cursor_state == CSt_DefaultArrow)
         {
             player->secondary_cursor_state = player->primary_cursor_state;
-            if (player->primary_cursor_state == CSt_PickAxe)
-            {
-                set_tag_untag_mode(plyr_idx);
-            }
         }
         if (player->cursor_button_down != 0)
         {
@@ -510,7 +486,6 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
                 else
                 {
                     player->render_roomspace.untag_mode = !player->render_roomspace.untag_mode;
-                    set_tag_untag_mode(plyr_idx);
                 }
             }
             player->secondary_cursor_state = CSt_DefaultArrow;

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -44,7 +44,6 @@ enum PlayerInitFlags {
     PlaF_NewMPMessage            = 0x04,
     PlaF_CreaturePassengerMode   = 0x08,
     PlaF_KeyboardInputDisabled   = 0x10,
-    PlaF_ChosenSlabHasActiveTask = 0x20, // Enabled when there are active tasks for the current slab. Used to determine if a high slab is tagged for digging (or not).
     PlaF_CompCtrl                = 0x40,
     PlaF_MouseInputDisabled      = 0x80,
 };
@@ -244,7 +243,7 @@ struct PlayerInfo {
     TbBool one_click_lock_cursor;
     TbBool ignore_next_PCtr_RBtnRelease;
     TbBool ignore_next_PCtr_LBtnRelease;
-    char swap_to_untag_mode; // 0 = no, 1 = maybe, 2= yes, -1 = disable
+    char swap_to_untag_mode;
     unsigned char roomspace_highlight_mode;
     TbBool roomspace_no_default;
     MapSubtlCoord cursor_subtile_x;

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -41,6 +41,26 @@ extern "C" {
 /******************************************************************************/
 TbBool reset_roomspace = false;
 
+static enum DigTagMode get_roomspace_slab_dig_tag_mode(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y, const unsigned char *predicted_slab_tag_modes)
+{
+    if (slab_coords_invalid(slb_x, slb_y)) {
+        return DigTagMode_Tag;
+    }
+    if (predicted_slab_tag_modes != NULL) {
+        unsigned char predicted_dig_tag_mode = predicted_slab_tag_modes[get_slab_number(slb_x, slb_y)];
+        if (predicted_dig_tag_mode == DigTagMode_Tag) {
+            return DigTagMode_Untag;
+        }
+        if (predicted_dig_tag_mode == DigTagMode_Untag) {
+            return DigTagMode_Tag;
+        }
+    }
+    if (find_from_task_list_by_slab(plyr_idx, slb_x, slb_y) != -1) {
+        return DigTagMode_Untag;
+    }
+    return DigTagMode_Tag;
+}
+
 static TbBool roomspace_slab_matches_dig_tag_mode(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y, enum DigTagMode dig_tag_mode, const unsigned char *predicted_slab_tag_modes)
 {
     if (slab_coords_invalid(slb_x, slb_y)) {
@@ -51,14 +71,7 @@ static TbBool roomspace_slab_matches_dig_tag_mode(PlayerNumber plyr_idx, MapSlab
     if (!subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false)) {
         return false;
     }
-    if (predicted_slab_tag_modes != NULL) {
-        unsigned char predicted_dig_tag_mode = predicted_slab_tag_modes[get_slab_number(slb_x, slb_y)];
-        if (predicted_dig_tag_mode != 0) {
-            return predicted_dig_tag_mode != dig_tag_mode;
-        }
-    }
-    TbBool slab_has_dig_task = find_from_task_list_by_slab(plyr_idx, slb_x, slb_y) != -1;
-    return slab_has_dig_task == (dig_tag_mode == DigTagMode_Untag);
+    return get_roomspace_slab_dig_tag_mode(plyr_idx, slb_x, slb_y, predicted_slab_tag_modes) == dig_tag_mode;
 }
 
 static TbBool get_roomspace_drag_scan_range(const struct RoomSpace *roomspace, unsigned char drag_direction, int *scan_start_x, int *scan_end_x, int *scan_step_x, int *scan_start_y, int *scan_end_y, int *scan_step_y)
@@ -168,7 +181,7 @@ struct RoomSpace create_box_roomspace_from_drag(struct RoomSpace roomspace, MapS
     return roomspace;
 }
 
-struct RoomSpace create_dig_highlight_roomspace(struct RoomSpace roomspace, unsigned char highlight_mode, int width, MapSlabCoord drag_start_x, MapSlabCoord drag_start_y, MapSlabCoord slb_x, MapSlabCoord slb_y)
+static struct RoomSpace create_dig_highlight_roomspace(struct RoomSpace roomspace, unsigned char highlight_mode, int width, MapSlabCoord drag_start_x, MapSlabCoord drag_start_y, MapSlabCoord slb_x, MapSlabCoord slb_y)
 {
     if (highlight_mode == drag_placement_mode) {
         roomspace = create_box_roomspace_from_drag(roomspace, drag_start_x, drag_start_y, slb_x, slb_y);
@@ -518,9 +531,9 @@ void reset_dungeon_build_room_ui_variables(PlayerNumber plyr_idx)
     player->user_defined_roomspace_width = DEFAULT_USER_ROOMSPACE_WIDTH;
 }
 
-void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, struct PlayerInfo *player, const struct Packet *pckt, MapSubtlCoord stl_x, MapSubtlCoord stl_y, const unsigned char *predicted_slab_tag_modes)
 {
-    struct PlayerInfo* player = get_player(plyr_idx);
+    PlayerNumber plyr_idx = player->id_number;
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
     struct RoomSpace current_roomspace;
@@ -529,18 +542,18 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNum
     TbBool one_click_mode_exclusive = false;
     MapSlabCoord drag_start_x = slb_x;
     MapSlabCoord drag_start_y = slb_y;
-    struct Packet* pckt = get_packet_direct(player->packet_num);
     if (player->ignore_next_PCtr_LBtnRelease)
     {
         // because player cancelled a tag/untag with RMB, we need to default back to vanilla 1x1 box
         player->render_roomspace.drag_mode = false;
         player->one_click_lock_cursor = false;
-        reset_dungeon_build_room_ui_variables(plyr_idx);
+        player->roomspace_detection_looseness = DEFAULT_USER_ROOMSPACE_DETECTION_LOOSENESS;
+        player->user_defined_roomspace_width = DEFAULT_USER_ROOMSPACE_WIDTH;
         current_roomspace = create_box_roomspace(player->render_roomspace, player->roomspace_width, player->roomspace_height, slb_x, slb_y);
         current_roomspace.highlight_mode = false;
         current_roomspace.untag_mode = false;
         current_roomspace.one_click_mode_exclusive = false;
-        current_roomspace = check_roomspace_for_diggable_slabs(current_roomspace, plyr_idx, NULL);
+        current_roomspace = check_roomspace_for_diggable_slabs(current_roomspace, plyr_idx, predicted_slab_tag_modes);
         player->boxsize = current_roomspace.slab_count;
         *roomspace = current_roomspace;
         return;
@@ -550,14 +563,17 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNum
         player->render_roomspace.drag_start_x = slb_x;
         player->render_roomspace.drag_start_y = slb_y;
     }
-    if ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld) // highlight "paint mode" enabled
+    if ((pckt->control_flags & PCtr_LBtnClick) != 0) {
+        player->render_roomspace.untag_mode = (get_roomspace_slab_dig_tag_mode(plyr_idx, slb_x, slb_y, predicted_slab_tag_modes) == DigTagMode_Untag);
+    }
+    if (((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld) || (((pckt->control_flags & PCtr_LBtnRelease) != 0) && player->one_click_lock_cursor)) // highlight "paint mode" enabled
     {
         player->one_click_lock_cursor = true;
         untag_mode = player->render_roomspace.untag_mode; // get tag/untag mode from the slab that was clicked (before the user started holding mouse button)
     }
     else // user is hovering the mouse cursor
     {
-        if (find_from_task_list(plyr_idx, get_subtile_number(stl_slab_center_subtile(stl_x),stl_slab_center_subtile(stl_y))) != -1)
+        if (get_roomspace_slab_dig_tag_mode(plyr_idx, slb_x, slb_y, predicted_slab_tag_modes) == DigTagMode_Untag)
         {
             untag_mode = true;
         }
@@ -613,7 +629,7 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNum
     current_roomspace.highlight_mode = highlight_mode;
     current_roomspace.untag_mode = untag_mode;
     current_roomspace.one_click_mode_exclusive = one_click_mode_exclusive;
-    current_roomspace = check_roomspace_for_diggable_slabs(current_roomspace, plyr_idx, NULL);
+    current_roomspace = check_roomspace_for_diggable_slabs(current_roomspace, plyr_idx, predicted_slab_tag_modes);
     if (player->swap_to_untag_mode == 1) // if swap_to_untag_mode == maybe
     {
         // highlight roomspace was started on undiggable highslab, and we are therefore in "tag mode"...
@@ -623,11 +639,11 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNum
             // then check for slabs for untagging instead, and if some are found, change to untag mode
             struct RoomSpace untag_roomspace = current_roomspace;
             untag_roomspace.untag_mode = true;
-            untag_roomspace = check_roomspace_for_diggable_slabs(untag_roomspace, plyr_idx, NULL);
-            if ((untag_roomspace.slab_count > 0) && ((pckt->control_flags & PCtr_LBtnAnyAction) == 0)) //only switch modes when no buttons are held
+            untag_roomspace = check_roomspace_for_diggable_slabs(untag_roomspace, plyr_idx, predicted_slab_tag_modes);
+            if ((untag_roomspace.slab_count > 0) && (((pckt->control_flags & PCtr_LBtnAnyAction) == 0) || ((pckt->control_flags & PCtr_LBtnClick) != 0)))
             {
                 current_roomspace = untag_roomspace;
-                player->swap_to_untag_mode = 2;
+                player->swap_to_untag_mode = -1;
             }
         }
         else if (current_roomspace.slab_count > 0)
@@ -644,12 +660,6 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNum
     if ((player->one_click_lock_cursor) && ((pckt->control_flags & PCtr_LBtnHeld) != 0) && (!current_roomspace.drag_mode))
     {
         current_roomspace.is_roomspace_a_box = true; // force full box cursor in "paint mode" - this stops the accurate boundbox appearing for a frame, before the slabs are tagged/untagged (which appears as flickering to the user)
-    }
-    if (player->swap_to_untag_mode == 2) // if swap_to_untag_mode == yes
-    {
-        // change to untag mode, as requested, and disable swap_to_untag_mode
-        set_tag_untag_mode(plyr_idx);
-        player->swap_to_untag_mode = -1; // disable
     }
     *roomspace = current_roomspace;
 }
@@ -988,7 +998,7 @@ static void find_next_point(struct RoomSpace *roomspace, unsigned char mode)
     }
 }
 
-int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, enum DigTagMode dig_tag_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count)
+int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count)
 {
     int dig_change_count = 0;
     if ((predicted_slab_tag_modes == NULL) != (predicted_task_count == NULL)) {
@@ -997,6 +1007,10 @@ int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *r
     }
     struct PlayerInfo* player = get_player(plyr_idx);
     struct Dungeon* dungeon = get_players_dungeon(player);
+    enum DigTagMode dig_tag_mode = DigTagMode_Tag;
+    if (roomspace->untag_mode) {
+        dig_tag_mode = DigTagMode_Untag;
+    }
     int scan_start_x = roomspace->left;
     int scan_end_x = roomspace->right;
     int scan_step_x = 1;
@@ -1068,11 +1082,7 @@ int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *r
 void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
-    enum DigTagMode dig_tag_mode = DigTagMode_Tag;
-    if ((player->allocflags & PlaF_ChosenSlabHasActiveTask) != 0) {
-        dig_tag_mode = DigTagMode_Untag;
-    }
-    int dig_change_count = apply_roomspace_dig_tag_selection(plyr_idx, roomspace, player->previous_cursor_subtile_x / STL_PER_SLB, player->previous_cursor_subtile_y / STL_PER_SLB, player->roomspace_highlight_mode, dig_tag_mode, NULL, NULL);
+    int dig_change_count = apply_roomspace_dig_tag_selection(plyr_idx, roomspace, player->previous_cursor_subtile_x / STL_PER_SLB, player->previous_cursor_subtile_y / STL_PER_SLB, player->roomspace_highlight_mode, NULL, NULL);
     if (is_my_player(player))
     {
         if ((dig_change_count > 0) && !local_dig_prediction_is_enabled()) {

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -170,12 +170,12 @@ struct RoomSpace create_box_roomspace_from_drag(struct RoomSpace roomspace, MapS
 
 struct RoomSpace create_dig_highlight_roomspace(struct RoomSpace roomspace, unsigned char highlight_mode, int width, MapSlabCoord drag_start_x, MapSlabCoord drag_start_y, MapSlabCoord slb_x, MapSlabCoord slb_y)
 {
-    if (highlight_mode == 1) {
+    if (highlight_mode == drag_placement_mode) {
         roomspace = create_box_roomspace_from_drag(roomspace, drag_start_x, drag_start_y, slb_x, slb_y);
         detect_roomspace_direction(&roomspace);
         return roomspace;
     }
-    if (highlight_mode == 2) {
+    if (highlight_mode == roomspace_detection_mode) {
         roomspace = create_box_roomspace(roomspace, width, width, slb_x, slb_y);
         roomspace.drag_direction = top_left_to_bottom_right;
         return roomspace;
@@ -562,7 +562,7 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNum
             untag_mode = true;
         }
     }
-    if ((player->swap_to_untag_mode == -1) && ((pckt->control_flags & PCtr_RBtnHeld) == PCtr_RBtnHeld) && (player->roomspace_highlight_mode == 2) && (!subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false)) && ((pckt->control_flags & PCtr_LBtnAnyAction) == 0))
+    if ((player->swap_to_untag_mode == -1) && ((pckt->control_flags & PCtr_RBtnHeld) == PCtr_RBtnHeld) && (player->roomspace_highlight_mode == roomspace_detection_mode) && (!subtile_is_diggable_for_player(plyr_idx, stl_x, stl_y, false)) && ((pckt->control_flags & PCtr_LBtnAnyAction) == 0))
     {
         // Allow RMB + CTRL to work as expected over lowslabs (for tagging and untagging)
         // we reset swap_to_untag_mode whenever LMB is not pressed (i.e. we are still in preview mode)
@@ -576,7 +576,7 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNum
             player->swap_to_untag_mode = 1; // maybe
         }
     }
-    if (player->roomspace_highlight_mode == 1)
+    if (player->roomspace_highlight_mode == drag_placement_mode)
     {
         if (((pckt->control_flags & PCtr_LBtnHeld) != 0) || ((pckt->control_flags & PCtr_LBtnRelease) != 0))
         {
@@ -599,7 +599,7 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNum
         }
         highlight_mode = true;
     }
-    else if (player->roomspace_highlight_mode == 2) // Define square room (mouse scroll-wheel changes size - default is 5x5)
+    else if (player->roomspace_highlight_mode == roomspace_detection_mode) // Define square room (mouse scroll-wheel changes size - default is 5x5)
     {
         if ((pckt->control_flags & PCtr_HeldAnyButton) != 0) // Block camera zoom/rotate if Ctrl is held with LMB/RMB
         {
@@ -1003,14 +1003,14 @@ int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *r
     int scan_start_y = roomspace->top;
     int scan_end_y = roomspace->bottom;
     int scan_step_y = 1;
-    if ((highlight_mode != 0) && !get_roomspace_drag_scan_range(roomspace, roomspace->drag_direction, &scan_start_x, &scan_end_x, &scan_step_x, &scan_start_y, &scan_end_y, &scan_step_y)) {
+    if ((highlight_mode != box_placement_mode) && !get_roomspace_drag_scan_range(roomspace, roomspace->drag_direction, &scan_start_x, &scan_end_x, &scan_step_x, &scan_start_y, &scan_end_y, &scan_step_y)) {
         return dig_change_count;
     }
     for (int current_y = scan_start_y; current_y != scan_end_y + scan_step_y; current_y += scan_step_y) {
         for (int current_x = scan_start_x; current_x != scan_end_x + scan_step_x; current_x += scan_step_x) {
             MapSlabCoord path_slb_x = current_x;
             MapSlabCoord path_slb_y = current_y;
-            if (highlight_mode == 0) {
+            if (highlight_mode == box_placement_mode) {
                 path_slb_x = previous_slb_x;
                 path_slb_y = previous_slb_y;
             }
@@ -1453,7 +1453,7 @@ void process_highlight_roomspace_inputs(PlayerNumber plyr_idx)
             }
         }
         set_player_roomspace_size(player, par2);
-        set_players_packet_action(player, PckA_SetRoomspaceHighlight, 2, par2, 0, 0);
+        set_players_packet_action(player, PckA_SetRoomspaceHighlight, roomspace_detection_mode, par2, 0, 0);
         reset_roomspace = true;
         return;
     }
@@ -1477,7 +1477,7 @@ void process_highlight_roomspace_inputs(PlayerNumber plyr_idx)
         if (par2 > 1)
         {
             set_player_roomspace_size(player, par2);
-            set_players_packet_action(player, PckA_SetRoomspaceHighlight, 2, par2, 0, 0);
+            set_players_packet_action(player, PckA_SetRoomspaceHighlight, roomspace_detection_mode, par2, 0, 0);
             reset_roomspace = true;
             return;
         }

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -30,6 +30,8 @@
 #include "config_settings.h"
 #include "slab_data.h"
 #include "tasks_list.h"
+#include "cursor_tag.h"
+#include "frontmenu_ingame_tabs.h"
 #include "roomspace_prediction.h"
 
 #include "keeperfx.hpp"
@@ -889,6 +891,82 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
     }
     best_roomspace.one_click_mode_exclusive = player->one_click_mode_exclusive;
     *roomspace = best_roomspace; // make sure we can render the correct boundbox to the user
+}
+
+TbBool update_dungeon_build_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    struct PlayerInfo *player = get_player(plyr_idx);
+    player->full_slab_cursor = 1;
+    if (is_my_player(player)) {
+        gui_room_type_highlighted = player->chosen_room_kind;
+    }
+    get_dungeon_build_user_roomspace(&player->render_roomspace, player->id_number, player->chosen_room_kind, stl_x, stl_y, player->roomspace_mode);
+    return tag_cursor_blocks_place_room(player->id_number, stl_x, stl_y, player->full_slab_cursor);
+}
+
+TbBool update_dungeon_sell_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    struct PlayerInfo *player = get_player(plyr_idx);
+    if (player->roomspace_mode != single_subtile_mode) {
+        player->full_slab_cursor = 1;
+    } else {
+        player->full_slab_cursor = 0;
+    }
+    get_dungeon_sell_user_roomspace(&player->render_roomspace, player->id_number, stl_x, stl_y);
+    return tag_cursor_blocks_sell_area(plyr_idx, stl_x, stl_y, player->full_slab_cursor);
+}
+
+void apply_roomspace_packet_action(struct PlayerInfo *player, const struct Packet *pckt)
+{
+    switch (pckt->action) {
+    case PckA_SetRoomspaceAuto:
+        player->roomspace_detection_looseness = (unsigned char)pckt->actn_par1;
+        player->roomspace_mode = roomspace_detection_mode;
+        player->one_click_mode_exclusive = false;
+        player->render_roomspace.highlight_mode = false;
+        return;
+    case PckA_SetRoomspaceMan:
+        player->user_defined_roomspace_width = pckt->actn_par1;
+        player->roomspace_width = pckt->actn_par1;
+        player->roomspace_height = pckt->actn_par1;
+        player->roomspace_mode = box_placement_mode;
+        player->one_click_mode_exclusive = false;
+        player->render_roomspace.highlight_mode = false;
+        player->roomspace_no_default = true;
+        return;
+    case PckA_SetRoomspaceDragPaint:
+    case PckA_SetRoomspaceDrag:
+        player->roomspace_drag_paint_mode = false;
+        if (pckt->action == PckA_SetRoomspaceDragPaint) {
+            player->roomspace_height = 1;
+            player->roomspace_width = 1;
+            player->roomspace_drag_paint_mode = true;
+        }
+        player->roomspace_detection_looseness = DEFAULT_USER_ROOMSPACE_DETECTION_LOOSENESS;
+        player->user_defined_roomspace_width = DEFAULT_USER_ROOMSPACE_WIDTH;
+        player->roomspace_mode = drag_placement_mode;
+        player->one_click_mode_exclusive = true;
+        player->render_roomspace.highlight_mode = false;
+        player->roomspace_no_default = false;
+        return;
+    case PckA_SetRoomspaceDefault:
+        player->roomspace_detection_looseness = DEFAULT_USER_ROOMSPACE_DETECTION_LOOSENESS;
+        player->user_defined_roomspace_width = DEFAULT_USER_ROOMSPACE_WIDTH;
+        player->roomspace_width = pckt->actn_par1;
+        player->roomspace_height = pckt->actn_par1;
+        player->roomspace_mode = box_placement_mode;
+        player->one_click_mode_exclusive = false;
+        player->roomspace_no_default = false;
+        return;
+    case PckA_SetRoomspaceWholeRoom:
+        player->render_roomspace.highlight_mode = false;
+        player->roomspace_mode = roomspace_detection_mode;
+        return;
+    case PckA_SetRoomspaceSubtile:
+        player->render_roomspace.highlight_mode = false;
+        player->roomspace_mode = single_subtile_mode;
+        return;
+    }
 }
 
 static void sell_at_point(struct RoomSpace *roomspace)

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -103,13 +103,14 @@ struct RoomSpace {
     TbBool drag_mode;
     unsigned char drag_direction;
 };
+struct PlayerInfo;
+struct Packet;
 /******************************************************************************/
 /******************************************************************************/
 int calc_distance_from_roomspace_centre(int total_distance, TbBool offset);
 
 struct RoomSpace create_box_roomspace(struct RoomSpace roomspace, int width,
 int height, int centre_x, int centre_y);
-struct RoomSpace create_dig_highlight_roomspace(struct RoomSpace roomspace, unsigned char highlight_mode, int width, MapSlabCoord drag_start_x, MapSlabCoord drag_start_y, MapSlabCoord slb_x, MapSlabCoord slb_y);
 struct RoomSpace check_roomspace_for_diggable_slabs(struct RoomSpace roomspace, PlayerNumber plyr_idx, const unsigned char *predicted_slab_tag_modes);
 
 int can_build_roomspace_of_dimensions(PlayerNumber plyr_idx, RoomKind rkind,
@@ -132,14 +133,14 @@ struct RoomSpace get_current_room_as_roomspace(PlayerNumber current_plyr_idx,
                                                MapSlabCoord cursor_x, 
                                                MapSlabCoord cursor_y);
 
-void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, struct PlayerInfo *player, const struct Packet *pckt, MapSubtlCoord stl_x, MapSubtlCoord stl_y, const unsigned char *predicted_slab_tag_modes);
 
 void get_dungeon_sell_user_roomspace(struct RoomSpace *roomspace, PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber plyr_idx, RoomKind rkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y, unsigned char mode);
 
 void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace);
-int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, enum DigTagMode dig_tag_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count);
+int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count);
 void keeper_sell_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace);
 void keeper_build_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace);
 

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -138,6 +138,9 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, struct Pl
 void get_dungeon_sell_user_roomspace(struct RoomSpace *roomspace, PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber plyr_idx, RoomKind rkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y, unsigned char mode);
+TbBool update_dungeon_build_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+TbBool update_dungeon_sell_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+void apply_roomspace_packet_action(struct PlayerInfo *player, const struct Packet *pckt);
 
 void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace);
 int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count);

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -105,7 +105,7 @@ static TbBool get_local_dig_prediction_roomspace(const struct Packet *pckt, stru
     MapSlabCoord slb_y = subtile_slab(coord_subtile(pckt->pos_y));
     MapSlabCoord drag_start_slb_x = slb_x;
     MapSlabCoord drag_start_slb_y = slb_y;
-    if ((*highlight_mode == 1) && ((pckt->control_flags & PCtr_LBtnAnyAction) != 0) && (local_dig_tag_prediction.last_packet_turn != 0)) {
+    if ((*highlight_mode == drag_placement_mode) && ((pckt->control_flags & PCtr_LBtnAnyAction) != 0) && (local_dig_tag_prediction.last_packet_turn != 0)) {
         drag_start_slb_x = local_dig_tag_prediction.drag_start_slb_x;
         drag_start_slb_y = local_dig_tag_prediction.drag_start_slb_y;
     }
@@ -157,18 +157,18 @@ void update_local_dig_tag_prediction(void)
     if (start_selection) {
         local_dig_tag_prediction.last_packet_turn = pckt->turn;
     }
-    if ((highlight_mode == 1) && start_selection) {
+    if ((highlight_mode == drag_placement_mode) && start_selection) {
         memcpy(local_dig_tag_prediction.drag_base_slab_tag_modes, local_dig_tag_prediction.slab_tag_modes, sizeof(local_dig_tag_prediction.slab_tag_modes));
         local_dig_tag_prediction.drag_base_task_count = local_dig_tag_prediction.predicted_task_count;
     }
-    if (highlight_mode == 1) {
+    if (highlight_mode == drag_placement_mode) {
         memcpy(local_dig_tag_prediction.slab_tag_modes, local_dig_tag_prediction.drag_base_slab_tag_modes, sizeof(local_dig_tag_prediction.slab_tag_modes));
         local_dig_tag_prediction.predicted_task_count = local_dig_tag_prediction.drag_base_task_count;
     }
     int changed_slab_count = apply_roomspace_dig_tag_selection(my_player_number, &roomspace, local_dig_tag_prediction.previous_slb_x, local_dig_tag_prediction.previous_slb_y, highlight_mode, local_dig_tag_prediction.dig_tag_mode, local_dig_tag_prediction.slab_tag_modes, &local_dig_tag_prediction.predicted_task_count);
     local_dig_tag_prediction.previous_slb_x = slb_x;
     local_dig_tag_prediction.previous_slb_y = slb_y;
-    if ((changed_slab_count > 0) && ((highlight_mode != 1) || ((pckt->control_flags & PCtr_LBtnRelease) != 0))) {
+    if ((changed_slab_count > 0) && ((highlight_mode != drag_placement_mode) || ((pckt->control_flags & PCtr_LBtnRelease) != 0))) {
         local_dig_tag_prediction.last_packet_turn = pckt->turn;
         play_non_3d_sample(118);
     }

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -91,6 +91,33 @@ static TbBool get_local_dig_prediction_roomspace(const struct Packet *pckt, stru
     return true;
 }
 
+static TbBool update_predicted_build_or_sell_roomspace_preview(struct RoomSpace *roomspace, PlayerNumber plyr_idx, const struct Packet *pckt)
+{
+    if ((pckt == NULL) || ((pckt->control_flags & PCtr_MapCoordsValid) == 0)) {
+        return false;
+    }
+    struct PlayerInfo *player = get_player(plyr_idx);
+    if ((player->work_state != PSt_BuildRoom) && (player->work_state != PSt_Sell)) {
+        return false;
+    }
+    struct Packet *direct_packet = get_packet_direct(player->packet_num);
+    struct PlayerInfo saved_player = *player;
+    struct Packet saved_packet = *direct_packet;
+    *direct_packet = *pckt;
+    apply_roomspace_packet_action(player, pckt);
+    MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
+    MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
+    if (player->work_state == PSt_BuildRoom) {
+        update_dungeon_build_roomspace_preview(plyr_idx, stl_x, stl_y);
+    } else {
+        update_dungeon_sell_roomspace_preview(plyr_idx, stl_x, stl_y);
+    }
+    *roomspace = player->render_roomspace;
+    *player = saved_player;
+    *direct_packet = saved_packet;
+    return true;
+}
+
 void update_local_dig_tag_prediction(void)
 {
     struct Packet *pckt = get_packet(my_player_number);
@@ -189,6 +216,12 @@ void update_local_dig_prediction_cursor_preview(void)
     struct RoomSpace roomspace;
     struct PlayerInfo predicted_player;
     if (!get_local_dig_prediction_roomspace(pckt, &predicted_player, &roomspace)) {
+        if (local_dig_prediction_is_enabled() && update_predicted_build_or_sell_roomspace_preview(&local_dig_render_roomspace, player->id_number, pckt)) {
+            local_dig_render_roomspace_active = true;
+            box_lag_compensation_x = 0;
+            box_lag_compensation_y = 0;
+            return;
+        }
         local_dig_render_roomspace_active = false;
         if (!local_dig_prediction_is_enabled()) {
             return;

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -11,10 +11,10 @@
 #include "cursor_tag.h"
 #include "engine_render.h"
 #include "player_data.h"
+#include "player_utils.h"
 #include "slab_data.h"
 #include "packets.h"
 #include "net_exchange_gameplay.h"
-#include "tasks_list.h"
 #include "roomspace.h"
 #include "roomspace_prediction.h"
 
@@ -25,6 +25,8 @@
 extern "C" {
 #endif
 /******************************************************************************/
+#define LOCAL_DIG_TAG_EXPIRY 3
+
 static struct {
     unsigned char slab_tag_modes[MAX_TILES_X * MAX_TILES_Y];
     unsigned char drag_base_slab_tag_modes[MAX_TILES_X * MAX_TILES_Y];
@@ -35,7 +37,7 @@ static struct {
     MapSlabCoord previous_slb_y;
     int predicted_task_count;
     int drag_base_task_count;
-    enum DigTagMode dig_tag_mode;
+    TbBool untag_mode;
 } local_dig_tag_prediction;
 
 static struct Packet local_dig_roomspace_prediction;
@@ -56,68 +58,44 @@ struct RoomSpace *get_local_dig_prediction_render_roomspace(struct RoomSpace *ro
     return roomspace;
 }
 
-static enum DigTagMode get_local_predicted_slab_dig_tag_mode(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
-{
-    MapSlabCoord slb_x = subtile_slab(stl_x);
-    MapSlabCoord slb_y = subtile_slab(stl_y);
-    if ((local_dig_tag_prediction.last_packet_turn != 0) && !slab_coords_invalid(slb_x, slb_y)) {
-        unsigned char predicted_dig_tag_mode = local_dig_tag_prediction.slab_tag_modes[get_slab_number(slb_x, slb_y)];
-        if (predicted_dig_tag_mode == DigTagMode_Tag) {
-            return DigTagMode_Untag;
-        }
-        if (predicted_dig_tag_mode == DigTagMode_Untag) {
-            return DigTagMode_Tag;
-        }
-    }
-    if (find_from_task_list_by_subtile(my_player_number, stl_x, stl_y) != -1) {
-        return DigTagMode_Untag;
-    }
-    return DigTagMode_Tag;
-}
-
-static enum DigTagMode get_local_predicted_packet_dig_tag_mode(const struct Packet *pckt)
-{
-    if (((pckt->control_flags & PCtr_LBtnClick) == 0) && (local_dig_tag_prediction.last_packet_turn != 0)) {
-        return local_dig_tag_prediction.dig_tag_mode;
-    }
-    MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
-    MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
-    return get_local_predicted_slab_dig_tag_mode(stl_x, stl_y);
-}
-
-static TbBool get_local_dig_prediction_roomspace(const struct Packet *pckt, struct RoomSpace *roomspace, unsigned char *highlight_mode)
+static TbBool get_local_dig_prediction_roomspace(const struct Packet *pckt, struct PlayerInfo *predicted_player, struct RoomSpace *roomspace)
 {
     if (!local_dig_prediction_is_enabled() || (pckt == NULL) || ((pckt->control_flags & PCtr_MapCoordsValid) == 0)) {
         return false;
     }
-    struct PlayerInfo *player = get_my_player();
+    *predicted_player = *get_my_player();
     unsigned char cursor_context = (unsigned char)((pckt->additional_packet_values & PCAdV_ContextMask) >> 1);
-    if ((cursor_context != CSt_PickAxe) && ((cursor_context != CSt_PowerHand) || (local_thing_under_hand != 0))) {
-        return false;
+    MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
+    MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
+    TbBool cursor_is_locked = (local_dig_tag_prediction.last_packet_turn != 0) && ((pckt->control_flags & (PCtr_LBtnHeld | PCtr_LBtnRelease)) != 0);
+    if (!cursor_is_locked && (((pckt->control_flags & PCtr_LBtnAnyAction) == 0) || ((pckt->control_flags & PCtr_LBtnClick) != 0))) {
+        predicted_player->swap_to_untag_mode = 0;
     }
-    int roomspace_width = player->user_defined_roomspace_width;
-    *highlight_mode = player->roomspace_highlight_mode;
+    if ((cursor_context != CSt_PickAxe) && !cursor_is_locked) {
+        if ((cursor_context != CSt_PowerHand) || (local_thing_under_hand != 0) || !can_dig_here(stl_x, stl_y, my_player_number, true)) {
+            return false;
+        }
+    }
     if (local_dig_roomspace_prediction.action != PckA_None) {
-        *highlight_mode = local_dig_roomspace_prediction.actn_par1;
-        roomspace_width = local_dig_roomspace_prediction.actn_par2;
+        predicted_player->roomspace_highlight_mode = local_dig_roomspace_prediction.actn_par1;
+        set_player_roomspace_size(predicted_player, local_dig_roomspace_prediction.actn_par2);
     }
-    MapSlabCoord slb_x = subtile_slab(coord_subtile(pckt->pos_x));
-    MapSlabCoord slb_y = subtile_slab(coord_subtile(pckt->pos_y));
-    MapSlabCoord drag_start_slb_x = slb_x;
-    MapSlabCoord drag_start_slb_y = slb_y;
-    if ((*highlight_mode == drag_placement_mode) && ((pckt->control_flags & PCtr_LBtnAnyAction) != 0) && (local_dig_tag_prediction.last_packet_turn != 0)) {
-        drag_start_slb_x = local_dig_tag_prediction.drag_start_slb_x;
-        drag_start_slb_y = local_dig_tag_prediction.drag_start_slb_y;
+    predicted_player->one_click_lock_cursor = cursor_is_locked;
+    predicted_player->render_roomspace.drag_mode = cursor_is_locked;
+    if (cursor_is_locked) {
+        predicted_player->render_roomspace.drag_start_x = local_dig_tag_prediction.drag_start_slb_x;
+        predicted_player->render_roomspace.drag_start_y = local_dig_tag_prediction.drag_start_slb_y;
+        predicted_player->render_roomspace.untag_mode = local_dig_tag_prediction.untag_mode;
     }
-    *roomspace = create_dig_highlight_roomspace(player->render_roomspace, *highlight_mode, roomspace_width, drag_start_slb_x, drag_start_slb_y, slb_x, slb_y);
+    get_dungeon_highlight_user_roomspace(roomspace, predicted_player, pckt, stl_x, stl_y, local_dig_tag_prediction.slab_tag_modes);
     return true;
 }
 
 void update_local_dig_tag_prediction(void)
 {
-    local_dig_render_roomspace_active = false;
     struct Packet *pckt = get_packet(my_player_number);
     if (!local_dig_prediction_is_enabled()) {
+        local_dig_render_roomspace_active = false;
         memset(&local_dig_tag_prediction, 0, sizeof(local_dig_tag_prediction));
         memset(&local_dig_roomspace_prediction, 0, sizeof(local_dig_roomspace_prediction));
         return;
@@ -130,7 +108,7 @@ void update_local_dig_tag_prediction(void)
         return;
     }
     if ((pckt->control_flags & PCtr_LBtnAnyAction) == 0) {
-        if ((local_dig_tag_prediction.last_packet_turn != 0) && (get_gameturn() - local_dig_tag_prediction.last_packet_turn > game.input_lag_turns + 3)) {
+        if ((local_dig_tag_prediction.last_packet_turn != 0) && (get_gameturn() - local_dig_tag_prediction.last_packet_turn > game.input_lag_turns + LOCAL_DIG_TAG_EXPIRY)) {
             memset(&local_dig_tag_prediction, 0, sizeof(local_dig_tag_prediction));
         }
         return;
@@ -145,30 +123,33 @@ void update_local_dig_tag_prediction(void)
         local_dig_tag_prediction.drag_start_slb_y = slb_y;
     }
     struct RoomSpace roomspace;
-    unsigned char highlight_mode;
-    if (!get_local_dig_prediction_roomspace(pckt, &roomspace, &highlight_mode)) {
+    struct PlayerInfo predicted_player;
+    if (!get_local_dig_prediction_roomspace(pckt, &predicted_player, &roomspace)) {
         memset(&local_dig_tag_prediction, 0, sizeof(local_dig_tag_prediction));
         return;
     }
     if (local_dig_tag_prediction.last_packet_turn == 0) {
         local_dig_tag_prediction.predicted_task_count = get_players_dungeon(get_my_player())->task_count;
     }
-    local_dig_tag_prediction.dig_tag_mode = get_local_predicted_packet_dig_tag_mode(pckt);
+    local_dig_tag_prediction.untag_mode = roomspace.untag_mode;
     if (start_selection) {
         local_dig_tag_prediction.last_packet_turn = pckt->turn;
     }
-    if ((highlight_mode == drag_placement_mode) && start_selection) {
+    if ((predicted_player.roomspace_highlight_mode == drag_placement_mode) && start_selection) {
         memcpy(local_dig_tag_prediction.drag_base_slab_tag_modes, local_dig_tag_prediction.slab_tag_modes, sizeof(local_dig_tag_prediction.slab_tag_modes));
         local_dig_tag_prediction.drag_base_task_count = local_dig_tag_prediction.predicted_task_count;
     }
-    if (highlight_mode == drag_placement_mode) {
+    if (predicted_player.roomspace_highlight_mode == drag_placement_mode) {
         memcpy(local_dig_tag_prediction.slab_tag_modes, local_dig_tag_prediction.drag_base_slab_tag_modes, sizeof(local_dig_tag_prediction.slab_tag_modes));
         local_dig_tag_prediction.predicted_task_count = local_dig_tag_prediction.drag_base_task_count;
     }
-    int changed_slab_count = apply_roomspace_dig_tag_selection(my_player_number, &roomspace, local_dig_tag_prediction.previous_slb_x, local_dig_tag_prediction.previous_slb_y, highlight_mode, local_dig_tag_prediction.dig_tag_mode, local_dig_tag_prediction.slab_tag_modes, &local_dig_tag_prediction.predicted_task_count);
+    if ((predicted_player.roomspace_highlight_mode == drag_placement_mode) && ((pckt->control_flags & PCtr_LBtnRelease) == 0)) {
+        return;
+    }
+    int changed_slab_count = apply_roomspace_dig_tag_selection(my_player_number, &roomspace, local_dig_tag_prediction.previous_slb_x, local_dig_tag_prediction.previous_slb_y, predicted_player.roomspace_highlight_mode, local_dig_tag_prediction.slab_tag_modes, &local_dig_tag_prediction.predicted_task_count);
     local_dig_tag_prediction.previous_slb_x = slb_x;
     local_dig_tag_prediction.previous_slb_y = slb_y;
-    if ((changed_slab_count > 0) && ((highlight_mode != drag_placement_mode) || ((pckt->control_flags & PCtr_LBtnRelease) != 0))) {
+    if (changed_slab_count > 0) {
         local_dig_tag_prediction.last_packet_turn = pckt->turn;
         play_non_3d_sample(118);
     }
@@ -201,28 +182,29 @@ void update_local_dig_prediction_cursor_preview(void)
 {
     struct PlayerInfo *player = get_my_player();
     const struct Packet *pckt = get_history_packet(player->packet_num, get_gameturn());
-    struct Packet *direct_packet = get_packet_direct(player->packet_num);
+    const struct Packet *direct_packet = get_packet_direct(player->packet_num);
     if ((local_dig_roomspace_prediction.action != PckA_None) && ((GameTurnDelta)(direct_packet->turn - local_dig_roomspace_prediction.turn) >= 0)) {
         memset(&local_dig_roomspace_prediction, 0, sizeof(local_dig_roomspace_prediction));
     }
     struct RoomSpace roomspace;
-    unsigned char highlight_mode;
-    if (!get_local_dig_prediction_roomspace(pckt, &roomspace, &highlight_mode)) {
+    struct PlayerInfo predicted_player;
+    if (!get_local_dig_prediction_roomspace(pckt, &predicted_player, &roomspace)) {
+        local_dig_render_roomspace_active = false;
+        if (!local_dig_prediction_is_enabled()) {
+            return;
+        }
+        if ((pckt != NULL) && ((player->primary_cursor_state == CSt_PickAxe) || ((player->primary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0)))) {
+            map_volume_box.visible = 0;
+            box_lag_compensation_x = 0;
+            box_lag_compensation_y = 0;
+        }
         return;
     }
     MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
-    enum DigTagMode dig_tag_mode = get_local_predicted_slab_dig_tag_mode(stl_x, stl_y);
-    if ((pckt->control_flags & PCtr_LBtnAnyAction) != 0) {
-        dig_tag_mode = get_local_predicted_packet_dig_tag_mode(pckt);
-    }
-    roomspace.untag_mode = (dig_tag_mode == DigTagMode_Untag);
-    local_dig_render_roomspace = check_roomspace_for_diggable_slabs(roomspace, my_player_number, local_dig_tag_prediction.slab_tag_modes);
+    local_dig_render_roomspace = roomspace;
     local_dig_render_roomspace_active = true;
-    struct Packet saved_packet = *direct_packet;
-    *direct_packet = *pckt;
-    tag_cursor_blocks_dig(my_player_number, stl_x, stl_y, true);
-    *direct_packet = saved_packet;
+    tag_cursor_blocks_dig(&predicted_player, pckt, &local_dig_render_roomspace, stl_x, stl_y, true);
     box_lag_compensation_x = 0;
     box_lag_compensation_y = 0;
 }


### PR DESCRIPTION
I've spotted a couple of issues with roomspace prediction. The biggest issue was that holding CTRL while holding a creature would display the 5x5 dig box even when the cursor was not over a slab. There were also a few smaller timing issues where the cursor box could switch between client-side prediction and authoritative rendering at the wrong time. Threw in some integer enum renames as well. I've refactored it to use more shared code instead of duplicated code, which will be more resilient for any future changes to roomspace that people might make. The tag/untag state also needed to be simplified.

The roomspace preview box is now 100% client-side for building/selling as well, previously it was only client-side for digging.