### PR TITLE
Fix mouse capture issues in AltInput+windowed modes

### DIFF
--- a/src/bflib_inputctrl.cpp
+++ b/src/bflib_inputctrl.cpp
@@ -338,7 +338,7 @@ static void process_event(const SDL_Event *ev)
             if (isMouseActivated)
             {
                 isMouseActivated = 0;
-                pointerHandler.SetPosition(ev->motion.x + lbDisplay.MouseWindowY, ev->motion.y + lbDisplay.MouseWindowY);
+                pointerHandler.SetMousePosition(ev->motion.x + lbDisplay.MouseWindowY, ev->motion.y + lbDisplay.MouseWindowY);
                 mouseDelta.x = 0;
                 mouseDelta.y = 0;
                 frac_x = 0;

--- a/src/bflib_mshandler.hpp
+++ b/src/bflib_mshandler.hpp
@@ -37,7 +37,6 @@ class MouseStateHandler {
     bool IsInstalled(void);
     bool Release(void);
     bool SetMousePosition(long x, long y);
-    bool SetPosition(long x, long y);
     bool SetMousePointerAndOffset(const struct TbSprite *mouseSprite, long x, long y);
     bool SetMousePointer(const struct TbSprite *mouseSprite);
     bool SetPointerOffset(long x, long y);
@@ -46,6 +45,7 @@ class MouseStateHandler {
     bool PointerBeginSwap(void);
     bool PointerEndSwap(void);
  protected:
+    bool SetPosition(long x, long y);
     bool SetPointer(const struct TbSprite *spr, struct TbPoint *pt);
     // Properties
     std::mutex lock;


### PR DESCRIPTION
Fix failure to correctly set game mouse position upon system mouse capture in AltInput+windowed modes.