### PR TITLE
Increase minimap drag resolution

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -645,7 +645,9 @@ static short get_bookmark_inputs(void)
             clear_key_pressed(kcode);
             if ((bmark->flags & 0x01) != 0)
             {
-                set_players_packet_action(player, PckA_BookmarkLoad, bmark->x, bmark->y, 0, 0);
+                const MapCoord x = subtile_coord_center(bmark->x);
+                const MapCoord y = subtile_coord_center(bmark->y);
+                set_players_packet_action(player, PckA_BookmarkLoad, x, y, 0, 0);
                 return true;
             }
         }

--- a/src/frontmenu_ingame_map.c
+++ b/src/frontmenu_ingame_map.c
@@ -852,25 +852,25 @@ void panel_map_update(long x, long y, long w, long h)
     }
 }
 
-static void do_map_rotate_stuff(float relpos_x, float relpos_y, float *stl_x, float *stl_y, long zoom)
+static void do_map_rotate_stuff(float relpos_x, float relpos_y, float *coord_x, float *coord_y, long zoom)
 {
     const struct PlayerInfo *player = get_my_player();
     const struct Camera *cam = get_local_camera(get_player_active_camera(player));
-    int angle = cam->rotation_angle_x & ANGLE_MASK_4;
-    int shift_x = -LbSinL(angle);
-    int shift_y = LbCosL(angle);
-    float dx = (shift_y * relpos_x + shift_x * relpos_y) / (1UL << 24);
-    float dy = (shift_y * relpos_y - shift_x * relpos_x) / (1UL << 24);
-    *stl_x = zoom * dx + cam->mappos.x.stl.num;
-    *stl_y = zoom * dy + cam->mappos.y.stl.num;
+    const int angle = cam->rotation_angle_x & ANGLE_MASK_4;
+    const int shift_x = -LbSinL(angle);
+    const int shift_y = LbCosL(angle);
+    const float dx = (shift_y * relpos_x + shift_x * relpos_y) / (1UL << 16);
+    const float dy = (shift_y * relpos_y - shift_x * relpos_x) / (1UL << 16);
+    *coord_x = zoom * dx + cam->mappos.x.val;
+    *coord_y = zoom * dy + cam->mappos.y.val;
 }
 
-static void do_map_rotate_stuff_round(float relpos_x, float relpos_y, int32_t *stl_x, int32_t *stl_y, long zoom)
+static void do_map_rotate_stuff_subtile(float relpos_x, float relpos_y, MapSubtlCoord *stl_x, MapSubtlCoord *stl_y, long zoom)
 {
     float tmp_x, tmp_y;
     do_map_rotate_stuff(relpos_x, relpos_y, &tmp_x, &tmp_y, zoom);
-    *stl_x = lroundf(tmp_x);
-    *stl_y = lroundf(tmp_y);
+    *stl_x = lroundf(tmp_x) / COORD_PER_STL;
+    *stl_y = lroundf(tmp_y) / COORD_PER_STL;
 }
 
 short do_left_map_drag(long begin_x, long begin_y, int32_t curr_x, int32_t curr_y, long zoom)
@@ -893,20 +893,22 @@ short do_left_map_drag(long begin_x, long begin_y, int32_t curr_x, int32_t curr_
     x = y = 0;
     frac_x = frac_y = 0;
   }
-  float stl_x, stl_y;
-  do_map_rotate_stuff(x, y, &stl_x, &stl_y, zoom);
-  stl_x += frac_x;
-  stl_y += frac_y;
-  curr_x = lroundf(stl_x);
-  curr_y = lroundf(stl_y);
-  frac_x = stl_x - curr_x;
-  frac_y = stl_y - curr_y;
+  float exact_x, exact_y;
+  do_map_rotate_stuff(x, y, &exact_x, &exact_y, zoom);
+  exact_x += frac_x;
+  exact_y += frac_y;
+  const MapCoord coord_x = lroundf(exact_x);
+  const MapCoord coord_y = lroundf(exact_y);
+  const MapSubtlCoord stl_x = coord_x / COORD_PER_STL;
+  const MapSubtlCoord stl_y = coord_y / COORD_PER_STL;
+  frac_x = exact_x - coord_x;
+  frac_y = exact_y - coord_y;
   player = get_my_player();
-  game.hand_over_subtile_x = curr_x;
-  game.hand_over_subtile_y = curr_y;
-  if (subtile_has_slab(curr_x, curr_y))
+  game.hand_over_subtile_x = stl_x;
+  game.hand_over_subtile_y = stl_y;
+  if (subtile_has_slab(stl_x, stl_y))
   {
-    set_players_packet_action(player, PckA_BookmarkLoad, curr_x, curr_y, 0, 0);
+    set_players_packet_action(player, PckA_BookmarkLoad, coord_x, coord_y, 0, 0);
   }
   return 1;
 }
@@ -926,13 +928,15 @@ short do_left_map_click(long begin_x, long begin_y, int32_t curr_x, int32_t curr
         LbMouseSetPosition(begin_x + MapDiagonalLength/2, begin_y + MapDiagonalLength/2);
       } else
       {
-        do_map_rotate_stuff_round(curr_x - begin_x - MapDiagonalLength/2, curr_y - begin_y - MapDiagonalLength/2, &curr_x, &curr_y, zoom);
+        do_map_rotate_stuff_subtile(curr_x - begin_x - MapDiagonalLength/2, curr_y - begin_y - MapDiagonalLength/2, &curr_x, &curr_y, zoom);
         game.hand_over_subtile_x = curr_x;
         game.hand_over_subtile_y = curr_y;
         if (subtile_has_slab(curr_x, curr_y))
         {
+          const MapCoord x = subtile_coord_center(curr_x);
+          const MapCoord y = subtile_coord_center(curr_y);
+          set_players_packet_action(player, PckA_BookmarkLoad, x, y, 0, 0);
           result = 1;
-          set_players_packet_action(player, PckA_BookmarkLoad, curr_x, curr_y, 0, 0);
         }
       }
     grabbed_small_map = 0;
@@ -949,7 +953,7 @@ short do_right_map_click(long start_x, long start_y, long curr_mx, long curr_my,
     SYNCDBG(17,"Starting");
     struct PlayerInfo *player;
     struct Thing *thing;
-    do_map_rotate_stuff_round(curr_mx - start_x - MapDiagonalLength/2, curr_my - start_y - MapDiagonalLength/2, &x, &y, zoom);
+    do_map_rotate_stuff_subtile(curr_mx - start_x - MapDiagonalLength/2, curr_my - start_y - MapDiagonalLength/2, &x, &y, zoom);
     game.hand_over_subtile_x = x;
     game.hand_over_subtile_y = y;
     player = get_my_player();

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -153,8 +153,8 @@ void init_local_cameras(struct PlayerInfo *player)
 
 void process_local_minimap_click(struct Packet* packet) {
     if (packet != NULL && packet->action == PckA_BookmarkLoad) {
-        long pos_x = subtile_coord_center(packet->actn_par1);
-        long pos_y = subtile_coord_center(packet->actn_par2);
+        const MapCoord pos_x = packet->actn_par1;
+        const MapCoord pos_y = packet->actn_par2;
         for (int i = CamIV_Isometric; i <= CamIV_FrontView; i++) {
             if (i != CamIV_FirstPerson) {
                 destination_local_cameras[i].mappos.x.val = pos_x;

--- a/src/packets.c
+++ b/src/packets.c
@@ -728,7 +728,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       }
       return 0;
   case PckA_BookmarkLoad:
-      set_player_cameras_position(player, subtile_coord_center(pckt->actn_par1), subtile_coord_center(pckt->actn_par2));
+      set_player_cameras_position(player, pckt->actn_par1, pckt->actn_par2);
       return 0;
   case PckA_SetGammaLevel:
       if (is_my_player(player))


### PR DESCRIPTION
Follow-up to #4885.

As I gather, maintaining packet compatibility is not much of a concern.  So now I propose increasing the resolution for `PckA_BookmarkLoad` to full MapCoords, instead of subtiles.  This makes dragging the minimap much smoother.

The fractional coordinate stuff introduced in #4885 is probably a bit overkill now.  Though I have left it in, as it is technically more correct.
