### PR TITLE
Disable dig prediction when dragging minimap

### DIFF
--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -55,7 +55,14 @@ static TbBool prevent_local_dig_prediction(const struct Packet *pckt)
     if ((pckt->control_flags & (PCtr_Gui | PCtr_MapCoordsValid)) != PCtr_MapCoordsValid) {
         return true;
     }
-    if ((pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing) || (battle_creature_over > 0)) {
+    switch (pckt->action)
+    {
+    case PckA_UsePwrHandPick:
+    case PckA_UsePwrOnThing:
+    case PckA_BookmarkLoad: // Dragging minimap
+        return true;
+    }
+    if (battle_creature_over > 0) {
         return true;
     }
     return false;


### PR DESCRIPTION
In multiplayer with >0 input lag turns, dig prediction marks your whole path when you drag the minimap.  This patch fixes that.

Possible alternative solution: check for `game.small_map_state == 2`.
