### PR TITLE
Multiplayer: keep lobbies alive after going to landview screen

### DIFF
--- a/src/front_landview_multiplayer.c
+++ b/src/front_landview_multiplayer.c
@@ -529,7 +529,7 @@ static LevelNumber frontnetmap_update_players(void)
             return SINGLEPLAYER_NOTSTARTED;
         }
         if (nspck->action_par1 == LEVELNUMBER_ERROR) {
-            if (fe_network_active) {
+            if (network_is_active()) {
                 if (LbNetwork_EnableNewPlayers(1)) {
                     ERRORLOG("Unable to enable new players joining exchange");
                 }

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -47,7 +47,6 @@
 #include "net_matchmaking.h"
 #include "net_lan.h"
 #include "net_input_lag.h"
-#include "bflib_enet.h"
 #include "config_campaigns.h"
 #include "post_inc.h"
 
@@ -643,9 +642,6 @@ void frontnet_start_update(void)
     frontnet_rewite_net_messages();
 
     LbNetwork_UpdateInputLagIfHost();
-    if (frontnet_service_selected(FrontendNetSvc_Online)) {
-        enet_matchmaking_host_update();
-    }
     if (frontnet_service_selected(FrontendNetSvc_LAN)) {
         lan_host_update();
     }

--- a/src/net_lobby.c
+++ b/src/net_lobby.c
@@ -219,6 +219,9 @@ TbError LbNetwork_ExchangeLogin(char *player_name)
 
 TbError LbNetwork_ExchangeFrontend(void *send_buf, void *server_buf, size_t frame_size)
 {
+    if ((my_player_number == get_host_player_id()) && frontnet_service_selected(FrontendNetSvc_Online)) {
+        enet_matchmaking_host_update();
+    }
     return exchange_frame_block(NETMSG_FRONTEND, send_buf, server_buf, frame_size);
 }
 


### PR DESCRIPTION
I thought it already operated this way, but apparently it needed some fixing.
The server-side fix has already been uploaded, it now only kills lobbies after 3 failed pings (5 seconds apart) instead of on the first failed ping.