### PR TITLE
Multiplayer: host uses correct defeat message

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -832,7 +832,7 @@ static short get_global_inputs(void)
       return true;
   if (player->victory_state != VicS_Undecided && is_game_key_pressed(Gkey_FinishLevel, true, false))
       {
-        if ((player->victory_state == VicS_LostLevel) && ((game.system_flags & GSF_NetworkActive) != 0) && (player->id_number == get_host_player_id()))
+        if ((player->victory_state == VicS_LostLevel) && ((game.system_flags & GSF_NetworkActive) != 0) && (player->id_number == get_host_player_id()) && network_human_contenders_remain())
         {
             return true;
         }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -3457,7 +3457,7 @@ void update_player_objectives(PlayerNumber plyr_idx)
           break;
       case VicS_LostLevel:
           TextStringId msg_idx = CpgStr_LevelLost;
-          if (((game.system_flags & GSF_NetworkActive) != 0) && (player->id_number == get_host_player_id())) {
+          if (((game.system_flags & GSF_NetworkActive) != 0) && (player->id_number == get_host_player_id()) && network_human_contenders_remain()) {
               msg_idx = GUIStr_NetHostLostWaitingForPlayers;
           }
           set_level_objective(player->id_number, get_string(msg_idx));

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -324,6 +324,17 @@ static TbBool network_has_remote_enemies_remaining(void)
     return false;
 }
 
+TbBool network_human_contenders_remain(void)
+{
+    for (PlayerNumber player_idx = 0; player_idx < PLAYERS_COUNT; player_idx++) {
+        struct PlayerInfo *player = get_player(player_idx);
+        if (player_exists(player) && (player->is_active == 1) && ((player->allocflags & PlaF_CompCtrl) == 0) && !player_cannot_win(player_idx)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static TbBool network_has_remote_users_remaining(void)
 {
     for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_players; user_id += 1) {

--- a/src/net_game.h
+++ b/src/net_game.h
@@ -50,6 +50,7 @@ long network_session_join(void);
 
 TbBool network_player_active(int plyr_idx);
 const char *network_player_name(int plyr_idx);
+TbBool network_human_contenders_remain(void);
 void process_player_leave_game_packet(struct PlayerInfo *player);
 void process_disconnected_network_players(void);
 void sync_initial_network_seed(void);

--- a/src/packets.c
+++ b/src/packets.c
@@ -653,7 +653,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
             quit_game = 1;
           }
           return 0;
-        } else if (host_packet && (victory_state == VicS_LostLevel)) {
+        } else if (host_packet && (victory_state == VicS_LostLevel) && network_human_contenders_remain()) {
           return 0;
         } else if (host_packet && (victory_state == VicS_WonLevel)) {
           player->additional_flags &= ~PlaAF_UnlockedLordTorture;


### PR DESCRIPTION
When the host loses, their loss message will now be different depending on whether other human players can still continue playing. Previously the host always saw: `"You have been defeated. As host, keep the game running until the match concludes."` and they couldn't press Space. But now if no human contenders remain then the host will see the normal defeat message and can press Space to finish.