### PR TITLE
Lua: Fix set creature.orientation by re-syncing FP camera

### DIFF
--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -27,6 +27,7 @@
 #include "config_crtrstates.h"
 #include "creature_states_mood.h"
 #include "thing_stats.h"
+#include "local_camera.h"
 
 #include "lua_base.h"
 #include "lua_params.h"
@@ -259,6 +260,12 @@ static int thing_set_field(lua_State *L) {
     if (strcmp(key, "orientation") == 0)
     {
         thing->move_angle_xy = luaL_checkinteger(L, 3);
+        // re-sync fp-camera with creature orientation
+        struct PlayerInfo* player = get_my_player();
+        if(player->controlled_thing_idx == thing->index && player->view_mode == PVM_CreatureView)
+        {
+            set_local_camera_destination(player);
+        }        
     } else if (strcmp(key, "pitch") == 0) 
     {
         thing->move_angle_z = luaL_checkinteger(L, 3);

--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -260,9 +260,11 @@ static int thing_set_field(lua_State *L) {
     if (strcmp(key, "orientation") == 0)
     {
         thing->move_angle_xy = luaL_checkinteger(L, 3);
-        // re-sync fp-camera with creature orientation
+        // Re-sync first-person camera with creature orientation
         struct PlayerInfo* player = get_my_player();
-        if(player->controlled_thing_idx == thing->index && player->view_mode == PVM_CreatureView)
+        if (!player_invalid(player)
+            && player->controlled_thing_idx == thing->index
+            && player->view_mode == PVM_CreatureView)
         {
             set_local_camera_destination(player);
         }        


### PR DESCRIPTION
Re-sync the first-person camera when a possessed creature's orientation is changed through Lua, preventing the camera from getting stuck at the wrong angle