### PR TITLE
Multiplayer: Fix various sync issues

### DIFF
--- a/src/custom_sprites.c
+++ b/src/custom_sprites.c
@@ -97,6 +97,8 @@ unsigned char base_pal[PALETTE_SIZE];
 
 int total_sprite_zip_count = 0;
 uint32_t sprite_zip_combined_checksum = 0;
+struct SpriteZipEntry sprite_zip_entries[SPRITE_ZIP_ENTRY_COUNT];
+uint8_t sprite_zip_entry_count = 0;
 
 // Used to cheaply detect mismatched custom sprites between players; makes file order matter when combining checksums, without this XOR alone gives the same result regardless of order.
 #define ROL32_5(x) (((uint32_t)(x) << 5) | ((uint32_t)(x) >> 27))
@@ -333,7 +335,20 @@ static int load_file_sprites(const char *path, const char *file_desc)
         }
     }
 
-    sprite_zip_combined_checksum = ROL32_5(sprite_zip_combined_checksum) ^ compute_zip_checksum(path);
+    uint32_t zip_checksum = compute_zip_checksum(path);
+    sprite_zip_combined_checksum = ROL32_5(sprite_zip_combined_checksum) ^ zip_checksum;
+    if (sprite_zip_entry_count < SPRITE_ZIP_ENTRY_COUNT) {
+        const char *filename = strrchr(path, '/');
+        if (filename == NULL) {
+            filename = path;
+        } else {
+            filename++;
+        }
+        struct SpriteZipEntry *entry = &sprite_zip_entries[sprite_zip_entry_count];
+        snprintf(entry->filename, sizeof(entry->filename), "%s", filename);
+        entry->checksum = zip_checksum;
+        sprite_zip_entry_count++;
+    }
     total_sprite_zip_count++;
 
     return add_flag;
@@ -430,6 +445,7 @@ void init_custom_sprites(LevelNumber lvnum)
     custom_sprites = create_spritesheet();
     total_sprite_zip_count = 0;
     sprite_zip_combined_checksum = 0;
+    sprite_zip_entry_count = 0;
     // This is a workaround because get_selected_level_number is zeroed on res change
     if (lvnum == SPRITE_LAST_LEVEL)
     {

--- a/src/custom_sprites.h
+++ b/src/custom_sprites.h
@@ -28,10 +28,20 @@ extern "C" {
 struct ObjectConfigStats;
 
 #define SPRITE_LAST_LEVEL -1
+#define SPRITE_ZIP_ENTRY_COUNT 48
+#define SPRITE_ZIP_ENTRY_NAME_LEN 64
+
+struct SpriteZipEntry {
+    char filename[SPRITE_ZIP_ENTRY_NAME_LEN];
+    uint32_t checksum;
+};
+
 void init_custom_sprites(LevelNumber level_no);
 
 extern int total_sprite_zip_count;
 extern uint32_t sprite_zip_combined_checksum;
+extern struct SpriteZipEntry sprite_zip_entries[SPRITE_ZIP_ENTRY_COUNT];
+extern uint8_t sprite_zip_entry_count;
 
 short get_anim_id(const char *name, struct ObjectConfigStats* objst);
 short get_anim_id_(const char* name);

--- a/src/net_checksums.c
+++ b/src/net_checksums.c
@@ -18,12 +18,16 @@
 /******************************************************************************/
 #include "pre_inc.h"
 #include "net_checksums.h"
+#include "bflib_dernc.h"
+#include "config.h"
 #include "game_legacy.h"
+#include "game_merge.h"
 #include "net_game.h"
 #include "packets.h"
 #include "player_data.h"
 #include "thing_data.h"
 #include "room_list.h"
+#include "slab_data.h"
 #include "creature_control.h"
 #include "thing_creature.h"
 #include "thing_list.h"
@@ -217,15 +221,37 @@ short checksums_different(void) {
     return mismatch;
 }
 
-TbBigChecksum calculate_network_startup_map_checksum(void) {
+TbBigChecksum calculate_network_startup_map_checksum(void)
+{
     TbBigChecksum checksum_mem = 0;
     for (int i = 1; i < THINGS_COUNT; i++) {
         struct Thing* thing = thing_get(i);
-        if (thing_exists(thing)) {
-            checksum_mem += thing->mappos.z.val + thing->mappos.y.val + thing->mappos.x.val;
+        if (thing_exists(thing) && !is_non_synchronized_thing_class(thing->class_id)) {
+            CHECKSUM_ADD(checksum_mem, get_thing_checksum(thing));
         }
     }
-    return checksum_mem + game.action_random_seed;
+    for (int32_t y = 0; y < game.map_tiles_y; y++) {
+        for (int32_t x = 0; x < game.map_tiles_x; x++) {
+            struct SlabMap* slb = get_slabmap_block(x, y);
+            CHECKSUM_ADD(checksum_mem, slb->kind);
+            CHECKSUM_ADD(checksum_mem, slb->owner);
+        }
+    }
+    LevelNumber lvnum = get_loaded_level_number();
+    short fgroup = get_level_fgroup(lvnum);
+    const char* script_exts[] = {"txt", "lua"};
+    for (int i = 0; i < sizeof(script_exts) / sizeof(script_exts[0]); i++) {
+        char* fname = prepare_file_fmtpath(fgroup, "map%05u.%s", lvnum, script_exts[i]);
+        int32_t file_size = (int32_t)LbFileLengthRnc(fname);
+        if (file_size > 0) {
+            unsigned char *file_buf = malloc(file_size);
+            if (file_buf != NULL && LbFileLoadAt(fname, file_buf) == file_size) {
+                CHECKSUM_ADD(checksum_mem, rnc_crc(file_buf, file_size));
+            }
+            free(file_buf);
+        }
+    }
+    return checksum_mem;
 }
 
 void update_turn_checksums(void) {

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -63,6 +63,8 @@ struct StartupSyncPacket {
     int32_t input_lag_turns;
     TbBigChecksum map_checksum;
     uint32_t sprite_zip_checksum;
+    uint8_t sprite_zip_entry_count;
+    struct SpriteZipEntry sprite_zip_entries[SPRITE_ZIP_ENTRY_COUNT];
     uint16_t initial_tendencies;
     uint32_t isometric_view_zoom_level;
     uint32_t frontview_zoom_level;
@@ -157,10 +159,54 @@ static TbBool verify_map_checksums(const struct StartupSyncPacket startup_sync_p
 
 static void verify_startup_sprite_zip_checksums(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
+    int host_player_id = get_host_player_id();
+    const struct StartupSyncPacket *host_sync = &startup_sync_packets[host_player_id];
     for (int i = 0; i < MAX_NET_USERS; i++) {
-        if (net_player_info[i].network_user_active && startup_sync_packets[i].sprite_zip_checksum != sprite_zip_combined_checksum) {
-            message_add(MsgType_Player, 0, get_string(GUIStr_NetVerifyFxdataSame));
-            message_add_fmt(MsgType_Player, 0, get_string(GUIStr_NetCustomSpriteMismatch), network_player_name(i));
+        if (!net_player_info[i].network_user_active || i == host_player_id) {
+            continue;
+        }
+        const struct StartupSyncPacket *client_sync = &startup_sync_packets[i];
+        if (client_sync->sprite_zip_checksum == host_sync->sprite_zip_checksum) {
+            continue;
+        }
+        TbBool reported = false;
+        for (int pass = 0; pass < 2; pass++) {
+            const struct StartupSyncPacket *source_sync = host_sync;
+            const struct StartupSyncPacket *target_sync = client_sync;
+            int target_player_id = i;
+            if (pass == 1) {
+                source_sync = client_sync;
+                target_sync = host_sync;
+                target_player_id = host_player_id;
+            }
+            for (int source_idx = 0; source_idx < source_sync->sprite_zip_entry_count; source_idx++) {
+                const struct SpriteZipEntry *source_entry = &source_sync->sprite_zip_entries[source_idx];
+                TbBool found = false;
+                for (int target_idx = 0; target_idx < target_sync->sprite_zip_entry_count; target_idx++) {
+                    const struct SpriteZipEntry *target_entry = &target_sync->sprite_zip_entries[target_idx];
+                    if (strcasecmp(source_entry->filename, target_entry->filename) != 0) {
+                        continue;
+                    }
+                    found = true;
+                    if (pass == 0 && source_entry->checksum != target_entry->checksum) {
+                        WARNLOG("Custom sprite zip differs for %s: %s", network_player_name(host_player_id), source_entry->filename);
+                        message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s differs for %.12s", source_entry->filename, network_player_name(host_player_id));
+                        WARNLOG("Custom sprite zip differs for %s: %s", network_player_name(i), source_entry->filename);
+                        message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s differs for %.12s", source_entry->filename, network_player_name(i));
+                        reported = true;
+                    }
+                    break;
+                }
+                if (!found) {
+                    WARNLOG("Custom sprite zip missing for %s: %s", network_player_name(target_player_id), source_entry->filename);
+                    message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s missing for %.12s", source_entry->filename, network_player_name(target_player_id));
+                    reported = true;
+                }
+            }
+        }
+        if (!reported) {
+            WARNLOG("Custom sprite zip order or overflow mismatch for %s", network_player_name(i));
+            message_add_fmt(MsgType_Blank, 0, "/fxdata/ zip order error");
         }
     }
 }
@@ -177,6 +223,8 @@ static void build_local_startup_sync(void)
     s_local_startup_sync.input_lag_turns = game.input_lag_turns;
     s_local_startup_sync.map_checksum = calculate_network_startup_map_checksum();
     s_local_startup_sync.sprite_zip_checksum = sprite_zip_combined_checksum;
+    s_local_startup_sync.sprite_zip_entry_count = sprite_zip_entry_count;
+    memcpy(s_local_startup_sync.sprite_zip_entries, sprite_zip_entries, sizeof(s_local_startup_sync.sprite_zip_entries));
     uint16_t initial_tendencies = 0;
     if (IMPRISON_BUTTON_DEFAULT) {initial_tendencies |= CrTend_Imprison;}
     if (FLEE_BUTTON_DEFAULT) {initial_tendencies |= CrTend_Flee;}

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -180,6 +180,7 @@ struct RoomSpace create_box_roomspace_from_drag(struct RoomSpace roomspace, MapS
     roomspace.drag_start_y = start_y;
     roomspace.drag_end_x = end_x;
     roomspace.drag_end_y = end_y;
+    detect_roomspace_direction(&roomspace);
     return roomspace;
 }
 
@@ -187,7 +188,6 @@ static struct RoomSpace create_dig_highlight_roomspace(struct RoomSpace roomspac
 {
     if (highlight_mode == drag_placement_mode) {
         roomspace = create_box_roomspace_from_drag(roomspace, drag_start_x, drag_start_y, slb_x, slb_y);
-        detect_roomspace_direction(&roomspace);
         return roomspace;
     }
     if (highlight_mode == roomspace_detection_mode) {
@@ -219,6 +219,7 @@ struct RoomSpace create_box_roomspace(struct RoomSpace roomspace, int width, int
     roomspace.untag_mode = false;
     roomspace.one_click_mode_exclusive = false;
     roomspace.drag_mode = false;
+    roomspace.drag_direction = top_left_to_bottom_right;
     return roomspace;
 }
 
@@ -740,28 +741,6 @@ void get_dungeon_sell_user_roomspace(struct RoomSpace *roomspace, PlayerNumber p
         current_roomspace.is_roomspace_a_box = true;
         current_roomspace.render_roomspace_as_box = true;
         current_roomspace = create_box_roomspace_from_drag(current_roomspace, drag_start_x, drag_start_y, slb_x, slb_y);
-        if (roomspace->drag_start_y > roomspace->drag_end_y)
-        {
-            if (roomspace->drag_start_x > roomspace->drag_end_x)
-            {
-                current_roomspace.drag_direction = bottom_right_to_top_left;
-            }
-            else
-            {
-                current_roomspace.drag_direction = bottom_left_to_top_right;
-            }
-        }
-        else
-        {
-            if (roomspace->drag_start_x > roomspace->drag_end_x)
-            {
-                current_roomspace.drag_direction = top_right_to_bottom_left;
-            }
-            else
-            {
-                current_roomspace.drag_direction = top_left_to_bottom_right;
-            }
-        }
         current_roomspace = check_roomspace_for_sellable_slabs(current_roomspace, plyr_idx);
         player->roomspace_width = current_roomspace.width;
         player->roomspace_height = current_roomspace.height;
@@ -857,10 +836,6 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
         else
         {
             temp_best_room = create_box_roomspace(best_roomspace, 1, 1, slb_x, slb_y);
-        }
-        if (!player->roomspace.is_active)
-        {
-            detect_roomspace_direction(&temp_best_room);
         }
         if (room_role_matches(rkind,RoRoF_PassWater|RoRoF_PassLava))
         {


### PR DESCRIPTION
- Improved `calculate_network_startup_map_checksum()` so that it ignores non-synchronized thing classes, and now syncs script files, slab kind, slab owner. So if someone edits their lua file by accident the issue will be more obvious.

- Custom sprite zip mismatches now display the name of the differing/missing zip file.

- Potential fix for a roomspace drag direction desync. (was possibly the cause in one of the logs reported, but I'm not sure)