### PR TITLE
In some cases count kinky torture as torture too

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -1283,7 +1283,7 @@ TbBool validate_target_generic
     )
 {
     if (!validate_target_even_in_prison(source, target, inst_idx, param1, param2) ||
-        creature_is_being_tortured(target) || creature_is_kept_in_prison(target))
+        creature_is_being_tortured_including_kinky(target) || creature_is_kept_in_prison(target))
     {
         return false;
     }
@@ -1634,8 +1634,8 @@ TbBool validate_target_benefits_from_healing
     }
     else
     {
-        if (creature_is_being_tortured(target) || creature_is_kept_in_prison(target) ||
-            creature_is_being_tortured(source) || creature_is_kept_in_prison(source))
+        if (creature_is_being_tortured_including_kinky(target) || creature_is_kept_in_prison(target) ||
+            creature_is_being_tortured_including_kinky(source) || creature_is_kept_in_prison(source))
         {
             return false;
         }
@@ -1873,8 +1873,8 @@ TbBool validate_target_requires_cleansing
     }
     else
     {
-        if (creature_is_being_tortured(target) || creature_is_kept_in_prison(target) ||
-            creature_is_being_tortured(source) || creature_is_kept_in_prison(source) ||
+        if (creature_is_being_tortured_including_kinky(target) || creature_is_kept_in_prison(target) ||
+            creature_is_being_tortured_including_kinky(source) || creature_is_kept_in_prison(source) ||
             creature_under_spell_effect(source, CSAfF_Freeze) || creature_under_spell_effect(source, CSAfF_Chicken)) // not allowed to cleanse others (only itself) even if source param1 is set
         {
             return false;

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -754,6 +754,14 @@ TbBool creature_is_being_tortured(const struct Thing *thing)
     return false;
 }
 
+TbBool creature_is_being_tortured_including_kinky(const struct Thing* thing)
+{
+    CrtrStateId i = get_creature_state_besides_interruptions(thing);
+    if ((i == CrSt_Torturing) || (i == CrSt_AtTortureRoom) || (i == CrSt_AtKinkyTortureRoom) || (i == CrSt_KinkyTorturing))
+        return true;
+    return false;
+}
+
 TbBool creature_is_leaving_and_cannot_be_stopped(const struct Thing *thing)
 {
     CrtrStateId i = get_creature_state_besides_interruptions(thing);

--- a/src/creature_states.h
+++ b/src/creature_states.h
@@ -363,6 +363,7 @@ TbBool creature_is_being_unconscious(const struct Thing *thing);
 TbBool creature_can_be_set_unconscious(const struct Thing *creatng, const struct Thing *killertng, CrDeathFlags flags);
 TbBool creature_is_celebrating(const struct Thing *thing);
 TbBool creature_is_being_tortured(const struct Thing *thing);
+TbBool creature_is_being_tortured_including_kinky(const struct Thing* thing);
 TbBool creature_is_being_sacrificed(const struct Thing *thing);
 TbBool creature_is_leaving_and_cannot_be_stopped(const struct Thing* thing);
 TbBool creature_is_kept_in_prison(const struct Thing *thing);


### PR DESCRIPTION
Creatures getting buffed right as they replace a bench for torture will stop the room torture bench from reappearing when they get off.

This PR does not actually fix this bug. However, it only appears when there is ranged-buff creatures with kinky-torture. Torture victims are normally excluded for range buffs. Kinky-torture was not excluded, it is now.