### PR TITLE
Native Linux build (AppImage, x86_64) -- GitHub Actions

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -1,0 +1,72 @@
+name: Build Linux AppImage
+
+# Builds a portable KeeperFX AppImage (bundles the engine, a modern SDL2, all
+# libraries and the free KeeperFX data) and - when triggered by an 'appimage-*'
+# tag - publishes it as a GitHub Release asset.
+#
+# The build runs inside a Debian 12 container (glibc 2.36 + ffmpeg 5.1) so the
+# AppImage runs on a wide range of distributions, while checkout / upload happen
+# on the host runner (which has git and Node for the JS actions).
+#
+# Maintainer notes (this workflow does nothing until you trigger it):
+#   * How to run it:
+#       - "Run workflow" on the Actions tab (workflow_dispatch) -> uploads the
+#         AppImage as a build artifact only, or
+#       - push a tag matching 'appimage-*' (e.g. appimage-v1.4.0) -> also
+#         publishes a GitHub Release with the AppImage attached.
+#   * The release step needs a GITHUB_TOKEN with write access. That is requested
+#     below via 'permissions: contents: write', but it only takes effect if the
+#     repo/org allows it: Settings -> Actions -> General -> Workflow permissions
+#     must be set to "Read and write permissions" (otherwise the release upload
+#     fails with 403). The artifact-only (workflow_dispatch) path needs no such
+#     permission.
+
+on:
+  workflow_dispatch:        # manual run from the Actions tab (uploads an artifact)
+  push:
+    tags:
+      - 'appimage-*'        # tag push also publishes a Release
+
+permissions:
+  contents: write           # allow the release step to create a release & upload assets
+
+jobs:
+  appimage:
+    name: Build portable AppImage (Debian 12)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build AppImage in a Debian 12 container
+        run: |
+          set -eux
+          mkdir -p dist/out
+          docker run --rm -v "$PWD":/src -w /src debian:12 \
+            bash dist/linux/build-appimage.sh /src/dist/out
+          sudo chown -R "$(id -u):$(id -g)" dist/out || true
+          ls -la dist/out
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: keeperfx-linux-appimage
+          path: dist/out/*.AppImage
+          if-no-files-found: error
+
+      - name: Publish Release (on appimage-* tag)
+        if: startsWith(github.ref, 'refs/tags/appimage-')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "KeeperFX Linux AppImage - ${{ github.ref_name }}"
+          files: dist/out/*.AppImage
+          generate_release_notes: true
+          body: |
+            Portable KeeperFX AppImage for **x86_64 Linux** (Ubuntu, Fedora, Linux Mint,
+            Debian, Arch, etc.). All libraries are bundled, so no dependencies need to be installed.
+
+            **You must own the original Dungeon Keeper** (GOG / Steam / CD); its files
+            are not bundled for copyright reasons. On first launch the AppImage creates a
+            game folder and prints which original files to copy into it.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ keeperfx.log
 crash_log.txt
 .local/
 .vscode/compile_and_copy_files.ps1
+
+# Linux AppImage build output
+/AppDir/
+/dist/out/

--- a/dist/linux/AppRun
+++ b/dist/linux/AppRun
@@ -1,0 +1,29 @@
+#!/bin/sh
+# KeeperFX AppImage launcher.
+#
+# KeeperFX needs a writable game folder containing both the free KeeperFX data
+# (bundled in this AppImage) and the original Dungeon Keeper files (which you must
+# own - GOG/Steam/CD - and which are NOT bundled for copyright reasons).
+HERE="$(dirname "$(readlink -f "$0")")"
+export LD_LIBRARY_PATH="$HERE/usr/lib:$LD_LIBRARY_PATH"
+
+GAMEDIR="${KEEPERFX_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}/keeperfx}"
+mkdir -p "$GAMEDIR"
+
+# Deploy the bundled free FX data. no-clobber keeps the user's original DK files,
+# their saves and their edited config untouched on subsequent runs / updates.
+cp -rn "$HERE/usr/share/keeperfx/." "$GAMEDIR/" 2>/dev/null || true
+
+cd "$GAMEDIR" || exit 1
+
+if [ ! -f "$GAMEDIR/sound/atlas/bullfrog.sbk" ] && [ ! -f "$GAMEDIR/data/cube.dat" ]; then
+  echo "============================================================"
+  echo " KeeperFX needs the original Dungeon Keeper files (you must"
+  echo " own the game - GOG/Steam/CD). Copy the contents of your DK"
+  echo " 'data', 'sound', 'ldata' and 'levels' folders into:"
+  echo "   $GAMEDIR"
+  echo " (GOG: use the installation folder; CD: the 'keeper' folder.)"
+  echo "============================================================"
+fi
+
+exec "$HERE/usr/bin/keeperfx" "$@"

--- a/dist/linux/build-appimage.sh
+++ b/dist/linux/build-appimage.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Build a portable KeeperFX AppImage.
+#
+# Must be run inside a Debian 12 (bookworm) environment - glibc 2.36 + ffmpeg 5.1 -
+# for broad distro compatibility (Ubuntu 22.10+/24.04, Fedora, Mint, Arch, ...).
+# Run from the repository root, e.g. in CI:
+#   docker run --rm -v "$PWD":/src -w /src debian:12 bash dist/linux/build-appimage.sh /src/dist/out
+#
+# The resulting AppImage bundles the engine, all libraries (incl. a modern SDL2)
+# and the freely-redistributable KeeperFX data. It NEVER contains the original
+# Dungeon Keeper files (copyright EA/Bullfrog) - the user supplies those at runtime.
+#
+# Usage: dist/linux/build-appimage.sh [OUTPUT_DIR]
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+export APPIMAGE_EXTRACT_AND_RUN=1   # run the tool AppImages without FUSE (works in containers)
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT_DIR="${1:-$REPO/dist/out}"
+
+# Version of this tree, from version.mk (e.g. 1.4.0). Used both to name the output
+# AppImage and, by default, to pick which release's free data to bundle.
+VER="$(grep -E '^VER_MAJOR=' "$REPO/version.mk" | cut -d= -f2).$(grep -E '^VER_MINOR=' "$REPO/version.mk" | cut -d= -f2).$(grep -E '^VER_RELEASE=' "$REPO/version.mk" | cut -d= -f2)"
+
+# Free KeeperFX data bundled into the AppImage. Defaults to THIS tree's version so
+# the bundled data always matches the engine being built. Override with
+# KFX_DATA_VERSION when building from a tree whose release has not been published
+# yet (the data is pulled from that version's GitHub release; a missing release is
+# reported with a clear error in step 5 rather than shipping mismatched data).
+KFX_DATA_VERSION="${KFX_DATA_VERSION:-$VER}"
+mkdir -p "$OUT_DIR"
+cd "$REPO"
+
+echo "######## 1. build dependencies ########"
+apt-get update -qq
+apt-get install -y -qq build-essential cmake ninja-build git pkg-config \
+  p7zip-full curl ca-certificates file wget squashfs-tools patchelf zsync jq \
+  libsdl2-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-image-dev \
+  libavformat-dev libavcodec-dev libavutil-dev libswresample-dev \
+  libopenal-dev libluajit-5.1-dev libspng-dev libminizip-dev \
+  libssl-dev libzstd-dev libminiupnpc-dev libnatpmp-dev zlib1g-dev \
+  libwayland-dev wayland-protocols libxkbcommon-dev libdecor-0-dev \
+  libx11-dev libxext-dev libxcursor-dev libxi-dev libxrandr-dev libxfixes-dev \
+  libxss-dev libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev \
+  libdbus-1-dev libudev-dev libpulse-dev libasound2-dev libibus-1.0-dev >/dev/null
+echo "glibc: $(ldd --version | head -1) | ffmpeg: $(pkg-config --modversion libavcodec)"
+
+# Modern SDL2 built from source: Debian 12 ships 2.26 (broken Wayland fullscreen).
+# Pinned to a fixed SDL2 release tag for reproducible builds - bump deliberately,
+# don't track the rolling SDL2 branch (which self-reports as an unreleased 2.33.x-dev).
+SDL2_TAG="${SDL2_TAG:-release-2.32.10}"
+echo "######## 2. modern SDL2 ($SDL2_TAG) ########"
+git config --global --add safe.directory '*' || true
+git clone -q --depth 1 -b "$SDL2_TAG" https://github.com/libsdl-org/SDL.git /tmp/sdl2-src
+cmake -S /tmp/sdl2-src -B /tmp/sdl2-build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu \
+  -DSDL_WAYLAND=ON -DSDL_X11=ON -DSDL_WAYLAND_LIBDECOR=ON -DSDL_STATIC=OFF >/dev/null
+cmake --build /tmp/sdl2-build >/dev/null
+cmake --install /tmp/sdl2-build >/dev/null
+ldconfig
+echo "bundled SDL2: $(pkg-config --modversion sdl2)"
+
+echo "######## 3. build engine (linux.mk) ########"
+# Drop any stale objects (e.g. when the working tree was previously built on a
+# different toolchain via a bind mount); a fresh CI checkout has none anyway.
+rm -rf obj bin src/ver_defs.h
+make -f linux.mk -j"$(nproc)" all
+file bin/keeperfx
+
+echo "######## 4. AppDir skeleton ########"
+APPDIR="$REPO/AppDir"
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/share/keeperfx" \
+         "$APPDIR/usr/share/applications" "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+cp bin/keeperfx "$APPDIR/usr/bin/keeperfx"
+
+echo "######## 5. free FX data ($KFX_DATA_VERSION; official release, already free of the 16 copyright files) ########"
+DATA_7Z="keeperfx_${KFX_DATA_VERSION//./_}_complete.7z"
+DATA_URL="https://github.com/dkfans/keeperfx/releases/download/v${KFX_DATA_VERSION}/${DATA_7Z}"
+# Expected sha256, resolved from the GitHub release API. Best-effort: if the API is
+# unreachable / rate-limited the digest is empty and verification is skipped with a
+# warning, but a real mismatch always fails the build.
+DATA_DIGEST="$(curl -fsSL "https://api.github.com/repos/dkfans/keeperfx/releases/tags/v${KFX_DATA_VERSION}" 2>/dev/null \
+  | jq -r --arg n "$DATA_7Z" '.assets[] | select(.name==$n) | .digest // empty' 2>/dev/null || true)"
+# Download (fail hard and clearly on a missing asset / 404, e.g. a tree ahead of any release).
+if ! curl -fLso "/tmp/$DATA_7Z" "$DATA_URL"; then
+  echo "ERROR: could not download free data for KeeperFX v${KFX_DATA_VERSION}:" >&2
+  echo "  $DATA_URL" >&2
+  echo "Set KFX_DATA_VERSION to a released version that ships a *_complete.7z (e.g. 1.4.0)." >&2
+  exit 1
+fi
+if [ -n "$DATA_DIGEST" ]; then
+  if echo "${DATA_DIGEST#sha256:}  /tmp/$DATA_7Z" | sha256sum -c - >/dev/null; then
+    echo "data checksum OK ($DATA_DIGEST)"
+  else
+    echo "ERROR: checksum mismatch for $DATA_7Z (expected $DATA_DIGEST)" >&2
+    exit 1
+  fi
+else
+  echo "WARNING: no digest published for $DATA_7Z; skipping checksum verification." >&2
+fi
+mkdir -p /tmp/fxdata && (cd /tmp/fxdata && 7z x -y "/tmp/$DATA_7Z" >/dev/null)
+for d in data fxdata ldata levels sound campgns creatrs mods music; do
+  [ -d "/tmp/fxdata/$d" ] && cp -r "/tmp/fxdata/$d" "$APPDIR/usr/share/keeperfx/"
+done
+[ -f /tmp/fxdata/keeperfx.cfg ] && cp /tmp/fxdata/keeperfx.cfg "$APPDIR/usr/share/keeperfx/"
+mkdir -p "$APPDIR/usr/share/keeperfx/save"
+
+echo "######## 6. icon + desktop ########"
+cp res/keeperfx_icon256-24bpp.png "$APPDIR/usr/share/icons/hicolor/256x256/apps/keeperfx.png"
+cp res/keeperfx_icon256-24bpp.png "$APPDIR/keeperfx.png"
+cp dist/linux/keeperfx.desktop "$APPDIR/usr/share/applications/keeperfx.desktop"
+
+echo "######## 7. bundle libraries (linuxdeploy) ########"
+cd /tmp
+wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+chmod +x linuxdeploy-x86_64.AppImage
+./linuxdeploy-x86_64.AppImage --appdir "$APPDIR" \
+  -e "$APPDIR/usr/bin/keeperfx" \
+  -d "$APPDIR/usr/share/applications/keeperfx.desktop" \
+  -i "$APPDIR/keeperfx.png" 2>&1 | tail -15
+
+echo "######## 8. custom AppRun (data setup; original DK files supplied by the user) ########"
+rm -f "$APPDIR/AppRun"   # linuxdeploy leaves a symlink -> usr/bin/keeperfx; replace with ours
+cp "$REPO/dist/linux/AppRun" "$APPDIR/AppRun"
+chmod +x "$APPDIR/AppRun"
+
+echo "######## 9. appimagetool ########"
+cd /tmp
+wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+chmod +x appimagetool-x86_64.AppImage
+OUT_FILE="$OUT_DIR/KeeperFX-${VER}-linux-x86_64.AppImage"
+ARCH=x86_64 ./appimagetool-x86_64.AppImage "$APPDIR" "$OUT_FILE" 2>&1 | tail -10
+chmod -R a+rwX "$OUT_DIR" || true
+echo "######## DONE ########"
+ls -la "$OUT_FILE"

--- a/dist/linux/keeperfx.desktop
+++ b/dist/linux/keeperfx.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=KeeperFX
+Comment=Open source remake and fan expansion of Dungeon Keeper
+Exec=keeperfx
+Icon=keeperfx
+Categories=Game;StrategyGame;
+Terminal=false


### PR DESCRIPTION
This adds a GitHub Actions workflow that builds and publishes a portable KeeperFX AppImage for x86_64 Linux - a single file that Linux players can download and run directly, with no dependencies to install.

#4962 got the native Linux build compiling cleanly on modern toolchains. This PR takes that working build and packages it into a downloadable, ready-to-run AppImage.

**You can test AppImages in forked repo:**
 - [Download AppImage test release  v1.4.0](https://github.com/DoubyCz/keeperfx/releases/download/appimage-v1.4.0/KeeperFX-1.4.0-linux-x86_64.AppImage) = 
 - [Download AppImage test release v1.3.2](https://github.com/DoubyCz/keeperfx/releases/download/appimage-v1.3.2-2/KeeperFX-1.3.2-linux-x86_64.AppImage) = 

Proposed changes:
- .github/workflows/linux-appimage.yml - the workflow.
- dist/linux/build-appimage.sh - the build itself. It runs inside a Debian 12 container (glibc 2.36 + ffmpeg 5.1) so the resulting AppImage works across a wide range of distros (Ubuntu, Fedora, Mint, Debian, Arch, ...).
- dist/linux/AppRun + dist/linux/keeperfx.desktop - the launcher and desktop entry.

How the AppImage works:
- It bundles the engine, a modern SDL2, ffmpeg and all the other libraries, plus the freely-redistributable KeeperFX data.
- It never contains the original Dungeon Keeper files (copyright EA/Bullfrog). On first launch AppRun sets up a game folder and tells the user which original files to copy in - same requirement as on Windows.

A couple of things I was careful about:
- SDL2 is built from a pinned release tag (Debian 12's own 2.26 has broken Wayland fullscreen), so the builds are reproducible rather than tracking a moving branch.
- The bundled free-data version follows the tree's version.mk, so the data always matches the engine that gets built, and the download is verified against the sha256 the release publishes.

Enabling the workflow:
Merging this is inert on its own: the workflow only triggers on a manual run or an appimage-* tag, never on a normal push or pull request, so nothing runs and nothing changes until you choose to. There are two ways to produce an AppImage, both starting the Debian 12 build described above:
- Actions tab -> "Build Linux AppImage" -> "Run workflow": builds from the branch you pick and uploads the AppImage as a build artifact (nothing is published).
- Push a tag like appimage-v1.4.0: builds from that tag and also publishes the AppImage as a GitHub Release.

The Release step needs "Read and write permissions" under Settings -> Actions -> General; the artifact-only path doesn't. This is spelled out in the workflow header too.

I've tested the whole thing end to end against current master: it produces a working KeeperFX-1.4.0 AppImage that starts up with the bundled SDL and only stops (as expected) once it starts looking for the original game data.

One known issue, deliberately left out of this PR:
On some multi-monitor setups the startup splash/legal screens can come up undersized in a corner instead of filling the screen. I'm aware of it and have a small engine-side fix ready, but I'd rather send that as its own separate PR so this one stays purely about the AppImage packaging - I didn't want to mix an engine behavior change into the build tooling.

Open to any feedback.

<img width="1151" height="270" alt="image" src="https://github.com/user-attachments/assets/fd05ea39-d789-4fee-bd69-bec0b14a903c" />

