### PR TITLE
Use an authoritative list for loading sprite zips from /fxdata/

### DIFF
--- a/src/custom_sprites.c
+++ b/src/custom_sprites.c
@@ -462,7 +462,10 @@ void init_custom_sprites(LevelNumber lvnum)
         ERRORLOG("Required Main FxData dir is missing");
     } else {
         char full_path[1024] = {0};
-        int cnt_zip = 0, cnt_sprite = 0, cnt_icon = 0;
+        char loaded_zip_names[1024] = {0};
+        int loaded_zip_names_len = 0;
+        const char *loaded_zip_name_sep = "";
+        int cnt_sprite = 0, cnt_icon = 0;
         for (int i = 0; i < REQUIRED_SPRITE_ZIP_COUNT; i++) {
             sprintf(full_path, "%s/%s", dname, required_sprite_zips[i]);
             if (!LbFileExists(full_path)) {
@@ -477,9 +480,12 @@ void init_custom_sprites(LevelNumber lvnum)
             if (add_flag & CLF_Icons) {
                 cnt_icon++;
             }
-            cnt_zip++;
+            if (loaded_zip_names_len < (int)sizeof(loaded_zip_names)) {
+                loaded_zip_names_len += snprintf(&loaded_zip_names[loaded_zip_names_len], sizeof(loaded_zip_names) - loaded_zip_names_len, "%s%s", loaded_zip_name_sep, required_sprite_zips[i]);
+            }
+            loaded_zip_name_sep = ", ";
         }
-        LbJustLog("Loaded %d listed sprite zip file(s) from Main FxData dir, loaded %d with animations and %d with icons. Used %d/%d sprite slots.\n", cnt_zip, cnt_sprite, cnt_icon, next_free_sprite, KEEPERSPRITE_ADD_NUM);
+        LbJustLog("Loaded /fxdata/ sprite zips: %s, sprite slots: %d/%d, animations: %d, icons: %d.\n", loaded_zip_names, next_free_sprite, KEEPERSPRITE_ADD_NUM, cnt_sprite, cnt_icon);
     }
 
     if (mods_conf.after_base_cnt > 0)

--- a/src/custom_sprites.c
+++ b/src/custom_sprites.c
@@ -25,6 +25,7 @@
 #include "gui_draw.h"
 #include "frontend.h"
 #include "bflib_dernc.h"
+#include "net_checksums.h"
 #include "sprites.h"
 #include "config_spritecolors.h"
 #include <spng.h>
@@ -95,13 +96,7 @@ static int num_added_lens_mists = 0;
 
 unsigned char base_pal[PALETTE_SIZE];
 
-int total_sprite_zip_count = 0;
-uint32_t sprite_zip_combined_checksum = 0;
-struct SpriteZipEntry sprite_zip_entries[SPRITE_ZIP_ENTRY_COUNT];
-uint8_t sprite_zip_entry_count = 0;
-
-// Used to cheaply detect mismatched custom sprites between players; makes file order matter when combining checksums, without this XOR alone gives the same result regardless of order.
-#define ROL32_5(x) (((uint32_t)(x) << 5) | ((uint32_t)(x) >> 27))
+TbBigChecksum required_sprite_zip_checksums[REQUIRED_SPRITE_ZIP_COUNT];
 
 // Indicates what custom assets to load
 enum CustomLoadFlags {
@@ -248,31 +243,6 @@ static int cmp_named_command(const void *a, const void *b)
 }
 
 
-static uint32_t compute_zip_checksum(const char *path)
-{
-    long file_length = LbFileLength(path);
-    if (file_length <= 0) {
-        return 0;
-    }
-    TbFileHandle handle = LbFileOpen(path, Lb_FILE_MODE_READ_ONLY);
-    if (handle == NULL) {
-        return 0;
-    }
-    unsigned char *buffer = malloc(file_length);
-    if (buffer == NULL) {
-        LbFileClose(handle);
-        return 0;
-    }
-    LbFileRead(handle, buffer, file_length);
-    LbFileClose(handle);
-    uint32_t checksum = 0;
-    for (long i = 0; i < file_length; i++) {
-        checksum = ROL32_5(checksum) ^ buffer[i];
-    }
-    free(buffer);
-    return checksum;
-}
-
 static int load_file_sprites(const char *path, const char *file_desc)
 {
     SYNCDBG(8, "Starting");
@@ -335,49 +305,37 @@ static int load_file_sprites(const char *path, const char *file_desc)
         }
     }
 
-    uint32_t zip_checksum = compute_zip_checksum(path);
-    sprite_zip_combined_checksum = ROL32_5(sprite_zip_combined_checksum) ^ zip_checksum;
-    if (sprite_zip_entry_count < SPRITE_ZIP_ENTRY_COUNT) {
-        const char *filename = strrchr(path, '/');
-        if (filename == NULL) {
-            filename = path;
-        } else {
-            filename++;
-        }
-        struct SpriteZipEntry *entry = &sprite_zip_entries[sprite_zip_entry_count];
-        snprintf(entry->filename, sizeof(entry->filename), "%s", filename);
-        entry->checksum = zip_checksum;
-        sprite_zip_entry_count++;
-    }
-    total_sprite_zip_count++;
-
     return add_flag;
 }
 
 static void load_dir_sprites(const char *dir_path, const char *dir_desc)
 {
     SYNCDBG(8, "Starting");
-    if (dir_path == NULL || dir_path[0] == 0)
+    if (dir_path == NULL || dir_path[0] == 0) {
         return;
+    }
     char full_path[1024] = {0};
     sprintf(full_path, "%s/%s", dir_path, "*.zip");
     struct TbFileEntry fe;
-    struct TbFileFind * ff = LbFileFindFirst(full_path, &fe);
+    struct TbFileFind *ff = LbFileFindFirst(full_path, &fe);
     int cnt_zip = 0, cnt_sprite = 0, cnt_icon = 0;
     if (ff) {
         do {
             sprintf(full_path, "%s/%s", dir_path, fe.Filename);
             int add_flag = load_file_sprites(full_path, NULL);
-            if (add_flag & CLF_Sprites)
+            if (add_flag & CLF_Sprites) {
                 cnt_sprite++;
-            if (add_flag & CLF_Icons)
+            }
+            if (add_flag & CLF_Icons) {
                 cnt_icon++;
+            }
             cnt_zip++;
         } while (LbFileFindNext(ff, &fe) >= 0);
         LbFileFindEnd(ff);
 
-        if (dir_desc != NULL)
+        if (dir_desc != NULL) {
             LbJustLog("Found %d sprite zip file(s) from %s, loaded %d with animations and %d with icons. Used %d/%d sprite slots.\n", cnt_zip, dir_desc, cnt_sprite, cnt_icon, next_free_sprite, KEEPERSPRITE_ADD_NUM);
+        }
     }
 }
 
@@ -443,9 +401,7 @@ void init_custom_sprites(LevelNumber lvnum)
     SYNCDBG(8, "Starting");
     free_spritesheet(&custom_sprites);
     custom_sprites = create_spritesheet();
-    total_sprite_zip_count = 0;
-    sprite_zip_combined_checksum = 0;
-    sprite_zip_entry_count = 0;
+    memset(required_sprite_zip_checksums, 0, sizeof(required_sprite_zip_checksums));
     // This is a workaround because get_selected_level_number is zeroed on res change
     if (lvnum == SPRITE_LAST_LEVEL)
     {
@@ -502,7 +458,29 @@ void init_custom_sprites(LevelNumber lvnum)
 
 
     char *dname = prepare_file_path(FGrp_FxData, NULL);
-    load_dir_sprites(dname, "Main FxData dir");
+    if (dname == NULL || dname[0] == 0) {
+        ERRORLOG("Required Main FxData dir is missing");
+    } else {
+        char full_path[1024] = {0};
+        int cnt_zip = 0, cnt_sprite = 0, cnt_icon = 0;
+        for (int i = 0; i < REQUIRED_SPRITE_ZIP_COUNT; i++) {
+            sprintf(full_path, "%s/%s", dname, required_sprite_zips[i]);
+            if (!LbFileExists(full_path)) {
+                ERRORLOG("Required /fxdata/%s is missing", required_sprite_zips[i]);
+                continue;
+            }
+            required_sprite_zip_checksums[i] = calculate_file_checksum(full_path);
+            int add_flag = load_file_sprites(full_path, NULL);
+            if (add_flag & CLF_Sprites) {
+                cnt_sprite++;
+            }
+            if (add_flag & CLF_Icons) {
+                cnt_icon++;
+            }
+            cnt_zip++;
+        }
+        LbJustLog("Loaded %d listed sprite zip file(s) from Main FxData dir, loaded %d with animations and %d with icons. Used %d/%d sprite slots.\n", cnt_zip, cnt_sprite, cnt_icon, next_free_sprite, KEEPERSPRITE_ADD_NUM);
+    }
 
     if (mods_conf.after_base_cnt > 0)
     {

--- a/src/custom_sprites.h
+++ b/src/custom_sprites.h
@@ -28,20 +28,24 @@ extern "C" {
 struct ObjectConfigStats;
 
 #define SPRITE_LAST_LEVEL -1
-#define SPRITE_ZIP_ENTRY_COUNT 48
-#define SPRITE_ZIP_ENTRY_NAME_LEN 64
 
-struct SpriteZipEntry {
-    char filename[SPRITE_ZIP_ENTRY_NAME_LEN];
-    uint32_t checksum;
+static const char * const required_sprite_zips[] = {
+    "colored_sprites.zip",
+    "creatures.zip",
+    "decorative_objects.zip",
+    "druid.zip",
+    "effects.zip",
+    "maiden.zip",
+    "natural_features.zip",
+    "time_mage.zip",
+    "trapsdoors.zip",
 };
+
+#define REQUIRED_SPRITE_ZIP_COUNT (sizeof(required_sprite_zips) / sizeof(required_sprite_zips[0]))
 
 void init_custom_sprites(LevelNumber level_no);
 
-extern int total_sprite_zip_count;
-extern uint32_t sprite_zip_combined_checksum;
-extern struct SpriteZipEntry sprite_zip_entries[SPRITE_ZIP_ENTRY_COUNT];
-extern uint8_t sprite_zip_entry_count;
+extern TbBigChecksum required_sprite_zip_checksums[REQUIRED_SPRITE_ZIP_COUNT];
 
 short get_anim_id(const char *name, struct ObjectConfigStats* objst);
 short get_anim_id_(const char* name);

--- a/src/net_checksums.c
+++ b/src/net_checksums.c
@@ -231,23 +231,29 @@ short checksums_different(void)
     return mismatch;
 }
 
+TbBigChecksum calculate_file_checksum(const char *fname)
+{
+    int32_t file_size = (int32_t)LbFileLengthRnc(fname);
+    TbBigChecksum checksum = 0;
+    CHECKSUM_ADD(checksum, file_size);
+    if (file_size <= 0) {
+        return checksum;
+    }
+    unsigned char *file_buf = malloc(file_size);
+    if (file_buf != NULL && LbFileLoadAt(fname, file_buf) == file_size) {
+        CHECKSUM_ADD(checksum, rnc_crc(file_buf, file_size));
+    }
+    free(file_buf);
+    return checksum;
+}
+
 void calculate_network_startup_map_checksums(TbBigChecksum checksums[NETWORK_STARTUP_MAP_FILE_COUNT])
 {
     LevelNumber lvnum = get_loaded_level_number();
     short fgroup = get_level_fgroup(lvnum);
     for (int i = 0; i < NETWORK_STARTUP_MAP_FILE_COUNT; i++) {
         char* fname = prepare_file_fmtpath(fgroup, "map%05u.%s", lvnum, network_startup_compare_files[i]);
-        int32_t file_size = (int32_t)LbFileLengthRnc(fname);
-        checksums[i] = 0;
-        CHECKSUM_ADD(checksums[i], file_size);
-        if (file_size <= 0) {
-            continue;
-        }
-        unsigned char *file_buf = malloc(file_size);
-        if (file_buf != NULL && LbFileLoadAt(fname, file_buf) == file_size) {
-            CHECKSUM_ADD(checksums[i], rnc_crc(file_buf, file_size));
-        }
-        free(file_buf);
+        checksums[i] = calculate_file_checksum(fname);
     }
 }
 

--- a/src/net_checksums.h
+++ b/src/net_checksums.h
@@ -42,6 +42,7 @@ void pack_desync_history_for_resync(void);
 void compare_desync_history_from_host(void);
 TbBigChecksum get_thing_checksum(const struct Thing *thing);
 short checksums_different(void);
+TbBigChecksum calculate_file_checksum(const char *fname);
 void calculate_network_startup_map_checksums(TbBigChecksum checksums[NETWORK_STARTUP_MAP_FILE_COUNT]);
 
 /******************************************************************************/

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -62,9 +62,7 @@ struct StartupSyncPacket {
     int32_t video_rotate_mode;
     int32_t input_lag_turns;
     TbBigChecksum map_checksums[NETWORK_STARTUP_MAP_FILE_COUNT];
-    uint32_t sprite_zip_checksum;
-    uint8_t sprite_zip_entry_count;
-    struct SpriteZipEntry sprite_zip_entries[SPRITE_ZIP_ENTRY_COUNT];
+    TbBigChecksum required_sprite_zip_checksums[REQUIRED_SPRITE_ZIP_COUNT];
     uint16_t initial_tendencies;
     uint32_t isometric_view_zoom_level;
     uint32_t frontview_zoom_level;
@@ -171,58 +169,26 @@ static TbBool verify_map_checksums(const struct StartupSyncPacket startup_sync_p
     return true;
 }
 
-static void verify_startup_sprite_zip_checksums(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
+static TbBool verify_startup_sprite_zip_checksums(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
     int host_player_id = get_host_player_id();
     const struct StartupSyncPacket *host_sync = &startup_sync_packets[host_player_id];
+    TbBool verified = true;
     for (int i = 0; i < MAX_NET_USERS; i++) {
         if (!net_player_info[i].network_user_active || i == host_player_id) {
             continue;
         }
         const struct StartupSyncPacket *client_sync = &startup_sync_packets[i];
-        if (client_sync->sprite_zip_checksum == host_sync->sprite_zip_checksum) {
-            continue;
-        }
-        TbBool reported = false;
-        for (int pass = 0; pass < 2; pass++) {
-            const struct StartupSyncPacket *source_sync = host_sync;
-            const struct StartupSyncPacket *target_sync = client_sync;
-            int target_player_id = i;
-            if (pass == 1) {
-                source_sync = client_sync;
-                target_sync = host_sync;
-                target_player_id = host_player_id;
+        for (int zip_idx = 0; zip_idx < REQUIRED_SPRITE_ZIP_COUNT; zip_idx++) {
+            if (client_sync->required_sprite_zip_checksums[zip_idx] == host_sync->required_sprite_zip_checksums[zip_idx]) {
+                continue;
             }
-            for (int source_idx = 0; source_idx < source_sync->sprite_zip_entry_count; source_idx++) {
-                const struct SpriteZipEntry *source_entry = &source_sync->sprite_zip_entries[source_idx];
-                TbBool found = false;
-                for (int target_idx = 0; target_idx < target_sync->sprite_zip_entry_count; target_idx++) {
-                    const struct SpriteZipEntry *target_entry = &target_sync->sprite_zip_entries[target_idx];
-                    if (strcasecmp(source_entry->filename, target_entry->filename) != 0) {
-                        continue;
-                    }
-                    found = true;
-                    if (pass == 0 && source_entry->checksum != target_entry->checksum) {
-                        WARNLOG("Custom sprite zip differs for %s: %s", network_player_name(host_player_id), source_entry->filename);
-                        message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s differs for %.12s", source_entry->filename, network_player_name(host_player_id));
-                        WARNLOG("Custom sprite zip differs for %s: %s", network_player_name(i), source_entry->filename);
-                        message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s differs for %.12s", source_entry->filename, network_player_name(i));
-                        reported = true;
-                    }
-                    break;
-                }
-                if (!found) {
-                    WARNLOG("Custom sprite zip missing for %s: %s", network_player_name(target_player_id), source_entry->filename);
-                    message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s missing for %.12s", source_entry->filename, network_player_name(target_player_id));
-                    reported = true;
-                }
-            }
-        }
-        if (!reported) {
-            WARNLOG("Custom sprite zip order or overflow mismatch for %s", network_player_name(i));
-            message_add_fmt(MsgType_Blank, 0, "/fxdata/ zip order error");
+            WARNLOG("Custom sprite zip differs between %s and %s: %s", network_player_name(host_player_id), network_player_name(i), required_sprite_zips[zip_idx]);
+            message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s differs for %.12s", required_sprite_zips[zip_idx], network_player_name(i));
+            verified = false;
         }
     }
+    return verified;
 }
 
 static struct StartupSyncPacket s_local_startup_sync;
@@ -236,9 +202,7 @@ static void build_local_startup_sync(void)
     s_local_startup_sync.video_rotate_mode = settings.video_rotate_mode;
     s_local_startup_sync.input_lag_turns = game.input_lag_turns;
     calculate_network_startup_map_checksums(s_local_startup_sync.map_checksums);
-    s_local_startup_sync.sprite_zip_checksum = sprite_zip_combined_checksum;
-    s_local_startup_sync.sprite_zip_entry_count = sprite_zip_entry_count;
-    memcpy(s_local_startup_sync.sprite_zip_entries, sprite_zip_entries, sizeof(s_local_startup_sync.sprite_zip_entries));
+    memcpy(s_local_startup_sync.required_sprite_zip_checksums, required_sprite_zip_checksums, sizeof(s_local_startup_sync.required_sprite_zip_checksums));
     uint16_t initial_tendencies = 0;
     if (IMPRISON_BUTTON_DEFAULT) {initial_tendencies |= CrTend_Imprison;}
     if (FLEE_BUTTON_DEFAULT) {initial_tendencies |= CrTend_Flee;}
@@ -268,7 +232,10 @@ static TbBool net_startup_sync_exchange_and_apply(void)
         return false;
     }
 
-    verify_startup_sprite_zip_checksums(s_startup_sync_packets);
+    if (!verify_startup_sprite_zip_checksums(s_startup_sync_packets)) {
+        create_frontend_error_box(5000, get_string(GUIStr_NetVerifyFxdataSame));
+        return false;
+    }
     const struct StartupSyncPacket *host_sync = &s_startup_sync_packets[get_host_player_id()];
     game.input_lag_turns = host_sync->input_lag_turns;
     game.skip_initial_input_turns = calculate_skip_input();
@@ -323,6 +290,15 @@ TbBool init_players_network_game(void)
 {
     SYNCDBG(4,"Starting");
     setup_network_player_numbers();
+    for (int zip_idx = 0; zip_idx < REQUIRED_SPRITE_ZIP_COUNT; zip_idx++) {
+        if (required_sprite_zip_checksums[zip_idx] != 0) {
+            continue;
+        }
+        WARNLOG("Required custom sprite zip missing: %s", required_sprite_zips[zip_idx]);
+        message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s missing", required_sprite_zips[zip_idx]);
+        create_frontend_error_box(5000, get_string(GUIStr_NetVerifyFxdataSame));
+        return false;
+    }
     build_local_startup_sync();
     return net_startup_sync_exchange_and_apply();
 }


### PR DESCRIPTION
It's happened at least half a dozen times now that people's `/fxdata/` directories have caused issues for multiplayer. It obviously needs to be more guarded, so let's stop with the "just tell people not to" approach.

In `custom_sprites.h` there's now a list that we as devs simply need to remember to edit in the future:
```
static const char * const required_sprite_zips[] = {
    "colored_sprites.zip",
    "creatures.zip",
    "decorative_objects.zip",
    "druid.zip",
    "effects.zip",
    "maiden.zip",
    "natural_features.zip",
    "time_mage.zip",
    "trapsdoors.zip",
};
```
The list determines load order which almost makes #4942 unnecessary... but that PR is still useful for other file load order situations.

I think it's worth doing this, it's a pretty minor thing to remember to edit for the future, the benefits are huge, there won't be any more multiplayer issues, any accidental zip additions to `/fxdata/` won't break things.

For singleplayer, players are now forced to use the `/mods/` directory for their zip additions. This is a good idea because otherwise they'd just dirty their `/fxdata/` directory since that's the path of least resistance. Now they can't. It's also preferable that we don't treat singleplayer and multiplayer separately with what we load from fxdata, that would introduce complexity to be imagining two different filesystems.

Changed the log to be a constant reminder to us that these are the only files being loaded from /fxdata/:
```
Loaded /fxdata/ sprite zips: colored_sprites.zip, creatures.zip, decorative_objects.zip, druid.zip, effects.zip, maiden.zip, natural_features.zip, time_mage.zip, trapsdoors.zip, sprite slots: 3420/16383, animations: 9, icons: 4.
```

If a file is missing it'll say:
```
Error: [0] init_custom_sprites: Required /fxdata/trapsdoors.zip is missing
```
Differing:
```
Warning: [0] verify_startup_sprite_zip_checksums: Custom sprite zip differs between player1name and player2name: trapsdoors.zip
```

And in multiplayer if a file is missing/differing it'll prevent play:

<img width="1926" height="1153" alt="Untitled" src="https://github.com/user-attachments/assets/df755725-b809-42a4-86ff-20cfcace7765" />

(this message is already translated from before)