### PR TITLE
Load files in deterministic order

### DIFF
--- a/src/linux.cpp
+++ b/src/linux.cpp
@@ -3,8 +3,12 @@
 #include "bflib_crash.h"
 #include "bflib_fileio.h"
 #include "cdrom.h"
+#include <algorithm>
+#include <ctype.h>
 #include <string>
 #include <memory>
+#include <utility>
+#include <vector>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
@@ -73,11 +77,8 @@ extern "C" void StopRedbookTrack()
 }
 
 struct TbFileFind {
-	std::string filespec;
-	std::string path;
-	std::string namebuf;
-	DIR * handle = nullptr;
-	bool is_pattern = false;
+	std::vector<std::pair<std::string, std::string>> names;
+	size_t index = 0;
 };
 
 bool filespec_is_pattern(const char * filespec) {
@@ -93,52 +94,55 @@ std::string directory_from_filespec(const char * filespec) {
 	}
 }
 
-bool find_file(TbFileFind * ff, TbFileEntry * fe) {
-	while (true) {
-		auto de = readdir(ff->handle);
-		if (!de) {
-			return false;
-		} else if (strcmp(de->d_name, ".") == 0) {
-			continue;
-		} else if (strcmp(de->d_name, "..") == 0) {
-			continue;
-		}
-		const std::string path = ff->path + "/" + de->d_name;
-		ff->namebuf = de->d_name;
-		fe->Filename = ff->namebuf.c_str();
-		if (ff->is_pattern) {
-			if (fnmatch(ff->filespec.c_str(), path.c_str(), FNM_FILE_NAME | FNM_CASEFOLD) != 0) {
-				continue;
-			}
-		}
-		struct stat sb;
-		if (stat(path.c_str(), &sb) < 0) {
-			continue;
-		} else if (!S_ISREG(sb.st_mode)) {
-			continue;
-		}
-		return true;
-	}
-	return false;
-}
-
 extern "C" TbFileFind * LbFileFindFirst(const char * filespec, TbFileEntry * fe)
 {
 	try {
 		auto ff = std::make_unique<TbFileFind>();
-		ff->is_pattern = filespec_is_pattern(filespec);
-		ff->filespec = filespec;
-		if (ff->is_pattern) {
-			ff->path = directory_from_filespec(filespec);
-			ff->handle = opendir(ff->path.c_str());
+		bool is_pattern = filespec_is_pattern(filespec);
+		std::string path;
+		if (is_pattern) {
+			path = directory_from_filespec(filespec);
 		} else {
-			ff->path = filespec;
-			ff->handle = opendir(filespec);
+			path = filespec;
 		}
-		if (ff->handle) {
-			if (find_file(ff.get(), fe)) {
-				return ff.release();
+		DIR *handle = opendir(path.c_str());
+		if (handle) {
+			while (true) {
+				auto de = readdir(handle);
+				if (!de) {
+					break;
+				}
+				if (strcmp(de->d_name, ".") == 0) {
+					continue;
+				}
+				if (strcmp(de->d_name, "..") == 0) {
+					continue;
+				}
+				const std::string file_path = path + "/" + de->d_name;
+				if (is_pattern) {
+					if (fnmatch(filespec, file_path.c_str(), FNM_FILE_NAME | FNM_CASEFOLD) != 0) {
+						continue;
+					}
+				}
+				struct stat sb;
+				if (stat(file_path.c_str(), &sb) < 0) {
+					continue;
+				}
+				if (!S_ISREG(sb.st_mode)) {
+					continue;
+				}
+				std::string key = de->d_name;
+				for (size_t i = 0; i < key.size(); i++) {
+					key[i] = (char)tolower((unsigned char)key[i]);
+				}
+				ff->names.emplace_back(key, de->d_name);
 			}
+			closedir(handle);
+		}
+		if (!ff->names.empty()) {
+			std::sort(ff->names.begin(), ff->names.end());
+			fe->Filename = ff->names[0].second.c_str();
+			return ff.release();
 		}
 	} catch (...) {}
 	return nullptr;
@@ -147,8 +151,12 @@ extern "C" TbFileFind * LbFileFindFirst(const char * filespec, TbFileEntry * fe)
 extern "C" int32_t LbFileFindNext(TbFileFind * ff, TbFileEntry * fe)
 {
 	try {
-		if (find_file(ff, fe)) {
-			return 1;
+		if (ff) {
+			ff->index++;
+			if (ff->index < ff->names.size()) {
+				fe->Filename = ff->names[ff->index].second.c_str();
+				return 1;
+			}
 		}
 	} catch (...) {}
 	return -1;
@@ -156,9 +164,6 @@ extern "C" int32_t LbFileFindNext(TbFileFind * ff, TbFileEntry * fe)
 
 extern "C" void LbFileFindEnd(TbFileFind * ff)
 {
-	if (ff) {
-		closedir(ff->handle);
-	}
 	delete ff;
 }
 

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -4,10 +4,15 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <algorithm>
+#include <ctype.h>
+#include <memory>
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>
 #include <shellapi.h>
+#include <string>
+#include <utility>
 #include <vector>
 #include "post_inc.h"
 
@@ -124,34 +129,32 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine,
 }
 
 struct TbFileFind {
-    HANDLE handle;
-    char * namebuf;
-    int namebuflen;
+    std::vector<std::pair<std::string, std::string>> names;
+    size_t index = 0;
 };
 
 extern "C" TbFileFind * LbFileFindFirst(const char * filespec, struct TbFileEntry * fentry)
 {
-    auto ffind = static_cast<TbFileFind *>(malloc(sizeof(struct TbFileFind)));
-    if (!ffind) {
-        return nullptr;
-    }
+    auto ffind = std::make_unique<TbFileFind>();
     WIN32_FIND_DATA fd;
-    ffind->handle = FindFirstFile(filespec, &fd);
-    if (ffind->handle == INVALID_HANDLE_VALUE) {
-        free(ffind);
+    HANDLE handle = FindFirstFile(filespec, &fd);
+    if (handle == INVALID_HANDLE_VALUE) {
         return nullptr;
     }
-    const auto namelen = strlen(fd.cFileName);
-    ffind->namebuf = static_cast<char *>(malloc(namelen + 1));
-    if (!ffind->namebuf) {
-        FindClose(ffind->handle);
-        free(ffind);
+    do {
+        std::string key = fd.cFileName;
+        for (size_t i = 0; i < key.size(); i++) {
+            key[i] = (char)tolower((unsigned char)key[i]);
+        }
+        ffind->names.emplace_back(key, fd.cFileName);
+    } while (FindNextFile(handle, &fd));
+    FindClose(handle);
+    if (ffind->names.empty()) {
         return nullptr;
     }
-    memcpy(ffind->namebuf, fd.cFileName, namelen + 1);
-    ffind->namebuflen = namelen;
-    fentry->Filename = ffind->namebuf;
-    return ffind;
+    std::sort(ffind->names.begin(), ffind->names.end());
+    fentry->Filename = ffind->names[0].second.c_str();
+    return ffind.release();
 }
 
 extern "C" int LbFileFindNext(struct TbFileFind * ffind, struct TbFileEntry * fentry)
@@ -159,29 +162,15 @@ extern "C" int LbFileFindNext(struct TbFileFind * ffind, struct TbFileEntry * fe
     if (!ffind) {
         return -1;
     }
-    WIN32_FIND_DATA fd;
-    if (!FindNextFile(ffind->handle, &fd)) {
+    ffind->index++;
+    if (ffind->index >= ffind->names.size()) {
         return -1;
     }
-    const int namelen = strlen(fd.cFileName);
-    if (namelen > ffind->namebuflen) {
-        auto buf = static_cast<char *>(realloc(ffind->namebuf, namelen + 1));
-        if (!buf) {
-            return -1;
-        }
-        ffind->namebuf = buf;
-        ffind->namebuflen = namelen;
-    }
-    memcpy(ffind->namebuf, fd.cFileName, namelen + 1);
-    fentry->Filename = ffind->namebuf;
+    fentry->Filename = ffind->names[ffind->index].second.c_str();
     return 1;
 }
 
 extern "C" void LbFileFindEnd(struct TbFileFind * ffind)
 {
-    if (ffind) {
-        FindClose(ffind->handle);
-        free(ffind->namebuf);
-        free(ffind);
-    }
+    delete ffind;
 }


### PR DESCRIPTION
This is to fix a multiplayer issue where zip files are loaded in a different order on different players' PCs, but this change will also affect singleplayer whenever the game loads a group of multiple files, which is a good thing for catching any unreproducible singleplayer bugs in the future. (a bug could be unreproducible if caused by file loading order)

Previously, `LbFileFindFirst` and `LbFileFindNext` just loaded files in the order the PC's filesystem says to, which can apparently differ in all sorts of ways, but now we're in charge of specifying the next file to be loaded, done alphabetically.

On Linux where two files can share the same filename it will load uppercase before lowercase:

```
Apple.cfg
apple.cfg
Banana.cfg
banana.cfg
```