### PR TITLE
Fix tooltips too big

### DIFF
--- a/src/bflib_sprfnt.c
+++ b/src/bflib_sprfnt.c
@@ -1029,8 +1029,8 @@ int LbTextStringPartWidthM(const char *text, int part, long units_per_px)
                 if (len > max_len)
                 {
                     max_len = len;
-                    len = 0;
                 }
+                len = 0;
             }
             else
                 if (chr == '\t')


### PR DESCRIPTION
same as #4104 but that one wasn't in the LbTextStringPartWidthM part, wich I merged with the non M version thus causing the bug to be back