### PR TITLE
Drop on path

### DIFF
--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -1,6 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
-; Note that most of the creature parameters are affected by creature level.
-; For every level above 1, they are raised by 35%.
+; Note that some of the creature parameters are affected by creature level.
+; These stats grow according to [experience] in creature.cfg.
 
 [attributes]
 ; Name is the creature identifier which should be used in level script.
@@ -109,39 +109,39 @@ HostileTowards = NULL
 ; Set to 0, leave empty, or remove the field for the creature to have no immunities.
 SpellImmunity = 0
 ; Creature properties:
-;   DROP_ON_PATH - Creature can be dropped on unclaimed path. Just like SPECIAL_DIGGER.
-;   BLEEDS - the creature leaves blood when is hit, slapped, dying or being injured in any way.
-;   HUMANOID_SKELETON - the creature leaves a skeleton if left in prison to die.
-;   PISS_ON_DEAD - creature feels urge to piss on nearby dead bodies.
-;   FLYING - creature normally isn't touching ground when moving and can move up and down.
-;   SEE_INVISIBLE - creature has natural ability which works like Sight spell.
-;   PASS_LOCKED_DOORS - creature can move through locked doors and won't fight with doors.
-;   SPECIAL_DIGGER - creature is different from 'real' creatures can dig and perform other dungeon tasks. Like an Imp.
-;   DIGGING_CREATURE - creature is a 'real' creature but can also dig and perform other dungeon task. Like a Tunneller.
-;   ARACHNID - creature is kind of spider.
-;   DIPTERA - creature is kind of fly.
-;   LORD - creature is lord of the land, usually arrives to level as final boss, and at arrival you can hear "beware, the lord of the land approaches".
-;   EVENTFUL_DEATH - when the creature dies the LAST_DEATH_EVENT[] script variable is updated, so mapmaker can use the location.
-;   SPECTATOR - creature is just a spectator for multiplayer games.
-;   EVIL - creature has evil nature.
-;   IMMUNE_TO_BOULDER - when boulder trap hits the creature, falls apart without dealing any damage.
-;   NO_CORPSE_ROTTING - Creature body can't be taken to rot on graveyard and will disappear quickly.
-;   NO_ENMHEART_ATTCK - Creature won't attack enemy dungeon heart on sight.
-;   TREMBLING - Creature is so heavy that ground trembles when it falls.
-;   FAT - Creature is so fat that he needs a brief rest during his movement animation.
-;   FEMALE - Creature is a female, does female sounds and has female name.
-;   INSECT - Creature is an insect (note that DIPTERA and ARACHNID creatures should also have INSECT set explicitly).
-;   ONE_OF_KIND - Creature name is set to kind name defined by 'NameTextID'.
+;   CANNOT_PICK_UP - Creature cannot be picked up by the hand.
+;   DROP_ON_PATH - Creature can be dropped on unclaimed path. Property is included with SPECIAL_DIGGER.
+;   NO_HEALTH_FLOWER - Do not draw the health/status flower above the creature.
+;   EVENTFUL_DEATH - When the creature dies the LAST_DEATH_EVENT[] script variable is updated, so mapmaker can use the location.
+;   ILLUMINATED - A bright light will shine from the Creature.
 ;   NO_IMPRISONMENT - Creature cannot be stunned for prison.
 ;   NO_RESURRECT - Creature cannot be resurrected with a resurrect creature special.
 ;   NO_TRANSFER - Creature cannot be transferred with a transfer creature special.
 ;   NO_STEAL_HERO - Creature cannot be stolen from a steal hero special.
 ;   PREFER_STEAL - Creature can be generated from steal hero special if there is nothing to steal from.
-;   ILLUMINATED - A bright light will shine from the Creature.
+;   ARACHNID - Creature is kind of spider.
+;   DIPTERA - Creature is kind of fly.
+;   INSECT - Creature is an insect (note that DIPTERA and ARACHNID creatures should also have INSECT set explicitly).
+;   FEMALE - Creature is a female, does female sounds and has female name.
+;   ONE_OF_KIND - Creature name is set to kind name defined by 'NameTextID'.
+;   LORD - Creature is lord of the land, usually arrives to level as final boss, and at arrival you can hear "beware, the lord of the land approaches".
+;   TREMBLING - Creature is so heavy that ground trembles when it falls.
+;   FAT - Creature is so fat that he needs a brief rest during his movement animation.
+;   BLEEDS - The creature leaves blood when is hit, slapped, dying or being injured in any way.
+;   EVIL - Creature has evil nature.
+;   IMMUNE_TO_BOULDER - When boulder trap hits the creature, falls apart without dealing any damage.
+;   NO_CORPSE_ROTTING - Creature body can't be taken to rot on graveyard and will disappear quickly.
+;   HUMANOID_SKELETON - The creature leaves a skeleton if left in prison to die.
+;   NO_ENMHEART_ATTCK - Creature won't attack enemy dungeon heart on sight.
+;   PISS_ON_DEAD - Creature feels urge to piss on nearby dead bodies.
 ;   ALLURING_SCVNGR - When scavenging will give the keeper a portal boost compared to rival keepers.
-;   NO_HEALTH_FLOWER - Do not draw the health/status flower above the creature.
-;   CANNOT_PICK_UP - Creature cannot be picked up by the hand.
-Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK NO_CORPSE_ROTTING
+;   SEE_INVISIBLE - Creature has natural ability which works like Sight spell.
+;   PASS_LOCKED_DOORS - Creature can move through locked doors and won't fight with doors.
+;   FLYING - Creature normally isn't touching ground when moving and can move up and down.
+;   SPECTATOR - Creature is just a spectator for multiplayer games.
+;   DIGGING_CREATURE - Creature is a 'real' creature but can also dig and perform other dungeon task. Like a Tunneller.
+;   SPECIAL_DIGGER - Creature is different from 'real' creatures can dig and perform other dungeon tasks. Like an Imp.
+Properties = EVIL SPECIAL_DIGGER BLEEDS NO_ENMHEART_ATTCK NO_CORPSE_ROTTING
 
 [attraction]
 ; Rooms required to attract the creature from entrance, and number of slabs which is needed (max 3 rooms).

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -141,7 +141,7 @@ SpellImmunity = 0
 ;   ALLURING_SCVNGR - When scavenging will give the keeper a portal boost compared to rival keepers.
 ;   NO_HEALTH_FLOWER - Do not draw the health/status flower above the creature.
 ;   CANNOT_PICK_UP - Creature cannot be picked up by the hand.
-Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK NO_CORPSE_ROTTING DROP_ON_PATH
+Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK NO_CORPSE_ROTTING
 
 [attraction]
 ; Rooms required to attract the creature from entrance, and number of slabs which is needed (max 3 rooms).

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -109,6 +109,7 @@ HostileTowards = NULL
 ; Set to 0, leave empty, or remove the field for the creature to have no immunities.
 SpellImmunity = 0
 ; Creature properties:
+;   DROP_ON_PATH - Creature can be dropped on unclaimed path.
 ;   BLEEDS - the creature leaves blood when is hit, slapped, dying or being injured in any way.
 ;   HUMANOID_SKELETON - the creature leaves a skeleton if left in prison to die.
 ;   PISS_ON_DEAD - creature feels urge to piss on nearby dead bodies.

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -109,7 +109,7 @@ HostileTowards = NULL
 ; Set to 0, leave empty, or remove the field for the creature to have no immunities.
 SpellImmunity = 0
 ; Creature properties:
-;   DROP_ON_PATH - Creature can be dropped on unclaimed path.
+;   DROP_ON_PATH - Creature can be dropped on unclaimed path. Just like SPECIAL_DIGGER.
 ;   BLEEDS - the creature leaves blood when is hit, slapped, dying or being injured in any way.
 ;   HUMANOID_SKELETON - the creature leaves a skeleton if left in prison to die.
 ;   PISS_ON_DEAD - creature feels urge to piss on nearby dead bodies.

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -141,7 +141,7 @@ SpellImmunity = 0
 ;   ALLURING_SCVNGR - When scavenging will give the keeper a portal boost compared to rival keepers.
 ;   NO_HEALTH_FLOWER - Do not draw the health/status flower above the creature.
 ;   CANNOT_PICK_UP - Creature cannot be picked up by the hand.
-Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK NO_CORPSE_ROTTING
+Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK NO_CORPSE_ROTTING DROP_ON_PATH
 
 [attraction]
 ; Rooms required to attract the creature from entrance, and number of slabs which is needed (max 3 rooms).

--- a/src/config_creature.h
+++ b/src/config_creature.h
@@ -66,6 +66,7 @@ enum CreatureModelFlags {
     CMF_IsDiggingCreature = 0x100000, // unit still counts as a regular creature but can also do digger tasks (like tunneler)
     CMF_NoHealthFlower    = 0x200000, // Do not draw the health/status flower above the creature.
     CMF_CannotPickUp      = 0x400000, // Creature cannot be picked up by the hand.
+    CMF_DropOnPath        = 0x800000, // Creature can be dropped on unclaimed path
 };
 
 // Before C23 standard, we cannot specify the underlaying type (in this case we want 64bit int) of enum.

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -132,6 +132,7 @@ const struct NamedCommand creatmodel_properties_commands[] = {
   {"DIGGING_CREATURE",  35},
   {"NO_HEALTH_FLOWER",  36},
   {"CANNOT_PICK_UP",    37},
+  {"DROP_ON_PATH",      38},
   {NULL,                 0},
   };
 
@@ -761,6 +762,10 @@ TbBool parse_creaturemodel_attributes_blocks(long crtr_model,char *buf,long len,
                 break;
             case 37: // CANNOT_PICK_UP
                 crconf->model_flags |= CMF_CannotPickUp;
+                n++;
+                break;
+            case 38: // DROP_ON_PATH
+                crconf->model_flags |= CMF_DropOnPath;
                 n++;
                 break;
             default:

--- a/src/cursor_tag.c
+++ b/src/cursor_tag.c
@@ -95,7 +95,7 @@ unsigned char tag_cursor_blocks_dig(struct PlayerInfo *player, const struct Pack
     return line_color;
 }
 
-void tag_cursor_blocks_thing_in_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool is_special_digger, TbBool full_slab)
+void tag_cursor_blocks_thing_in_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool allow_unclaimed_path, TbBool full_slab)
 {
   SYNCDBG(7,"Starting");
   MapSlabCoord slb_x = subtile_slab(stl_x);
@@ -103,7 +103,7 @@ void tag_cursor_blocks_thing_in_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x,
   if (is_my_player_number(plyr_idx) && !game_is_busy_doing_gui() && (game.small_map_state != 2) )
     {
         map_volume_box.visible = true;
-        map_volume_box.color = can_drop_thing_here(stl_x, stl_y, plyr_idx, is_special_digger);
+        map_volume_box.color = can_drop_thing_here(stl_x, stl_y, plyr_idx, allow_unclaimed_path);
         if (full_slab)
         {
             map_volume_box.beg_x = subtile_coord(slab_subtile(slb_x, 0), 0);

--- a/src/cursor_tag.h
+++ b/src/cursor_tag.h
@@ -32,7 +32,7 @@ struct PlayerInfo;
 struct Packet;
 struct RoomSpace;
 unsigned char tag_cursor_blocks_dig(struct PlayerInfo *player, const struct Packet *pckt, struct RoomSpace *render_roomspace, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab);
-void tag_cursor_blocks_thing_in_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool is_special_digger, TbBool full_slab);
+void tag_cursor_blocks_thing_in_hand(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool allow_unclaimed_path, TbBool full_slab);
 TbBool tag_cursor_blocks_sell_area(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab);
 TbBool tag_cursor_blocks_place_door(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab);

--- a/src/lvl_script_value.c
+++ b/src/lvl_script_value.c
@@ -587,6 +587,13 @@ void script_process_value(unsigned long var_index, unsigned long plr_range_id, l
               clear_flag(crconf->model_flags, CMF_CannotPickUp);
           }
           break;
+      case 38: // DROP_ON_PATH
+          if (param3 >= 1) {
+              set_flag(crconf->model_flags, CMF_DropOnPath);
+          } else {
+              clear_flag(crconf->model_flags, CMF_DropOnPath);
+          }
+          break;
       default:
           SCRPTERRLOG("Unknown creature property '%ld'", param2);
           break;

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -226,7 +226,7 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
         if (player->hand_thing_idx == 0) {
             create_power_hand(player->id_number);
         }
-        long allow_unclaimed_path = thing_is_creature_droppable_on_path(thing);
+        long allow_unclaimed_path = is_creature_droppable_on_path(thing);
         if ((can_drop_thing_here(stl_x, stl_y, player->id_number, allow_unclaimed_path)
              || !can_dig_here(stl_x, stl_y, player->id_number, true))
             && (!player->one_click_lock_cursor))

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -226,14 +226,14 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
         if (player->hand_thing_idx == 0) {
             create_power_hand(player->id_number);
         }
-        long is_digger = thing_is_creature_digger(thing);
-        if ((can_drop_thing_here(stl_x, stl_y, player->id_number, is_digger)
+        long allow_unclaimed_path = thing_is_creature_droppable_on_path(thing);
+        if ((can_drop_thing_here(stl_x, stl_y, player->id_number, allow_unclaimed_path)
              || !can_dig_here(stl_x, stl_y, player->id_number, true))
             && (!player->one_click_lock_cursor))
         {
             player->render_roomspace = create_box_roomspace(player->render_roomspace, 1, 1, subtile_slab(stl_x), subtile_slab(stl_y));
             player->full_slab_cursor = (player->roomspace_mode != single_subtile_mode);
-            tag_cursor_blocks_thing_in_hand(plyr_idx, stl_x, stl_y, is_digger, player->full_slab_cursor);
+            tag_cursor_blocks_thing_in_hand(plyr_idx, stl_x, stl_y, allow_unclaimed_path, player->full_slab_cursor);
         } else
         {
             player->additional_flags |= PlaAF_ChosenSubTileIsHigh;

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -990,7 +990,7 @@ short dump_first_held_thing_on_map(PlayerNumber plyr_idx, MapSubtlCoord stl_x, M
     }
     // Check if drop position is allowed
     struct Thing *droptng = thing_get(dungeon->things_in_hand[0]);
-    if (!can_drop_thing_here(stl_x, stl_y, plyr_idx, thing_is_creature_droppable_on_path(droptng))) {
+    if (!can_drop_thing_here(stl_x, stl_y, plyr_idx, is_creature_droppable_on_path(droptng))) {
         // Make a rejection sound
         if (is_my_player_number(plyr_idx))
         {
@@ -1584,7 +1584,7 @@ short can_place_thing_here(struct Thing *thing, long stl_x, long stl_y, long dng
 {
     struct Coord3d pos;
     TbBool allow_unclaimed_path;
-    allow_unclaimed_path = thing_is_creature_droppable_on_path(thing);
+    allow_unclaimed_path = is_creature_droppable_on_path(thing);
     if (!can_drop_thing_here(stl_x, stl_y, dngn_idx, allow_unclaimed_path)) {
       return false;
     }

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -990,7 +990,7 @@ short dump_first_held_thing_on_map(PlayerNumber plyr_idx, MapSubtlCoord stl_x, M
     }
     // Check if drop position is allowed
     struct Thing *droptng = thing_get(dungeon->things_in_hand[0]);
-    if (!can_drop_thing_here(stl_x, stl_y, plyr_idx, thing_is_creature_digger(droptng))) {
+    if (!can_drop_thing_here(stl_x, stl_y, plyr_idx, thing_is_creature_droppable_on_path(droptng))) {
         // Make a rejection sound
         if (is_my_player_number(plyr_idx))
         {
@@ -1583,10 +1583,11 @@ TbBool can_drop_thing_here(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumbe
 short can_place_thing_here(struct Thing *thing, long stl_x, long stl_y, long dngn_idx)
 {
     struct Coord3d pos;
-    TbBool is_digger;
-    is_digger = thing_is_creature_digger(thing);
-    if (!can_drop_thing_here(stl_x, stl_y, dngn_idx, is_digger))
+    TbBool allow_unclaimed_path;
+    allow_unclaimed_path = thing_is_creature_droppable_on_path(thing);
+    if (!can_drop_thing_here(stl_x, stl_y, dngn_idx, allow_unclaimed_path)) {
       return false;
+    }
     pos.x.val = subtile_coord_center(stl_x);
     pos.y.val = subtile_coord_center(stl_y);
     pos.z.val = get_thing_height_at(thing, &pos);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -4692,12 +4692,12 @@ TbBool thing_is_creature_digger(const struct Thing *thing)
   return any_flag_is_set(get_creature_model_flags(thing),(CMF_IsSpecDigger|CMF_IsDiggingCreature));
 }
 
-TbBool thing_is_creature_droppable_on_path(const struct Thing *thing)
+TbBool is_creature_droppable_on_path(const struct Thing *thing)
 {
     if (!thing_is_creature(thing)) {
         return false;
     }
-    return flag_is_set(get_creature_model_flags(thing), CMF_DropOnPath);
+    return any_flag_is_set(get_creature_model_flags(thing), (CMF_IsSpecDigger|CMF_DropOnPath));
 }
 
 /** Returns if a thing is special digger creature.

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -4692,6 +4692,14 @@ TbBool thing_is_creature_digger(const struct Thing *thing)
   return any_flag_is_set(get_creature_model_flags(thing),(CMF_IsSpecDigger|CMF_IsDiggingCreature));
 }
 
+TbBool thing_is_creature_droppable_on_path(const struct Thing *thing)
+{
+    if (!thing_is_creature(thing)) {
+        return false;
+    }
+    return flag_is_set(get_creature_model_flags(thing), CMF_DropOnPath);
+}
+
 /** Returns if a thing is special digger creature.
  *
  * @param thing The thing to be checked.

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -134,7 +134,7 @@ void draw_creature_view(struct Thing *thing);
 
 TbBool creature_is_for_dungeon_diggers_list(const struct Thing *creatng);
 TbBool creature_kind_is_for_dungeon_diggers_list(PlayerNumber plyr_idx, ThingModel crmodel);
-TbBool thing_is_creature_droppable_on_path(const struct Thing *thing);
+TbBool is_creature_droppable_on_path(const struct Thing *thing);
 void set_first_creature(struct Thing *thing);
 void remove_first_creature(struct Thing *thing);
 long player_list_creature_filter_needs_to_be_placed_in_room_for_job(const struct Thing *thing, MaxTngFilterParam param, long maximizer);

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -134,6 +134,7 @@ void draw_creature_view(struct Thing *thing);
 
 TbBool creature_is_for_dungeon_diggers_list(const struct Thing *creatng);
 TbBool creature_kind_is_for_dungeon_diggers_list(PlayerNumber plyr_idx, ThingModel crmodel);
+TbBool thing_is_creature_droppable_on_path(const struct Thing *thing);
 void set_first_creature(struct Thing *thing);
 void remove_first_creature(struct Thing *thing);
 long player_list_creature_filter_needs_to_be_placed_in_room_for_job(const struct Thing *thing, MaxTngFilterParam param, long maximizer);


### PR DESCRIPTION
In order to not harm compatibility of existing maps, `imp.cfg` Properties will not have the `DROP_ON_PATH` property. Instead, `SPECIAL_DIGGER` will continue to have the built-in property of `DROP_ON_PATH`.