### PR TITLE
Multiplayer: disallow disconnection victories for co-op maps + refactor

### DIFF
--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -118,7 +118,7 @@ msgid ""
 msgstr ""
 "Bravo pour votre avidité, Gardien. Vous devez maintenant transformer une "
 "partie de votre Donjon en Antre où les créatures se reposeront et pourront "
-"récupéré. La zone que vos lutins ont fini d'exploiter serait idéale. "
+"récupérer. La zone que vos lutins ont fini d'exploiter serait idéale. "
 "Sélectionnez l'icône Antre dans le panneau des salles."
 
 #. Level Eversmile objective after Lair built

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -368,6 +368,7 @@ static CoroutineLoopState startup_network_game_tail(CoroutineLoop *context)
     TbBool ShouldAssignCpuKeepers = coroutine_args(context)[0];
     if (game.game_kind == GKind_MultiGame) {
         setup_alliances();
+        are_disconnect_victories_allowed();
     }
     if (fe_computer_players || ShouldAssignCpuKeepers)
     {

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -167,6 +167,7 @@ static void verify_startup_sprite_zip_checksums(const struct StartupSyncPacket s
 
 static struct StartupSyncPacket s_local_startup_sync;
 static struct StartupSyncPacket s_startup_sync_packets[MAX_NET_USERS];
+static TbBool network_disconnect_victory_enabled;
 
 static void build_local_startup_sync(void)
 {
@@ -264,6 +265,19 @@ TbBool init_players_network_game(void)
     return net_startup_sync_exchange_and_apply();
 }
 
+void are_disconnect_victories_allowed(void)
+{
+    struct PlayerInfo *myplyr = get_my_player();
+    network_disconnect_victory_enabled = false;
+    for (int player_index = 0; player_index < game.active_players_count; player_index++) {
+        struct PlayerInfo *player = get_player(player_index);
+        if (player_exists(player) && !is_my_player(player) && players_are_enemies(myplyr->id_number, player->id_number)) {
+            network_disconnect_victory_enabled = true;
+            return;
+        }
+    }
+}
+
 /** Check whether a network player is active.
  *
  * @param plyr_idx
@@ -295,7 +309,7 @@ static void resolve_network_quit_outcome(struct PlayerInfo *player)
     set_player_as_won_level(player);
 }
 
-static TbBool network_has_enemies_to_defeat(void)
+static TbBool network_has_remote_enemies_remaining(void)
 {
     struct PlayerInfo *myplyr = get_my_player();
     for (int i = 0; i < PLAYERS_COUNT; i++) {
@@ -310,7 +324,7 @@ static TbBool network_has_enemies_to_defeat(void)
     return false;
 }
 
-static TbBool network_has_connected_remote_users(void)
+static TbBool network_has_remote_users_remaining(void)
 {
     for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_players; user_id += 1) {
         if (user_id != netstate.my_id && netstate.users[user_id].progress != USER_UNUSED) {
@@ -320,23 +334,12 @@ static TbBool network_has_connected_remote_users(void)
     return false;
 }
 
-static TbBool replace_network_player_with_ai(struct PlayerInfo *player, const char *departure_message_format)
+static void replace_network_player_with_ai(struct PlayerInfo *player)
 {
-    if (is_my_player(player) || (player->allocflags & PlaF_CompCtrl) != 0) {
-        return false;
-    }
-    if (departure_message_format != NULL && player->id_number != get_host_player_id() && player->player_name[0] != '\0') {
-        message_add_fmt(MsgType_Blank, 0, departure_message_format, player->player_name);
-        JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);
-    }
-    if (player->victory_state != VicS_Undecided) {
-        return false;
-    }
     player->allocflags |= PlaF_CompCtrl;
     toggle_computer_player(player->id_number);
     message_add(MsgType_Player, player->id_number, get_string(GUIStr_NetAiTookOver));
     JUSTLOG("p:%d computer took over", player->id_number);
-    return true;
 }
 
 static void stop_network_game_state(void)
@@ -353,14 +356,11 @@ static void stop_network_game_state(void)
     setup_count_players();
 }
 
-static void stop_network_game_and_quit(short complete_quit)
+static void stop_network_game_and_quit_to_main_menu(void)
 {
     LbNetwork_Stop();
     stop_network_game_state();
     quit_game = 1;
-    if (complete_quit) {
-        exit_keeper = 1;
-    }
 }
 
 static void stop_network_game_and_continue_locally(void)
@@ -370,62 +370,35 @@ static void stop_network_game_and_continue_locally(void)
     get_my_player()->display_objective_turn = get_gameturn() + 1;
 }
 
-void process_quit_packet(struct PlayerInfo *player, short complete_quit)
+static TbBool host_already_won_level(void)
 {
-    struct PlayerInfo *myplyr = get_my_player();
-    if ((game.system_flags & GSF_NetworkActive) == 0) {
-        player->allocflags &= ~PlaF_Allocated;
-        if (player == myplyr) {
-            quit_game = 1;
-            if (complete_quit) {
-                exit_keeper = 1;
-            }
+    GameTurn newest_turn = get_gameturn();
+    for (GameTurnDelta offset = 0; offset <= game.input_lag_turns; offset += 1) {
+        if ((GameTurn)offset > newest_turn) {
+            break;
         }
-        return;
+        const struct Packet *host_packet = get_history_packet(get_host_player_id(), newest_turn - offset);
+        if (host_packet != NULL && host_packet->action == PckA_FinishGame && host_packet->actn_par1 == VicS_WonLevel) {
+            return true;
+        }
     }
+    return false;
+}
 
-    TbBool replaced_with_ai = replace_network_player_with_ai(player, get_string(GUIStr_NetPlayerDisconnected));
-    if (player != myplyr) {
-        OnDroppedUser(player->packet_num, NETDROP_MANUAL);
-        if (player->id_number == get_host_player_id()) {
+void process_player_leave_game_packet(struct PlayerInfo *player)
+{
+    if (player != get_my_player()) {
+        if ((game.system_flags & GSF_NetworkActive) != 0) {
+            OnDroppedUser(player->packet_num, NETDROP_MANUAL);
             process_disconnected_network_players();
             return;
         }
+    } else if ((game.system_flags & GSF_NetworkActive) != 0) {
+        stop_network_game_and_quit_to_main_menu();
+    } else {
+        quit_game = 1;
     }
-    TbBool has_enemies_to_defeat = network_has_enemies_to_defeat();
-    if (has_enemies_to_defeat && replaced_with_ai) {
-        return;
-    }
-
-    int32_t plyr_count = 0;
-    short winning_quit = winning_player_quitting(player, &plyr_count);
-    if (winning_quit) {
-        for (int i = 0; i < PLAYERS_COUNT; i++) {
-            struct PlayerInfo *swplyr = get_player(i);
-            if (player_exists(swplyr) && (swplyr->is_active == 1)) {
-                resolve_network_quit_outcome(swplyr);
-            }
-        }
-    }
-    if (player == myplyr || player->id_number == get_host_player_id() || !has_enemies_to_defeat) {
-        if (player != myplyr) {
-            resolve_network_quit_outcome(myplyr);
-        }
-        if (winning_quit && (plyr_count > 1)) {
-            myplyr->additional_flags |= PlaAF_UnlockedLordTorture;
-        }
-        if (player == myplyr || has_enemies_to_defeat || !network_has_connected_remote_users()) {
-            if ((player != myplyr) && (myplyr->victory_state != VicS_Undecided)) {
-                stop_network_game_and_continue_locally();
-            } else {
-                stop_network_game_and_quit(complete_quit);
-            }
-        }
-    }
-
-    if (!replaced_with_ai) {
-        player->allocflags &= ~PlaF_Allocated;
-    }
+    player->allocflags &= ~PlaF_Allocated;
 }
 
 void process_disconnected_network_players(void)
@@ -433,36 +406,45 @@ void process_disconnected_network_players(void)
     if ((game.system_flags & GSF_NetworkActive) == 0) {
         return;
     }
+    struct PlayerInfo *myplyr = get_my_player();
     TbBool host_disconnected = (netstate.my_id != SERVER_ID) && (netstate.users[SERVER_ID].progress == USER_UNUSED);
-    const char *departure_message_format = get_string(GUIStr_NetPlayerDisconnected);
-    if (host_disconnected) {
-        departure_message_format = NULL;
-        GameTurn newest_turn = get_gameturn();
-        for (GameTurnDelta offset = 0; offset <= game.input_lag_turns; offset += 1) {
-            if ((GameTurn)offset > newest_turn) {
-                break;
-            }
-            const struct Packet *host_packet = get_history_packet(get_host_player_id(), newest_turn - offset);
-            if (host_packet != NULL && host_packet->action == PckA_FinishGame && host_packet->actn_par1 == VicS_WonLevel) {
-                get_my_player()->additional_flags &= ~PlaAF_UnlockedLordTorture;
-                quit_game = 1;
-                return;
-            }
-        }
-    }
     TbBool disconnected = host_disconnected;
+    TbBool enemy_disconnected = false;
+    TbBool winning_quit = false;
+    int32_t plyr_count = 0;
+    if (host_disconnected && host_already_won_level()) {
+        myplyr->additional_flags &= ~PlaAF_UnlockedLordTorture;
+        quit_game = 1;
+        return;
+    }
     for (int player_index = 0; player_index < MAX_NET_USERS; player_index++) {
         struct PlayerInfo *player = get_player(player_index);
         if (!player_exists(player) || is_my_player(player) || (!host_disconnected && network_player_active(player->packet_num))) {
             continue;
         }
         disconnected = true;
-        if (!replace_network_player_with_ai(player, departure_message_format) && player->victory_state != VicS_Undecided) {
+        if (network_disconnect_victory_enabled && players_are_enemies(myplyr->id_number, player->id_number)) {
+            enemy_disconnected = true;
+            if (!winning_quit && winning_player_quitting(player, &plyr_count)) {
+                winning_quit = true;
+            }
+        }
+        if ((player->allocflags & PlaF_CompCtrl) == 0) {
+            if (!host_disconnected && player->id_number != get_host_player_id() && player->player_name[0] != '\0') {
+                message_add_fmt(MsgType_Blank, 0, get_string(GUIStr_NetPlayerDisconnected), player->player_name);
+                JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);
+            }
+            if (player->victory_state == VicS_Undecided) {
+                replace_network_player_with_ai(player);
+                continue;
+            }
+        }
+        if (player->victory_state != VicS_Undecided) {
             player->allocflags &= ~PlaF_Allocated;
         }
     }
 
-    TbBool has_enemies_to_defeat = network_has_enemies_to_defeat();
+    TbBool has_enemies_to_defeat = network_has_remote_enemies_remaining();
     if (!disconnected || (!host_disconnected && has_enemies_to_defeat)) {
         return;
     }
@@ -473,15 +455,27 @@ void process_disconnected_network_players(void)
             return;
         }
     }
-    struct PlayerInfo *myplyr = get_my_player();
-    resolve_network_quit_outcome(myplyr);
-    if (!host_disconnected && network_has_connected_remote_users()) {
+    if (winning_quit) {
+        for (int i = 0; i < PLAYERS_COUNT; i++) {
+            struct PlayerInfo *swplyr = get_player(i);
+            if (player_exists(swplyr) && (swplyr->is_active == 1)) {
+                resolve_network_quit_outcome(swplyr);
+            }
+        }
+    }
+    if (enemy_disconnected) {
+        resolve_network_quit_outcome(myplyr);
+    }
+    if (winning_quit && (plyr_count > 1)) {
+        myplyr->additional_flags |= PlaAF_UnlockedLordTorture;
+    }
+    if (!host_disconnected && network_has_remote_users_remaining()) {
         return;
     }
-    if (myplyr->victory_state != VicS_Undecided) {
-        stop_network_game_and_continue_locally();
+    if (enemy_disconnected && myplyr->victory_state == VicS_Undecided) {
+        stop_network_game_and_quit_to_main_menu();
     } else {
-        stop_network_game_and_quit(false);
+        stop_network_game_and_continue_locally();
     }
 }
 

--- a/src/net_game.h
+++ b/src/net_game.h
@@ -44,12 +44,13 @@ short setup_network_service(enum FrontendNetService service);
 int setup_old_network_service(void);
 TbBool init_players_network_game(void);
 void setup_count_players(void);
+void are_disconnect_victories_allowed(void);
 
 long network_session_join(void);
 
 TbBool network_player_active(int plyr_idx);
 const char *network_player_name(int plyr_idx);
-void process_quit_packet(struct PlayerInfo *player, short complete_quit);
+void process_player_leave_game_packet(struct PlayerInfo *player);
 void process_disconnected_network_players(void);
 void sync_initial_network_seed(void);
 unsigned long get_host_player_id(void);

--- a/src/packets.c
+++ b/src/packets.c
@@ -20,6 +20,7 @@
 #include "packets.h"
 #include "net_input_lag.h"
 #include "net_checksums.h"
+#include "net_lobby.h"
 
 #include <math.h>
 
@@ -656,6 +657,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
           return 0;
         } else if (host_packet && (victory_state == VicS_WonLevel)) {
           player->additional_flags &= ~PlaAF_UnlockedLordTorture;
+          LbNetwork_Stop();
           quit_game = 1;
           return 0;
         }

--- a/src/packets.c
+++ b/src/packets.c
@@ -616,36 +616,24 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         free_swipe_graphic();
       }
       player->display_flags |= PlaF6_PlyrHasQuit;
-      process_quit_packet(player, 0);
+      process_player_leave_game_packet(player);
       return 1;
   case PckA_ForceApplicationClose:
       {
-        extern unsigned char exit_keeper;
         if (is_my_player(player))
         {
           turn_off_all_menus();
           frontend_save_continue_game(true);
           free_swipe_graphic();
-          // For ALT+F4, just exit directly without network cleanup
           exit_keeper = 1;
         }
         else
         {
-          // Other player force-quit, just mark them as quit
           player->display_flags |= PlaF6_PlyrHasQuit;
-          process_quit_packet(player, 0);
+          process_player_leave_game_packet(player);
         }
         return 1;
       }
-  case PckA_SaveGameAndQuit:
-      if (is_my_player(player))
-      {
-        turn_off_all_menus();
-        frontend_save_continue_game(true);
-      }
-      player->display_flags |= PlaF6_PlyrHasQuit;
-      process_quit_packet(player, 1);
-      return 1;
   case PckA_NoOperation:
       return 1;
   case PckA_FinishGame:
@@ -668,6 +656,8 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
           return 0;
         } else if (host_packet && (victory_state == VicS_WonLevel)) {
           player->additional_flags &= ~PlaAF_UnlockedLordTorture;
+          quit_game = 1;
+          return 0;
         }
       }
       switch (victory_state)
@@ -1641,10 +1631,8 @@ void process_packets(void)
 // Using Alt-F4, or similar operating system close requests
 void force_application_close()
 {
-    extern unsigned char exit_keeper;
     extern int frontend_menu_state;
 
-    // Check if we're in gameplay vs frontend
     if (frontend_menu_state == 0)
     {
         struct PlayerInfo* player = get_my_player();
@@ -1659,7 +1647,6 @@ void force_application_close()
     }
     else
     {
-        // We're in the frontend, just exit directly
         exit_keeper = 1;
     }
 }

--- a/src/packets.h
+++ b/src/packets.h
@@ -39,7 +39,7 @@ enum TbPacketAction {
         PckA_None = 0,
         PckA_QuitToMainMenu, // Quit
         PckA_ForceApplicationClose,
-        PckA_SaveGameAndQuit,
+        PckA_UnusedSlot003,
         PckA_NoOperation,
         PckA_FinishGame, // 5
         PckA_Login,      // From `enum NetMessageType`


### PR DESCRIPTION
- Fixed the issue of "If all human players are allied then one leaves, all others win."

- Also in addition I've added a function `are_disconnect_victories_allowed()` which checks if any players have any human enemies at the start, if not then disconnections won't play into the winstate at all.

- Some of the leaving and disconnection code was scattered and confusing, I've centralized it with this refactor.

- Removed the unused `PckA_SaveGameAndQuit`.

Something for mapmakers to keep in mind is the way this command works:
```
IF(PLAYER0,ALL_DUNGEONS_DESTROYED == 1)
	WIN_GAME
ENDIF
```
It checks if other keepers are "friendly or defeated", so being allied can fulfill the win condition. That means testing this PR with all players allied is a little difficult on the original MP maps because you just win instantly thanks to that DKScript.