### PR TITLE
Multiplayer: Fix frameskip

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3493,9 +3493,11 @@ extern "C" void network_yield_waiting_gameplay_packets()
     poll_inputs();
     gameplay_loop_draw();
     gameplay_loop_timestep();
+    game.process_turn_time = min(game.process_turn_time, (long double)1.0);
     frametime_start_measurement(Frametime_Logic);
-    if (frametime_enabled())
+    if (frametime_enabled()) {
         framerate_measurement_capture(Framerate_Logic);
+    }
 }
 
 extern "C" void update_velocity(void);

--- a/src/net_exchange_gameplay.c
+++ b/src/net_exchange_gameplay.c
@@ -94,7 +94,7 @@ static void update_turn_speed_adjustment(void)
 {
     TbClockMSec sync_age_ms = LbTimerClock() - server_turn_received_at;
     multiplayer_speed_adjustment_ns = 0;
-    if (netstate.my_id == SERVER_ID || server_turn_received_at == 0 || turns_per_second <= 0
+    if (game.frame_skip > 0 || netstate.my_id == SERVER_ID || server_turn_received_at == 0 || turns_per_second <= 0
         || sync_age_ms > TURN_SYNC_INTERVAL_MS * 3) {
         return;
     }


### PR DESCRIPTION
Fixes #4892

Unfortunately the camera barely moves while frameskipping in multiplayer. I can fix it if necessary but it'll require a bit of a refactor. And it doesn't seem that important.