### PR TITLE
Remove unused Name fields

### DIFF
--- a/campgns/ami2019_crtr/archer.cfg
+++ b/campgns/ami2019_crtr/archer.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = ARCHER
-
 [experience]
 Powers = SWING_WEAPON_FIST FIRE_ARROW NULL NAVIGATING_MISSILE NULL SPEED NULL SLOW NULL NULL
 PowersLevelRequired = 1 1 0 4 0 6 0 8 0 0

--- a/campgns/ami2019_crtr/avatar.cfg
+++ b/campgns/ami2019_crtr/avatar.cfg
@@ -1,5 +1,4 @@
 [attributes]
-Name = AVATAR
 Defence = 110
 ThingSize = 256 512
 Properties = BLEEDS HUMANOID_SKELETON IMMUNE_TO_BOULDER LORD NO_STEAL_HERO

--- a/campgns/ami2019_crtr/druid.cfg
+++ b/campgns/ami2019_crtr/druid.cfg
@@ -1,6 +1,3 @@
-[attributes]
-Name = DRUID
-
 [annoyance]
 GoingPostal = 100
 

--- a/campgns/ami2019_crtr/horny.cfg
+++ b/campgns/ami2019_crtr/horny.cfg
@@ -1,3 +1,2 @@
 [attributes]
-Name = HORNY
 Defence = 70

--- a/campgns/ami2019_crtr/imp.cfg
+++ b/campgns/ami2019_crtr/imp.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = IMP
 Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK
 
 [appearance]

--- a/campgns/ami2019_crtr/knight.cfg
+++ b/campgns/ami2019_crtr/knight.cfg
@@ -1,4 +1,3 @@
 [attributes]
-Name = KNIGHT
 Defence = 30
 Properties = BLEEDS HUMANOID_SKELETON NO_STEAL_HERO

--- a/campgns/ami2019_crtr/samurai.cfg
+++ b/campgns/ami2019_crtr/samurai.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SAMURAI
 Properties = BLEEDS HUMANOID_SKELETON
 
 [experience]

--- a/campgns/ami2019_crtr/sorceror.cfg
+++ b/campgns/ami2019_crtr/sorceror.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SORCEROR
 Health = 375
 
 [experience]

--- a/campgns/ami2019_crtr/tentacle.cfg
+++ b/campgns/ami2019_crtr/tentacle.cfg
@@ -1,7 +1,4 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = TENTACLE
-
 [experience]
 SleepExperience = WATER 600

--- a/campgns/ami2019_crtr/troll.cfg
+++ b/campgns/ami2019_crtr/troll.cfg
@@ -1,3 +1,2 @@
 [attributes]
-Name = TROLL
 Defence = 50

--- a/campgns/ami2019_crtr/tunneller.cfg
+++ b/campgns/ami2019_crtr/tunneller.cfg
@@ -1,5 +1,4 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = TUNNELLER
 GoldHold = 500

--- a/campgns/ami2019_crtr/vampire.cfg
+++ b/campgns/ami2019_crtr/vampire.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = VAMPIRE
-
 [experience]
 Powers = SWING_WEAPON_FIST FLY SLOW TELEPORT HEAL DRAIN POISON_CLOUD ARMOUR WIND WORD_OF_POWER
 PowersLevelRequired = 1 2 3 4 5 6 6 7 8 10

--- a/campgns/ami2019_crtr/witch.cfg
+++ b/campgns/ami2019_crtr/witch.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = WITCH
 Health = 350
 
 [experience]

--- a/campgns/ami2019_crtr/wizard.cfg
+++ b/campgns/ami2019_crtr/wizard.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = WIZARD
 Properties = BLEEDS HUMANOID_SKELETON
 
 [experience]

--- a/campgns/dzjr06lv_crtr/archer.cfg
+++ b/campgns/dzjr06lv_crtr/archer.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = ARCHER
 FearStronger = 0
 FearsomeFactor = 100
 Pay = 75

--- a/campgns/dzjr06lv_crtr/avatar.cfg
+++ b/campgns/dzjr06lv_crtr/avatar.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = AVATAR
 Health = 2000
 Strength = 140
 Dexterity = 180

--- a/campgns/dzjr06lv_crtr/barbarian.cfg
+++ b/campgns/dzjr06lv_crtr/barbarian.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = BARBARIAN
 Armour = 80
 FearStronger = 0
 FearsomeFactor = 100

--- a/campgns/dzjr06lv_crtr/bile_demon.cfg
+++ b/campgns/dzjr06lv_crtr/bile_demon.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = BILE_DEMON
 Health = 2200
 FearStronger = 0
 FearsomeFactor = 100

--- a/campgns/dzjr06lv_crtr/bug.cfg
+++ b/campgns/dzjr06lv_crtr/bug.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = BUG
 Strength = 15
 Armour = 80
 FearStronger = 0

--- a/campgns/dzjr06lv_crtr/dark_mistress.cfg
+++ b/campgns/dzjr06lv_crtr/dark_mistress.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = DARK_MISTRESS
 Health = 650
 Strength = 35
 Armour = 60

--- a/campgns/dzjr06lv_crtr/demonspawn.cfg
+++ b/campgns/dzjr06lv_crtr/demonspawn.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = DEMONSPAWN
 Health = 350
 FearWounded = 36
 FearStronger = 0

--- a/campgns/dzjr06lv_crtr/dragon.cfg
+++ b/campgns/dzjr06lv_crtr/dragon.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = DRAGON
 Health = 700
 HealThreshold = 200
 Armour = 70

--- a/campgns/dzjr06lv_crtr/dwarfa.cfg
+++ b/campgns/dzjr06lv_crtr/dwarfa.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = DWARFA
 Strength = 30
 Dexterity = 40
 FearStronger = 0

--- a/campgns/dzjr06lv_crtr/fairy.cfg
+++ b/campgns/dzjr06lv_crtr/fairy.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = FAIRY
 Health = 200
 HealThreshold = 255
 FearStronger = 0

--- a/campgns/dzjr06lv_crtr/fly.cfg
+++ b/campgns/dzjr06lv_crtr/fly.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = FLY
 Health = 200
 Armour = 20
 Dexterity = 60

--- a/campgns/dzjr06lv_crtr/ghost.cfg
+++ b/campgns/dzjr06lv_crtr/ghost.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = GHOST
 Health = 30
 Strength = 0
 Armour = 0

--- a/campgns/dzjr06lv_crtr/giant.cfg
+++ b/campgns/dzjr06lv_crtr/giant.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = GIANT
 Strength = 120
 Armour = 40
 FearStronger = 0

--- a/campgns/dzjr06lv_crtr/hell_hound.cfg
+++ b/campgns/dzjr06lv_crtr/hell_hound.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = HELL_HOUND
 Health = 550
 Strength = 35
 Armour = 50

--- a/campgns/dzjr06lv_crtr/horny.cfg
+++ b/campgns/dzjr06lv_crtr/horny.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = HORNY
 Health = 1600
 Strength = 120
 Armour = 100

--- a/campgns/dzjr06lv_crtr/imp.cfg
+++ b/campgns/dzjr06lv_crtr/imp.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = IMP
 FearStronger = 0
 DamageToBoulder = 20
 Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK

--- a/campgns/dzjr06lv_crtr/knight.cfg
+++ b/campgns/dzjr06lv_crtr/knight.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = KNIGHT
 Health = 1100
 HealThreshold = 150
 Armour = 120

--- a/campgns/dzjr06lv_crtr/monk.cfg
+++ b/campgns/dzjr06lv_crtr/monk.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = MONK
 Health = 700
 HealRequirement = 150
 HealThreshold = 200

--- a/campgns/dzjr06lv_crtr/orc.cfg
+++ b/campgns/dzjr06lv_crtr/orc.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = ORC
 Health = 600
 Strength = 80
 Armour = 50

--- a/campgns/dzjr06lv_crtr/samurai.cfg
+++ b/campgns/dzjr06lv_crtr/samurai.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = SAMURAI
 Health = 900
 FearStronger = 0
 FearsomeFactor = 100

--- a/campgns/dzjr06lv_crtr/skeleton.cfg
+++ b/campgns/dzjr06lv_crtr/skeleton.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = SKELETON
 Health = 300
 Strength = 45
 Armour = 10

--- a/campgns/dzjr06lv_crtr/sorceror.cfg
+++ b/campgns/dzjr06lv_crtr/sorceror.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = SORCEROR
 HealThreshold = 255
 Armour = 10
 Dexterity = 60

--- a/campgns/dzjr06lv_crtr/spider.cfg
+++ b/campgns/dzjr06lv_crtr/spider.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = SPIDER
 Health = 550
 Strength = 25
 Armour = 70

--- a/campgns/dzjr06lv_crtr/tentacle.cfg
+++ b/campgns/dzjr06lv_crtr/tentacle.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = TENTACLE
 Strength = 65
 Armour = 30
 Dexterity = 70

--- a/campgns/dzjr06lv_crtr/thief.cfg
+++ b/campgns/dzjr06lv_crtr/thief.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = THIEF
 FearStronger = 0
 Defence = 80
 Pay = 72

--- a/campgns/dzjr06lv_crtr/troll.cfg
+++ b/campgns/dzjr06lv_crtr/troll.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = TROLL
 Health = 400
 Strength = 30
 Armour = 75

--- a/campgns/dzjr06lv_crtr/tunneller.cfg
+++ b/campgns/dzjr06lv_crtr/tunneller.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = TUNNELLER
 Health = 600
 Strength = 30
 Armour = 40

--- a/campgns/dzjr06lv_crtr/vampire.cfg
+++ b/campgns/dzjr06lv_crtr/vampire.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = VAMPIRE
 Health = 900
 HealThreshold = 200
 Strength = 90

--- a/campgns/dzjr06lv_crtr/witch.cfg
+++ b/campgns/dzjr06lv_crtr/witch.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = WITCH
 Health = 400
 FearStronger = 0
 FearsomeFactor = 100

--- a/campgns/dzjr06lv_crtr/wizard.cfg
+++ b/campgns/dzjr06lv_crtr/wizard.cfg
@@ -3,7 +3,6 @@
 ; Values and sections which are not here will be left at default.
 
 [attributes]
-Name = WIZARD
 Health = 500
 HealThreshold = 255
 FearStronger = 0

--- a/campgns/lqizgood_crtr/archer.cfg
+++ b/campgns/lqizgood_crtr/archer.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = ARCHER
-
 [attraction]
 EntranceRoom = WORKSHOP NULL NULL
 RoomSlabsRequired = 1 0 0

--- a/campgns/lqizgood_crtr/avatar.cfg
+++ b/campgns/lqizgood_crtr/avatar.cfg
@@ -1,5 +1,4 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = AVATAR
 Properties = BLEEDS HUMANOID_SKELETON IMMUNE_TO_BOULDER ONE_OF_KIND NO_STEAL_HERO

--- a/campgns/lqizgood_crtr/barbarian.cfg
+++ b/campgns/lqizgood_crtr/barbarian.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = BARBARIAN
-
 [attraction]
 EntranceRoom = TRAINING NULL NULL
 RoomSlabsRequired = 1 0 0

--- a/campgns/lqizgood_crtr/dwarfa.cfg
+++ b/campgns/lqizgood_crtr/dwarfa.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = DWARFA
-
 [attraction]
 EntranceRoom = NULL NULL NULL
 RoomSlabsRequired = 0 0 0

--- a/campgns/lqizgood_crtr/fairy.cfg
+++ b/campgns/lqizgood_crtr/fairy.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = FAIRY
-
 [attraction]
 EntranceRoom = RESEARCH NULL NULL
 RoomSlabsRequired = 9 0 0

--- a/campgns/lqizgood_crtr/giant.cfg
+++ b/campgns/lqizgood_crtr/giant.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = GIANT
-
 [attraction]
 EntranceRoom = TRAINING GARDEN NULL
 RoomSlabsRequired = 25 25 0

--- a/campgns/lqizgood_crtr/imp.cfg
+++ b/campgns/lqizgood_crtr/imp.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = IMP
 Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK
 
 [appearance]

--- a/campgns/lqizgood_crtr/knight.cfg
+++ b/campgns/lqizgood_crtr/knight.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = KNIGHT
 Properties = BLEEDS HUMANOID_SKELETON NO_STEAL_HERO
 
 [attraction]

--- a/campgns/lqizgood_crtr/monk.cfg
+++ b/campgns/lqizgood_crtr/monk.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = MONK
-
 [attraction]
 EntranceRoom = TEMPLE GRAVEYARD NULL
 RoomSlabsRequired = 9 1 0

--- a/campgns/lqizgood_crtr/samurai.cfg
+++ b/campgns/lqizgood_crtr/samurai.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SAMURAI
 Properties = BLEEDS HUMANOID_SKELETON SEE_INVISIBLE
 
 [attraction]

--- a/campgns/lqizgood_crtr/thief.cfg
+++ b/campgns/lqizgood_crtr/thief.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = THIEF
-
 [attraction]
 EntranceRoom = NULL NULL NULL
 RoomSlabsRequired = 0 0 0

--- a/campgns/lqizgood_crtr/tunneller.cfg
+++ b/campgns/lqizgood_crtr/tunneller.cfg
@@ -1,5 +1,4 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = TUNNELLER
 GoldHold = 500

--- a/campgns/lqizgood_crtr/witch.cfg
+++ b/campgns/lqizgood_crtr/witch.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = WITCH
-
 [attraction]
 EntranceRoom = SCAVENGER NULL NULL
 RoomSlabsRequired = 9 0 0

--- a/campgns/lqizgood_crtr/wizard.cfg
+++ b/campgns/lqizgood_crtr/wizard.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = WIZARD
-
 [attraction]
 EntranceRoom = RESEARCH NULL NULL
 RoomSlabsRequired = 25 0 0

--- a/campgns/twinkprs_crtr/archer.cfg
+++ b/campgns/twinkprs_crtr/archer.cfg
@@ -3,9 +3,6 @@
 ; Values and sections which are not here will be left at default.
 ; Note that it is a partial config file - do not replace global config with this file.
 
-[attributes]
-Name = ARCHER
-
 [experience]
 Powers = SWING_WEAPON_FIST FIRE_ARROW NULL NAVIGATING_MISSILE NULL SPEED NULL SLOW NULL NULL
 PowersLevelRequired = 1 1 0 4 0 6 0 8 0 0

--- a/campgns/twinkprs_crtr/ghost.cfg
+++ b/campgns/twinkprs_crtr/ghost.cfg
@@ -4,5 +4,4 @@
 ; Note that it is a partial config file - do not replace global config with this file.
 
 [attributes]
-Name = GHOST
 Properties = FLYING SEE_INVISIBLE EVIL

--- a/campgns/twinkprs_crtr/imp.cfg
+++ b/campgns/twinkprs_crtr/imp.cfg
@@ -4,7 +4,6 @@
 ; Note that it is a partial config file - do not replace global config with this file.
 
 [attributes]
-Name = IMP
 Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK
 
 [appearance]

--- a/campgns/twinkprs_crtr/samurai.cfg
+++ b/campgns/twinkprs_crtr/samurai.cfg
@@ -4,5 +4,4 @@
 ; Note that it is a partial config file - do not replace global config with this file.
 
 [attributes]
-Name = SAMURAI
 Properties = BLEEDS HUMANOID_SKELETON SEE_INVISIBLE

--- a/campgns/twinkprs_crtr/tunneller.cfg
+++ b/campgns/twinkprs_crtr/tunneller.cfg
@@ -4,5 +4,4 @@
 ; Note that it is a partial config file - do not replace global config with this file.
 
 [attributes]
-Name = TUNNELLER
 GoldHold = 500

--- a/config/creatrs/archer.cfg
+++ b/config/creatrs/archer.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = ARCHER
 NameTextID = 285
 Health = 300
 HealRequirement = 150

--- a/config/creatrs/avatar.cfg
+++ b/config/creatrs/avatar.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = AVATAR
 NameTextID = 547
 Health = 3000
 HealRequirement = 150

--- a/config/creatrs/barbarian.cfg
+++ b/config/creatrs/barbarian.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = BARBARIAN
 NameTextID = 275
 Health = 700
 HealRequirement = 150

--- a/config/creatrs/bile_demon.cfg
+++ b/config/creatrs/bile_demon.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = BILE_DEMON
 NameTextID = 273
 Health = 1200
 HealRequirement = 150

--- a/config/creatrs/bird.cfg
+++ b/config/creatrs/bird.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Model Configuration file
 
 [attributes]
-Name = BIRD
 NameTextID = 1044
 Health = 275
 HealRequirement = 0

--- a/config/creatrs/bug.cfg
+++ b/config/creatrs/bug.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = BUG
 NameTextID = 260
 Health = 250
 HealRequirement = 150

--- a/config/creatrs/dark_mistress.cfg
+++ b/config/creatrs/dark_mistress.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = DARK_MISTRESS
 NameTextID = 272
 Health = 700
 HealRequirement = 100

--- a/config/creatrs/demonspawn.cfg
+++ b/config/creatrs/demonspawn.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = DEMONSPAWN
 NameTextID = 262
 Health = 325
 HealRequirement = 150

--- a/config/creatrs/dragon.cfg
+++ b/config/creatrs/dragon.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = DRAGON
 NameTextID = 268
 Health = 900
 HealRequirement = 150

--- a/config/creatrs/druid.cfg
+++ b/config/creatrs/druid.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = DRUID
 NameTextID = 1042
 Health = 400
 HealRequirement = 150

--- a/config/creatrs/dwarfa.cfg
+++ b/config/creatrs/dwarfa.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = DWARFA
 NameTextID = 279
 Health = 500
 HealRequirement = 150

--- a/config/creatrs/fairy.cfg
+++ b/config/creatrs/fairy.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = FAIRY
 NameTextID = 258
 Health = 150
 HealRequirement = 150

--- a/config/creatrs/floating_spirit.cfg
+++ b/config/creatrs/floating_spirit.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = FLOATING_SPIRIT
 NameTextID = 201
 Health = 1
 HealRequirement = 0

--- a/config/creatrs/fly.cfg
+++ b/config/creatrs/fly.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = FLY
 NameTextID = 264
 Health = 150
 HealRequirement = 150

--- a/config/creatrs/ghost.cfg
+++ b/config/creatrs/ghost.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = GHOST
 NameTextID = 271
 Health = 200
 HealRequirement = 150

--- a/config/creatrs/giant.cfg
+++ b/config/creatrs/giant.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = GIANT
 NameTextID = 284
 Health = 650
 HealRequirement = 150

--- a/config/creatrs/hell_hound.cfg
+++ b/config/creatrs/hell_hound.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = HELL_HOUND
 NameTextID = 270
 Health = 600
 HealRequirement = 150

--- a/config/creatrs/horny.cfg
+++ b/config/creatrs/horny.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = HORNY
 NameTextID = 267
 Health = 2000
 HealRequirement = 150

--- a/config/creatrs/imp.cfg
+++ b/config/creatrs/imp.cfg
@@ -3,9 +3,6 @@
 ; These stats grow according to [experience] in creature.cfg.
 
 [attributes]
-; Name is the creature identifier which should be used in level script.
-; Note that this file name must match the name here.
-Name = IMP
 ; Language-specific name of the creature, as index in translation strings file.
 NameTextID = 259
 ; Base health a creature has at level 1. The minimum is 1, and the recommended maximum is 100000, though exceeding this is possible.

--- a/config/creatrs/knight.cfg
+++ b/config/creatrs/knight.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = KNIGHT
 NameTextID = 276
 Health = 950
 HealRequirement = 150

--- a/config/creatrs/maiden.cfg
+++ b/config/creatrs/maiden.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = MAIDEN
 NameTextID = 1045
 Health = 800
 HealRequirement = 150

--- a/config/creatrs/monk.cfg
+++ b/config/creatrs/monk.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = MONK
 NameTextID = 286
 Health = 325
 HealRequirement = 130

--- a/config/creatrs/orc.cfg
+++ b/config/creatrs/orc.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = ORC
 NameTextID = 278
 Health = 700
 HealRequirement = 150

--- a/config/creatrs/samurai.cfg
+++ b/config/creatrs/samurai.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SAMURAI
 NameTextID = 282
 Health = 700
 HealRequirement = 100

--- a/config/creatrs/skeleton.cfg
+++ b/config/creatrs/skeleton.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SKELETON
 NameTextID = 266
 Health = 500
 HealRequirement = 150

--- a/config/creatrs/sorceror.cfg
+++ b/config/creatrs/sorceror.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SORCEROR
 NameTextID = 263
 Health = 350
 HealRequirement = 150

--- a/config/creatrs/spider.cfg
+++ b/config/creatrs/spider.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SPIDER
 NameTextID = 265
 Health = 400
 HealRequirement = 150

--- a/config/creatrs/spiderling.cfg
+++ b/config/creatrs/spiderling.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SPIDERLING
 NameTextID = 1046
 Health = 200
 HealRequirement = 0

--- a/config/creatrs/tentacle.cfg
+++ b/config/creatrs/tentacle.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = TENTACLE
 NameTextID = 269
 Health = 700
 HealRequirement = 150

--- a/config/creatrs/thief.cfg
+++ b/config/creatrs/thief.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = THIEF
 NameTextID = 281
 Health = 250
 HealRequirement = 150

--- a/config/creatrs/time_mage.cfg
+++ b/config/creatrs/time_mage.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = TIME_MAGE
 NameTextID = 1043
 Health = 470
 HealRequirement = 150

--- a/config/creatrs/troll.cfg
+++ b/config/creatrs/troll.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = TROLL
 NameTextID = 261
 Health = 450
 HealRequirement = 150

--- a/config/creatrs/tunneller.cfg
+++ b/config/creatrs/tunneller.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = TUNNELLER
 NameTextID = 546
 Health = 350
 HealRequirement = 150

--- a/config/creatrs/vampire.cfg
+++ b/config/creatrs/vampire.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = VAMPIRE
 NameTextID = 274
 Health = 800
 HealRequirement = 150

--- a/config/creatrs/witch.cfg
+++ b/config/creatrs/witch.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = WITCH
 NameTextID = 283
 Health = 300
 HealRequirement = 150

--- a/config/creatrs/wizard.cfg
+++ b/config/creatrs/wizard.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = WIZARD
 NameTextID = 277
 Health = 350
 HealRequirement = 150

--- a/config/mods/tunneller_imp_swap/creatrs/imp.cfg
+++ b/config/mods/tunneller_imp_swap/creatrs/imp.cfg
@@ -1,7 +1,6 @@
 ;Imp that works the same but looks like Tunneller
 
 [attributes]
-Name = IMP
 NameTextID = 546
 LairObject = LAIR_TUNLR
 

--- a/config/mods/tunneller_imp_swap/creatrs/tunneller.cfg
+++ b/config/mods/tunneller_imp_swap/creatrs/tunneller.cfg
@@ -1,7 +1,6 @@
 ;Tunneller that works the same but looks like Imp
 
 [attributes]
-Name = TUNNELLER
 NameTextID = 259
 LairObject = LAIR_IMP
 

--- a/levels/classic_crtr/archer.cfg
+++ b/levels/classic_crtr/archer.cfg
@@ -1,8 +1,5 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
-[attributes]
-Name = ARCHER
-
 [experience]
 Powers = SWING_WEAPON_FIST FIRE_ARROW NULL NAVIGATING_MISSILE NULL SPEED NULL SLOW NULL NULL
 PowersLevelRequired = 1 1 0 4 0 6 0 8 0 0

--- a/levels/classic_crtr/dark_mistress.cfg
+++ b/levels/classic_crtr/dark_mistress.cfg
@@ -1,5 +1,4 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = DARK_MISTRESS
 Defence = 105

--- a/levels/classic_crtr/imp.cfg
+++ b/levels/classic_crtr/imp.cfg
@@ -1,7 +1,6 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = IMP
 Properties = BLEEDS SPECIAL_DIGGER EVIL NO_ENMHEART_ATTCK
 
 [appearance]

--- a/levels/classic_crtr/samurai.cfg
+++ b/levels/classic_crtr/samurai.cfg
@@ -1,5 +1,4 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = SAMURAI
 Properties = BLEEDS HUMANOID_SKELETON SEE_INVISIBLE

--- a/levels/classic_crtr/tunneller.cfg
+++ b/levels/classic_crtr/tunneller.cfg
@@ -1,5 +1,4 @@
 ; KeeperFX Creature Kind Configuration file version 1.0.
 
 [attributes]
-Name = TUNNELLER
 GoldHold = 500

--- a/levels/legacy_crtr/archer.cfg
+++ b/levels/legacy_crtr/archer.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = ARCHER
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 60

--- a/levels/legacy_crtr/avatar.cfg
+++ b/levels/legacy_crtr/avatar.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = AVATAR
 Dexterity = 180
 FearWounded = 0
 Defence = 110

--- a/levels/legacy_crtr/barbarian.cfg
+++ b/levels/legacy_crtr/barbarian.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = BARBARIAN
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 60

--- a/levels/legacy_crtr/bile_demon.cfg
+++ b/levels/legacy_crtr/bile_demon.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = BILE_DEMON
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 30

--- a/levels/legacy_crtr/bug.cfg
+++ b/levels/legacy_crtr/bug.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = BUG
 FearStronger = 0
 Defence = 40
 Luck = 1

--- a/levels/legacy_crtr/dark_mistress.cfg
+++ b/levels/legacy_crtr/dark_mistress.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = DARK_MISTRESS
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 70

--- a/levels/legacy_crtr/demonspawn.cfg
+++ b/levels/legacy_crtr/demonspawn.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = DEMONSPAWN
 FearStronger = 0
 Defence = 50
 Luck = 8

--- a/levels/legacy_crtr/dragon.cfg
+++ b/levels/legacy_crtr/dragon.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = DRAGON
 HealRequirement = 150
 Armour = 90
 FearStronger = 0

--- a/levels/legacy_crtr/dwarfa.cfg
+++ b/levels/legacy_crtr/dwarfa.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = DWARFA
 FearStronger = 0
 Defence = 30
 Luck = 1

--- a/levels/legacy_crtr/fairy.cfg
+++ b/levels/legacy_crtr/fairy.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = FAIRY
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 30

--- a/levels/legacy_crtr/fly.cfg
+++ b/levels/legacy_crtr/fly.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = FLY
 FearStronger = 0
 Defence = 30
 Luck = 6

--- a/levels/legacy_crtr/ghost.cfg
+++ b/levels/legacy_crtr/ghost.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = GHOST
 FearStronger = 0
 Defence = 60
 Luck = 4

--- a/levels/legacy_crtr/giant.cfg
+++ b/levels/legacy_crtr/giant.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = GIANT
 FearStronger = 0
 Defence = 30
 Luck = 8

--- a/levels/legacy_crtr/hell_hound.cfg
+++ b/levels/legacy_crtr/hell_hound.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = HELL_HOUND
 FearStronger = 0
 Defence = 50
 Luck = 3

--- a/levels/legacy_crtr/horny.cfg
+++ b/levels/legacy_crtr/horny.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = HORNY
 Strength = 150
 Dexterity = 160
 FearWounded = 0

--- a/levels/legacy_crtr/imp.cfg
+++ b/levels/legacy_crtr/imp.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = IMP
 FearStronger = 0
 Defence = 5
 ; Luck values in legacy are 2.55 times higher than in the original game. KeeperFX has luck as a percentage, DK1 as a x/255 ratio.

--- a/levels/legacy_crtr/knight.cfg
+++ b/levels/legacy_crtr/knight.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = KNIGHT
 FearWounded = 0
 Defence = 30
 Luck = 6

--- a/levels/legacy_crtr/monk.cfg
+++ b/levels/legacy_crtr/monk.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = MONK
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 80

--- a/levels/legacy_crtr/orc.cfg
+++ b/levels/legacy_crtr/orc.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = ORC
 FearWounded = 4
 FearStronger = 0
 Defence = 65

--- a/levels/legacy_crtr/samurai.cfg
+++ b/levels/legacy_crtr/samurai.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = SAMURAI
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 70

--- a/levels/legacy_crtr/skeleton.cfg
+++ b/levels/legacy_crtr/skeleton.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = SKELETON
 Defence = 50
 Luck = 1
 ; In the original game, you could force-feed creatures even if they did not have any needs for eating. Setting HungerFill to 1 while HungerRate is set to 0 enables this mechanic.

--- a/levels/legacy_crtr/sorceror.cfg
+++ b/levels/legacy_crtr/sorceror.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = SORCEROR
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 30

--- a/levels/legacy_crtr/spider.cfg
+++ b/levels/legacy_crtr/spider.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = SPIDER
 FearStronger = 0
 Defence = 50
 Luck = 1

--- a/levels/legacy_crtr/tentacle.cfg
+++ b/levels/legacy_crtr/tentacle.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = TENTACLE
 FearStronger = 0
 Defence = 50
 Luck = 1

--- a/levels/legacy_crtr/thief.cfg
+++ b/levels/legacy_crtr/thief.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = THIEF
 FearStronger = 0
 Defence = 80
 Luck = 5

--- a/levels/legacy_crtr/troll.cfg
+++ b/levels/legacy_crtr/troll.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = TROLL
 FearStronger = 0
 Defence = 50
 Luck = 4

--- a/levels/legacy_crtr/tunneller.cfg
+++ b/levels/legacy_crtr/tunneller.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = TUNNELLER
 FearStronger = 0
 Defence = 40
 GoldHold = 500

--- a/levels/legacy_crtr/vampire.cfg
+++ b/levels/legacy_crtr/vampire.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = VAMPIRE
 Defence = 80
 Luck = 10
 DamageToBoulder = 20

--- a/levels/legacy_crtr/witch.cfg
+++ b/levels/legacy_crtr/witch.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = WITCH
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 30

--- a/levels/legacy_crtr/wizard.cfg
+++ b/levels/legacy_crtr/wizard.cfg
@@ -3,7 +3,6 @@
 ; Note that it is partial config file - do not replace global config with this file.
 
 [attributes]
-Name = WIZARD
 FearStronger = 0
 FearsomeFactor = 100
 Defence = 30

--- a/src/config_crtrmodel.c
+++ b/src/config_crtrmodel.c
@@ -55,7 +55,7 @@ extern "C" {
 /******************************************************************************/
 
 const struct NamedCommand creatmodel_attributes_commands[] = {
-  {"NAME",                1},
+  {"NAME",                1}, // Deprecated entry kept to avoid noisy errors from old configs and scripts.
   {"HEALTH",              2},
   {"HEALREQUIREMENT",     3},
   {"HEALTHRESHOLD",       4},
@@ -284,7 +284,7 @@ TbBool parse_creaturemodel_attributes_blocks(long crtr_model,char *buf,long len,
       switch (cmd_num)
       {
       case 1: // NAME
-          // Name is ignored - it was defined in creature.cfg
+          // Name is ignored - it is defined in creature.cfg
           break;
       case 2: // HEALTH
           if (get_conf_parameter_single(buf,&pos,len,word_buf,sizeof(word_buf)) > 0)


### PR DESCRIPTION
`Name` field isn't used by KeeperFX, only `NameTextID` is.

The reason to remove it is it's misleading, it's a source of confusion with mapmakers thinking it does things that it doesn't, and it could even be a source of bugs if you insert the `Name` into the `Creatures =` field in `creature.cfg` while your `Name` field differs from your `filename.cfg`