### PR TITLE
Multiplayer: Close lobbies faster

### DIFF
--- a/src/net_game.c
+++ b/src/net_game.c
@@ -289,6 +289,7 @@ void setup_count_players(void)
 TbBool init_players_network_game(void)
 {
     SYNCDBG(4,"Starting");
+    TbBool initialized = true;
     setup_network_player_numbers();
     for (int zip_idx = 0; zip_idx < REQUIRED_SPRITE_ZIP_COUNT; zip_idx++) {
         if (required_sprite_zip_checksums[zip_idx] != 0) {
@@ -297,10 +298,17 @@ TbBool init_players_network_game(void)
         WARNLOG("Required custom sprite zip missing: %s", required_sprite_zips[zip_idx]);
         message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s missing", required_sprite_zips[zip_idx]);
         create_frontend_error_box(5000, get_string(GUIStr_NetVerifyFxdataSame));
-        return false;
+        initialized = false;
+        break;
     }
-    build_local_startup_sync();
-    return net_startup_sync_exchange_and_apply();
+    if (netstate.my_id == SERVER_ID && frontnet_service_selected(FrontendNetSvc_Online)) {
+        matchmaking_close_lobby();
+    }
+    if (initialized) {
+        build_local_startup_sync();
+        initialized = net_startup_sync_exchange_and_apply();
+    }
+    return initialized;
 }
 
 void are_disconnect_victories_allowed(void)

--- a/src/net_matchmaking.c
+++ b/src/net_matchmaking.c
@@ -323,9 +323,12 @@ static int matchmaking_connect_thread(void *)
 
 void matchmaking_connect_async(void)
 {
+    matchmaking_init();
     if (SDL_AtomicCAS(&connect_thread_active, 0, 1) == SDL_FALSE)
         return;
-    matchmaking_init();
+    SDL_LockMutex(mutex);
+    connect_gave_up = 0;
+    SDL_UnlockMutex(mutex);
     resolve_public_ips_async();
     SDL_Thread *thread = SDL_CreateThread(matchmaking_connect_thread, "matchmaking", NULL);
     if (thread) {
@@ -368,23 +371,44 @@ int matchmaking_connect(void)
 
 void matchmaking_disconnect(void)
 {
+    if (mutex == NULL) {
+        return;
+    }
     Uint32 wait_deadline = SDL_GetTicks() + CONNECT_TIMEOUT_MS * 3;
     while (SDL_AtomicGet(&connect_thread_active) && SDL_GetTicks() < wait_deadline) {
         SDL_Delay(10);
     }
     wait_for_public_ip_resolution();
+    matchmaking_close_lobby();
     SDL_LockMutex(mutex);
     connect_gave_up = 0;
     SDL_AtomicSet(&ips_resolved, 0);
+    if (curl_handle) {
+        websocket_cleanup();
+        LbNetLog("Matchmaking: disconnected\n");
+    }
+    SDL_UnlockMutex(mutex);
+}
+
+void matchmaking_close_lobby(void)
+{
+    if (mutex == NULL) {
+        return;
+    }
+    SDL_LockMutex(mutex);
+    connect_gave_up = 1;
     if (curl_handle) {
         if (hosted_lobby_id[0] != '\0') {
             char delete_message[SEND_BUFFER_SIZE];
             snprintf(delete_message, sizeof(delete_message), "{\"action\":\"delete\",\"id\":\"%s\"}", hosted_lobby_id);
             websocket_send(delete_message);
         }
-        websocket_cleanup();
-        LbNetLog("Matchmaking: disconnected\n");
+        if (curl_handle) {
+            websocket_cleanup();
+        }
     }
+    hosted_lobby_id[0] = '\0';
+    lan_set_lobby_id("");
     SDL_UnlockMutex(mutex);
 }
 
@@ -433,6 +457,10 @@ int matchmaking_create(const char *name, int udp_ipv4_port, int udp_ipv6_port)
     SDL_LockMutex(mutex);
     if (!curl_handle) {
         LbNetLog("Matchmaking: not connected to server, lobby won't be listed online\n");
+        SDL_UnlockMutex(mutex);
+        return -1;
+    }
+    if (connect_gave_up) {
         SDL_UnlockMutex(mutex);
         return -1;
     }

--- a/src/net_matchmaking.h
+++ b/src/net_matchmaking.h
@@ -48,6 +48,7 @@ void matchmaking_connect_async(void);
 int matchmaking_connect(void);
 int matchmaking_request_list(void);
 void matchmaking_disconnect(void);
+void matchmaking_close_lobby(void);
 void matchmaking_refresh_sessions(void);
 int matchmaking_create(const char *name, int udp_ipv4_port, int udp_ipv6_port);
 int matchmaking_punch(const char *lobby_id, int udp_ipv4_port, int udp_ipv6_port, PunchAddresses *output);


### PR DESCRIPTION
Until now with closing lobbies I've been relying on a single ping failure from the master server to the host. It was simply:
1. a player requests the lobby list
2. the master server pings all the lobby hosts
3. if they fail to respond then those lobbies are removed from the master server
4. so the player who requested the lobby list will correctly not see those (ghost) lobbies

However, with recent reports of some players' lobbies disappearing after 10 minutes it's become obvious that a single ping failure is a bad idea because of packetloss. So I changed it to 3 pings, 5 seconds apart. But now this means it takes ~15 seconds for a dead lobby to actually be removed after you request the lobby list. So this PR makes it so when the host starts their game, they will send a "delete lobby" request to the master server.