### PR TITLE
Multiplayer: attempt at fixing a desync when players disconnect

### DIFF
--- a/src/cursor_tag.c
+++ b/src/cursor_tag.c
@@ -71,14 +71,13 @@ unsigned char tag_cursor_blocks_dig(struct PlayerInfo *player, const struct Pack
         }
         else
         {
-            struct Dungeon* dungeon = get_players_dungeon(player);
-            if ( (render_roomspace->drag_mode) && (dungeon->task_count + render_roomspace->slab_count > MAPTASKS_COUNT) )
-            {
-                line_color = SLC_REDFLASH;
-            }
-            else if (dungeon->task_count >= MAPTASKS_COUNT)
-            {
-                line_color = SLC_REDYELLOW;
+            struct Dungeon* dungeon = get_dungeon(player->id_number);
+            if (!dungeon_invalid(dungeon)) {
+                if ((render_roomspace->drag_mode) && (dungeon->task_count + render_roomspace->slab_count > MAPTASKS_COUNT)) {
+                    line_color = SLC_REDFLASH;
+                } else if (dungeon->task_count >= MAPTASKS_COUNT) {
+                    line_color = SLC_REDYELLOW;
+                }
             }
         }
     }

--- a/src/net_checksums.c
+++ b/src/net_checksums.c
@@ -194,7 +194,8 @@ static struct ChecksumSnapshot* find_snapshot(GameTurn turn) {
     return NULL;
 }
 
-short checksums_different(void) {
+short checksums_different(void)
+{
     int host_player_id = get_host_player_id();
     struct Packet* host_packet = get_packet(host_player_id);
     TbBigChecksum host_checksum = host_packet->checksum;
@@ -202,7 +203,16 @@ short checksums_different(void) {
 
     for (int i = 0; i < PLAYERS_COUNT; i++) {
         struct PlayerInfo* player = get_player(i);
-        if (i == host_player_id || !player_exists(player) || ((player->allocflags & PlaF_CompCtrl) != 0)) {
+        if (i == host_player_id) {
+            continue;
+        }
+        if (!player_exists(player)) {
+            continue;
+        }
+        if ((player->allocflags & PlaF_CompCtrl) != 0) {
+            continue;
+        }
+        if (!network_player_active(player->packet_num)) {
             continue;
         }
         struct Packet* packet = get_packet_direct(player->packet_num);


### PR DESCRIPTION
also fixes some log spam.

if this doesn't fix the desync on disconnect then I believe I'll need to run all the "player disconnected so replace with ai" code through the packet system which is an annoying refactor