### PR TITLE
Multiplayer: fix predicted tagging through windows

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -531,20 +531,16 @@ void create_message_box(const char *title, const char *line1, const char *line2,
 short game_is_busy_doing_gui(void)
 {
     struct PlayerInfo *player = get_my_player();
-    if (player->one_click_lock_cursor)
-      return false;
-    if (!busy_doing_gui)
-      return false;
-    if (battle_creature_over <= 0)
-      return true;
-    PowerKind pwkind = player->chosen_power_kind;
-    struct Thing *thing;
-    thing = thing_get(battle_creature_over);
-    if (!thing_is_invalid(thing) && can_cast_power_on_thing(player->id_number, thing, pwkind))
-    {
+    if (battle_creature_over > 0) {
         return true;
     }
-    return false;
+    if (player->one_click_lock_cursor) {
+        return false;
+    }
+    if (!busy_doing_gui) {
+        return false;
+    }
+    return true;
 }
 
 TbBool get_button_area_input(struct GuiButton *gbtn, int modifiers)

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -10,6 +10,7 @@
 #include "map_data.h"
 #include "cursor_tag.h"
 #include "engine_render.h"
+#include "frontmenu_ingame_evnt.h"
 #include "player_data.h"
 #include "player_utils.h"
 #include "slab_data.h"
@@ -45,6 +46,20 @@ static struct Packet local_dig_roomspace_prediction;
 static struct RoomSpace local_dig_render_roomspace;
 static TbBool local_dig_render_roomspace_active;
 
+static TbBool prevent_local_dig_prediction(const struct Packet *pckt)
+{
+    if (pckt == NULL) {
+        return true;
+    }
+    if ((pckt->control_flags & (PCtr_Gui | PCtr_MapCoordsValid)) != PCtr_MapCoordsValid) {
+        return true;
+    }
+    if ((pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing) || (battle_creature_over > 0)) {
+        return true;
+    }
+    return false;
+}
+
 TbBool local_dig_prediction_is_enabled(void)
 {
     return ((game.system_flags & GSF_NetworkActive) != 0) && !game.packet_load_enable && (game.input_lag_turns > 0);
@@ -60,7 +75,7 @@ struct RoomSpace *get_local_dig_prediction_render_roomspace(struct RoomSpace *ro
 
 static TbBool get_local_dig_prediction_roomspace(const struct Packet *pckt, struct PlayerInfo *predicted_player, struct RoomSpace *roomspace)
 {
-    if (!local_dig_prediction_is_enabled() || (pckt == NULL) || ((pckt->control_flags & PCtr_MapCoordsValid) == 0)) {
+    if (!local_dig_prediction_is_enabled() || prevent_local_dig_prediction(pckt)) {
         return false;
     }
     *predicted_player = *get_my_player();
@@ -93,7 +108,7 @@ static TbBool get_local_dig_prediction_roomspace(const struct Packet *pckt, stru
 
 static TbBool update_predicted_build_or_sell_roomspace_preview(struct RoomSpace *roomspace, PlayerNumber plyr_idx, const struct Packet *pckt)
 {
-    if ((pckt == NULL) || ((pckt->control_flags & PCtr_MapCoordsValid) == 0)) {
+    if (prevent_local_dig_prediction(pckt)) {
         return false;
     }
     struct PlayerInfo *player = get_player(plyr_idx);


### PR DESCRIPTION
When you clicked on gui window while in dig mode and there's terrain behind the window, it would briefly tag the terrain behind the window (then undo it as authoritative catches up).

Also fixes this minor display issue (present in singleplayer) where it would incorrectly show the dig cursor while specifically hovering a creature icon:
<img width="3840" height="2160" alt="Untitled" src="https://github.com/user-attachments/assets/555d6499-cd4a-49ca-9f0a-5c7872aa4d4c" />