### PR TITLE
Multiplayer: Only go to Torture Screen if winner outscores loser

### DIFF
--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -270,7 +270,7 @@ void place_single_slab_type_on_map(SlabKind slbkind, MapSlabCoord slb_x, MapSlab
 void turn_off_query(PlayerNumber plyr_idx);
 TbBool set_gamma(char corrlvl, TbBool do_set);
 void level_lost_go_first_person(PlayerNumber plyr_idx);
-short winning_player_quitting(struct PlayerInfo *player, int32_t *plyr_count);
+TbBool player_is_sole_remaining_contender(struct PlayerInfo *player);
 short lose_level(struct PlayerInfo *player);
 short resign_level(struct PlayerInfo *player);
 short complete_level(struct PlayerInfo *player);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1951,33 +1951,22 @@ void process_objective(const char *msg_text, PlayerNumber plyr_idx, TbMapLocatio
     display_objectives(player->id_number, x, y);
 }
 
-short winning_player_quitting(struct PlayerInfo *player, int32_t *plyr_count)
+TbBool player_is_sole_remaining_contender(struct PlayerInfo *candidate)
 {
-    struct PlayerInfo *swplyr;
+    struct PlayerInfo *checked_player;
     int i;
-    int k;
-    int n;
-    if (player->victory_state == VicS_LostLevel)
-    {
-      return 0;
+    int remaining_contenders;
+    if (candidate->victory_state == VicS_LostLevel) {
+        return false;
     }
-    k = 0;
-    n = 0;
-    for (i=0; i < PLAYERS_COUNT; i++)
-    {
-      swplyr = get_player(i);
-      if (player_exists(swplyr))
-      {
-        if (swplyr->is_active == 1)
-        {
-          k++;
-          if (swplyr->victory_state == VicS_LostLevel)
-            n++;
+    remaining_contenders = 0;
+    for (i=0; i < PLAYERS_COUNT; i++) {
+        checked_player = get_player(i);
+        if (player_exists(checked_player) && (checked_player->is_active == 1) && (checked_player->victory_state != VicS_LostLevel)) {
+            remaining_contenders++;
         }
-      }
     }
-    *plyr_count = k;
-    return ((k - n) == 1);
+    return (remaining_contenders == 1);
 }
 
 short lose_level(struct PlayerInfo *player)

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -421,8 +421,7 @@ void process_disconnected_network_players(void)
     TbBool host_disconnected = (netstate.my_id != SERVER_ID) && (netstate.users[SERVER_ID].progress == USER_UNUSED);
     TbBool disconnected = host_disconnected;
     TbBool enemy_disconnected = false;
-    TbBool winning_quit = false;
-    int32_t plyr_count = 0;
+    struct PlayerInfo *winning_player = NULL;
     if (host_disconnected && host_already_won_level()) {
         myplyr->additional_flags &= ~PlaAF_UnlockedLordTorture;
         quit_game = 1;
@@ -436,8 +435,8 @@ void process_disconnected_network_players(void)
         disconnected = true;
         if (network_disconnect_victory_enabled && players_are_enemies(myplyr->id_number, player->id_number)) {
             enemy_disconnected = true;
-            if (!winning_quit && winning_player_quitting(player, &plyr_count)) {
-                winning_quit = true;
+            if ((winning_player == NULL) && player_is_sole_remaining_contender(player)) {
+                winning_player = player;
             }
         }
         if ((player->allocflags & PlaF_CompCtrl) == 0) {
@@ -466,7 +465,7 @@ void process_disconnected_network_players(void)
             return;
         }
     }
-    if (winning_quit) {
+    if (winning_player != NULL) {
         for (int i = 0; i < PLAYERS_COUNT; i++) {
             struct PlayerInfo *swplyr = get_player(i);
             if (player_exists(swplyr) && (swplyr->is_active == 1)) {
@@ -477,8 +476,10 @@ void process_disconnected_network_players(void)
     if (enemy_disconnected) {
         resolve_network_quit_outcome(myplyr);
     }
-    if (winning_quit && (plyr_count > 1)) {
+    if ((winning_player != NULL) && winning_player_outscores_losers(winning_player)) {
         myplyr->additional_flags |= PlaAF_UnlockedLordTorture;
+    } else {
+        myplyr->additional_flags &= ~PlaAF_UnlockedLordTorture;
     }
     if (!host_disconnected && network_has_remote_users_remaining()) {
         return;

--- a/src/packets.c
+++ b/src/packets.c
@@ -648,7 +648,11 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       if (network_is_active()) {
         if (victory_state == VicS_WonLevel) {
           player->victory_state = VicS_WonLevel;
-          get_my_player()->additional_flags |= PlaAF_UnlockedLordTorture;
+          if (winning_player_outscores_losers(player)) {
+            get_my_player()->additional_flags |= PlaAF_UnlockedLordTorture;
+          } else {
+            get_my_player()->additional_flags &= ~PlaAF_UnlockedLordTorture;
+          }
           quit_game = 1;
           return 0;
         }

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -61,6 +61,8 @@
 
 /******************************************************************************/
 
+#define TORTURE_SCREEN_SCORE_REQUIREMENT 120
+
 TbBool player_has_lost(PlayerNumber plyr_idx)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
@@ -128,7 +130,7 @@ void set_player_as_won_level(struct PlayerInfo *player)
     player->display_objective_turn = get_gameturn() + 300;
   if (my_player)
   {
-    if (lord_of_the_land_in_prison_or_tortured())
+    if (!network_is_active() && lord_of_the_land_in_prison_or_tortured())
     {
         SYNCLOG("Lord Of The Land kept captive. Torture tower unlocked.");
         player->additional_flags |= PlaAF_UnlockedLordTorture;
@@ -217,6 +219,55 @@ long compute_player_final_score(struct PlayerInfo *player, long gameplay_score)
     if (player_has_lost(player->id_number))
         i /= 2;
     return i;
+}
+
+TbBool winning_player_outscores_losers(struct PlayerInfo *winner)
+{
+    struct Dungeon* dungeon;
+    if (player_invalid(winner) || dungeon_invalid(dungeon = get_dungeon(winner->id_number))) {
+        return false;
+    }
+    uint64_t winner_score = dungeon->lvstats.player_score;
+    if (winner_score == 0) {
+        winner_score = compute_player_final_score(winner, dungeon->max_gameplay_score);
+    }
+    if (winner_score == 0) {
+        return false;
+    }
+    TbBool loser_found = false;
+    int32_t score_player_id = 0;
+    uint64_t score_loser = 0;
+    uint64_t winning_score = winner_score * 100;
+    uint64_t required_score = 0;
+    for (int32_t i = 0; i < PLAYERS_COUNT; i++) {
+        struct PlayerInfo* player = get_player(i);
+        if ((player == winner) || !player_exists(player) || (player->is_active != 1) || (player->victory_state != VicS_LostLevel)) {
+            continue;
+        }
+        dungeon = get_dungeon(player->id_number);
+        if (dungeon_invalid(dungeon)) {
+            continue;
+        }
+        uint64_t loser_score = dungeon->lvstats.player_score;
+        if (loser_score == 0) {
+            loser_score = compute_player_final_score(player, dungeon->max_gameplay_score);
+        }
+        uint64_t loser_required_score = loser_score * TORTURE_SCREEN_SCORE_REQUIREMENT;
+        if (!loser_found || (loser_required_score > required_score)) {
+            score_player_id = player->id_number;
+            score_loser = loser_score;
+            required_score = loser_required_score;
+        }
+        loser_found = true;
+        if (winning_score < loser_required_score) {
+            SYNCLOG("Skipping Torture Screen (winner needs %d%% higher score). Winner p:%d score:%" PRIu64 ". Loser p:%d score:%" PRIu64 ".", TORTURE_SCREEN_SCORE_REQUIREMENT - 100, winner->id_number, winner_score, player->id_number, loser_score);
+            return false;
+        }
+    }
+    if (loser_found) {
+        SYNCLOG("Score requirement met for Torture Screen (winner has over %d%% higher score). Winner p:%d score:%" PRIu64 ". Loser p:%d score:%" PRIu64 ".", TORTURE_SCREEN_SCORE_REQUIREMENT - 100, winner->id_number, winner_score, score_player_id, score_loser);
+    }
+    return loser_found;
 }
 
 /**

--- a/src/player_utils.h
+++ b/src/player_utils.h
@@ -43,6 +43,7 @@ void set_player_as_won_level(struct PlayerInfo *player);
 void set_player_as_lost_level(struct PlayerInfo *player);
 
 long compute_player_final_score(struct PlayerInfo *player, long gameplay_score);
+TbBool winning_player_outscores_losers(struct PlayerInfo *winner);
 
 #define take_money_from_dungeon(plyr_idx, amount_take, only_whole_sum) take_money_from_dungeon_f(plyr_idx, amount_take, only_whole_sum, __func__)
 long take_money_from_dungeon_f(PlayerNumber plyr_idx, GoldAmount amount_take, TbBool only_whole_sum, const char *func_name);

--- a/tests/tst_fixes.cpp
+++ b/tests/tst_fixes.cpp
@@ -189,9 +189,9 @@ void level_lost_go_first_person(PlayerNumber plyr_idx)
 {
 }
 
-short winning_player_quitting(struct PlayerInfo *player, long *plyr_count)
+TbBool player_is_sole_remaining_contender(struct PlayerInfo *player)
 {
-    return 0;
+    return false;
 }
 
 struct Thing *get_queryable_object_near(MapCoord pos_x, MapCoord pos_y, long plyr_idx)


### PR DESCRIPTION
If the winning player has at least 20% higher score than the losing player (compares using the highest scoring loser if there's multiple players), then go to the Torture Screen, otherwise we skip it.

The value for this is defined here: `#define TORTURE_SCREEN_SCORE_REQUIREMENT 120` as a percentage.

It's logged if you want to see the score comparison:

`Sync: [349] winning_player_outscores_losers: Score requirement met for Torture Screen (winner has over 20% higher score). Winner p:0 score:100. Loser p:1 score:50.`