### PR TITLE
lua display set health

### DIFF
--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -26,6 +26,7 @@
 #include "magic_powers.h"
 #include "config_crtrstates.h"
 #include "creature_states_mood.h"
+#include "thing_stats.h"
 
 #include "lua_base.h"
 #include "lua_params.h"
@@ -271,7 +272,20 @@ static int thing_set_field(lua_State *L) {
         change_creature_owner(thing, new_owner);
     } else if (strcmp(key, "health") == 0)
     {
-        thing->health = luaL_checkinteger(L, 3);
+    HitPoints new_health = luaL_checkinteger(L, 3);
+    if (thing_is_creature(thing))
+    {
+        HitPoints old_health = thing->health;
+        if (new_health > old_health) {
+            apply_health_to_thing_and_display_health(thing, new_health - old_health);
+        } else if (new_health < old_health) {
+            apply_damage_to_thing(thing, old_health - new_health, -1);
+        }
+    }
+    else
+    {
+        thing->health = new_health;     // Doors, Hearts, Traps, ...
+    }
     } else if (strcmp(key, "pos") == 0) 
     {
         struct Coord3d pos;

--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -42,8 +42,6 @@ static int thing_get_field(lua_State *L);
 static const struct luaL_Reg thing_methods[];
 
 
-
-
 /**********************************************/
 // things
 /**********************************************/
@@ -272,20 +270,22 @@ static int thing_set_field(lua_State *L) {
         change_creature_owner(thing, new_owner);
     } else if (strcmp(key, "health") == 0)
     {
-    HitPoints new_health = luaL_checkinteger(L, 3);
-    if (thing_is_creature(thing))
-    {
-        HitPoints old_health = thing->health;
-        if (new_health > old_health) {
-            apply_health_to_thing_and_display_health(thing, new_health - old_health);
-        } else if (new_health < old_health) {
-            apply_damage_to_thing(thing, old_health - new_health, -1);
+        HitPoints new_health = luaL_checkinteger(L, 3);
+        if (thing_is_creature(thing))
+        {
+            HitPoints old_health = thing->health;
+            if (new_health > old_health)
+            {
+                apply_health_to_thing_and_display_health(thing, new_health - old_health);
+            } else if (new_health < old_health) 
+            {
+                apply_damage_to_thing(thing, old_health - new_health, -1);
+            }
         }
-    }
-    else
-    {
-        thing->health = new_health;     // Doors, Hearts, Traps, ...
-    }
+        else
+        {
+            thing->health = new_health;    // Doors, Hearts, Traps, ...
+        }
     } else if (strcmp(key, "pos") == 0) 
     {
         struct Coord3d pos;


### PR DESCRIPTION
Previously, modifying creature.health through Lua did not show the usual health flower effect.

Reducing health now correctly triggers the on_apply_damage_to_thing hook
and healing and damage are now displayed using the standard health flower effect.