### PR TITLE
Fixed PayDayProgress rule causing a memory overflow

### DIFF
--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -44,6 +44,7 @@ static int64_t value_x10(const struct NamedField* named_field, const char* value
 
 static void assign_MapCreatureLimit_script(const struct NamedField* named_field, int64_t value, const struct NamedFieldSet* named_fields_set, int idx, const char* src_str, unsigned char flags);
 static void assign_AlliesShareVision_script(const struct NamedField* named_field, int64_t value, const struct NamedFieldSet* named_fields_set, int idx, const char* src_str, unsigned char flags);
+static void assign_PayDayProgress_script(const struct NamedField* named_field, int64_t value, const struct NamedFieldSet* named_fields_set, int idx, const char* src_str, unsigned char flags);
 
 /******************************************************************************/
 static TbBool load_rules_config_file(const char *fname, unsigned short flags);
@@ -207,7 +208,7 @@ static const struct NamedField rules_health_named_fields[] = {
 
 static const struct NamedField rules_script_only_named_fields[] = {
   //name            //field                   //min //max
-{"PayDayProgress",0,field(game.pay_day_progress[0]),0,0,INT32_MAX,NULL,value_default,assign_default},
+{"PayDayProgress",0,field(game.pay_day_progress[0]),0,0,INT32_MAX,NULL,value_default,assign_PayDayProgress_script},
 {NULL},
 };
 
@@ -286,6 +287,11 @@ static void assign_AlliesShareVision_script(const struct NamedField* named_field
     }
 }
 
+static void assign_PayDayProgress_script(const struct NamedField* named_field, int64_t value, const struct NamedFieldSet* named_fields_set, int idx, const char* src_str, unsigned char flags)
+{
+    game.pay_day_progress[idx] = value;
+}
+
 static int64_t value_x10(const struct NamedField* named_field, const char* value_text, const struct NamedFieldSet* named_fields_set, int idx, const char* src_str, unsigned char flags)
 {
 
@@ -339,9 +345,12 @@ static void set_rules_defaults()
     for (size_t i = 0; i < sizeof(ruleblocks) / sizeof(ruleblocks[0]); i++) {
         const struct NamedField* field = ruleblocks[i];
         while (field->name != NULL) {
-            for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
-            {
-                assign_default(field, field->default_value, &rules_named_fields_set, plyr_idx, "rules", ccf_SplitExecution | ccf_DuringLevel);
+            for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++) {
+                if (ruleblocks[i] == rules_script_only_named_fields) {
+                    assign_named_field_value(field, field->default_value, &rules_named_fields_set, plyr_idx, "rules", ccf_SplitExecution | ccf_DuringLevel);
+                } else {
+                    assign_default(field, field->default_value, &rules_named_fields_set, plyr_idx, "rules", ccf_SplitExecution | ccf_DuringLevel);
+                }
             }
             field++;
         }

--- a/src/config_rules.c
+++ b/src/config_rules.c
@@ -206,6 +206,7 @@ static const struct NamedField rules_health_named_fields[] = {
   {NULL},
 };
 
+// Fields here are not inside game.conf.rules, so assign_default cannot be used.
 static const struct NamedField rules_script_only_named_fields[] = {
   //name            //field                   //min //max
 {"PayDayProgress",0,field(game.pay_day_progress[0]),0,0,INT32_MAX,NULL,value_default,assign_PayDayProgress_script},


### PR DESCRIPTION
Fixes #4877

The script-only rules inside of `rules_script_only_named_fields` can't use `assign_default`, they need their own assign functions.

It's because `assign_default` assumes the field is inside `game.conf.rules` when it calculates where to write to memory. (assign_default can't be fixed)