### PR TITLE
Fix set lua textures with numbers

### DIFF
--- a/src/lua_api_map.c
+++ b/src/lua_api_map.c
@@ -97,7 +97,7 @@ static int map_set_field(lua_State *L) {
     if (strcmp(key, "default_texture") == 0) {
         LevelNumber lvnumb = get_loaded_level_number();
         if (lua_isnumber(L, 3)) {
-            // Integer input is 0-based: ID 0 = tmapa000.dat, ID 15 = tmapa015.dat.
+            // Integer input is 0-based: ID 0 = tmapa000.dat
             // Store as 1-based internally (texture_id + 1) to match string input convention.
             // Negative values mean no-op — leave game.texture_id unchanged.
             long texture_id = lua_tointeger(L, 3);
@@ -107,8 +107,8 @@ static int map_set_field(lua_State *L) {
                 load_texture_map_file(texture_id, lvnumb, get_level_fgroup(lvnumb));
             }
         } else {
-            // String input uses texture_pack_desc values ("STANDARD"=1, "ANCIENT"=2, ...).
-            // These are 1-based, so subtract 1 to get the 0-based filename index.
+            // String input is 1-based and uses texture_pack_desc values ("STANDARD"=1, "ANCIENT"=2, ...).
+            // Subtract 1 to get the 0-based filename index.
             // "NONE"=0 has no file, so skip the load.
             long texture_id = luaL_checkNamedCommand(L, 3, texture_pack_desc);
             game.texture_id = texture_id;

--- a/src/lua_api_map.c
+++ b/src/lua_api_map.c
@@ -95,11 +95,24 @@ static int map_set_field(lua_State *L) {
     const char *key = luaL_checkstring(L, 2);
 
     if (strcmp(key, "default_texture") == 0) {
-        long texture_id = luaL_checkNamedCommand(L, 3, texture_pack_desc);
-        game.texture_id = texture_id;                           
         LevelNumber lvnumb = get_loaded_level_number();
-        load_texture_map_file(texture_id, lvnumb, get_level_fgroup(lvnumb));
-
+        if (lua_isnumber(L, 3)) {
+            // Integer input is 0-based: ID 0 = tmapa000.dat, ID 15 = tmapa015.dat.
+            // load_texture_map_file uses the ID directly as the filename index.
+            // Negative values mean reset — skip the file load.
+            long texture_id = lua_tointeger(L, 3);
+            game.texture_id = texture_id;
+            if (texture_id >= 0)
+                load_texture_map_file(texture_id, lvnumb, get_level_fgroup(lvnumb));
+        } else {
+            // String input uses texture_pack_desc values ("STANDARD"=1, "ANCIENT"=2, ...).
+            // These are 1-based, so subtract 1 to get the 0-based filename index.
+            // "NONE"=0 has no file, so skip the load.
+            long texture_id = luaL_checkNamedCommand(L, 3, texture_pack_desc);
+            game.texture_id = texture_id;
+            if (texture_id > 0)
+                load_texture_map_file(texture_id - 1, lvnumb, get_level_fgroup(lvnumb));
+        }
         return 0;
     }
 

--- a/src/lua_api_map.c
+++ b/src/lua_api_map.c
@@ -80,9 +80,9 @@ static int map_get_field(lua_State *L){
     } else if (strcmp(key, "default_texture") == 0) {
         const char *name = get_conf_parameter_text(texture_pack_desc, game.texture_id);
         if (name[0] != '\0') {
-            lua_pushstring(L, name);            // "STANDARD", "ANCIENT", ...
+            lua_pushstring(L, name);                    // "STANDARD", "ANCIENT", ...
         } else {
-            lua_pushinteger(L, game.texture_id); // 17, 20, ... (Custom)
+            lua_pushinteger(L, game.texture_id - 1);    // convert 1-based storage back to 0-based
         }
     } else {
         return luaL_error(L, "Unknown field '%s' for MAP", key);
@@ -98,12 +98,14 @@ static int map_set_field(lua_State *L) {
         LevelNumber lvnumb = get_loaded_level_number();
         if (lua_isnumber(L, 3)) {
             // Integer input is 0-based: ID 0 = tmapa000.dat, ID 15 = tmapa015.dat.
-            // load_texture_map_file uses the ID directly as the filename index.
-            // Negative values mean reset — skip the file load.
+            // Store as 1-based internally (texture_id + 1) to match string input convention.
+            // Negative values mean no-op — leave game.texture_id unchanged.
             long texture_id = lua_tointeger(L, 3);
-            game.texture_id = texture_id;
             if (texture_id >= 0)
+            {
+                game.texture_id = texture_id + 1;
                 load_texture_map_file(texture_id, lvnumb, get_level_fgroup(lvnumb));
+            }
         } else {
             // String input uses texture_pack_desc values ("STANDARD"=1, "ANCIENT"=2, ...).
             // These are 1-based, so subtract 1 to get the 0-based filename index.

--- a/src/lua_api_map.c
+++ b/src/lua_api_map.c
@@ -100,6 +100,7 @@ static int map_set_field(lua_State *L) {
             // Integer input is 0-based: ID 0 = tmapa000.dat
             // Store as 1-based internally (texture_id + 1) to match string input convention.
             // Negative values mean no-op — leave game.texture_id unchanged.
+            // TODO: align with PLAYER:set_texture() where negative values trigger a reset.
             long texture_id = lua_tointeger(L, 3);
             if (texture_id >= 0)
             {

--- a/src/lua_api_player.c
+++ b/src/lua_api_player.c
@@ -48,10 +48,10 @@ static int lua_Set_texture(lua_State *L)
         // set_player_texture uses slab_ext_data where slot 0 is the base map texture
         // and slot N+1 holds tmapaN.dat, so we add 1 to convert. -1 means reset.
         long n = lua_tointeger(L, 2);
-        if (n < 0)
+        if (n < 0) 
             texture_id = -1;
-        else
-            texture_id = n + 1;
+        else 
+            texture_id = n + 1; 
     } else {
         // String input uses texture_pack_desc values ("STANDARD"=1, "ANCIENT"=2, ...).
         // These values already match the slab_ext_data slot layout, so no offset needed.

--- a/src/lua_api_player.c
+++ b/src/lua_api_player.c
@@ -41,8 +41,25 @@ static int lua_Add_gold_to_player(lua_State *L)
 static int lua_Set_texture(lua_State *L)
 {
     struct PlayerRange player_range = luaL_checkPlayerRange(L, 1);
-    long texture_id = luaL_checkNamedCommand(L,2,texture_pack_desc);
-
+    
+    long texture_id;
+    if (lua_isnumber(L, 2)) {
+        // Integer input is 0-based (0=tmapa000.dat, 15=tmapa015.dat).
+        // set_player_texture uses slab_ext_data where slot 0 is the base map texture
+        // and slot N+1 holds tmapaN.dat, so we add 1 to convert. -1 means reset.
+        long n = lua_tointeger(L, 2);
+        if (n < 0)
+            texture_id = -1;
+        else
+            texture_id = n + 1;
+    } else {
+        // String input uses texture_pack_desc values ("STANDARD"=1, "ANCIENT"=2, ...).
+        // These values already match the slab_ext_data slot layout, so no offset needed.
+        // "NONE"=0 has no corresponding texture file, so treat it as reset (-1).
+        texture_id = luaL_checkNamedCommand(L, 2, texture_pack_desc);
+        if (texture_id == 0)
+            texture_id = -1;
+    }
     for (PlayerNumber i = player_range.start_idx; i < player_range.end_idx; i++)
     {
         set_player_texture(i, texture_id);

--- a/src/lua_api_player.c
+++ b/src/lua_api_player.c
@@ -44,7 +44,7 @@ static int lua_Set_texture(lua_State *L)
     
     long texture_id;
     if (lua_isnumber(L, 2)) {
-        // Integer input is 0-based (0=tmapa000.dat, 15=tmapa015.dat).
+        // Integer input is 0-based: ID 0 = tmapa000.dat
         // set_player_texture uses slab_ext_data where slot 0 is the base map texture
         // and slot N+1 holds tmapaN.dat, so we add 1 to convert. -1 means reset.
         long n = lua_tointeger(L, 2);
@@ -53,8 +53,8 @@ static int lua_Set_texture(lua_State *L)
         else 
             texture_id = n + 1; 
     } else {
-        // String input uses texture_pack_desc values ("STANDARD"=1, "ANCIENT"=2, ...).
-        // These values already match the slab_ext_data slot layout, so no offset needed.
+        // String input is 1-based and uses texture_pack_desc values ("STANDARD"=1, "ANCIENT"=2, ...).
+        // These values already match the slab_ext_data slot layout.
         // "NONE"=0 has no corresponding texture file, so treat it as reset (-1).
         texture_id = luaL_checkNamedCommand(L, 2, texture_pack_desc);
         if (texture_id == 0)

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -850,7 +850,8 @@ TbBool player_can_claim_slab(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabC
 void set_player_texture(PlayerNumber plyr_idx, long texture_id)
 {
     struct Dungeon* dungeon = get_dungeon(plyr_idx);
-    if (texture_id < 0)
+    TbBool reset = (texture_id < 0);
+    if (reset)
         dungeon->texture_pack = 0;
     else
         dungeon->texture_pack = texture_id;
@@ -862,7 +863,7 @@ void set_player_texture(PlayerNumber plyr_idx, long texture_id)
             struct SlabMap* slb = get_slabmap_block(slb_x,slb_y);
             if (slabmap_owner(slb) == plyr_idx)
             {
-                if (texture_id < 0)
+                if (reset)
                 {
                     game.slab_ext_data[get_slab_number(slb_x,slb_y)] = game.slab_ext_data_initial[get_slab_number(slb_x,slb_y)];
                 }

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -850,7 +850,10 @@ TbBool player_can_claim_slab(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabC
 void set_player_texture(PlayerNumber plyr_idx, long texture_id)
 {
     struct Dungeon* dungeon = get_dungeon(plyr_idx);
-    dungeon->texture_pack = texture_id;
+    if (texture_id < 0)
+        dungeon->texture_pack = 0;
+    else
+        dungeon->texture_pack = texture_id;
 
     for (MapSlabCoord slb_y=0; slb_y < game.map_tiles_y; slb_y++)
     {
@@ -859,7 +862,7 @@ void set_player_texture(PlayerNumber plyr_idx, long texture_id)
             struct SlabMap* slb = get_slabmap_block(slb_x,slb_y);
             if (slabmap_owner(slb) == plyr_idx)
             {
-                if (texture_id == 0)
+                if (texture_id < 0)
                 {
                     game.slab_ext_data[get_slab_number(slb_x,slb_y)] = game.slab_ext_data_initial[get_slab_number(slb_x,slb_y)];
                 }


### PR DESCRIPTION
Fixes #4813.

This change introduces a consistent texture ID scheme for both PLAYER:set_texture() and Map.default_texture:

Integer IDs are now 0-based (0 = tmapa000.dat).
-1 is used as the reset value for set_texture.
Named texture strings continue to work as before.
Integer and string inputs are handled separately to avoid ID translation issues.
