### PR TITLE
Get the native Linux build working on modern GCC

### DIFF
--- a/deps/centitoml/toml_conv.c
+++ b/deps/centitoml/toml_conv.c
@@ -158,7 +158,7 @@ static int toml_is_d(token_t src, char *buf, int buflen) {
     /* decimal point, if used, must be surrounded by at least one digit on each
      * side */
     {
-        char *dot = strchr(s, '.');
+        const char *dot = strchr(s, '.');
         if (dot && (dot < e))
         {
             if (dot == s || !isdigit(dot[-1]) || !isdigit(dot[1]))

--- a/linux.mk
+++ b/linux.mk
@@ -339,6 +339,16 @@ KFX_LDFLAGS += -flto=auto
 TOML_CFLAGS += -flto
 endif
 
+# All downloaded dependencies must be unpacked before any object is compiled.
+# Otherwise a parallel build (make -jN) can start compiling a source that
+# includes a not-yet-extracted dependency header (e.g. <enet6/enet.h>) and fail
+# on the first run. Used as an order-only prerequisite of every object below.
+DEPS_EXTRACTED = \
+	deps/centijson/include/json.h \
+	deps/astronomy/include/astronomy.h \
+	deps/enet6/include/enet6/enet.h \
+	deps/libcurl/lib/libcurl.a
+
 all: bin/keeperfx
 
 clean:
@@ -350,15 +360,15 @@ clean:
 bin/keeperfx: $(KFX_OBJECTS) $(TOML_OBJECTS) deps/libcurl/lib/libcurl.a | bin
 	$(CXX) -o $@ $(KFX_OBJECTS) $(TOML_OBJECTS) $(KFX_LDFLAGS)
 
-$(KFX_C_OBJECTS): obj/%.o: src/%.c src/ver_defs.h | obj
+$(KFX_C_OBJECTS): obj/%.o: src/%.c src/ver_defs.h | obj $(DEPS_EXTRACTED)
 	$(MKDIR) $(dir $@)
 	$(CC) $(KFX_CFLAGS) -c $< -o $@
 
-$(KFX_CXX_OBJECTS): obj/%.o: src/%.cpp src/ver_defs.h | obj
+$(KFX_CXX_OBJECTS): obj/%.o: src/%.cpp src/ver_defs.h | obj $(DEPS_EXTRACTED)
 	$(MKDIR) $(dir $@)
 	$(CXX) $(KFX_CXXFLAGS) -c $< -o $@
 
-$(TOML_OBJECTS): obj/centitoml/%.o: deps/centitoml/%.c | obj/centitoml
+$(TOML_OBJECTS): obj/centitoml/%.o: deps/centitoml/%.c | obj/centitoml $(DEPS_EXTRACTED)
 	$(CC) $(TOML_CFLAGS) -c $< -o $@
 
 bin obj deps/astronomy deps/centijson deps/enet6 deps/libcurl obj/centitoml:

--- a/linux.mk
+++ b/linux.mk
@@ -292,7 +292,8 @@ KFX_INCLUDES = \
 	-Ideps/astronomy/include \
 	-Ideps/enet6/include \
 	-Ideps/libcurl/include \
-	$(shell pkg-config --cflags-only-I luajit)
+	$(shell pkg-config --cflags-only-I luajit) \
+	$(shell pkg-config --cflags-only-I libavformat)
 
 KFX_CFLAGS += -g -DDEBUG -DBFDEBUG_LEVEL=0 -O3 -march=x86-64 $(KFX_INCLUDES) -Wall -Wextra -Werror -Wno-unused-parameter -Wno-absolute-value -Wno-unknown-pragmas -Wno-format-truncation -Wno-sign-compare
 KFX_CXXFLAGS += -g -DDEBUG -DBFDEBUG_LEVEL=0 -O3 -march=x86-64 $(KFX_INCLUDES) -Wall -Wextra -Werror -Wno-unused-parameter -Wno-unknown-pragmas -Wno-format-truncation -Wno-sign-compare

--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -1614,9 +1614,7 @@ TbBool triangle_check_and_add_navitree_bak(long ttri)
         ERRORLOG("invalid triangle received");
         return false;
     }
-    long n;
     long nskipped;
-    n = 0;
     nskipped = 0;
     long i;
     long k;
@@ -1644,7 +1642,6 @@ TbBool triangle_check_and_add_navitree_bak(long ttri)
                 }
             }
         }
-        n++;
     }
     if (nskipped != 0) {
         NAVIDBG(6,"navigate heap full, %ld points ignored",nskipped);

--- a/src/bflib_fileio.c
+++ b/src/bflib_fileio.c
@@ -139,7 +139,7 @@ int create_directory_for_file(const char * fname)
 {
   const int size = strlen(fname) + 1;
   char * tmp = (char *) malloc(size);
-  char * separator = strchr(fname, '/');
+  const char * separator = strchr(fname, '/');
 
   while (separator != NULL) {
     memcpy(tmp, fname, separator - fname);

--- a/src/config_campaigns.c
+++ b/src/config_campaigns.c
@@ -1408,15 +1408,21 @@ TbBool load_campaigns_list(struct CampaignsList *clist, short fgroup, const char
     char* fname = prepare_file_path(fgroup, "*.cfg"); // add campaigns
     struct TbFileEntry fe;
     struct TbFileFind * ff = LbFileFindFirst(fname, &fe);
+#if (BFDEBUG_LEVEL > 0)
     long cnum_all = 0;
     long cnum_ok = 0;
+#endif
     if (ff) {
         do {
             if (load_campaign_to_list(fe.Filename, clist, fgroup))
             {
+#if (BFDEBUG_LEVEL > 0)
                 cnum_ok++;
+#endif
             }
+#if (BFDEBUG_LEVEL > 0)
             cnum_all++;
+#endif
         } while (LbFileFindNext(ff, &fe) >= 0);
         LbFileFindEnd(ff);
     }

--- a/src/config_creature.c
+++ b/src/config_creature.c
@@ -1768,7 +1768,6 @@ TbBool parse_creaturetype_angerjob_blocks(char *buf, long len, const char *confi
                     cmd_num = 0;
                 }
             }
-            int n = 0;
             switch (cmd_num)
             {
             case 1: // NAME
@@ -1778,7 +1777,6 @@ TbBool parse_creaturetype_angerjob_blocks(char *buf, long len, const char *confi
                         COMMAND_TEXT(cmd_num), blocknamelen, blockname, config_textname);
                     break;
                 }
-                n++;
                 break;
             case ccr_comment:
                 break;
@@ -1856,7 +1854,6 @@ TbBool parse_creaturetype_attackpref_blocks(char *buf, long len, const char *con
                     cmd_num = 0;
                 }
             }
-            int n = 0;
             switch (cmd_num)
             {
             case 1: // NAME
@@ -1866,7 +1863,6 @@ TbBool parse_creaturetype_attackpref_blocks(char *buf, long len, const char *con
                         COMMAND_TEXT(cmd_num), blocknamelen, blockname, config_textname);
                     break;
                 }
-                n++;
                 break;
             case ccr_comment:
                 break;

--- a/src/config_keeperfx.c
+++ b/src/config_keeperfx.c
@@ -378,7 +378,7 @@ static void load_file_configuration(const char *fname, const char *sname, const 
     while (pos<len)
     {
       // Finding command number in this line
-      int i = 0, n = 0;
+      int i = 0;
       int cmd_num = recognize_conf_command(buf, &pos, len, conf_commands);
       // Now store the config item in correct place
       int k;
@@ -691,23 +691,18 @@ static void load_file_configuration(const char *fname, const char *sname, const 
             {
               case 1: // LEGAL
                 set_flag(start_params.startup_flags, SFlg_Legal);
-                n++;
                 break;
               case 2: // FX
                 set_flag(start_params.startup_flags, SFlg_FX);
-                n++;
                 break;
               case 3: // BULLFROG
                 set_flag(start_params.startup_flags, SFlg_Bullfrog);
-                n++;
                 break;
               case 4: // EA
                 set_flag(start_params.startup_flags, SFlg_EA);
-                n++;
                 break;
               case 5: // INTRO
                 set_flag(start_params.startup_flags, SFlg_Intro);
-                n++;
                 break;
               default:
                 CONFWRNLOG("Incorrect value of \"%s\" parameter \"%s\" in %s file.",

--- a/src/custom_sprites.c
+++ b/src/custom_sprites.c
@@ -1562,7 +1562,6 @@ static unsigned char* decode_png_to_indexed_internal(unzFile zip, const char *fi
 
 
     // Convert RGBA to palette indices using rgb_to_pal_table
-    int transparent_count = 0, opaque_count = 0;
     for (size_t i = 0; i < indexed_size; i++)
     {
         unsigned char red = rgba_buffer[i * 4 + 0];
@@ -1576,17 +1575,14 @@ static unsigned char* decode_png_to_indexed_internal(unzFile zip, const char *fi
             if (alpha < 128) {
                 // Transparent pixel - use palette index 255 as transparency marker
                 indexed_data[i] = 255;
-                transparent_count++;
             } else if (rgb_to_pal_table != NULL) {
                 // Use lookup table for color conversion
                 indexed_data[i] = rgb_to_pal_table[
                     ((red >> 2) << 12) | ((green >> 2) << 6) | (blue >> 2)
                 ];
-                opaque_count++;
             } else {
                 // Fallback: simple grayscale conversion
                 indexed_data[i] = (red + green + blue) / 3;
-                opaque_count++;
             }
         }
         else
@@ -2116,11 +2112,10 @@ short get_anim_id(const char *name, struct ObjectConfigStats *objst)
     if (0 == strcmp(name, "0"))
         return 0;
 
-    char *P = strrchr(name, ':');
-    if (P != NULL)
+    if (strrchr(name, ':') != NULL)
     {
         char *name2 = strdup(name);
-        P = strchr(name2, ':');
+        char *P = strchr(name2, ':');
         *P = 0; // removing :
         P++;
         key.name = name2;

--- a/src/dungeon_data.c
+++ b/src/dungeon_data.c
@@ -217,7 +217,7 @@ void add_heart_health(PlayerNumber plyr_idx,HitPoints healthdelta,TbBool warn_on
         long long new_health = heartng->health + healthdelta;
         if (new_health > objst->health)
         {
-            SCRIPTDBG(7,"Player %u's calculated heart health (%I64d) is greater than maximum: %d", heartng->owner, new_health, objst->health);
+            SCRIPTDBG(7,"Player %u's calculated heart health (%lld) is greater than maximum: %d", heartng->owner, new_health, objst->health);
             new_health = objst->health;
         }
         heartng->health = new_health;

--- a/src/dungeon_data.c
+++ b/src/dungeon_data.c
@@ -19,6 +19,7 @@
 #include "pre_inc.h"
 #include "dungeon_data.h"
 
+#include <inttypes.h>
 #include "globals.h"
 #include "bflib_basics.h"
 #include "config_terrain.h"
@@ -214,10 +215,10 @@ void add_heart_health(PlayerNumber plyr_idx,HitPoints healthdelta,TbBool warn_on
     {
         struct ObjectConfigStats* objst = get_object_model_stats(heartng->model);
         long old_health = heartng->health;
-        long long new_health = heartng->health + healthdelta;
+        int64_t new_health = heartng->health + healthdelta;
         if (new_health > objst->health)
         {
-            SCRIPTDBG(7,"Player %u's calculated heart health (%lld) is greater than maximum: %d", heartng->owner, new_health, objst->health);
+            SCRIPTDBG(7,"Player %u's calculated heart health (%" PRId64 ") is greater than maximum: %d", heartng->owner, new_health, objst->health);
             new_health = objst->health;
         }
         heartng->health = new_health;

--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -1481,7 +1481,6 @@ static int lua_Set_computer_process(lua_State *L)
     long config_value_3 = luaL_checkinteger(L,5);
     long config_value_4 = luaL_checkinteger(L,6);
     long config_value_5 = luaL_checkinteger(L,7);
-    long n = 0;
     for (long i = player_range.start_idx; i < player_range.end_idx; i++)
     {
         struct Computer2* comp = get_computer_player(i);
@@ -1500,7 +1499,6 @@ static int lua_Set_computer_process(lua_State *L)
                 cproc->process_configuration_value_3 = config_value_3;
                 cproc->process_configuration_value_4 = config_value_4;
                 cproc->process_configuration_value_5 = config_value_5;
-                n++;
             }
         }
     }
@@ -1517,7 +1515,6 @@ static int lua_Set_computer_checks(lua_State *L)
     long tertiary_parameter = luaL_checkinteger(L,6);
     long last_run_turn = luaL_checkinteger(L,7);
 
-    long n = 0;
     for (long i = player_range.start_idx; i < player_range.end_idx; i++)
     {
         struct Computer2* comp = get_computer_player(i);
@@ -1536,7 +1533,6 @@ static int lua_Set_computer_checks(lua_State *L)
                 ccheck->secondary_parameter = secondary_parameter;
                 ccheck->tertiary_parameter = tertiary_parameter;
                 ccheck->last_run_turn = last_run_turn;
-                n++;
             }
         }
     }
@@ -1585,7 +1581,6 @@ static int lua_Set_computer_event(lua_State *L)
     long tertiary_parameter = luaL_checkinteger(L,6);
     long last_test_gameturn = luaL_checkinteger(L,7);
 
-    long n = 0;
     for (long i = player_range.start_idx; i < player_range.end_idx; i++)
     {
         struct Computer2* comp = get_computer_player(i);
@@ -1602,7 +1597,6 @@ static int lua_Set_computer_event(lua_State *L)
                 event->secondary_parameter = secondary_parameter;
                 event->tertiary_parameter = tertiary_parameter;
                 event->last_test_gameturn = last_test_gameturn;
-                n++;
             }
         }
     }

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -12,6 +12,7 @@
  */
 /******************************************************************************/
 #include "pre_inc.h"
+#include <inttypes.h>
 #include <math.h>
 #include <string.h>
 #include "bflib_sound.h"
@@ -4891,7 +4892,7 @@ static void set_power_configuration_check(const struct ScriptLine *scline)
         DEALLOCATE_SCRIPT_VALUE
         return;
     }
-    long long number_value = 0;
+    int64_t number_value = 0;
     long k;
     switch (powervar)
     {
@@ -5127,15 +5128,15 @@ static void set_power_configuration_check(const struct ScriptLine *scline)
     {
         if ( (powervar == 5) && (value->chars[3] != -1) )
         {
-            SCRIPTDBG(7, "Toggling %s castability flag: %lld", powername, (long long)number_value);
+            SCRIPTDBG(7, "Toggling %s castability flag: %" PRId64, powername, number_value);
         }
         else if ( (powervar == 14) && (value->chars[3] != -1) )
         {
-            SCRIPTDBG(7, "Toggling %s property flag: %lld", powername, (long long)number_value);
+            SCRIPTDBG(7, "Toggling %s property flag: %" PRId64, powername, number_value);
         }
         else
         {
-            SCRIPTDBG(7, "Setting power %s property %s to %lld", powername, property, (long long)number_value);
+            SCRIPTDBG(7, "Setting power %s property %s to %" PRId64, powername, property, number_value);
         }
     }
     #endif

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5127,15 +5127,15 @@ static void set_power_configuration_check(const struct ScriptLine *scline)
     {
         if ( (powervar == 5) && (value->chars[3] != -1) )
         {
-            SCRIPTDBG(7, "Toggling %s castability flag: %I64d", powername, number_value);
+            SCRIPTDBG(7, "Toggling %s castability flag: %lld", powername, (long long)number_value);
         }
         else if ( (powervar == 14) && (value->chars[3] != -1) )
         {
-            SCRIPTDBG(7, "Toggling %s property flag: %I64d", powername, number_value);
+            SCRIPTDBG(7, "Toggling %s property flag: %lld", powername, (long long)number_value);
         }
         else
         {
-            SCRIPTDBG(7, "Setting power %s property %s to %I64d", powername, property, number_value);
+            SCRIPTDBG(7, "Setting power %s property %s to %lld", powername, property, (long long)number_value);
         }
     }
     #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3934,10 +3934,9 @@ static TbBool wait_at_frontend(void)
 
 void game_loop(void)
 {
-    unsigned long total_play_turns;
-    unsigned long playtime;
-    playtime = 0;
-    total_play_turns = 0;
+#if (BFDEBUG_LEVEL > 0)
+    unsigned long playtime = 0;
+#endif
     SYNCDBG(0,"Entering gameplay loop.");
 
     while ( !exit_keeper )
@@ -3990,7 +3989,9 @@ void game_loop(void)
       LbMouseSetPosition(mspos_x_bak, mspos_y_bak);
 
       unsigned long starttime;
+#if (BFDEBUG_LEVEL > 0)
       unsigned long endtime;
+#endif
       struct Dungeon *dungeon;
       // get_my_dungeon() can't be used here because players are not initialized yet
       dungeon = get_dungeon(my_player_number);
@@ -4026,13 +4027,16 @@ void game_loop(void)
       // Reset sounds back to the fxdata baseline so the main menu (and any
       // subsequent campaign/freeplay selection) hears unmodified defaults.
       sound_reset_to_fxdata_baseline();
+#if (BFDEBUG_LEVEL > 0)
       endtime = LbTimerClock();
+#endif
       quit_game = 0;
       if ((game.operation_flags & GOF_SingleLevel) != 0)
           exit_keeper=true;
+#if (BFDEBUG_LEVEL > 0)
       playtime += endtime-starttime;
+#endif
       SYNCDBG(0,"Play time is %lu seconds",playtime>>10);
-      total_play_turns += get_gameturn();
       reset_eye_lenses();
       close_packet_file();
       game.packet_load_enable = false;

--- a/src/player_compevents.c
+++ b/src/player_compevents.c
@@ -726,8 +726,6 @@ long computer_event_save_tortured(struct Computer2* comp, struct ComputerEvent* 
         }
     }
 
-    unsigned long moved = 0;
-    unsigned long slapped = 0;
     struct Dungeon* victdungeon;
     for (int j = 0; j < DUNGEONS_COUNT; j++)
     {
@@ -773,7 +771,6 @@ long computer_event_save_tortured(struct Computer2* comp, struct ComputerEvent* 
                     {
                         if (try_game_action(comp, dungeon->owner, GA_UsePwrSlap, 0, 0, 0, creatng->index, 0) > Lb_OK)
                         {
-                            slapped++;
                             continue;
                         }
 
@@ -791,10 +788,7 @@ long computer_event_save_tortured(struct Computer2* comp, struct ComputerEvent* 
                 if (is_task_in_progress_using_hand(comp)) {
                     return CTaskRet_Unk4;
                 }
-                if (create_task_move_creature_to_subtile(comp, creatng, destroom->central_stl_x, destroom->central_stl_y, CrSt_CreatureInPrison))
-                {
-                    moved++;
-                }
+                create_task_move_creature_to_subtile(comp, creatng, destroom->central_stl_x, destroom->central_stl_y, CrSt_CreatureInPrison);
             }
         }
     }


### PR DESCRIPTION
The site still says **"For Linux — coming soon…"** over on https://keeperfx.net/ — maybe it's about time to light that button up? I'd love to help get there. 🙂

This first PR is the foundation: build fixes. It makes the existing native Linux target (`make -f linux.mk`) actually build on a modern toolchain. `linux.mk` compiles with `-Wall -Wextra -Werror`, and recent GCC (15, on Arch and current Fedora) is stricter than the i686-mingw toolchain CI uses, so the native build currently fails on warnings the Windows build never surfaces — which is exactly what #4489 runs into.

<details>
<summary>What this PR actually changes — the build fixes</summary>

All warnings are fixed at the source; **nothing is suppressed and `-Werror` stays on**:

- **-Wunused-but-set-variable** — removed dead counters that were set but never read; the few used only for debug logging are kept behind `#if (BFDEBUG_LEVEL > 0)` (matching the existing convention).
- **-Wdiscarded-qualifiers** — `strchr`/`strrchr` results kept in `const` pointers, or the mutable copy taken from the non-const buffer instead.
- **-Wformat** — the MSVC-only `%I64d` modifier replaced with portable `%lld` + a `(long long)` cast.
- **Parallel build race** — sources including downloaded dependency headers (e.g. `<enet6/enet.h>`) now carry an order-only prerequisite, so `make -jN` no longer fails on the first run.
- **Fedora ffmpeg include** — added `pkg-config --cflags-only-I libavformat` to `KFX_INCLUDES` (a no-op on Arch/Debian). Found by @torndar in #4489.

After this, `make -f linux.mk -j` builds cleanly with `-Werror` on GCC 15, and the Fedora include is sorted. It also hardens the existing `build-prototype-linux` CI job against newer compilers.
</details>

---

### Scope & follow-up PR

The second PR — the rest of the Linux tooling — is already done in my fork, and Linux gamers can test it today:

- 📦 Portable AppImage (built by GitHub Actions): https://github.com/DoubyCz/keeperfx/releases/tag/appimage-v1.3.2-2
- 🅰️ Arch AUR package: https://aur.archlinux.org/packages/keeperfx-git

If you're open to it, I'll send the rest upstream as **a separate, focused follow-up PR** so it can be reviewed on its own (the portable AppImage build + CI workflow, plus the first-run GUI that asks where your original game data is). My hope is to land all of this upstream so I can retire my fork and let the main repo be the home for Linux too.

<img width="1151" height="270" alt="image" src="https://github.com/user-attachments/assets/89583cf3-c904-4c4a-a5a8-d9fce6fc3add" />

