### PR TITLE
Multiplayer: Startup map verification now checks the actual files

### DIFF
--- a/src/net_checksums.c
+++ b/src/net_checksums.c
@@ -231,37 +231,24 @@ short checksums_different(void)
     return mismatch;
 }
 
-TbBigChecksum calculate_network_startup_map_checksum(void)
+void calculate_network_startup_map_checksums(TbBigChecksum checksums[NETWORK_STARTUP_MAP_FILE_COUNT])
 {
-    TbBigChecksum checksum_mem = 0;
-    for (int i = 1; i < THINGS_COUNT; i++) {
-        struct Thing* thing = thing_get(i);
-        if (thing_exists(thing) && !is_non_synchronized_thing_class(thing->class_id)) {
-            CHECKSUM_ADD(checksum_mem, get_thing_checksum(thing));
-        }
-    }
-    for (int32_t y = 0; y < game.map_tiles_y; y++) {
-        for (int32_t x = 0; x < game.map_tiles_x; x++) {
-            struct SlabMap* slb = get_slabmap_block(x, y);
-            CHECKSUM_ADD(checksum_mem, slb->kind);
-            CHECKSUM_ADD(checksum_mem, slb->owner);
-        }
-    }
     LevelNumber lvnum = get_loaded_level_number();
     short fgroup = get_level_fgroup(lvnum);
-    const char* script_exts[] = {"txt", "lua"};
-    for (int i = 0; i < sizeof(script_exts) / sizeof(script_exts[0]); i++) {
-        char* fname = prepare_file_fmtpath(fgroup, "map%05u.%s", lvnum, script_exts[i]);
+    for (int i = 0; i < NETWORK_STARTUP_MAP_FILE_COUNT; i++) {
+        char* fname = prepare_file_fmtpath(fgroup, "map%05u.%s", lvnum, network_startup_compare_files[i]);
         int32_t file_size = (int32_t)LbFileLengthRnc(fname);
-        if (file_size > 0) {
-            unsigned char *file_buf = malloc(file_size);
-            if (file_buf != NULL && LbFileLoadAt(fname, file_buf) == file_size) {
-                CHECKSUM_ADD(checksum_mem, rnc_crc(file_buf, file_size));
-            }
-            free(file_buf);
+        checksums[i] = 0;
+        CHECKSUM_ADD(checksums[i], file_size);
+        if (file_size <= 0) {
+            continue;
         }
+        unsigned char *file_buf = malloc(file_size);
+        if (file_buf != NULL && LbFileLoadAt(fname, file_buf) == file_size) {
+            CHECKSUM_ADD(checksums[i], rnc_crc(file_buf, file_size));
+        }
+        free(file_buf);
     }
-    return checksum_mem;
 }
 
 void update_turn_checksums(void) {

--- a/src/net_checksums.h
+++ b/src/net_checksums.h
@@ -30,12 +30,19 @@ extern "C" {
 struct PlayerInfo;
 struct Thing;
 
+static const char * const network_startup_compare_files[] = {
+    "slb", "dat", "clm", "own", "wib", "inf", "flg", "wlb", "slx",
+    "lgtfx", "lgt", "aptfx", "apt", "tngfx", "tng", "txt", "lua"
+};
+
+#define NETWORK_STARTUP_MAP_FILE_COUNT (sizeof(network_startup_compare_files) / sizeof(network_startup_compare_files[0]))
+
 void update_turn_checksums(void);
 void pack_desync_history_for_resync(void);
 void compare_desync_history_from_host(void);
 TbBigChecksum get_thing_checksum(const struct Thing *thing);
 short checksums_different(void);
-TbBigChecksum calculate_network_startup_map_checksum(void);
+void calculate_network_startup_map_checksums(TbBigChecksum checksums[NETWORK_STARTUP_MAP_FILE_COUNT]);
 
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -61,7 +61,7 @@ struct StartupSyncPacket {
     uint8_t startup_sync_packet_valid;
     int32_t video_rotate_mode;
     int32_t input_lag_turns;
-    TbBigChecksum map_checksum;
+    TbBigChecksum map_checksums[NETWORK_STARTUP_MAP_FILE_COUNT];
     uint32_t sprite_zip_checksum;
     uint8_t sprite_zip_entry_count;
     struct SpriteZipEntry sprite_zip_entries[SPRITE_ZIP_ENTRY_COUNT];
@@ -146,10 +146,24 @@ static void setup_players_from_startup_packets(const struct StartupSyncPacket st
 
 static TbBool verify_map_checksums(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
-    const TbBigChecksum host_checksum = startup_sync_packets[get_host_player_id()].map_checksum;
+    const TbBigChecksum *host = startup_sync_packets[get_host_player_id()].map_checksums;
     for (int i = 0; i < MAX_NET_USERS; i++) {
-        if (net_player_info[i].network_user_active && startup_sync_packets[i].map_checksum != host_checksum) {
-            ERRORLOG("Level checksums %08x(Host) != %08x(Client) for player %d", host_checksum, startup_sync_packets[i].map_checksum, i);
+        const TbBigChecksum *client = startup_sync_packets[i].map_checksums;
+        if (!net_player_info[i].network_user_active) {
+            continue;
+        }
+        int diff_count = 0;
+        for (int j = 0; j < NETWORK_STARTUP_MAP_FILE_COUNT; j++) {
+            if (client[j] == host[j]) {
+                continue;
+            }
+            if (diff_count == 0) {
+                ERRORLOG("Level checksums differ for player %d", i);
+            }
+            ERRORLOG("Level file map%05u.%s differs for player %d", get_loaded_level_number(), network_startup_compare_files[j], i);
+            diff_count++;
+        }
+        if (diff_count != 0) {
             return false;
         }
     }
@@ -221,7 +235,7 @@ static void build_local_startup_sync(void)
     s_local_startup_sync.startup_sync_packet_valid = 1;
     s_local_startup_sync.video_rotate_mode = settings.video_rotate_mode;
     s_local_startup_sync.input_lag_turns = game.input_lag_turns;
-    s_local_startup_sync.map_checksum = calculate_network_startup_map_checksum();
+    calculate_network_startup_map_checksums(s_local_startup_sync.map_checksums);
     s_local_startup_sync.sprite_zip_checksum = sprite_zip_combined_checksum;
     s_local_startup_sync.sprite_zip_entry_count = sprite_zip_entry_count;
     memcpy(s_local_startup_sync.sprite_zip_entries, sprite_zip_entries, sizeof(s_local_startup_sync.sprite_zip_entries));


### PR DESCRIPTION
I've changed the way the initial map verification works, instead of looking at stuff generated on the map, it now directly compares the actual files. This is a safer approach because there could be some other unknown factor causing things being created on the map in a desynced fashion. But we can just rely on a resync to solve those kinds of unknown issues.

In both players logs it'll tell you the name of the file(s) that differ:
`Error: [0] verify_map_checksums: Level file map00052.wib differs for player 1`

So this should completely solve the ambiguity of this error, it now just means your files are different:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dda9c2f6-9003-4158-aec1-4b4fe1973263" />