### PR TITLE
Small safety fixes: RNC header bounds, hand-rule guards, multi-monitor frontend

### DIFF
--- a/src/bflib_dernc.c
+++ b/src/bflib_dernc.c
@@ -459,6 +459,9 @@ long LbFileLengthRnc(const char *fname)
 
 long UnpackM1(void * buffer, ulong bufsize)
 {
+    // Guard against reading past a buffer too small to even hold the header
+    if (bufsize < sizeof(rnc_header))
+        return 0;
     long retcode;
     rnc_header header;
     memcpy(&header, buffer, sizeof(header));

--- a/src/bflib_video.c
+++ b/src/bflib_video.c
@@ -339,6 +339,30 @@ unsigned short LbGetCurrentDisplayIndex()
             ERRORLOG("SDL_GetWindowDisplayIndex failed: %s", SDL_GetError());
         }
     }
+    else
+    {
+        // No game window exists yet (e.g. the startup splash/legal screens). The window
+        // has not been placed on a monitor, so we can't ask SDL where it is. On Wayland the
+        // compositor decides the monitor - usually the one under the mouse cursor (where the
+        // user launched the game). Pick the display containing the cursor so the splash and
+        // frontend resolution match the monitor the window will actually open on, instead of
+        // defaulting to display 0 which may be a differently-sized monitor.
+        int mouse_x = 0, mouse_y = 0;
+        SDL_GetGlobalMouseState(&mouse_x, &mouse_y);
+        int num_displays = SDL_GetNumVideoDisplays();
+        for (int d = 0; d < num_displays; d++)
+        {
+            SDL_Rect bounds = {0, 0, 0, 0};
+            if (SDL_GetDisplayBounds(d, &bounds) != 0)
+                continue;
+            if ((mouse_x >= bounds.x) && (mouse_x < bounds.x + bounds.w) &&
+                (mouse_y >= bounds.y) && (mouse_y < bounds.y + bounds.h))
+            {
+                current_display_id = (unsigned short)d;
+                break;
+            }
+        }
+    }
     return current_display_id;
 }
 

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -1701,8 +1701,21 @@ TbBool eval_hand_rule_for_thing(struct HandRule *rule, const struct Thing *thing
 
 TbBool thing_pickup_is_blocked_by_hand_rule(const struct Thing *thing_to_pick, PlayerNumber plyr_idx) {
     struct Dungeon* dungeon = get_dungeon(plyr_idx);
+    if (dungeon_invalid(dungeon))
+    {
+        ERRORLOG("Invalid dungeon for player %d, creature index %d model %d owner %d",
+            (int)plyr_idx, (int)thing_to_pick->index, (int)thing_to_pick->model, (int)thing_to_pick->owner);
+        return false;
+    }
     if (thing_is_creature(thing_to_pick) && thing_to_pick->owner == plyr_idx)
     {
+        if (thing_to_pick->model < 0 || thing_to_pick->model >= CREATURE_TYPES_MAX)
+        {
+            ERRORLOG("Creature index %d has out-of-range model %d (max %d), class_id %d, owner %d, alloc_flags 0x%02x",
+                (int)thing_to_pick->index, (int)thing_to_pick->model, (int)CREATURE_TYPES_MAX,
+                (int)thing_to_pick->class_id, (int)thing_to_pick->owner, (unsigned)thing_to_pick->alloc_flags);
+            return false;
+        }
         struct HandRule hand_rule;
         TbBool overwrite_default_block = false;
         for (int i = HAND_RULE_SLOTS_COUNT - 1; i >= 0; i--)


### PR DESCRIPTION
Three small, independent fixes — each in its own commit.

**1. `dernc`: bounds-check `UnpackM1`**
It copied the 18-byte RNC header out of the buffer *before* checking the buffer was that big, so a file smaller than the header caused an out-of-bounds read. Now it returns early (as "not compressed") when the buffer is too small.

**2. `power_hand`: guard invalid dungeon and out-of-range model**
`thing_pickup_is_blocked_by_hand_rule()` indexed `dungeon->hand_rules[model]` without checking the dungeon was valid or that `model` was in `[0, CREATURE_TYPES_MAX)`. An invalid dungeon (e.g. an unowned player) or a bad model dereferenced a bad pointer / read out of bounds. Both are now guarded, with a log line for the offending thing.

**3. `video`: pick the display under the cursor for the pre-window frontend**
Before a game window exists (splash/frontend), `LbGetCurrentDisplayIndex()` always returned display 0, so on multi-monitor setups the splash could size for the wrong screen. It now picks the display containing the mouse cursor, falling back to the old default. (Also the monitor a Wayland compositor opens the window on.)

The first two are adapted from @cerwym's fork, the third from @DoubyCz's — credited in the commit messages. I came across them while working on a native macOS build and they looked worth sending on their own.

Disclosure: reviewed and prepared with the help of Claude Code.
