### PR TITLE
Improve code readability for network_is_active

### DIFF
--- a/src/config_keeperfx.c
+++ b/src/config_keeperfx.c
@@ -235,7 +235,7 @@ TbBool resize_movies_enabled(void)
  */
 TbBool freeze_game_on_focus_lost(void)
 {
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
     {
         return false;
     }

--- a/src/config_mods.c
+++ b/src/config_mods.c
@@ -22,7 +22,7 @@ static struct ModsConfig stored_mods_conf = {0};
 const struct ModsConfig *get_loaded_mods_conf(void)
 {
     static const struct ModsConfig empty_mods_conf = {0};
-    if (game.system_flags & GSF_NetworkActive)
+    if (network_is_active())
         return &empty_mods_conf;
     return &stored_mods_conf;
 }

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -264,7 +264,7 @@ static void update_gui_layer(void)
 {
     // Determine the current/correct GUI Layer to use at this moment
 
-    if ((game.system_flags & GSF_NetworkActive) == 1) // no one click on multiplayer.
+    if (network_is_active()) // no one click on multiplayer.
     {
         //todo Make multiplayer work with 1-click
         set_current_gui_layer(GuiLayer_Default);
@@ -420,7 +420,7 @@ static short get_players_message_inputs(void)
     if (is_key_pressed(KC_RETURN, KMod_NONE)) {
         memcpy(player->mp_pending_message, player->mp_message_text, PLAYER_MP_MESSAGE_LEN);
         set_players_packet_action(player, PckA_PlyrMsgEnd, 0, 0, 0, 0);
-        if ((game.system_flags & GSF_NetworkActive) != 0) {
+        if (network_is_active()) {
             send_network_chat_message(player->id_number, player->mp_message_text);
         }
         player->allocflags &= ~PlaF_NewMPMessage;
@@ -567,7 +567,7 @@ static short get_packet_load_game_control_inputs(void)
 {
   if (is_game_key_pressed(Gkey_ExitGame, true, false))
   {
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
       LbNetwork_Stop();
     quit_game = 1;
     exit_keeper = 1;
@@ -731,7 +731,7 @@ static short get_global_inputs(void)
     return true;
   }
   if (((player->view_type == PVT_DungeonTop) || (player->view_type == PVT_CreatureContrl))
-  && (((game.system_flags & GSF_NetworkActive) != 0) ||
+  && (network_is_active() ||
      ((game.flags_gui & GGUI_SoloChatEnabled) != 0)))
   {
       if (is_key_pressed(KC_RETURN,KMod_NONE))
@@ -832,7 +832,7 @@ static short get_global_inputs(void)
       return true;
   if (player->victory_state != VicS_Undecided && is_game_key_pressed(Gkey_FinishLevel, true, false))
       {
-        if ((player->victory_state == VicS_LostLevel) && ((game.system_flags & GSF_NetworkActive) != 0) && (player->id_number == get_host_player_id()))
+        if (player->victory_state == VicS_LostLevel && network_is_active() && player->id_number == get_host_player_id())
         {
             return true;
         }
@@ -865,7 +865,7 @@ static TbBool get_level_lost_inputs(void)
       get_players_message_inputs();
       return true;
     }
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
     {
       if (is_key_pressed(KC_RETURN,KMod_NONE))
       {
@@ -933,7 +933,7 @@ static TbBool get_level_lost_inputs(void)
         {
           turn_off_all_window_menus();
           set_flag_value(game.operation_flags, GOF_ShowPanel, (game.operation_flags & GOF_ShowGui) != 0);
-          if (((game.system_flags & GSF_NetworkActive) != 0)
+          if (network_is_active()
             || (lbDisplay.PhysicalScreenWidth > 320))
           {
                 if (toggle_status_menu(0))
@@ -2925,7 +2925,7 @@ static short get_inputs(void)
     case PVT_MapFadeIn:
         if (player->view_mode != PVM_ParchFadeIn)
         {
-          if ((game.system_flags & GSF_NetworkActive) == 0)
+          if (!network_is_active())
             game.operation_flags &= ~GOF_Paused;
           player->status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible) [duplicate? unneeded?]
           set_players_packet_action(player, PckA_SetViewType, PVT_MapScreen, 0,0,0);

--- a/src/front_torture.c
+++ b/src/front_torture.c
@@ -237,7 +237,7 @@ void fronttorture_input(void)
         pckt->actn_par2 = GetMouseY();
     }
     // Exchange packet with other players
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
     {
         if (LbNetwork_ExchangeFrontend(pckt, game.packets, sizeof(struct Packet)))
             ERRORLOG("LbNetwork_Exchange failed");
@@ -265,7 +265,7 @@ void fronttorture_input(void)
     if ((pckt->action & 0x01) != 0)
     {
         frontend_set_state(FeSt_LEVEL_STATS);
-        if ((game.system_flags & GSF_NetworkActive) != 0)
+        if (network_is_active())
             LbNetwork_Stop();
         return;
     }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -637,7 +637,7 @@ TbBool get_button_area_input(struct GuiButton *gbtn, int modifiers)
 
 void maintain_loadsave(struct GuiButton *gbtn)
 {
-    if ((game.system_flags & GSF_NetworkActive) == 0)
+    if (!network_is_active())
         gbtn->flags |= LbBtnF_Enabled;
     else
         gbtn->flags &= ~LbBtnF_Enabled;
@@ -1663,7 +1663,7 @@ short frontend_save_continue_game(short allow_lvnum_grow)
     memcpy(&dungeon->lvstats, scratch, sizeof(struct LevelStats));
     set_flag_value(player->additional_flags, PlaAF_UnlockedLordTorture, flg_mem);
     // Only save continue if level was won, not a free play level, not a multiplayer level and not in packet mode
-    if (((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active()
      || ((game.operation_flags & GOF_SingleLevel) != 0)
      || (game.packet_load_enable)
      || (is_freeplay_level(lvnum))
@@ -3442,7 +3442,7 @@ void update_player_objectives(PlayerNumber plyr_idx)
     struct PlayerInfo *player;
     SYNCDBG(6,"Starting for player %d",(int)plyr_idx);
     player = get_player(plyr_idx);
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
     {
       if ((!player->display_objective_turn) && (player->victory_state != VicS_Undecided))
         player->display_objective_turn = get_gameturn()+1;
@@ -3457,7 +3457,7 @@ void update_player_objectives(PlayerNumber plyr_idx)
           break;
       case VicS_LostLevel:
           TextStringId msg_idx = CpgStr_LevelLost;
-          if (((game.system_flags & GSF_NetworkActive) != 0) && (player->id_number == get_host_player_id())) {
+          if (network_is_active() && player->id_number == get_host_player_id()) {
               msg_idx = GUIStr_NetHostLostWaitingForPlayers;
           }
           set_level_objective(player->id_number, get_string(msg_idx));
@@ -3646,7 +3646,7 @@ FrontendMenuState get_menu_state_when_back_from_substate(FrontendMenuState subst
     case FeSt_DRAG:
         return FeSt_TORTURE;
     case FeSt_LEVEL_STATS:
-        if ((game.system_flags & GSF_NetworkActive) != 0)
+        if (network_is_active())
             return FeSt_NET_SESSION;
         lvnum = get_loaded_level_number();
         if (is_multiplayer_level(lvnum))
@@ -3733,7 +3733,7 @@ FrontendMenuState get_startup_menu_state(void)
   {
     player = get_my_player();
     lvnum = get_loaded_level_number();
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
     { // If played real network game, then resulting screen isn't changed based on victory
         SYNCLOG("Network game summary state selected");
         if ((player->additional_flags & PlaAF_UnlockedLordTorture) != 0)

--- a/src/game_legacy.c
+++ b/src/game_legacy.c
@@ -33,6 +33,11 @@ GameTurn get_gameturn()
 {
     return game.play_gameturn;
 }
+
+TbBool network_is_active(void)
+{
+    return flag_is_set(game.system_flags, GSF_NetworkActive);
+}
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -415,6 +415,8 @@ extern int32_t turns_per_second_draw_current;
 extern int32_t turns_per_second_draw_main;
 extern int32_t turns_per_second_draw_secondary;
 
+TbBool network_is_active(void);
+
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/gui_boxmenu.c
+++ b/src/gui_boxmenu.c
@@ -974,7 +974,7 @@ TbBool point_is_over_gui_box(ScreenCoord x, ScreenCoord y)
 
 long gfa_single_player_mode(struct GuiBox* gbox, struct GuiBoxOption* goptn, int32_t * tag)
 {
-    return ((game.system_flags & GSF_NetworkActive) == 0);
+    return !network_is_active();
 }
 
 TbBool cheat_menu_is_active()

--- a/src/gui_parchment.c
+++ b/src/gui_parchment.c
@@ -935,7 +935,7 @@ void zoom_to_parchment_map(void)
     else
       set_flag(game.operation_flags, GOF_ShowPanel);
     struct PlayerInfo* player = get_my_player();
-    if (((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active()
         || (lbDisplay.PhysicalScreenWidth > 320))
     {
       if (!toggle_status_menu(0))
@@ -952,7 +952,7 @@ void zoom_to_parchment_map(void)
 void zoom_from_parchment_map(void)
 {
     struct PlayerInfo* player = get_my_player();
-    if (((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active()
         || (lbDisplay.PhysicalScreenWidth > 320))
     {
         if ((game.operation_flags & GOF_ShowPanel) != 0)

--- a/src/lvl_script.c
+++ b/src/lvl_script.c
@@ -1130,7 +1130,7 @@ void process_level_script(void)
   struct PlayerInfo *player;
   player = get_my_player();
   TbBool process_script = false;
-  if ((game.system_flags & GSF_NetworkActive) != 0) {
+  if (network_is_active()) {
       process_script = true;
   }
   if (player->victory_state == VicS_Undecided) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1983,7 +1983,7 @@ short lose_level(struct PlayerInfo *player)
 {
     if (!is_my_player(player))
         return false;
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
     {
         LbNetwork_Stop();
     }
@@ -1995,7 +1995,7 @@ short resign_level(struct PlayerInfo *player)
 {
     if (!is_my_player(player))
         return false;
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
     {
         LbNetwork_Stop();
     }
@@ -2008,7 +2008,7 @@ short complete_level(struct PlayerInfo *player)
     SYNCDBG(6,"Starting");
     if (!is_my_player(player))
         return false;
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
     {
         LbNetwork_Stop();
         quit_game = 1;
@@ -2077,7 +2077,7 @@ void check_players_won(void)
 {
   SYNCDBG(8,"Starting");
 
-    if (!flag_is_set(game.system_flags,GSF_NetworkActive))
+    if (!network_is_active())
         return;
 
     struct PlayerInfo* curPlayer;
@@ -3360,7 +3360,7 @@ TbBool keeper_wait_for_screen_focus(void)
         }
         if (LbIsActive())
           return true;
-        if ((game.system_flags & GSF_NetworkActive) != 0)
+        if (network_is_active())
           return true;
         if (!freeze_game_on_focus_lost())
           return true;

--- a/src/net_checksums.c
+++ b/src/net_checksums.c
@@ -237,7 +237,7 @@ void update_turn_checksums(void) {
     snapshot_info->thing_count = 0;
     snapshot_info->player_count = 0;
     snapshot_info->room_count = 0;
-    if ((game.system_flags & GSF_NetworkActive) != 0) {
+    if (network_is_active()) {
         for (int i = 1; i < SYNCED_THINGS_COUNT; i++) {
             struct Thing* thing = thing_get(i);
             if (!thing_exists(thing) || is_non_synchronized_thing_class(thing->class_id)) {

--- a/src/net_exchange_common.c
+++ b/src/net_exchange_common.c
@@ -385,7 +385,7 @@ void process_peer_msgs(NetUserId peer_id, void *server_buf, size_t frame_size)
 
 void wait_for_all_players(void)
 {
-    if ((game.system_flags & GSF_NetworkActive) == 0) {
+    if (!network_is_active()) {
         return;
     }
 

--- a/src/net_exchange_gameplay.c
+++ b/src/net_exchange_gameplay.c
@@ -153,7 +153,7 @@ void process_gameplay_chat_message(int player_id, const char *message)
     struct PlayerInfo *player = prepare_network_chat_message(player_id, message);
     if (message[0] != '\0') {
         lua_on_chatmsg(player_id, player->mp_message_text);
-        if (player->mp_message_text[0] != cmd_char || !cmd_exec(player_id, player->mp_message_text + 1) || (game.system_flags & GSF_NetworkActive) != 0) {
+        if (player->mp_message_text[0] != cmd_char || !cmd_exec(player_id, player->mp_message_text + 1) || network_is_active()) {
             message_add(MsgType_Player, player_id, player->mp_message_text);
         }
     }

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -388,12 +388,12 @@ static TbBool host_already_won_level(void)
 void process_player_leave_game_packet(struct PlayerInfo *player)
 {
     if (player != get_my_player()) {
-        if ((game.system_flags & GSF_NetworkActive) != 0) {
+        if (network_is_active()) {
             OnDroppedUser(player->packet_num, NETDROP_MANUAL);
             process_disconnected_network_players();
             return;
         }
-    } else if ((game.system_flags & GSF_NetworkActive) != 0) {
+    } else if (network_is_active()) {
         stop_network_game_and_quit_to_main_menu();
     } else {
         quit_game = 1;
@@ -403,7 +403,7 @@ void process_player_leave_game_packet(struct PlayerInfo *player)
 
 void process_disconnected_network_players(void)
 {
-    if ((game.system_flags & GSF_NetworkActive) == 0) {
+    if (!network_is_active()) {
         return;
     }
     struct PlayerInfo *myplyr = get_my_player();
@@ -503,7 +503,7 @@ long network_session_join(void)
 
 void sync_initial_network_seed(void)
 {
-   if ((game.system_flags & GSF_NetworkActive) == 0) {
+   if (!network_is_active()) {
       return;
    }
    if (!LbNetwork_Resync(&game.action_random_seed, sizeof(game.action_random_seed))) {

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -26,7 +26,7 @@ enum InputLagMode {
 
 TbBool input_lag_skips_initial_processing(void)
 {
-    if ((game.system_flags & GSF_NetworkActive) == 0) {
+    if (!network_is_active()) {
         return false;
     }
     if ((game.operation_flags & GOF_Paused) != 0) {
@@ -55,7 +55,7 @@ void LbNetwork_UpdateInputLagIfHost(void) {
     static int total_ping = 0;
     static int sample_count = 0;
     static int previous_remote_player_count = -1;
-    if ((game.system_flags & GSF_NetworkActive) == 0) { return; }
+    if (!network_is_active()) { return; }
     if (frontend_menu_state == FeSt_START_MPLEVEL) { return; }
     if (my_player_number != get_host_player_id()) { return; }
     if (!netstate.sp) { return; }

--- a/src/packets.c
+++ b/src/packets.c
@@ -345,7 +345,7 @@ void process_pause_packet(long curr_pause, long new_pause)
       set_flag_value(game.operation_flags, GOF_Paused, curr_pause);
       if ((game.operation_flags & GOF_Paused) != 0) {
           set_flag_value(game.operation_flags, GOF_WorldInfluence, new_pause);
-          if ((game.system_flags & GSF_NetworkActive) != 0) {
+          if (network_is_active()) {
               game.skip_initial_input_turns = game.input_lag_turns + 1;
           }
       }
@@ -645,7 +645,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         turn_off_all_menus();
         free_swipe_graphic();
       }
-      if ((game.system_flags & GSF_NetworkActive) != 0) {
+      if (network_is_active()) {
         TbBool host_packet = player->packet_num == get_host_player_id();
         if (!my_player) {
           if ((victory_state == VicS_WonLevel) || (host_packet && (player->victory_state != VicS_LostLevel))) {
@@ -773,7 +773,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       player->cameras[CamIV_Parchment].rotation_angle_x = 0;
       player->cameras[CamIV_FrontView].rotation_angle_x = 0;
       player->cameras[CamIV_Isometric].rotation_angle_x = 0;
-      if (((game.system_flags & GSF_NetworkActive) != 0)
+      if (network_is_active()
           || (lbDisplay.PhysicalScreenWidth > 320))
       {
         if (is_my_player_number(plyr_idx))
@@ -1582,12 +1582,12 @@ void process_packets(void)
         return;
     }
 
-    if ((game.system_flags & GSF_NetworkActive) != 0) {
+    if (network_is_active()) {
         MULTIPLAYER_LOG("process_packets: Loading packets from packet history");
         load_old_packets();
     }
 
-    if ((game.system_flags & GSF_NetworkActive) != 0 && checksums_different()) {
+    if (network_is_active() && checksums_different()) {
         set_flag(game.system_flags, GSF_NetGameNoSync);
         clear_flag(game.system_flags, GSF_NetSeedNoSync);
     } else {
@@ -1617,7 +1617,7 @@ void process_packets(void)
     if (quit_game || exit_keeper) {
         return;
     }
-    if (((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active()
      && ((game.system_flags & (GSF_NetGameNoSync | GSF_NetSeedNoSync)) != 0))
     {
         if (resync_game_allowed()) {

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -124,7 +124,7 @@ void set_player_as_won_level(struct PlayerInfo *player)
   // Computing player score
   dungeon->lvstats.player_score = compute_player_final_score(player, dungeon->max_gameplay_score);
   dungeon->lvstats.allow_save_score = 1;
-  if ((game.system_flags & GSF_NetworkActive) == 0)
+  if (!network_is_active())
     player->display_objective_turn = get_gameturn() + 300;
   if (my_player)
   {
@@ -197,9 +197,9 @@ void set_player_as_lost_level(struct PlayerInfo *player)
         }
     }
     set_player_state(player, PSt_CtrlDungeon, 0);
-    if ((game.system_flags & GSF_NetworkActive) == 0)
+    if (!network_is_active())
         player->display_objective_turn = get_gameturn() + 300;
-    if ((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active())
         reveal_whole_map(player);
     if ((dungeon->computer_enabled & 0x01) != 0)
         toggle_computer_player(player->id_number);
@@ -208,7 +208,7 @@ void set_player_as_lost_level(struct PlayerInfo *player)
 long compute_player_final_score(struct PlayerInfo *player, long gameplay_score)
 {
     long i;
-    if (((game.system_flags & GSF_NetworkActive) != 0)
+    if (network_is_active()
       || !is_singleplayer_level(game.loaded_level_number)) {
         i = 2 * gameplay_score;
     } else {

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -47,7 +47,7 @@ static TbBool local_dig_render_roomspace_active;
 
 TbBool local_dig_prediction_is_enabled(void)
 {
-    return ((game.system_flags & GSF_NetworkActive) != 0) && !game.packet_load_enable && (game.input_lag_turns > 0);
+    return network_is_active() && !game.packet_load_enable && (game.input_lag_turns > 0);
 }
 
 struct RoomSpace *get_local_dig_prediction_render_roomspace(struct RoomSpace *roomspace)


### PR DESCRIPTION
This line has been annoying me WAY too much: `if ((game.system_flags & GSF_NetworkActive) != 0)` and it's everywhere.