### PR TITLE
feat: Speech Localisation in Scripting, seperate sfx queue

### DIFF
--- a/config/fxdata/sounds.cfg
+++ b/config/fxdata/sounds.cfg
@@ -8,7 +8,11 @@
 ;   3. <campaign config dir>/sounds.cfg      — campaign-specific overrides
 ;   4. mods/<name>/sounds.cfg                — mods listed after the campaign (after_campaign)
 ;   5. levels/map<NNNNN>.sounds.cfg          — per-map overrides (reset between maps)
-;
+
+[system]
+; Maximum number of queued speeches before new ones are skipped.
+SpeechQueueLimit = 4
+
 ; Note : Sounds are reset when returning to the main menu and will default to the following ids listed here
 ;
 ; Format:
@@ -28,12 +32,7 @@
 ;
 ; Supported formats: WAV, OGG, MP3, FLAC
 
-
-[system]
-; Maximum number of queued speeches before new ones are skipped.
-SPEECH_QUEUE_LIMIT     = 4
-
-[common]
+[sounds]
 ; Player action refused (e.g. trying to build where you can't)
 REFUSAL                = 119
 ; GUI tab click
@@ -127,7 +126,6 @@ SPELL_STARS            = 76
 ; Spell cast — armageddon
 SPELL_ARMAGEDDON       = 180
 
-[powers]
 ; Each power's announcement voice (SoundSamples) is listed with its cast effect (SoundPlayed) below it.
 ; POWER_IMP has no cast sound — it simply spawns an imp.
 POWER_IMP              = 831
@@ -179,11 +177,6 @@ CAST_SLAP              = 75
 CAST_REBOUND           = 926  ; also FiringSound for SHOT_RANGED_REBOUND
 CAST_FLIGHT            = 953
 CAST_VISION            = 923
-
-[creatures]
-; Creature sounds are defined in creatrs/*.cfg
-
-[effects]
 
 ; === Shot Travel Sounds (ShotSound field in magic.cfg — looped/played while projectile is in flight) ===
 ; Note: SHOT_FREEZE here is the registered sound name, not the shot model name.
@@ -269,7 +262,6 @@ TRAP_TRIGGER_TNT       = 141
 ;       It is a separate klaxon sound used by certain gameplay events (map events, easter egg cheats).
 TRAP_TRIGGER_ALARM     = 90
 
-[objects]
 ; === Object Ambient Sounds ===
 ; Torch / candle flame crackle — AmbienceSound for TORCH, TEMPLE_STATUE, TORCHUN, and CANDLESTCK
 TORCH_AMBIENCE         = 78
@@ -281,6 +273,7 @@ DUNGEON_HEART_BEAM     = 157
 ; Hero gate ambient hum
 HERO_GATE_AMBIENCE     = 973
 
+[speech]
 ; =============================================================================
 ; Speech overrides
 ; Override any mentor speech message with a custom audio file.
@@ -319,7 +312,7 @@ HERO_GATE_AMBIENCE     = 973
 ;   Achew, Chgreche, WorkerJobsLimit, GameLoaded, GameSaved, DefeatedKeeper,
 ;   LevelFailed, LevelWon, SenceAvatar, AvatarBodyVanish, GameFinalVictory
 ; =============================================================================
-[speech]
+
 ; Uncomment and set paths to override individual speech messages:
 ; GraveyardMadeVampire = custom_vampire.ogg
 ; LevelWon             = victory_fanfare.ogg

--- a/config/fxdata/sounds.cfg
+++ b/config/fxdata/sounds.cfg
@@ -28,6 +28,11 @@
 ;
 ; Supported formats: WAV, OGG, MP3, FLAC
 
+
+[system]
+; Maximum number of queued speeches before new ones are skipped.
+SPEECH_QUEUE_LIMIT     = 4
+
 [common]
 ; Player action refused (e.g. trying to build where you can't)
 REFUSAL                = 119

--- a/src/config_mods.c
+++ b/src/config_mods.c
@@ -163,6 +163,19 @@ static void recheck_block_mod_list_exist(struct ModConfigItem *mod_items, long m
                 strcat(config_dirs, "FGrp_CmpgCrtrs");
         }
 
+        fname = prepare_file_path_mod(mod_dir, FGrp_LrgSound, NULL);
+        if (fname[0] != 0 && LbFileExists(fname))
+        {
+            mod_state->sound = 1;
+
+            strcat(config_dirs, str_sep);
+            str_sep = ", ";
+            if (memcmp(main_dir, fname, main_len) == 0)
+                strcat(config_dirs, fname+main_len+1);
+            else
+                strcat(config_dirs, "FGrp_LrgSound");
+        }
+
         if (config_dirs[0] == 0)
             WARNMSG("The '%s' mod configured in '%s' section exists but has no valid configuration.", mod_item->name, block_name);
         else

--- a/src/config_mods.h
+++ b/src/config_mods.h
@@ -62,6 +62,8 @@ struct ModExistState{
 
     int crtr_data;	// FGrp_CrtrData: creaturemodel
     int cmpg_crtrs;	// FGrp_CmpgCrtrs: creaturemodel
+
+    int sound;		// FGrp_LrgSound: custom sound files (mods/<name>/sound/)
 };
 
 struct ModConfigItem {

--- a/src/config_sounds.c
+++ b/src/config_sounds.c
@@ -789,19 +789,12 @@ static TbBool load_sounds_config_file(const char *fname, unsigned short flags)
     }
     
     TbBool result = true;
-    
-    // Parse known sections
-    const char* sections[] = {"common", "ui", "traps", "creatures", "powers", "effects", "doors", "objects", NULL};
-    
-    for (int i = 0; sections[i] != NULL; i++)
-    {
-        if (!parse_sounds_section(buf, len, fname, flags, sections[i]))
-        {
-            result = false;
-        }
-    }
 
-    parse_system_section(buf, len, fname, flags);
+    parse_system_section(buf, len, fname, flags);  
+    if (!parse_sounds_section(buf, len, fname, flags, "sounds"))
+    {
+        result = false;
+    }
     parse_speech_section(buf, len, fname, flags);
     
     free(buf);

--- a/src/config_sounds.c
+++ b/src/config_sounds.c
@@ -662,6 +662,101 @@ static TbBool parse_sounds_section(char* buf, long len, const char* config_textn
     return true;
 }
 
+
+/**
+ * @brief Parse a [system] block with engine-level audio settings.
+ *
+* Supported keys:
+*   speech_queue_limit = <positive integer>
+*/
+static TbBool parse_system_section(char* buf, long len, const char* config_textname,
+                                       unsigned short flags)
+{
+    (void)flags;
+    int32_t pos = 0;
+    const char* blockname = NULL;
+    int blocknamelen = 0;
+    TbBool found_section = false;
+
+    while (iterate_conf_blocks(buf, &pos, len, &blockname, &blocknamelen))
+    {
+        if (blocknamelen > 0 && strncasecmp(blockname, "system", blocknamelen) == 0)
+        {
+            found_section = true;
+            break;
+        }
+    }
+
+    if (!found_section)
+        return true;
+
+    while (pos < len)
+    {
+        if (buf[pos] == '[') break;
+
+        if (buf[pos] == '\n' || buf[pos] == '\r') { pos++; continue; }
+
+        if (buf[pos] == ';' || buf[pos] == '#')
+        {
+            while (pos < len && buf[pos] != '\n' && buf[pos] != '\r') pos++;
+            continue;
+        }
+
+        char name_buf[COMMAND_WORD_LEN];
+        char value_buf[COMMAND_WORD_LEN];
+
+        if (get_conf_parameter_single(buf, &pos, len, name_buf, sizeof(name_buf)) <= 0)
+        {
+            while (pos < len && buf[pos] != '\n' && buf[pos] != '\r') pos++;
+            while (pos < len && (buf[pos] == '\n' || buf[pos] == '\r')) pos++;
+            continue;
+        }
+
+        if (get_conf_parameter_single(buf, &pos, len, value_buf, sizeof(value_buf)) <= 0)
+        {
+            while (pos < len && (buf[pos] == '=' || buf[pos] == ' ' || buf[pos] == '\t')) pos++;
+            if (get_conf_parameter_single(buf, &pos, len, value_buf, sizeof(value_buf)) <= 0)
+            {
+                WARNLOG("Missing value for system setting '%s' in %s", name_buf, config_textname);
+                while (pos < len && buf[pos] != '\n' && buf[pos] != '\r') pos++;
+                while (pos < len && (buf[pos] == '\n' || buf[pos] == '\r')) pos++;
+                continue;
+            }
+        }
+        if (value_buf[0] == '=')
+        {
+            if (get_conf_parameter_single(buf, &pos, len, value_buf, sizeof(value_buf)) <= 0)
+            {
+                WARNLOG("Missing value after '=' for system setting '%s' in %s", name_buf, config_textname);
+                while (pos < len && buf[pos] != '\n' && buf[pos] != '\r') pos++;
+                while (pos < len && (buf[pos] == '\n' || buf[pos] == '\r')) pos++;
+                continue;
+            }
+        }
+
+        if (strcasecmp(name_buf, "speech_queue_limit") == 0)
+        {
+            long limit = strtol(value_buf, NULL, 10);
+            if (limit <= 0)
+            {
+                WARNLOG("Invalid speech queue limit '%s' in %s; expected a positive integer", value_buf, config_textname);
+            }
+            else
+            {
+                g_speech_queue_limit = (int)limit;
+                SYNCDBG(8, "Speech queue limit set to %d", g_speech_queue_limit);
+            }
+        } else {
+            WARNLOG("Unknown system setting '%s' in %s", name_buf, config_textname);
+        }
+
+        while (pos < len && buf[pos] != '\n' && buf[pos] != '\r') pos++;
+        while (pos < len && (buf[pos] == '\n' || buf[pos] == '\r')) pos++;
+    }
+
+    return true;
+}
+
 /**
  * @brief Main loader for sounds.cfg
  */
@@ -706,6 +801,7 @@ static TbBool load_sounds_config_file(const char *fname, unsigned short flags)
         }
     }
 
+    parse_system_section(buf, len, fname, flags);
     parse_speech_section(buf, len, fname, flags);
     
     free(buf);
@@ -797,6 +893,7 @@ void sound_reset_to_fxdata_baseline(void)
 {
     sound_manager_clear_custom_sounds();
     sound_manager_clear_registry();
+    g_speech_queue_limit = 4;
     load_sounds_config();
     SYNCDBG(7, "sound_reset_to_fxdata_baseline: reset to fxdata defaults");
 }

--- a/src/config_sounds.c
+++ b/src/config_sounds.c
@@ -666,8 +666,6 @@ static TbBool parse_sounds_section(char* buf, long len, const char* config_textn
 /**
  * @brief Parse a [system] block with engine-level audio settings.
  *
-* Supported keys:
-*   speech_queue_limit = <positive integer>
 */
 static TbBool parse_system_section(char* buf, long len, const char* config_textname,
                                        unsigned short flags)
@@ -734,7 +732,7 @@ static TbBool parse_system_section(char* buf, long len, const char* config_textn
             }
         }
 
-        if (strcasecmp(name_buf, "speech_queue_limit") == 0)
+        if (strcasecmp(name_buf, "SpeechQueueLimit") == 0)
         {
             long limit = strtol(value_buf, NULL, 10);
             if (limit <= 0)

--- a/src/config_sounds.h
+++ b/src/config_sounds.h
@@ -306,6 +306,13 @@ extern SoundSmplTblID snd_hit_wall_boulder;       /* HitWallSound for SHOT_BOULD
 extern char g_speech_overrides[SMsg_MAX][512];
 
 /**
+ * @brief Maximum number of queued speeches before new ones are dropped.
+ * Populated by the [system] section of sounds.cfg via speech_queue_limit setting.
+ * Defaults to 4. Can be overridden per campaign.
+ */
+extern int g_speech_queue_limit;
+
+/**
  * @brief Resolve a sound name or file path to a sample ID.
  *
  * Used by toml-based config parsers (e.g. effects.toml) via CONDITIONAL_ASSIGN_SOUND.

--- a/src/gui_soundmsgs.cpp
+++ b/src/gui_soundmsgs.cpp
@@ -22,6 +22,7 @@
 #include "config_settings.h"
 #include "config_keeperfx.h"
 #include "game_legacy.h"
+#include "sound_manager.h"
 #include "bflib_sndlib.h"
 #include "bflib_fileio.h"
 #include "bflib_planar.h"
@@ -489,17 +490,21 @@ void script_play_message(TbBool param_is_string, const char msgtype_id, const sh
     }
     else
     {
-        const char * filepath = prepare_file_fmtpath(FGrp_CmpgMedia,"%s", filename);
         switch (msgtype_id)
         {
             case 1: // speech message
             {
-                output_custom_message(filepath, settings.mentor_volume);
+                output_message_from_path(filename, settings.mentor_volume);
                 break;
             }
             case 2: // sound effect
             {
-                play_streamed_sample(filepath, settings.sound_volume);
+                const SoundSmplTblID sound_id = sound_manager_load_named_sound(filename, filename, 1);
+                if (sound_id > 0) {
+                    play_non_3d_sample(sound_id);
+                } else {
+                    WARNLOG("Unable to resolve sound effect '%s' for PLAY_MESSAGE", filename);
+                }
                 break;
             }
         }

--- a/src/gui_soundmsgs.cpp
+++ b/src/gui_soundmsgs.cpp
@@ -117,7 +117,7 @@ bool already_in_queue(const Message & msg)
 
 bool push_queue(std::unique_ptr<Message> msg)
 {
-	if (g_message_queue.size() >= MAX_QUEUED_MESSAGES) {
+	if (g_message_queue.size() >= (size_t)g_speech_queue_limit) {
 		SYNCDBG(8, "message queue full");
 		return false;
 	} else if (g_current_message && g_current_message->is(*msg)) {

--- a/src/gui_soundmsgs.cpp
+++ b/src/gui_soundmsgs.cpp
@@ -35,6 +35,9 @@
 #include "config.h"
 #include "post_inc.h"
 
+// Maximum number of messages that can be queued at once.
+int g_speech_queue_limit = 4;
+
 namespace {
 
 struct Message;
@@ -43,8 +46,6 @@ std::deque<std::unique_ptr<Message>> g_message_queue;
 std::map<SoundSmplTblID, long> g_recent_samples;
 std::map<std::string, long> g_recent_filenames;
 std::unique_ptr<Message> g_current_message;
-
-#define MAX_QUEUED_MESSAGES 4
 
 enum MessageType {
 	MT_Default = 1,

--- a/src/gui_soundmsgs.h
+++ b/src/gui_soundmsgs.h
@@ -40,6 +40,9 @@ extern "C" {
 #define MESSAGE_DURATION_CRTR_JOINED   500
 #define MESSAGE_DURATION_STARVING      500
 
+/** Maximum number of queued speeches before new ones are skipped. */
+extern int g_speech_queue_limit;
+
 enum TbSpeechMessages {
         SMsg_None = 0,
         SMsg_CreatrAngryAnyReason,

--- a/src/sound_manager.cpp
+++ b/src/sound_manager.cpp
@@ -544,70 +544,92 @@ SoundEmitterID sound_manager_play_effect_named(const char* name, long priority, 
     return KeeperFX::SoundManager::getInstance().playEffectNamed(name, priority, volume);
 }
 
+// Attempt to find a sound file candidate in the sound/ subdir of every mod in a list.
+// Returns true and fills out_path on first match (list iterated in reverse so higher-priority
+// mods — those loaded later — win).
+static bool find_in_mod_sound_dirs(const char* candidate, char* out_path, size_t out_size,
+                                   const struct ModConfigItem* mod_items, long mod_cnt)
+{
+    for (long i = mod_cnt - 1; i >= 0; i--) {
+        const struct ModConfigItem* mod_item = mod_items + i;
+        if (!mod_item->state.sound) continue;
+        char mod_dir[256];
+        snprintf(mod_dir, sizeof(mod_dir), "%s/%s", MODS_DIR_NAME, mod_item->name);
+        const char* resolved = prepare_file_path_mod(mod_dir, FGrp_LrgSound, candidate);
+        if (resolved != NULL && LbFileExists(resolved)) {
+            SYNCDBG(8, "[mod %s/sound] '%s' -> '%s' (FOUND)", mod_item->name, candidate, resolved);
+            snprintf(out_path, out_size, "%s", resolved);
+            return true;
+        }
+        SYNCDBG(8, "[mod %s/sound] '%s' -> '%s' (not found)",
+            mod_item->name, candidate, resolved ? resolved : "(null)");
+    }
+    return false;
+}
+
 // Resolve a sound file path specified in a creature cfg.
-// Search order:
-//   1. FGrp_CmpgCrtrs/<path>   (alongside the .cfg files)
-//   2. FGrp_CmpgMedia/<path>   (campaign MEDIA_LOCATION)
+// Search order mirrors the config load order, interleaving mod tiers with game dirs:
+//   after_map mods/sound/  >  FGrp_CmpgLvls  >  FGrp_CmpgCrtrs
+//   > after_campaign mods/sound/  >  FGrp_CmpgConfig  >  FGrp_CrtrData
+//   > after_base mods/sound/  >  FGrp_FxData  >  FGrp_CmpgMedia  >  FGrp_Main
 // If the path has no extension, each location is tried with .wav, .mp3, .ogg, .flac.
 // Returns true and fills out_path (size 2048) on success.
 static bool resolve_creature_sound_path(const char* path_in, char* out_path, size_t out_size)
 {
-    // Search order: most specific location first, base (FxData) last.
-    // Mirrors the sprite loading convention: FxData is the base loaded first and
-    // overridden by campaign/level. Here the most specific location wins on duplicates,
-    // and a config at any level can reference a file that only exists at a more specific location.
-    static const TbFileGroups groups[] = {
-        FGrp_CmpgLvls, FGrp_CmpgCrtrs, FGrp_CmpgConfig,
-        FGrp_CrtrData, FGrp_FxData, FGrp_CmpgMedia, FGrp_Main
-    };
-    [[maybe_unused]]
-    static const char* group_names[] = {
-        "FGrp_CmpgLvls", "FGrp_CmpgCrtrs", "FGrp_CmpgConfig",
-        "FGrp_CrtrData", "FGrp_FxData", "FGrp_CmpgMedia", "FGrp_Main"
-    };
     static const char* exts[] = { "", ".wav", ".mp3", ".ogg", ".flac", NULL };
 
     const char* dot   = strrchr(path_in, '.');
     const char* slash = strrchr(path_in, '/');
     bool has_ext = (dot != NULL) && (slash == NULL || dot > slash);
 
-    for (int gi = 0; gi < (int)(sizeof(groups)/sizeof(groups[0])); gi++) {
-        for (int ei = 0; exts[ei] != NULL; ei++) {
-            if (has_ext && ei > 0) break;
-            if (!has_ext && ei == 0) continue;
+    for (int ei = 0; exts[ei] != NULL; ei++) {
+        if (has_ext && ei > 0) break;
+        if (!has_ext && ei == 0) continue;
 
-            char candidate[2048];
-            snprintf(candidate, sizeof(candidate), "%s%s", path_in, exts[ei]);
-            const char* resolved = prepare_file_path((TbFileGroups)groups[gi], candidate);
-            bool exists = (resolved != NULL) && LbFileExists(resolved);
-            SYNCDBG(8, "[%s] '%s' -> '%s' (%s)",
-                group_names[gi], candidate,
-                resolved ? resolved : "(null)",
-                exists ? "FOUND" : "not found");
-            if (exists) {
-                snprintf(out_path, out_size, "%s", resolved);
-                return true;
-            }
-        }
+        char candidate[2048];
+        snprintf(candidate, sizeof(candidate), "%s%s", path_in, exts[ei]);
+
+        // after_map mods override everything, then map-level game dirs
+        if (find_in_mod_sound_dirs(candidate, out_path, out_size,
+                mods_conf.after_map_item, mods_conf.after_map_cnt)) return true;
+        const char* r;
+        r = prepare_file_path(FGrp_CmpgLvls, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+        r = prepare_file_path(FGrp_CmpgCrtrs, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+
+        // after_campaign mods override campaign dirs, then campaign-level game dirs
+        if (find_in_mod_sound_dirs(candidate, out_path, out_size,
+                mods_conf.after_campaign_item, mods_conf.after_campaign_cnt)) return true;
+        r = prepare_file_path(FGrp_CmpgConfig, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+        r = prepare_file_path(FGrp_CrtrData, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+
+        // after_base mods override fxdata, then base game dirs
+        if (find_in_mod_sound_dirs(candidate, out_path, out_size,
+                mods_conf.after_base_item, mods_conf.after_base_cnt)) return true;
+        r = prepare_file_path(FGrp_FxData, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+        r = prepare_file_path(FGrp_CmpgMedia, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+        r = prepare_file_path(FGrp_Main, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
     }
     SYNCDBG(5, "Custom sound path not found: '%s'", path_in);
     return false;
 }
 
 // Resolve a sound file path specified in sounds.cfg (or any other non-creature cfg).
-// Search order:
-//   1. FGrp_CmpgLvls/<path>    (map-level config folder)
-//   2. FGrp_CmpgConfig/<path>  (campaign config folder)
-//   3. FGrp_FxData/<path>      (base game fxdata/)
-//   4. FGrp_CmpgMedia/<path>   (campaign MEDIA_LOCATION)
-//   5. FGrp_Main/<path>        (game root directory)
+// Search order mirrors the config load order, interleaving mod tiers with game dirs:
+//   after_map mods/sound/  >  FGrp_CmpgLvls
+//   > after_campaign mods/sound/  >  FGrp_CmpgConfig
+//   > after_base mods/sound/  >  FGrp_FxData  >  FGrp_CmpgMedia  >  FGrp_Main
+// Sound files in mods MUST live in mods/<name>/sound/ — no other mod subdirectory is searched.
 // If the path has no extension, each location is tried with .wav, .mp3, .ogg, .flac.
 // Returns true and fills out_path (size 2048) on success.
 static bool resolve_sounds_cfg_sound_path(const char* path_in, char* out_path, size_t out_size)
 {
-    static const TbFileGroups groups[] = { FGrp_CmpgLvls, FGrp_CmpgConfig, FGrp_FxData, FGrp_CmpgMedia, FGrp_Main };
-    [[maybe_unused]]
-    static const char* group_names[]   = { "FGrp_CmpgLvls", "FGrp_CmpgConfig", "FGrp_FxData", "FGrp_CmpgMedia", "FGrp_Main" };
     static const char* exts[] = { "", ".wav", ".mp3", ".ogg", ".flac", NULL };
 
     const char* dot   = strrchr(path_in, '.');
@@ -616,24 +638,35 @@ static bool resolve_sounds_cfg_sound_path(const char* path_in, char* out_path, s
 
     SYNCDBG(7,"Sound path search for '%s' (has_ext=%d)", path_in, (int)has_ext);
 
-    for (int gi = 0; gi < (int)(sizeof(groups)/sizeof(groups[0])); gi++) {
-        for (int ei = 0; exts[ei] != NULL; ei++) {
-            if (has_ext && ei > 0) break;
-            if (!has_ext && ei == 0) continue;
+    for (int ei = 0; exts[ei] != NULL; ei++) {
+        if (has_ext && ei > 0) break;
+        if (!has_ext && ei == 0) continue;
 
-            char candidate[2048];
-            snprintf(candidate, sizeof(candidate), "%s%s", path_in, exts[ei]);
-            const char* resolved = prepare_file_path((TbFileGroups)groups[gi], candidate);
-            bool exists = (resolved != NULL) && LbFileExists(resolved);
-            SYNCDBG(7,"[%s] '%s' -> '%s' (%s)",
-                group_names[gi], candidate,
-                resolved ? resolved : "(null)",
-                exists ? "FOUND" : "not found");
-            if (exists) {
-                snprintf(out_path, out_size, "%s", resolved);
-                return true;
-            }
-        }
+        char candidate[2048];
+        snprintf(candidate, sizeof(candidate), "%s%s", path_in, exts[ei]);
+
+        // after_map mods override everything, then the map-level game dir
+        if (find_in_mod_sound_dirs(candidate, out_path, out_size,
+                mods_conf.after_map_item, mods_conf.after_map_cnt)) return true;
+        const char* r;
+        r = prepare_file_path(FGrp_CmpgLvls, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+
+        // after_campaign mods override campaign dirs, then the campaign game dir
+        if (find_in_mod_sound_dirs(candidate, out_path, out_size,
+                mods_conf.after_campaign_item, mods_conf.after_campaign_cnt)) return true;
+        r = prepare_file_path(FGrp_CmpgConfig, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+
+        // after_base mods override fxdata, then base game dirs
+        if (find_in_mod_sound_dirs(candidate, out_path, out_size,
+                mods_conf.after_base_item, mods_conf.after_base_cnt)) return true;
+        r = prepare_file_path(FGrp_FxData, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+        r = prepare_file_path(FGrp_CmpgMedia, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
+        r = prepare_file_path(FGrp_Main, candidate);
+        if (r && LbFileExists(r)) { snprintf(out_path, out_size, "%s", r); return true; }
     }
     SYNCDBG(7,"Sound path NOT resolved : '%s'", path_in);
     return false;

--- a/src/sound_manager.cpp
+++ b/src/sound_manager.cpp
@@ -4,6 +4,7 @@
 #include "bflib_fileio.h"
 #include "creature_control.h"
 #include "config_creature.h"
+#include "config_mods.h"
 #include "game_legacy.h"
 #include <cstdio>
 #include <fstream>


### PR DESCRIPTION
This pull request introduces major improvements to how sound files and speech message limits are managed, especially with respect to mod support and configuration flexibility. The most important changes are the addition of a `[system]` section in `sounds.cfg` for engine-level audio settings, a configurable speech message queue limit, and enhanced mod sound file resolution logic that allows mods to override sound files in a structured and prioritized way.

Playing a sound effect should no longer affect / stop messages in scripts as it's now sent to a different queue

**Configurable Speech Queue Limit and System Audio Settings**

- Added a `[system]` section to `sounds.cfg`, allowing engine-level audio settings to be configured, including a new `speech_queue_limit` option for limiting the number of queued speech messages. This limit is now parsed at load time and defaults to 4 if not set. (`config/fxdata/sounds.cfg`, `src/config_sounds.c`, `src/config_sounds.h`, `src/gui_soundmsgs.cpp`, `src/gui_soundmsgs.h`) [[1]](diffhunk://#diff-758b71a4dacdaa54c2a9a552fb9bd67463c86a5302b14eb84010c816b66eff7dR31-R35) [[2]](diffhunk://#diff-9d4a8ea1699765b8a1985d046fc01ac3badde2c4bb10c6bedaacf80cc1f99f78R665-R759) [[3]](diffhunk://#diff-9d4a8ea1699765b8a1985d046fc01ac3badde2c4bb10c6bedaacf80cc1f99f78R804) [[4]](diffhunk://#diff-9d4a8ea1699765b8a1985d046fc01ac3badde2c4bb10c6bedaacf80cc1f99f78R896) [[5]](diffhunk://#diff-80177213d8fc30d6cdaa5bdbd94b3ef44cb73fef7f6ecdf5deb4473cc79817b3R308-R314) [[6]](diffhunk://#diff-44444e93d0250f2cf22e82ddb700e7cc3c343a259f7d7eb3a7bb8ca05c8f86d0R39-R41) [[7]](diffhunk://#diff-44444e93d0250f2cf22e82ddb700e7cc3c343a259f7d7eb3a7bb8ca05c8f86d0L119-R121) [[8]](diffhunk://#diff-5c5fc372d7f6c13f73bba2e7f884ed2bda89805be187dece9eda38a943480e74R43-R45)

**Mod Support for Custom Sound Files**

- Extended the mod system to support custom sound files located in `mods/<name>/sound/`, tracked via a new `sound` field in `ModExistState`, and updated mod existence checks accordingly. (`src/config_mods.c`, `src/config_mods.h`) [[1]](diffhunk://#diff-72a416c800d3ae9d67268c224bde5ca1466dffd62ba1b2d719f7373c8c752fe1R166-R178) [[2]](diffhunk://#diff-59a52d00c3d97d3ba0ff5e149132aacf959f401136d4b656f82698379f004f38R65-R66)

**Sound File Resolution Logic Overhaul**

- Overhauled the sound file resolution logic to interleave mod directories with standard game directories, ensuring that mods can override base and campaign sounds in a clear priority order. This applies to both creature sound references and general sound config files. (`src/sound_manager.cpp`) [[1]](diffhunk://#diff-1c7e1884672dba0faac0f92ccd517f9f2305d5342356d4a934aedf6031b7dba4R547-L609) [[2]](diffhunk://#diff-1c7e1884672dba0faac0f92ccd517f9f2305d5342356d4a934aedf6031b7dba4L618-R669)

**General Refactoring and Integration**

- Removed hardcoded speech queue limits and replaced them with the new configurable value throughout the codebase. (`src/gui_soundmsgs.cpp`) [[1]](diffhunk://#diff-44444e93d0250f2cf22e82ddb700e7cc3c343a259f7d7eb3a7bb8ca05c8f86d0L47-L48) [[2]](diffhunk://#diff-44444e93d0250f2cf22e82ddb700e7cc3c343a259f7d7eb3a7bb8ca05c8f86d0L119-R121)
- Updated sound message playback logic to use the new sound manager and mod-aware file resolution, improving reliability and mod compatibility. (`src/gui_soundmsgs.cpp`)

These changes collectively make the audio system more flexible, easier to configure, and much more mod-friendly, especially for campaigns and custom content.