### PR TITLE
Added rule: Reset skills when dropped

### DIFF
--- a/config/fxdata/rules.cfg
+++ b/config/fxdata/rules.cfg
@@ -107,6 +107,8 @@ StunGoodEnemyChance = 100
 StunWithoutPrisonChance = 0
 ; Creature health percentage threshold below which the creature will prioritize sleeping in Lair over all other activities, ignoring Call to Arms. But doesn't affect fleeing from ongoing fights. [0-100]
 CriticalHealthPercentage = 13
+; Reset creature skill cooldowns when dropped so creatures cannot cast immediately. [0-1]
+ResetSkillsWhenDropped = 0
 
 [magic]
 ; Game turns creatures remain around Dungeon Heart during Hold Audience spell effect.

--- a/config/fxdata/rules.cfg
+++ b/config/fxdata/rules.cfg
@@ -107,8 +107,8 @@ StunGoodEnemyChance = 100
 StunWithoutPrisonChance = 0
 ; Creature health percentage threshold below which the creature will prioritize sleeping in Lair over all other activities, ignoring Call to Arms. But doesn't affect fleeing from ongoing fights. [0-100]
 CriticalHealthPercentage = 13
-; When dropping a creature delay its skill cooldowns by this many game turns. Capped by each skill's original cooldown.
-DelaySkillCooldownsOnDrop = 0
+; When dropping a creature delay its attack and spell cooldowns by this many game turns. Capped by each ability's original cooldown.
+InstanceDelayOnDrop = 0
 
 [magic]
 ; Game turns creatures remain around Dungeon Heart during Hold Audience spell effect.

--- a/config/fxdata/rules.cfg
+++ b/config/fxdata/rules.cfg
@@ -107,8 +107,8 @@ StunGoodEnemyChance = 100
 StunWithoutPrisonChance = 0
 ; Creature health percentage threshold below which the creature will prioritize sleeping in Lair over all other activities, ignoring Call to Arms. But doesn't affect fleeing from ongoing fights. [0-100]
 CriticalHealthPercentage = 13
-; Reset creature skill cooldowns when dropped so creatures cannot cast immediately. [0-1]
-ResetSkillsWhenDropped = 0
+; When dropping a creature delay its skill cooldowns by this many game turns. Capped by each skill's original cooldown.
+DelaySkillCooldownsOnDrop = 0
 
 [magic]
 ; Game turns creatures remain around Dungeon Heart during Hold Audience spell effect.

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -132,7 +132,7 @@ static const struct NamedField rules_creatures_named_fields[] = {
   {"STUNEVILENEMYCHANCE",        0, field(game.conf.rules[0].creature.stun_enemy_chance_evil)    , 100,        0,       100,NULL,value_default, assign_default},
   {"STUNGOODENEMYCHANCE",        0, field(game.conf.rules[0].creature.stun_enemy_chance_good)    , 100,        0,       100,NULL,value_default, assign_default},
   {"STUNWITHOUTPRISONCHANCE",    0, field(game.conf.rules[0].creature.stun_without_prison_chance),   0,        0,       100,NULL,value_default, assign_default},
-  {"DELAYSKILLCOOLDOWNSONDROP", 0, field(game.conf.rules[0].creature.delay_skill_cooldowns_on_drop),   0,        0, INT32_MAX,NULL,value_default, assign_default},
+  {"INSTANCEDELAYONDROP",       0, field(game.conf.rules[0].creature.instance_delay_on_drop),   0,        0, INT32_MAX,NULL,value_default, assign_default},
   {NULL},
 };
 

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -132,6 +132,7 @@ static const struct NamedField rules_creatures_named_fields[] = {
   {"STUNEVILENEMYCHANCE",        0, field(game.conf.rules[0].creature.stun_enemy_chance_evil)    , 100,        0,       100,NULL,value_default, assign_default},
   {"STUNGOODENEMYCHANCE",        0, field(game.conf.rules[0].creature.stun_enemy_chance_good)    , 100,        0,       100,NULL,value_default, assign_default},
   {"STUNWITHOUTPRISONCHANCE",    0, field(game.conf.rules[0].creature.stun_without_prison_chance),   0,        0,       100,NULL,value_default, assign_default},
+  {"RESETSKILLSWHENDROPPED",     0, field(game.conf.rules[0].creature.reset_skills_when_dropped  ),   0,        0,         1,NULL,value_default, assign_default},
   {NULL},
 };
 

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -132,7 +132,7 @@ static const struct NamedField rules_creatures_named_fields[] = {
   {"STUNEVILENEMYCHANCE",        0, field(game.conf.rules[0].creature.stun_enemy_chance_evil)    , 100,        0,       100,NULL,value_default, assign_default},
   {"STUNGOODENEMYCHANCE",        0, field(game.conf.rules[0].creature.stun_enemy_chance_good)    , 100,        0,       100,NULL,value_default, assign_default},
   {"STUNWITHOUTPRISONCHANCE",    0, field(game.conf.rules[0].creature.stun_without_prison_chance),   0,        0,       100,NULL,value_default, assign_default},
-  {"RESETSKILLSWHENDROPPED",     0, field(game.conf.rules[0].creature.reset_skills_when_dropped  ),   0,        0,         1,NULL,value_default, assign_default},
+  {"DELAYSKILLCOOLDOWNSONDROP", 0, field(game.conf.rules[0].creature.delay_skill_cooldowns_on_drop),   0,        0, INT32_MAX,NULL,value_default, assign_default},
   {NULL},
 };
 

--- a/src/config_rules.h
+++ b/src/config_rules.h
@@ -120,7 +120,7 @@ struct CreatureRulesConfig {
     unsigned char stun_enemy_chance_evil;
     unsigned char stun_enemy_chance_good;
     unsigned char stun_without_prison_chance;
-    GameTurnDelta delay_skill_cooldowns_on_drop;
+    GameTurnDelta instance_delay_on_drop;
 };
 
 struct MagicRulesConfig {

--- a/src/config_rules.h
+++ b/src/config_rules.h
@@ -120,7 +120,7 @@ struct CreatureRulesConfig {
     unsigned char stun_enemy_chance_evil;
     unsigned char stun_enemy_chance_good;
     unsigned char stun_without_prison_chance;
-    TbBool reset_skills_when_dropped;
+    GameTurnDelta delay_skill_cooldowns_on_drop;
 };
 
 struct MagicRulesConfig {

--- a/src/config_rules.h
+++ b/src/config_rules.h
@@ -120,6 +120,7 @@ struct CreatureRulesConfig {
     unsigned char stun_enemy_chance_evil;
     unsigned char stun_enemy_chance_good;
     unsigned char stun_without_prison_chance;
+    TbBool reset_skills_when_dropped;
 };
 
 struct MagicRulesConfig {

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -446,14 +446,14 @@ void process_creature_instance(struct Thing *thing)
     }
 }
 
-void delay_creature_cooldowns(struct Thing *thing)
+void delay_instances_on_drop(struct Thing *thing)
 {
     GameTurn current_turn = get_gameturn();
-    GameTurnDelta drop_cooldown_penalty_turns = game.conf.rules[thing->owner].creature.delay_skill_cooldowns_on_drop;
+    GameTurnDelta instance_delay_turns = game.conf.rules[thing->owner].creature.instance_delay_on_drop;
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     for (int32_t i = 1; i < game.conf.crtr_conf.instances_count; i++) {
         struct InstanceInfo* inst_inf = creature_instance_info_get(i);
-        GameTurnDelta cooldown_penalty_turns = min(drop_cooldown_penalty_turns, inst_inf->reset_time);
+        GameTurnDelta cooldown_penalty_turns = min(instance_delay_turns, inst_inf->reset_time);
         GameTurnDelta cooldown_turns = inst_inf->reset_time + cctrl->inst_total_turns - cctrl->inst_action_turns;
         GameTurnDelta cooldown_turns_elapsed = (GameTurnDelta)(current_turn - cctrl->instance_use_turn[i]);
         GameTurnDelta required_elapsed_turns = cooldown_turns - cooldown_penalty_turns;

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -446,11 +446,20 @@ void process_creature_instance(struct Thing *thing)
     }
 }
 
-void reset_creature_instance_cooldowns(struct Thing *thing)
+void delay_creature_cooldowns(struct Thing *thing)
 {
+    GameTurn current_turn = get_gameturn();
+    GameTurnDelta drop_cooldown_penalty_turns = game.conf.rules[thing->owner].creature.delay_skill_cooldowns_on_drop;
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
-    for (long i = 1; i < game.conf.crtr_conf.instances_count; i++) {
-        cctrl->instance_use_turn[i] = get_gameturn();
+    for (int32_t i = 1; i < game.conf.crtr_conf.instances_count; i++) {
+        struct InstanceInfo* inst_inf = creature_instance_info_get(i);
+        GameTurnDelta cooldown_penalty_turns = min(drop_cooldown_penalty_turns, inst_inf->reset_time);
+        GameTurnDelta cooldown_turns = inst_inf->reset_time + cctrl->inst_total_turns - cctrl->inst_action_turns;
+        GameTurnDelta cooldown_turns_elapsed = current_turn - cctrl->instance_use_turn[i];
+        if (cooldown_turns_elapsed > cooldown_turns) {
+            cooldown_turns_elapsed = cooldown_turns;
+        }
+        cctrl->instance_use_turn[i] = current_turn - cooldown_turns_elapsed + cooldown_penalty_turns;
     }
 }
 

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -455,11 +455,11 @@ void delay_creature_cooldowns(struct Thing *thing)
         struct InstanceInfo* inst_inf = creature_instance_info_get(i);
         GameTurnDelta cooldown_penalty_turns = min(drop_cooldown_penalty_turns, inst_inf->reset_time);
         GameTurnDelta cooldown_turns = inst_inf->reset_time + cctrl->inst_total_turns - cctrl->inst_action_turns;
-        GameTurnDelta cooldown_turns_elapsed = current_turn - cctrl->instance_use_turn[i];
-        if (cooldown_turns_elapsed > cooldown_turns) {
-            cooldown_turns_elapsed = cooldown_turns;
+        GameTurnDelta cooldown_turns_elapsed = (GameTurnDelta)(current_turn - cctrl->instance_use_turn[i]);
+        GameTurnDelta required_elapsed_turns = cooldown_turns - cooldown_penalty_turns;
+        if (cooldown_turns_elapsed > required_elapsed_turns) {
+            cctrl->instance_use_turn[i] = current_turn - required_elapsed_turns;
         }
-        cctrl->instance_use_turn[i] = current_turn - cooldown_turns_elapsed + cooldown_penalty_turns;
     }
 }
 

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -446,6 +446,14 @@ void process_creature_instance(struct Thing *thing)
     }
 }
 
+void reset_creature_instance_cooldowns(struct Thing *thing)
+{
+    struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
+    for (long i = 1; i < game.conf.crtr_conf.instances_count; i++) {
+        cctrl->instance_use_turn[i] = get_gameturn();
+    }
+}
+
 long instf_creature_fire_shot(struct Thing *creatng, int32_t *param)
 {
     struct Thing *target;

--- a/src/creature_instances.h
+++ b/src/creature_instances.h
@@ -146,7 +146,7 @@ extern Creature_Target_Search_Func creature_instances_search_targets_func_list[]
 #define creature_instance_info_get(inst_idx) creature_instance_info_get_f(inst_idx,__func__)
 struct InstanceInfo *creature_instance_info_get_f(CrInstance inst_idx,const char *func_name);
 void process_creature_instance(struct Thing *thing);
-void reset_creature_instance_cooldowns(struct Thing *thing);
+void delay_creature_cooldowns(struct Thing *thing);
 TbBool process_creature_self_spell_casting(struct Thing* thing);
 CrInstance process_creature_ranged_buff_spell_casting(struct Thing* thing);
 

--- a/src/creature_instances.h
+++ b/src/creature_instances.h
@@ -146,6 +146,7 @@ extern Creature_Target_Search_Func creature_instances_search_targets_func_list[]
 #define creature_instance_info_get(inst_idx) creature_instance_info_get_f(inst_idx,__func__)
 struct InstanceInfo *creature_instance_info_get_f(CrInstance inst_idx,const char *func_name);
 void process_creature_instance(struct Thing *thing);
+void reset_creature_instance_cooldowns(struct Thing *thing);
 TbBool process_creature_self_spell_casting(struct Thing* thing);
 CrInstance process_creature_ranged_buff_spell_casting(struct Thing* thing);
 

--- a/src/creature_instances.h
+++ b/src/creature_instances.h
@@ -146,7 +146,7 @@ extern Creature_Target_Search_Func creature_instances_search_targets_func_list[]
 #define creature_instance_info_get(inst_idx) creature_instance_info_get_f(inst_idx,__func__)
 struct InstanceInfo *creature_instance_info_get_f(CrInstance inst_idx,const char *func_name);
 void process_creature_instance(struct Thing *thing);
-void delay_creature_cooldowns(struct Thing *thing);
+void delay_instances_on_drop(struct Thing *thing);
 TbBool process_creature_self_spell_casting(struct Thing* thing);
 CrInstance process_creature_ranged_buff_spell_casting(struct Thing* thing);
 

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -945,8 +945,8 @@ void drop_held_thing_on_ground(struct Dungeon *dungeon, struct Thing *droptng, c
     remove_thing_from_limbo(droptng);
     if (thing_is_creature(droptng))
     {
-        if (game.conf.rules[droptng->owner].creature.delay_skill_cooldowns_on_drop > 0) {
-            delay_creature_cooldowns(droptng);
+        if (game.conf.rules[droptng->owner].creature.instance_delay_on_drop > 0) {
+            delay_instances_on_drop(droptng);
         }
         initialise_thing_state(droptng, CrSt_CreatureBeingDropped);
         stop_creature_sound(droptng, 5);

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -40,6 +40,7 @@
 #include "thing_stats.h"
 #include "thing_navigate.h"
 #include "creature_graphics.h"
+#include "creature_instances.h"
 #include "creature_states.h"
 #include "creature_states_mood.h"
 #include "creature_states_combt.h"
@@ -944,6 +945,9 @@ void drop_held_thing_on_ground(struct Dungeon *dungeon, struct Thing *droptng, c
     remove_thing_from_limbo(droptng);
     if (thing_is_creature(droptng))
     {
+        if (game.conf.rules[droptng->owner].creature.reset_skills_when_dropped) {
+            reset_creature_instance_cooldowns(droptng);
+        }
         initialise_thing_state(droptng, CrSt_CreatureBeingDropped);
         stop_creature_sound(droptng, 5);
         if (is_my_player_number(dungeon->owner)) {

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -945,8 +945,8 @@ void drop_held_thing_on_ground(struct Dungeon *dungeon, struct Thing *droptng, c
     remove_thing_from_limbo(droptng);
     if (thing_is_creature(droptng))
     {
-        if (game.conf.rules[droptng->owner].creature.reset_skills_when_dropped) {
-            reset_creature_instance_cooldowns(droptng);
+        if (game.conf.rules[droptng->owner].creature.delay_skill_cooldowns_on_drop > 0) {
+            delay_creature_cooldowns(droptng);
         }
         initialise_thing_state(droptng, CrSt_CreatureBeingDropped);
         stop_creature_sound(droptng, 5);


### PR DESCRIPTION
When creatures are dropped, reset their skills.

I like this nerf because it rewards attacking via walking and normal encounters, while it punishes attacking via dropping. But the punishment is very subtle and difficult to see, I bet players wouldn't even notice. Unlike something like stun-on-drop which is massively noticeable and annoying, this one doesn't feel annoying.

It does slightly affect creature balance, but that's something for mapmakers to take into consideration and buff their wizards to compensate, if they want to.