### PR TITLE
Add FLAC / OGG support, fix Emitter stacking on SFX

### DIFF
--- a/config/fxdata/sounds.cfg
+++ b/config/fxdata/sounds.cfg
@@ -279,7 +279,7 @@ HERO_GATE_AMBIENCE     = 973
 ; Override any mentor speech message with a custom audio file.
 ; The path is relative to the game MEDIA_LOCATION/[language]/ folder. The MEDIA_LOCATION is specified in the campaign/mappack config, the language is the 3 letter ISO 639-2 code.
 ; If a speech is not available in a [language] it will try to read it directly from the MEDIA_LOCATION, or otherwise try from the /eng/ folder.
-; Syntax:  <SMsg_Name> = <relative/path/to/file.ogg>
+; Syntax:  <SMsg_Name> = <relative/path/to/file>
 ;
 ; Example:
 ;   GraveyardMadeVampire = custom_vampire.ogg

--- a/src/bflib_sndlib.cpp
+++ b/src/bflib_sndlib.cpp
@@ -913,7 +913,7 @@ extern "C" int InitialiseSDLAudio()
 		ERRORLOG("Unable to initialise SDL audio subsystem: %s", SDL_GetError());
 		return 0;
 	}
-	int flags = Mix_Init(MIX_INIT_OGG|MIX_INIT_MP3);
+	int flags = Mix_Init(MIX_INIT_OGG|MIX_INIT_MP3|MIX_INIT_FLAC);
 	if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 4096) < 0)
 	{
 		ERRORLOG("Could not open audio device for SDL mixer: %s", Mix_GetError());
@@ -1028,12 +1028,12 @@ static TbBool decode_mp3_and_store(const char* filepath, int sample_id,
 	return true;
 }
 
-// Load a WAV or MP3 file and append it to g_custom_bank as a signed-16-bit
+// Load a WAV, OGG, FLAC, or MP3 file and append it to g_custom_bank as a signed-16-bit
 // OpenAL buffer.
-//   - Plain WAV  : SDL_LoadWAV_RW (SDL2.dll only, no libxmp dependency)
-//   - Plain MP3  : dr_mp3 single-header decoder (compiled in, no external DLLs)
-//   - BMU V1.0   : 8-byte wrapper used by some campaigns; contains a plain MP3
-//                  stream after the header — stripped and decoded via dr_mp3.
+//   - WAV / OGG / FLAC : Mix_LoadWAV_RW (SDL_mixer; OGG and FLAC require MIX_INIT_OGG/MIX_INIT_FLAC)
+//   - Plain MP3        : dr_mp3 single-header decoder (compiled in, no external DLLs)
+//   - BMU V1.0         : 8-byte wrapper used by some campaigns; contains a plain MP3
+//                        stream after the header — stripped and decoded via dr_mp3.
 extern "C" TbBool custom_sound_load_wav(const char* filepath, int sample_id)
 {
 	// Resolve to absolute path so the decoders can find the file regardless of
@@ -1088,44 +1088,35 @@ extern "C" TbBool custom_sound_load_wav(const char* filepath, int sample_id)
 		return decode_mp3_and_store(filepath, sample_id, data, size);
 	}
 
-	// --- WAV path: SDL_LoadWAV_RW (SDL2.dll, no libxmp dependency) ---
+	// --- WAV / OGG / FLAC path: Mix_LoadWAV_RW (SDL_mixer decodes all three) ---
 	SDL_RWops* rw = SDL_RWFromConstMem(data, (int)size);
 	if (!rw) {
 		ERRORLOG("Cannot create RWops for %s: %s", filepath, SDL_GetError());
 		return false;
 	}
 
-	SDL_AudioSpec spec = {};
-	Uint8* wav_buf = nullptr;
-	Uint32 wav_len = 0;
-	// freesrc=1 closes rw whether or not decoding succeeds.
-	if (SDL_LoadWAV_RW(rw, 1, &spec, &wav_buf, &wav_len) == nullptr) {
-		ERRORLOG("Cannot decode audio file %s: %s", filepath, SDL_GetError());
+	// freesrc=1: Mix_LoadWAV_RW closes rw regardless of success/failure.
+	Mix_Chunk* chunk = Mix_LoadWAV_RW(rw, 1);
+	if (chunk == nullptr) {
+		ERRORLOG("Cannot decode audio file %s: %s", filepath, Mix_GetError());
 		return false;
 	}
 
-	// Map SDL format to OpenAL.
-	ALenum al_fmt;
-	switch (spec.format) {
-	case AUDIO_U8:
-	case AUDIO_S8:
-		al_fmt = (spec.channels == 1) ? AL_FORMAT_MONO8 : AL_FORMAT_STEREO8;
-		break;
-	case AUDIO_S16LSB:
-	case AUDIO_S16MSB:
-	default:
-		al_fmt = (spec.channels == 1) ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
-		break;
-	}
+	// Mix_LoadWAV_RW converts decoded PCM to the mixer's output format
+	// (44100 Hz / Sint16 / stereo, as set in Mix_OpenAudio).
+	int mix_freq = 0, mix_channels = 0;
+	Uint16 mix_fmt = 0;
+	Mix_QuerySpec(&mix_freq, &mix_fmt, &mix_channels);
+	const ALenum al_fmt = (mix_channels == 1) ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
 
 	try {
-		const std::vector<uint8_t> pcm(wav_buf, wav_buf + wav_len);
-		g_custom_bank.emplace_back(filepath, sample_id, pcm, al_fmt, spec.freq);
+		const std::vector<uint8_t> pcm(chunk->abuf, chunk->abuf + chunk->alen);
+		g_custom_bank.emplace_back(filepath, sample_id, pcm, al_fmt, mix_freq);
 	} catch (...) {
-		SDL_FreeWAV(wav_buf);
-		ERRORLOG("Out of memory buffering WAV %s", filepath);
+		Mix_FreeChunk(chunk);
+		ERRORLOG("Out of memory buffering audio %s", filepath);
 		return false;
 	}
-	SDL_FreeWAV(wav_buf);
+	Mix_FreeChunk(chunk);
 	return true;
 }

--- a/src/bflib_sndlib.cpp
+++ b/src/bflib_sndlib.cpp
@@ -844,6 +844,22 @@ extern "C" SoundMilesID play_sample(
 		buf = &g_banks[0][smptbl_id].buffer;
 	}
 	try {
+		// ctype 2/3: if this emitter is already playing the same sample, restart it in-place
+		// rather than allocating a new source (mirrors MSS single-voice-per-slot behaviour and
+		// prevents sounds from stacking — e.g. hailstorm projectiles all hitting the same target).
+		if (ctype == 2 || ctype == 3) {
+			for (auto & source : g_sources) {
+				if (source.emit_id == emit_id && source.smptbl_id == smptbl_id) {
+					source.stop();
+					source.gain(volume);
+					source.pan(pan);
+					source.repeat(repeats == -1);
+					source.pitch(pitch);
+					source.play(*buf);
+					return source.mss_id;
+				}
+			}
+		}
 		for (auto & source : g_sources) {
 			if (source.emit_id == 0) {
 				source.gain(volume);


### PR DESCRIPTION
This pull request makes several improvements to the game's audio system, focusing on expanding supported audio formats, improving resource handling, and preventing sound stacking. The most important changes are grouped below:

**Audio format support and decoding improvements:**

* Added FLAC support by initializing `MIX_INIT_FLAC` in the SDL_mixer setup, allowing the game to load FLAC audio files in addition to WAV, OGG, and MP3.
* Updated the audio loading path to use `Mix_LoadWAV_RW` from SDL_mixer for WAV, OGG, and FLAC files, ensuring consistent decoding and output format, and simplified mapping to OpenAL formats.
* Updated documentation and comments to reflect the expanded support for OGG and FLAC files in addition to WAV and MP3. [[1]](diffhunk://#diff-505dec2f1df81d80d486f2d2edbf692fd344283f4ac99f3bf07d503d72985d8fL1031-R1049) [[2]](diffhunk://#diff-758b71a4dacdaa54c2a9a552fb9bd67463c86a5302b14eb84010c816b66eff7dL282-R282)

**Sound resource management and playback logic:**

* Modified the sample playback logic to prevent sound stacking: for emitter types 2 and 3, if a sound is already playing for a given emitter and sample, the sound is restarted in place instead of allocating a new source. This mirrors the original MSS single-voice-per-slot behavior. I.e, the reason why the hailstorm exploded in your ears was because ALL emitters played at once