### PR TITLE
fix(sounds): Centralize sound id calculation

### DIFF
--- a/src/bflib_sndlib.cpp
+++ b/src/bflib_sndlib.cpp
@@ -28,7 +28,6 @@
 #include <deque>
 #include <mutex>
 #include <atomic>
-#include <set>
 
 #include "post_inc.h"
 
@@ -55,7 +54,7 @@ SoundVolume g_music_volume = 0;
 ALCdevice_ptr g_openal_device;
 ALCcontext_ptr g_openal_context;
 std::atomic<Mix_Music *> g_mix_music;
-std::set<uint32_t> g_tick_samples;
+
 bool g_bb_king_mode = false;
 
 enum source_flags {
@@ -683,7 +682,6 @@ extern "C" void MonitorStreamedSoundTrack() {
 			ERRORLOG("%s", e.what());
 		}
 	}
-	g_tick_samples.clear();
 }
 
 extern "C" void * GetSoundDriver() {
@@ -845,13 +843,7 @@ extern "C" SoundMilesID play_sample(
 		}
 		buf = &g_banks[0][smptbl_id].buffer;
 	}
-	// Don't play the same unified sample twice on the same tick
-	const uint32_t tick_sample_key = (uint32_t)(uint16_t)smptbl_id;
-	if (g_tick_samples.count(tick_sample_key) > 0) {
-		return 0;
-	}
 	try {
-		g_tick_samples.emplace(tick_sample_key);
 		for (auto & source : g_sources) {
 			if (source.emit_id == 0) {
 				source.gain(volume);

--- a/src/creature_control.c
+++ b/src/creature_control.c
@@ -32,6 +32,7 @@
 #include "lens_api.h"
 #include "light_data.h"
 #include "sounds.h"
+#include "bflib_sound.h"
 #include "game_legacy.h"
 #include "post_inc.h"
 
@@ -260,12 +261,25 @@ struct CreatureSound *get_creature_sound(struct Thing *thing, long snd_idx)
     }
 }
 
+// Convert a CreatureSound slot + variant index to the unified sample ID used by the sound emitter.
+// Standard sounds: index is a positive raw effect-bank ID; return index+i.
+// Custom sounds:   index is negative (-(bank+1)); thing_play_sample converts these to
+//                  get_custom_offset() + (-index-1) + i.  We must produce the same unified ID
+//                  so that S3DEmitterIsPlayingSample / S3DDeleteSampleFromEmitter can match.
+static inline SoundSmplTblID creature_sound_unified_id(const struct CreatureSound* crsound, long i)
+{
+    if (crsound->index < 0) {
+        return (SoundSmplTblID)(get_custom_offset() + (-crsound->index - 1) + i);
+    }
+    return (SoundSmplTblID)(crsound->index + i);
+}
+
 TbBool playing_creature_sound(struct Thing *thing, long snd_idx)
 {
     struct CreatureSound* crsound = get_creature_sound(thing, snd_idx);
     for (long i = 0; i < crsound->count; i++)
     {
-        if (S3DEmitterIsPlayingSample(thing->snd_emitter_id, crsound->index+i))
+        if (S3DEmitterIsPlayingSample(thing->snd_emitter_id, creature_sound_unified_id(crsound, i)))
           return true;
     }
     return false;
@@ -274,16 +288,17 @@ TbBool playing_creature_sound(struct Thing *thing, long snd_idx)
 void stop_creature_sound(struct Thing *thing, long snd_idx)
 {
     struct CreatureSound* crsound = get_creature_sound(thing, snd_idx);
-    if (crsound->index <= 0) {
+    if (crsound->index == 0) {
         SYNCDBG(19,"No sample %ld for creature %d",snd_idx,thing->model);
         return;
     }
 
     for (int i = 0; i < crsound->count; i++)
     {
-        if (S3DEmitterIsPlayingSample(thing->snd_emitter_id, crsound->index+i))
+        SoundSmplTblID uid = creature_sound_unified_id(crsound, i);
+        if (S3DEmitterIsPlayingSample(thing->snd_emitter_id, uid))
         {
-            S3DDeleteSampleFromEmitter(thing->snd_emitter_id, crsound->index+i);
+            S3DDeleteSampleFromEmitter(thing->snd_emitter_id, uid);
         }
     }
 }
@@ -327,14 +342,15 @@ void play_creature_sound_and_create_sound_thing(struct Thing *thing, long snd_id
         return;
     }
     struct CreatureSound* crsound = get_creature_sound(thing, snd_idx);
-    if (crsound->index <= 0) {
+    if (crsound->index == 0) {
         SYNCDBG(14,"No sample %ld for creature %d",snd_idx,thing->model);
         return;
     }
     long i = SOUND_RANDOM(crsound->count);
     struct Thing* efftng = create_effect(&thing->mappos, TngEff_Dummy, thing->owner);
     if (!thing_is_invalid(efftng)) {
-        thing_play_sample(efftng, crsound->index+i, NORMAL_PITCH, 0, 3, 0, sound_priority, FULL_LOUDNESS);
+        thing_play_sample(efftng, (SoundSmplTblID)(crsound->index < 0 ? crsound->index - i : crsound->index + i),
+            NORMAL_PITCH, 0, 3, 0, sound_priority, FULL_LOUDNESS);
     }
 }
 

--- a/src/creature_control.c
+++ b/src/creature_control.c
@@ -261,19 +261,6 @@ struct CreatureSound *get_creature_sound(struct Thing *thing, long snd_idx)
     }
 }
 
-// Convert a CreatureSound slot + variant index to the unified sample ID used by the sound emitter.
-// Standard sounds: index is a positive raw effect-bank ID; return index+i.
-// Custom sounds:   index is negative (-(bank+1)); thing_play_sample converts these to
-//                  get_custom_offset() + (-index-1) + i.  We must produce the same unified ID
-//                  so that S3DEmitterIsPlayingSample / S3DDeleteSampleFromEmitter can match.
-static inline SoundSmplTblID creature_sound_unified_id(const struct CreatureSound* crsound, long i)
-{
-    if (crsound->index < 0) {
-        return (SoundSmplTblID)(get_custom_offset() + (-crsound->index - 1) + i);
-    }
-    return (SoundSmplTblID)(crsound->index + i);
-}
-
 TbBool playing_creature_sound(struct Thing *thing, long snd_idx)
 {
     struct CreatureSound* crsound = get_creature_sound(thing, snd_idx);

--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -21,6 +21,7 @@
 
 #include "bflib_basics.h"
 #include "globals.h"
+#include "bflib_sound.h"
 
 #include "ariadne.h"
 #include "creature_graphics.h"
@@ -470,6 +471,18 @@ void stop_creature_sound(struct Thing *thing, long snd_idx);
 void play_creature_sound_and_create_sound_thing(struct Thing *thing, long snd_idx, long a2);
 struct CreatureSound *get_creature_sound(struct Thing *thing, long snd_idx);
 TbBool creature_can_gain_experience(const struct Thing *thing);
+
+/** Convert a CreatureSound slot + variant index to the unified sample ID.
+ *  Standard sounds: index is a positive raw effect-bank ID; returns index+i.
+ *  Custom sounds:   index is negative -(bank+1); thing_play_sample converts
+ *                   these to get_custom_offset()+(-index-1)+i. We produce
+ *                   the same unified ID so S3DEmitterIsPlayingSample can match. */
+static inline SoundSmplTblID creature_sound_unified_id(const struct CreatureSound *crsound, long i)
+{
+    if (crsound->index < 0)
+        return (SoundSmplTblID)(get_custom_offset() + (-crsound->index - 1) + i);
+    return (SoundSmplTblID)(crsound->index + i);
+}
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -4681,7 +4681,8 @@ short seek_the_enemy(struct Thing *creatng)
                 if ((dist < 2304) && (get_gameturn()-cctrl->countdown < 20))
                 {
                     crsound = get_creature_sound(creatng, CrSnd_Fight);
-                    thing_play_sample(creatng, crsound->index + SOUND_RANDOM(crsound->count), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
+                    long fight_i = SOUND_RANDOM(crsound->count);
+                    thing_play_sample(creatng, creature_sound_unified_id(crsound, fight_i), NORMAL_PITCH, 0, 3, 0, 2, FULL_LOUDNESS);
                     set_creature_instance(creatng, CrInst_CELEBRATE_SHORT, 0, 0);
                     return 1;
                 }

--- a/src/creature_states_mood.c
+++ b/src/creature_states_mood.c
@@ -133,7 +133,8 @@ short creature_piss(struct Thing *thing)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(thing);
     struct CreatureSound* crsound = get_creature_sound(thing, CrSnd_Piss);
-    unsigned short sound_idx = crsound->index + THING_RANDOM(thing, crsound->count);
+    long piss_i = THING_RANDOM(thing, crsound->count);
+    SoundSmplTblID sound_idx = creature_sound_unified_id(crsound, piss_i);
     if (!S3DEmitterIsPlayingSample(thing->snd_emitter_id, sound_idx)) {
         thing_play_sample(thing, sound_idx, NORMAL_PITCH, 0, 3, 1, 6, FULL_LOUDNESS);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2358,7 +2358,7 @@ void update_near_creatures_for_footsteps(int32_t *near_creatures, const struct C
         {
             struct CreatureSound *crsound;
             crsound = get_creature_sound(thing, CrSnd_Foot);
-            if (crsound->index > 0)
+            if (crsound->index != 0)
             {
                 struct CreatureControl *cctrl;
                 cctrl = creature_control_get_from_thing(thing);

--- a/src/sound_manager.cpp
+++ b/src/sound_manager.cpp
@@ -253,6 +253,7 @@ bool SoundManager::setCreatureSound(const std::string& creature_model, const std
     override.creature_model = creature_model;
     override.sound_type = sound_type;
     override.custom_sound_name = custom_sound_name;
+    override.count = count;
     creature_sound_overrides_.push_back(override);
     
     // Modify the creature configuration to use custom sound(s)
@@ -311,11 +312,7 @@ SoundSmplTblID SoundManager::getSoundId(const char* name) const {
     // Fall back to built-in sound registry (numeric IDs from fxdata/sounds.cfg etc.)
     auto it = sound_registry_.find(name_str);
     if (it != sound_registry_.end()) {
-        SoundSmplTblID id = it->second.sample_id;
-        if (it->second.count > 1) {
-            id = it->second.sample_id + (UNSYNC_RANDOM(it->second.count));
-        }
-        return id;
+        return it->second.sample_id;
     }
     
     return 0;
@@ -380,57 +377,16 @@ int SoundManager::getSoundCount(const char* name) const {
     return 0;
 }
 
-// Play a named sound effect
+// Play a named sound effect (picks a random variant when count > 1)
 SoundEmitterID SoundManager::playEffectNamed(const char* name, long priority, SoundVolume volume) {
-    SoundSmplTblID id = getSoundId(name);
-    if (id == 0) {
+    SoundSmplTblID base_id = getSoundId(name);
+    if (base_id == 0) {
         WARNLOG("Cannot play unknown sound '%s'", name);
         return 0;
     }
-    
+    int count = getSoundCount(name);
+    SoundSmplTblID id = (count > 1) ? base_id + UNSYNC_RANDOM(count) : base_id;
     return playEffect(id, priority, volume);
-}
-
-// Print statistics
-void SoundManager::printStats() const {
-    SYNCLOG("=== SoundManager Statistics ===");
-    SYNCLOG("Initialized: %s", initialized_ ? "YES" : "NO");
-    SYNCLOG("Total sounds played: %d", total_plays_);
-    SYNCLOG("Named sounds registered: %u", (unsigned)sound_registry_.size());
-    SYNCLOG("Custom sounds loaded: %u", (unsigned)total_custom_sounds_);
-    SYNCLOG("Next custom sample ID: %d", next_custom_sample_id_);
-    
-    if (!sound_registry_.empty()) {
-        SYNCLOG("Named sound registry:");
-        for (const auto& pair : sound_registry_) {
-            SYNCLOG("  - '%s' -> ID %d (count %d)",
-                   pair.first.c_str(),
-                   pair.second.sample_id,
-                   pair.second.count);
-        }
-    }
-    
-    if (!custom_sounds_.empty()) {
-        SYNCLOG("Custom sounds:");
-        for (const auto& pair : custom_sounds_) {
-            SYNCLOG("  - '%s' -> sample %d (path: %s) [%s]",
-                   pair.first.c_str(),
-                   pair.second.sample_id,
-                   pair.second.filepath.c_str(),
-                   pair.second.loaded ? "LOADED" : "NOT LOADED");
-        }
-    }
-    
-    if (!creature_sound_overrides_.empty()) {
-        SYNCLOG("Creature sound overrides:");
-        for (const auto& override : creature_sound_overrides_) {
-            SYNCLOG("  - %s.%s -> '%s'",
-                   override.creature_model.c_str(),
-                   override.sound_type.c_str(),
-                   override.custom_sound_name.c_str());
-        }
-    }
-    SYNCLOG("=====================================");
 }
 
 // Forward declaration for C function in bflib_sndlib.cpp
@@ -495,8 +451,7 @@ void SoundManager::reapplyCreatureSounds() {
                     ov.custom_sound_name.c_str());
             continue;
         }
-        int count = getSoundCount(ov.custom_sound_name.c_str());
-        if (count <= 0) count = 1;
+        int count = ov.count > 0 ? ov.count : 1;
         setCreatureSound(ov.creature_model, ov.sound_type, ov.custom_sound_name, count);
     }
 }
@@ -545,10 +500,6 @@ TbBool sound_manager_set_creature_sound(const char* creature_model, const char* 
 
 TbBool sound_manager_is_custom_sound_loaded(const char* name) {
     return KeeperFX::SoundManager::getInstance().isCustomSoundLoaded(name);
-}
-
-void sound_manager_print_stats(void) {
-    KeeperFX::SoundManager::getInstance().printStats();
 }
 
 void sound_manager_clear_custom_sounds(void) {

--- a/src/sound_manager.cpp
+++ b/src/sound_manager.cpp
@@ -34,12 +34,12 @@ SoundManager::SoundManager()
     , snapshot_total_custom_sounds_(0)
     , snapshot_valid_(false)
 {
-    SYNCLOG("Constructor called");
+    SYNCDBG(7,"Constructor called");
 }
 
 // Destructor
 SoundManager::~SoundManager() {
-    SYNCLOG("Destructor called - played %d sounds total", total_plays_);
+    SYNCDBG(7,"Destructor called - played %d sounds total", total_plays_);
 }
 
 // Initialize
@@ -68,16 +68,16 @@ bool SoundManager::initialize() {
 // Play sound effect
 SoundEmitterID SoundManager::playEffect(SoundSmplTblID sample_id, long priority, SoundVolume volume) {
     if (!initialized_) {
-        SYNCLOG("Not initialized, cannot play sound %d", sample_id);
+        SYNCDBG(8,"Not initialized, cannot play sound %d", sample_id);
         return 0;
     }
     
     if (SoundDisabled) {
-        SYNCLOG("Sound disabled, skipping sample %d", sample_id);
+        SYNCDBG(18,"Sound disabled, skipping sample %d", sample_id);
         return 0;
     }
     
-    SYNCLOG("Playing effect: sample=%d, priority=%ld, volume=%ld",
+    SYNCDBG(18,"Playing effect: sample=%d, priority=%ld, volume=%ld",
            sample_id, priority, volume);
     
     total_plays_++;
@@ -90,12 +90,12 @@ SoundEmitterID SoundManager::playEffect(SoundSmplTblID sample_id, long priority,
 // Play creature sound
 void SoundManager::playCreatureSound(struct Thing* thing, long sound_type, long priority) {
     if (!initialized_ || thing_is_invalid(thing)) {
-        SYNCLOG("Cannot play creature sound (initialized=%d, thing_valid=%d)",
+        SYNCDBG(8,"Cannot play creature sound (initialized=%d, thing_valid=%d)",
                initialized_, !thing_is_invalid(thing));
         return;
     }
     
-    SYNCLOG("Playing creature sound: thing_idx=%d, type=%ld, priority=%ld",
+    SYNCDBG(18,"Playing creature sound: thing_idx=%d, type=%ld, priority=%ld",
            thing->index, sound_type, priority);
     
     total_plays_++;
@@ -110,7 +110,7 @@ void SoundManager::stopEffect(SoundEmitterID emitter_id) {
         return;
     }
     
-    SYNCLOG("Stopping sound: emitter_id=%ld", emitter_id);
+    SYNCDBG(18,"Stopping sound: emitter_id=%ld", emitter_id);
     
     S3DDestroySoundEmitterAndSamples(emitter_id);
 }
@@ -122,7 +122,7 @@ bool SoundManager::isEffectPlaying(SoundEmitterID emitter_id) const {
     }
     
     bool playing = S3DEmitterIsPlayingAnySample(emitter_id);
-    SYNCLOG("Checking if playing: emitter_id=%ld, playing=%d",
+    SYNCDBG(18,"Checking if playing: emitter_id=%ld, playing=%d",
            emitter_id, playing);
     return playing;
 }
@@ -130,11 +130,11 @@ bool SoundManager::isEffectPlaying(SoundEmitterID emitter_id) const {
 // Play music
 bool SoundManager::playMusic(int track_number) {
     if (!initialized_) {
-        SYNCLOG("Not initialized, cannot play music");
+        SYNCDBG(8,"Not initialized, cannot play music");
         return false;
     }
     
-    SYNCLOG("Playing music track %d", track_number);
+    SYNCDBG(18,"Playing music track %d", track_number);
     
     if (track_number == 0) {
         stopMusic();
@@ -146,7 +146,7 @@ bool SoundManager::playMusic(int track_number) {
 
 // Stop music
 void SoundManager::stopMusic() {
-    SYNCLOG("Stopping music");
+    SYNCDBG(18,"Stopping music");
     stop_music();
 }
 

--- a/src/sound_manager.h
+++ b/src/sound_manager.h
@@ -176,11 +176,6 @@ public:
     bool isInitialized() const { return initialized_; }
     
     /**
-     * @brief Get statistics (for testing)
-     */
-    void printStats() const;
-    
-    /**
      * @brief Clear all custom sounds - used during save/load to rebuild fresh bank
      */
     void clearCustomSounds();
@@ -230,6 +225,7 @@ private:
         std::string creature_model;
         std::string sound_type;
         std::string custom_sound_name;
+        int count = 1;
     };
     
     // Named sound registry entry (for built-in sounds)
@@ -273,7 +269,6 @@ SoundSmplTblID sound_manager_load_custom_sound(const char* name, const char* fil
 SoundSmplTblID sound_manager_get_custom_sound_id(const char* name);
 TbBool sound_manager_set_creature_sound(const char* creature_model, const char* sound_type, const char* custom_sound_name);
 TbBool sound_manager_is_custom_sound_loaded(const char* name);
-void sound_manager_print_stats(void);
 void sound_manager_clear_custom_sounds(void);
 void sound_manager_clear_registry(void);
 void sound_manager_save_snapshot(void);

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -169,7 +169,7 @@ void play_thing_walking(struct Thing *thing)
                 smpl_idx = snd_foot_snow + smpl_variant;
             } else {
                 struct CreatureSound* crsound = get_creature_sound(thing, CrSnd_Foot);
-                smpl_idx = crsound->index + smpl_variant;
+                smpl_idx = (long)creature_sound_unified_id(crsound, smpl_variant);
             }
             cctrl->footstep_counter++;
             if (cctrl->footstep_counter >= 4)

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6850,8 +6850,7 @@ void controlled_creature_pick_thing_up(struct Thing *creatng, struct Thing *pick
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     cctrl->pickup_object_id = picktng->index;
     struct CreatureSound* crsound = get_creature_sound(creatng, CrSnd_Hit);
-    unsigned short smpl_idx = crsound->index + 1;
-    thing_play_sample(creatng, smpl_idx, 90, 0, 3, 0, 2, FULL_LOUDNESS * 5/4);
+    thing_play_sample(creatng, creature_sound_unified_id(crsound, 1), 90, 0, 3, 0, 2, FULL_LOUDNESS * 5/4);
     display_controlled_pick_up_thing_name(picktng, (GUI_MESSAGES_DELAY >> 4), plyr_idx);
 }
 /**


### PR DESCRIPTION
Add creature_sound_unified_id() helper that mirrors the conversion done in thing_play_sample, and use it throughout.