### PR TITLE
Fix SDL library targets for compilation

### DIFF
--- a/libexterns.mk
+++ b/libexterns.mk
@@ -68,14 +68,14 @@ endif
 
 ifneq (,$(findstring .tar.gz,$(SDL_NET_PACKAGE)))
 
-libsdlnet: sdl/lib/libSDL2_net.lib
+libsdlnet: sdl/lib/libSDL2_net.dll.a
 
-sdl/lib/libSDL2_net.lib: sdl/$(SDL_NET_PACKAGE)
+sdl/lib/libSDL2_net.dll.a: sdl/$(SDL_NET_PACKAGE)
 	-$(ECHO) 'Extracting package: $<'
 	$(MKDIR) sdl/lib sdl/include/SDL2
 	cd "$(<D)"; \
 	tar -xzf "$(<F)"
-	$(MV) sdl/SDL2_net-*/$(ARCH)/include/SDL2/* sdl/include/SDL2/
+	$(CP) sdl/SDL2_net-*/$(ARCH)/include/SDL2/* sdl/include/SDL2/
 	$(CP) -r sdl/SDL2_net-*/$(ARCH)/lib/* sdl/lib/
 	$(CP) sdl/SDL2_net-*/$(ARCH)/bin/SDL2_net.dll sdl/for_final_package/
 	-$(ECHO) 'Finished extracting: $<'
@@ -119,14 +119,14 @@ endif
 
 ifneq (,$(findstring .tar.gz,$(SDL_MIXER_PACKAGE)))
 
-libsdlmixer: sdl/lib/libSDL2_mixer.lib
+libsdlmixer: sdl/lib/libSDL2_mixer.dll.a
 
-sdl/lib/libSDL2_mixer.lib: sdl/$(SDL_MIXER_PACKAGE)
+sdl/lib/libSDL2_mixer.dll.a: sdl/$(SDL_MIXER_PACKAGE)
 	-$(ECHO) 'Extracting package: $<'
 	$(MKDIR) sdl/lib sdl/include/SDL2
 	cd "$(<D)"; \
 	tar -xzf "$(<F)"
-	$(MV) sdl/SDL2_mixer-*/$(ARCH)/include/SDL2/* sdl/include/SDL2/
+	$(CP) sdl/SDL2_mixer-*/$(ARCH)/include/SDL2/* sdl/include/SDL2/
 	$(CP) -r sdl/SDL2_mixer-*/$(ARCH)/lib/* sdl/lib/
 	$(CP) sdl/SDL2_mixer-*/$(ARCH)/bin/SDL2_mixer.dll sdl/for_final_package/
 	-$(ECHO) 'Finished extracting: $<'
@@ -170,14 +170,14 @@ endif
 
 ifneq (,$(findstring .tar.gz,$(SDL_IMAGE_PACKAGE)))
 
-libsdlimage: sdl/lib/libSDL2_image.lib
+libsdlimage: sdl/lib/libSDL2_image.dll.a
 
-sdl/lib/libSDL2_image.lib: sdl/$(SDL_IMAGE_PACKAGE)
+sdl/lib/libSDL2_image.dll.a: sdl/$(SDL_IMAGE_PACKAGE)
 	-$(ECHO) 'Extracting package: $<'
 	$(MKDIR) sdl/lib sdl/include/SDL2
 	cd "$(<D)"; \
 	tar -xzf "$(<F)"
-	$(MV) sdl/SDL2_image-*/$(ARCH)/include/SDL2/* sdl/include/SDL2/
+	$(CP) sdl/SDL2_image-*/$(ARCH)/include/SDL2/* sdl/include/SDL2/
 	$(CP) -r sdl/SDL2_image-*/$(ARCH)/lib/* sdl/lib/
 	$(CP) sdl/SDL2_image-*/$(ARCH)/bin/SDL2_image.dll sdl/for_final_package/
 	-$(ECHO) 'Finished extracting: $<'


### PR DESCRIPTION
Uses the correct SDL import library files when compiling.

This issue is kinda vague but I get compilation issues every now and then and it's very surprising to me that others haven't. I haven't got an error on hand right now, if I can reproduce it I'll provide more info then.