### PR TITLE
Multiplayer: Add WinnerTorturesLoser rule to rules.cfg + torture screen timeouts

### DIFF
--- a/config/fxdata/rules.cfg
+++ b/config/fxdata/rules.cfg
@@ -52,6 +52,8 @@ AlliesShareCta = 0
 AlliesShareDrop = 0
 ; Allow allied players to share map vision, which is removed as soon as alliance is broken. [0-1]
 AlliesShareVision = 0
+; Show the torture screen after multiplayer games. [0-1]
+WinnerTorturesLoser = 0
 ; Maximum number of objects or creatures a player can hold simultaneously. [0-64]
 MaxThingsInHand = 8
 ; Total number of creatures allowed on the map at once. [0-1022]

--- a/levels/classic_cfgs/rules.cfg
+++ b/levels/classic_cfgs/rules.cfg
@@ -4,3 +4,4 @@
 [game]
 DungeonHeartHealHealth = 1
 MapCreatureLimit =  255
+WinnerTorturesLoser = 1

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -98,6 +98,7 @@ static const struct NamedField rules_game_named_fields[] = {
   {"ALLIESSHAREVISION",         0, field(game.conf.rules[0].game.allies_share_vision       ),           0,        0,                  1,NULL,                           value_default, assign_AlliesShareVision_script},
   {"ALLIESSHAREDROP",           0, field(game.conf.rules[0].game.allies_share_drop         ),           0,        0,                  1,NULL,                           value_default, assign_default},
   {"ALLIESSHARECTA",            0, field(game.conf.rules[0].game.allies_share_cta          ),           0,        0,                  1,NULL,                           value_default, assign_default},
+  {"WINNERTORTURESLOSER",       0, field(game.conf.rules[0].game.winner_tortures_loser     ),           0,        0,                  1,NULL,                           value_default, assign_default},
   {"DISPLAYPORTALLIMIT",        0, field(game.conf.rules[0].game.display_portal_limit      ),           0,        0,                  1,NULL,                           value_default, assign_default},
   {"MAXTHINGSINHAND",           0, field(game.conf.rules[0].game.max_things_in_hand        ),           8,        0, MAX_THINGS_IN_HAND,NULL,                           value_default, assign_default},
   {"TORTUREPAYDAY",             0, field(game.conf.rules[0].game.torture_payday            ),          50,        0,          USHRT_MAX,NULL,                           value_default, assign_default},

--- a/src/config_rules.h
+++ b/src/config_rules.h
@@ -92,6 +92,7 @@ struct GameRulesConfig {
     TbBool allies_share_vision;
     TbBool allies_share_drop;
     TbBool allies_share_cta;
+    TbBool winner_tortures_loser;
     TbBool display_portal_limit;
     unsigned char max_things_in_hand;
     unsigned short torture_payday;

--- a/src/front_torture.c
+++ b/src/front_torture.c
@@ -29,6 +29,7 @@
 #include "bflib_filelst.h"
 #include "bflib_dernc.h"
 #include "bflib_keybrd.h"
+#include "bflib_datetm.h"
 #include "bflib_video.h"
 #include "bflib_vidraw.h"
 #include "bflib_mouse.h"
@@ -61,11 +62,15 @@ static long torture_sprite_frame;
 static long torture_door_selected;
 static struct DoorSoundState door_sound_state[TORTURE_DOORS_COUNT];
 static struct TortureState torture_state;
+static TbClockMSec torture_idle_start;
+static TbClockMSec torture_screen_start;
 static unsigned char *torture_background;
 static unsigned char *torture_palette;
 extern struct DoorDesc doors[TORTURE_DOORS_COUNT];
 extern struct TbSpriteSheet *fronttor_sprites;
 long torture_doors_available = TORTURE_DOORS_COUNT;
+#define TORTURE_MULTIPLAYER_IDLE_TIMEOUT 10000
+#define TORTURE_MULTIPLAYER_MAX_TIME 45000
 /******************************************************************************/
 #ifdef __cplusplus
 }
@@ -167,6 +172,8 @@ void fronttorture_load(void)
         LbMouseChangeSpriteAndHotspot(0, 0, 0);
     }
     torture_left_button = 0;
+    torture_idle_start = LbTimerClock();
+    torture_screen_start = torture_idle_start;
 }
 
 TbBool fronttorture_draw(void)
@@ -236,6 +243,18 @@ void fronttorture_input(void)
         pckt->actn_par1 = GetMouseX();
         pckt->actn_par2 = GetMouseY();
     }
+    if (network_is_active())
+    {
+        TbClockMSec now = LbTimerClock();
+        if (now - torture_idle_start >= TORTURE_MULTIPLAYER_IDLE_TIMEOUT)
+        {
+            pckt->action |= 0x01;
+        }
+        if (now - torture_screen_start >= TORTURE_MULTIPLAYER_MAX_TIME)
+        {
+            pckt->action |= 0x01;
+        }
+    }
     // Exchange packet with other players
     if (network_is_active())
     {
@@ -254,6 +273,7 @@ void fronttorture_input(void)
     {
         x = pckt->actn_par1;
         y = pckt->actn_par2;
+        torture_idle_start = LbTimerClock();
     } else
     {
         plyr_idx = my_player_number;

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -478,7 +478,11 @@ void process_disconnected_network_players(void)
         resolve_network_quit_outcome(myplyr);
     }
     if (winning_quit && (plyr_count > 1)) {
-        myplyr->additional_flags |= PlaAF_UnlockedLordTorture;
+        if (game.conf.rules[myplyr->id_number].game.winner_tortures_loser) {
+            myplyr->additional_flags |= PlaAF_UnlockedLordTorture;
+        } else {
+            myplyr->additional_flags &= ~PlaAF_UnlockedLordTorture;
+        }
     }
     if (!host_disconnected && network_has_remote_users_remaining()) {
         return;

--- a/src/packets.c
+++ b/src/packets.c
@@ -648,7 +648,11 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       if (network_is_active()) {
         if (victory_state == VicS_WonLevel) {
           player->victory_state = VicS_WonLevel;
-          get_my_player()->additional_flags |= PlaAF_UnlockedLordTorture;
+          if (game.conf.rules[player->id_number].game.winner_tortures_loser) {
+              get_my_player()->additional_flags |= PlaAF_UnlockedLordTorture;
+          } else {
+              get_my_player()->additional_flags &= ~PlaAF_UnlockedLordTorture;
+          }
           quit_game = 1;
           return 0;
         }


### PR DESCRIPTION
- Added a rule for `WinnerTorturesLoser` with the intention that it's only enabled by default for the original Bullfrog multiplayer maps because it fits Bullfrog's vision.
- If there's no torture action performed for 10 seconds then it auto-exits the torture screen for everyone, this should fix all permanent lock-up issues.
- Also added a maximum torture time, so it just auto-exits the torture screen after 45 seconds have passed, we don't need the winning player extending torture time infinitely.