### PR TITLE
fix comparing dropped_turn with gameturn

### DIFF
--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -2858,7 +2858,7 @@ struct Thing *find_creature_for_defend_pickup(struct Computer2 *comp)
                     {
                         if (!creature_is_doing_lair_activity(thing) && !creature_is_being_dropped(thing))
                         {
-                            if (cctrl->dropped_turn < (COMPUTER_REDROP_DELAY + get_gameturn()))
+                            if ((cctrl->dropped_turn + COMPUTER_REDROP_DELAY) < get_gameturn())
                             {
                                 struct PerExpLevelValues* expvalues;
                                 struct CreatureModelConfig* crconf = creature_stats_get(thing->model);


### PR DESCRIPTION
The check preventing computers redropping their creatures was being ignored.