### PR TITLE
Added creature properties: NO_HEALTH_FLOWER and CANNOT_PICK_UP

### DIFF
--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -138,6 +138,8 @@ SpellImmunity = 0
 ;   PREFER_STEAL - Creature can be generated from steal hero special if there is nothing to steal from.
 ;   ILLUMINATED - A bright light will shine from the Creature.
 ;   ALLURING_SCVNGR - When scavenging will give the keeper a portal boost compared to rival keepers.
+;   NO_HEALTH_FLOWER - Do not draw the health/status flower above the creature.
+;   CANNOT_PICK_UP - Creature cannot be picked up by the hand.
 Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK NO_CORPSE_ROTTING
 
 [attraction]

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -65,6 +65,7 @@ enum CreatureModelFlags {
     CMF_EventfulDeath     = 0x080000, // The LAST_DEATH_EVENT[] script location is updated on death.
     CMF_IsDiggingCreature = 0x100000, // unit still counts as a regular creature but can also do digger tasks (like tunneler)
     CMF_NoHealthFlower    = 0x200000,
+    CMF_CannotPickUp      = 0x400000,
 };
 
 // Before C23 standard, we cannot specify the underlaying type (in this case we want 64bit int) of enum.

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -64,6 +64,7 @@ enum CreatureModelFlags {
     CMF_PreferSteal       = 0x040000, // The creature can be generated from Steal Hero special if there's nothing to steal.
     CMF_EventfulDeath     = 0x080000, // The LAST_DEATH_EVENT[] script location is updated on death.
     CMF_IsDiggingCreature = 0x100000, // unit still counts as a regular creature but can also do digger tasks (like tunneler)
+    CMF_NoHealthFlower    = 0x200000,
 };
 
 // Before C23 standard, we cannot specify the underlaying type (in this case we want 64bit int) of enum.

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -64,8 +64,8 @@ enum CreatureModelFlags {
     CMF_PreferSteal       = 0x040000, // The creature can be generated from Steal Hero special if there's nothing to steal.
     CMF_EventfulDeath     = 0x080000, // The LAST_DEATH_EVENT[] script location is updated on death.
     CMF_IsDiggingCreature = 0x100000, // unit still counts as a regular creature but can also do digger tasks (like tunneler)
-    CMF_NoHealthFlower    = 0x200000,
-    CMF_CannotPickUp      = 0x400000,
+    CMF_NoHealthFlower    = 0x200000, // Do not draw the health/status flower above the creature.
+    CMF_CannotPickUp      = 0x400000, // Creature cannot be picked up by the hand.
 };
 
 // Before C23 standard, we cannot specify the underlaying type (in this case we want 64bit int) of enum.

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -754,11 +754,11 @@ TbBool parse_creaturemodel_attributes_blocks(long crtr_model,char *buf,long len,
                 crconf->model_flags |= CMF_IsDiggingCreature;
                 n++;
                 break;
-            case 36:
+            case 36: // NO_HEALTH_FLOWER
                 crconf->model_flags |= CMF_NoHealthFlower;
                 n++;
                 break;
-            case 37:
+            case 37: // CANNOT_PICK_UP
                 crconf->model_flags |= CMF_CannotPickUp;
                 n++;
                 break;

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -129,6 +129,7 @@ const struct NamedCommand creatmodel_properties_commands[] = {
   {"PREFER_STEAL",      33},
   {"EVENTFUL_DEATH",    34},
   {"DIGGING_CREATURE",  35},
+  {"NO_HEALTH_FLOWER",  36},
   {NULL,                 0},
   };
 
@@ -750,6 +751,10 @@ TbBool parse_creaturemodel_attributes_blocks(long crtr_model,char *buf,long len,
                 break;
             case 35: // DIGGING_CREATURE
                 crconf->model_flags |= CMF_IsDiggingCreature;
+                n++;
+                break;
+            case 36:
+                crconf->model_flags |= CMF_NoHealthFlower;
                 n++;
                 break;
             default:

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -130,6 +130,7 @@ const struct NamedCommand creatmodel_properties_commands[] = {
   {"EVENTFUL_DEATH",    34},
   {"DIGGING_CREATURE",  35},
   {"NO_HEALTH_FLOWER",  36},
+  {"CANNOT_PICK_UP",    37},
   {NULL,                 0},
   };
 
@@ -755,6 +756,10 @@ TbBool parse_creaturemodel_attributes_blocks(long crtr_model,char *buf,long len,
                 break;
             case 36:
                 crconf->model_flags |= CMF_NoHealthFlower;
+                n++;
+                break;
+            case 37:
+                crconf->model_flags |= CMF_CannotPickUp;
                 n++;
                 break;
             default:

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -5306,9 +5306,8 @@ void draw_status_sprites(long scrpos_x, long scrpos_y, struct Thing *thing)
 
     struct CreatureControl *cctrl;
     cctrl = creature_control_get_from_thing(thing);
-    if (cctrl->force_health_flower_hidden == true)
-        return;
-    if (flag_is_set(get_creature_model_flags(thing), CMF_NoHealthFlower)) {
+    if ((cctrl->force_health_flower_hidden == true) || flag_is_set(get_creature_model_flags(thing), CMF_NoHealthFlower)) {
+        lbDisplay.DrawFlags = flg_mem;
         return;
     }
     if (flag_is_set(game.mode_flags,MFlg_NoHeroHealthFlower))

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -5308,6 +5308,9 @@ void draw_status_sprites(long scrpos_x, long scrpos_y, struct Thing *thing)
     cctrl = creature_control_get_from_thing(thing);
     if (cctrl->force_health_flower_hidden == true)
         return;
+    if (flag_is_set(get_creature_model_flags(thing), CMF_NoHealthFlower)) {
+        return;
+    }
     if (flag_is_set(game.mode_flags,MFlg_NoHeroHealthFlower))
     {
         if (local_thing_under_hand != thing->index) {

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -573,6 +573,13 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
           recalculate_all_creature_digger_lists();
           update_creatr_model_activities_list(1);
           break;
+      case 36:
+          if (param3 >= 1) {
+              set_flag(crconf->model_flags, CMF_NoHealthFlower);
+          } else {
+              clear_flag(crconf->model_flags, CMF_NoHealthFlower);
+          }
+          break;
       default:
           SCRPTERRLOG("Unknown creature property '%ld'", param2);
           break;

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -573,14 +573,14 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
           recalculate_all_creature_digger_lists();
           update_creatr_model_activities_list(1);
           break;
-      case 36:
+      case 36: // NO_HEALTH_FLOWER
           if (param3 >= 1) {
               set_flag(crconf->model_flags, CMF_NoHealthFlower);
           } else {
               clear_flag(crconf->model_flags, CMF_NoHealthFlower);
           }
           break;
-      case 37:
+      case 37: // CANNOT_PICK_UP
           if (param3 >= 1) {
               set_flag(crconf->model_flags, CMF_CannotPickUp);
           } else {

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -580,6 +580,13 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
               clear_flag(crconf->model_flags, CMF_NoHealthFlower);
           }
           break;
+      case 37:
+          if (param3 >= 1) {
+              set_flag(crconf->model_flags, CMF_CannotPickUp);
+          } else {
+              clear_flag(crconf->model_flags, CMF_CannotPickUp);
+          }
+          break;
       default:
           SCRPTERRLOG("Unknown creature property '%ld'", param2);
           break;

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -249,10 +249,6 @@ TbBool can_thing_be_picked_up2_by_player(const struct Thing *thing, PlayerNumber
     {
         return (thing_is_object(thing) && object_is_pickable_by_hand_for_use(thing, plyr_idx));
     }
-    if (flag_is_set(get_creature_model_flags(thing), CMF_CannotPickUp)) {
-        return false;
-    }
-
     if ( (game.armageddon_cast_turn > 0) && ( (game.conf.rules[game.armageddon_caster_idx].magic.armageddon_count_down + game.armageddon_cast_turn) <= get_gameturn()) )
     {
         return false;

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -219,6 +219,9 @@ TbBool armageddon_blocks_creature_pickup(const struct Thing *thing, PlayerNumber
 
 long can_thing_be_picked_up_by_player(const struct Thing *thing, PlayerNumber plyr_idx)
 {
+    if (thing_is_creature(thing) && flag_is_set(get_creature_model_flags(thing), CMF_CannotPickUp)) {
+        return false;
+    }
     if (thing_is_creature(thing) && thing_pickup_is_blocked_by_hand_rule(thing, plyr_idx)) {
         return false;
     }
@@ -245,6 +248,9 @@ TbBool can_thing_be_picked_up2_by_player(const struct Thing *thing, PlayerNumber
     if(!thing_is_creature(thing))
     {
         return (thing_is_object(thing) && object_is_pickable_by_hand_for_use(thing, plyr_idx));
+    }
+    if (flag_is_set(get_creature_model_flags(thing), CMF_CannotPickUp)) {
+        return false;
     }
 
     if ( (game.armageddon_cast_turn > 0) && ( (game.conf.rules[game.armageddon_caster_idx].magic.armageddon_count_down + game.armageddon_cast_turn) <= get_gameturn()) )


### PR DESCRIPTION
Added `NO_HEALTH_FLOWER` and `CANNOT_PICK_UP` as creature properties. You can set them here:
`/creatrs/bile_demon.cfg` --> `[attributes]` --> `Properties`.

Some aspects to consider with `CANNOT_PICK_UP`:

The creature still flashes white when hovered and the cursor still turns into the Hand of Evil. Which I guess might be necessary if you want them to still be slappable and targetable by powers like Heal.
In the GUI creature tab, the creature number is listed as red instead of yellow. It did this automatically, but I think it's probably a good idea anyway because then you know why your clicks aren't responding, you've got a little feedback like this.