### PR TITLE
Multiplayer: implement drop user function

### DIFF
--- a/src/bflib_enet.cpp
+++ b/src/bflib_enet.cpp
@@ -768,7 +768,7 @@ namespace
      */
     void bf_enet_drop_user(NetUserId id)
     {
-        ERRORLOG("Dropping ENet user %d", (int)id);
+        LbNetLog("ENet: dropping user %d\n", (int)id);
         destroy_incoming_queue(id);
         if (host) {
             for (ENetPeer *peer = host->peers; peer < &host->peers[host->peerCount]; peer += 1) {

--- a/src/bflib_enet.cpp
+++ b/src/bflib_enet.cpp
@@ -768,6 +768,7 @@ namespace
      */
     void bf_enet_drop_user(NetUserId id)
     {
+        ERRORLOG("Dropping ENet user %d", (int)id);
         destroy_incoming_queue(id);
         if (host) {
             for (ENetPeer *peer = host->peers; peer < &host->peers[host->peerCount]; peer += 1) {

--- a/src/bflib_enet.cpp
+++ b/src/bflib_enet.cpp
@@ -766,10 +766,20 @@ namespace
      * Disconnects a user.
      * @param id User to be dropped.
      */
-    void bf_enet_drop_user(NetUserId)
+    void bf_enet_drop_user(NetUserId id)
     {
-        fprintf(stderr, "enet_drop_user not implemented\n");
-        ERRORLOG("enet_drop_user not implemented");
+        destroy_incoming_queue(id);
+        if (host) {
+            for (ENetPeer *peer = host->peers; peer < &host->peers[host->peerCount]; peer += 1) {
+                if (peer->state == ENET_PEER_STATE_CONNECTED && NetUserId(reinterpret_cast<ptrdiff_t>(peer->data)) == id) {
+                    enet_peer_disconnect_now(peer, 0);
+                    break;
+                }
+            }
+        }
+        if (g_drop_callback != nullptr) {
+            g_drop_callback(id, NETDROP_MANUAL);
+        }
     }
 
 }


### PR DESCRIPTION
This is a bit of a blind fix, but according to a log that was provided after hitting `"bf_enet_drop_user: enet_drop_user not implemented"` the frontend would rapidly switch between `FeSt_NET_START` and `FeSt_MP_MAPPACK_SELECT` in a permanent loop. It seems a fairly straightforward fix, just implement enet_drop_user.