### PR TITLE
Multiplayer: fix custody slapping for client players

### DIFF
--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6529,32 +6529,23 @@ TngUpdateRet update_creature(struct Thing *thing)
 
 TbBool creature_is_slappable(const struct Thing *thing, PlayerNumber plyr_idx)
 {
-    struct Room *room;
-    if (creature_is_being_unconscious(thing))
-    {
+    if (creature_is_being_unconscious(thing)) {
         return false;
     }
-    if (creature_is_leaving_and_cannot_be_stopped(thing))
-    {
+    if (creature_is_leaving_and_cannot_be_stopped(thing)) {
         return false;
     }
-    if (thing->owner != plyr_idx)
-    {
-        if (creature_is_kept_in_prison(thing) || creature_is_being_tortured(thing))
-        {
-            room = get_room_creature_works_in(thing);
-            return (room->owner == plyr_idx);
+    if (thing->owner != plyr_idx) {
+        if (creature_is_kept_in_prison(thing) || creature_is_being_tortured(thing)) {
+            return creature_is_kept_in_custody_by_player(thing, plyr_idx);
         }
         return false;
     }
-    if (creature_is_being_sacrificed(thing) || creature_is_being_summoned(thing))
-    {
+    if (creature_is_being_sacrificed(thing) || creature_is_being_summoned(thing)) {
         return false;
     }
-    if (creature_is_kept_in_prison(thing) || creature_is_being_tortured(thing))
-    {
-        room = get_room_creature_works_in(thing);
-        return (room->owner == plyr_idx);
+    if (creature_is_kept_in_prison(thing) || creature_is_being_tortured(thing)) {
+        return creature_is_kept_in_custody_by_player(thing, plyr_idx);
     }
     return true;
 }


### PR DESCRIPTION
There's been a very peculiar bug for over a year where any player other than Red was unable to spam slap their imprisoned/tortured minions, it had a cooldown of about a second before you were allowed to slap again.

I suspect this was left here to just be enforced on Computer players. But there doesn't seem to be any problem with them repeatedly slapping their creatures out of the prison, apparently there's already a 500 turn cooldown gate on it for Computer players.