### PR TITLE
Potential trap preview fix

### DIFF
--- a/src/cursor_tag.c
+++ b/src/cursor_tag.c
@@ -19,6 +19,7 @@
 #include "pre_inc.h"
 #include "globals.h"
 #include "bflib_basics.h"
+#include "config_trapdoor.h"
 #include "map_data.h"
 #include "player_data.h"
 #include "dungeon_data.h"
@@ -366,35 +367,27 @@ TbBool tag_cursor_blocks_steal_slab(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
     return (colour != SLC_RED);
 }
 
-TbBool tag_cursor_blocks_place_trap(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab, ThingModel trpkind)
+TbBool tag_cursor_blocks_place_trap(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, ThingModel trpkind)
 {
     SYNCDBG(7,"Starting");
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
     TbBool can_place = can_place_trap_on(plyr_idx, stl_x, stl_y, trpkind);
     int floor_height = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
-    if (is_my_player_number(plyr_idx))
-    {
-        if (!game_is_busy_doing_gui() && (game.small_map_state != 2))
-        {
-            struct PlayerInfo* player = get_player(plyr_idx);
-            player->render_roomspace.is_roomspace_a_box = true;
-            player->render_roomspace.render_roomspace_as_box = true;
-            if (full_slab)
-            {
-                // Move to first subtile on a slab
-                stl_x = slab_subtile(slb_x,0);
-                stl_y = slab_subtile(slb_y,0);
-                player->render_roomspace.is_roomspace_a_single_subtile = false;
-                draw_map_volume_box(subtile_coord(stl_x,0), subtile_coord(stl_y,0),
-                subtile_coord(stl_x+STL_PER_SLB,0), subtile_coord(stl_y+STL_PER_SLB,0), floor_height, can_place);
-            }
-            else
-            {
-                player->render_roomspace.is_roomspace_a_single_subtile = true;
-                draw_map_volume_box(subtile_coord(stl_x,0), subtile_coord(stl_y,0), subtile_coord(stl_x+1,0), subtile_coord(stl_y+1,0), floor_height, can_place);
-            }
+    struct PlayerInfo* player = get_player(plyr_idx);
+    TbBool full_slab = !get_trap_model_stats(trpkind)->place_on_subtile;
+    player->full_slab_cursor = full_slab;
+    if (is_my_player_number(plyr_idx) && !game_is_busy_doing_gui() && (game.small_map_state != 2)) {
+        MapSubtlCoord box_size = 1;
+        if (full_slab) {
+            stl_x = slab_subtile(slb_x, 0);
+            stl_y = slab_subtile(slb_y, 0);
+            box_size = STL_PER_SLB;
         }
+        player->render_roomspace.is_roomspace_a_box = true;
+        player->render_roomspace.render_roomspace_as_box = true;
+        player->render_roomspace.is_roomspace_a_single_subtile = !full_slab;
+        draw_map_volume_box(subtile_coord(stl_x, 0), subtile_coord(stl_y, 0), subtile_coord(stl_x + box_size, 0), subtile_coord(stl_y + box_size, 0), floor_height, can_place);
     }
     return can_place;
 }

--- a/src/cursor_tag.h
+++ b/src/cursor_tag.h
@@ -40,7 +40,7 @@ void tag_cursor_blocks_place_terrain(PlayerNumber plyr_idx, MapSubtlCoord stl_x,
 TbBool tag_cursor_blocks_place_thing(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool tag_cursor_blocks_order_creature(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, struct Thing* creatng);
 TbBool tag_cursor_blocks_steal_slab(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
-TbBool tag_cursor_blocks_place_trap(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool full_slab, ThingModel trapmodel);
+TbBool tag_cursor_blocks_place_trap(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, ThingModel trapmodel);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -664,9 +664,7 @@ TbBool process_dungeon_control_packet_dungeon_place_trap(long plyr_idx)
         }
         return false;
     }
-    struct TrapConfigStats *trapst = get_trap_model_stats(player->chosen_trap_kind);
-    player->full_slab_cursor = (trapst->place_on_subtile == false);
-    long i = tag_cursor_blocks_place_trap(player->id_number, stl_x, stl_y, player->full_slab_cursor, player->chosen_trap_kind);
+    TbBool can_place = tag_cursor_blocks_place_trap(player->id_number, stl_x, stl_y, player->chosen_trap_kind);
     if ((pckt->control_flags & PCtr_LBtnClick) == 0)
     {
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->cursor_button_down != 0))
@@ -676,7 +674,7 @@ TbBool process_dungeon_control_packet_dungeon_place_trap(long plyr_idx)
         }
         return false;
     }
-    if (i == 0)
+    if (can_place == 0)
     {
         if (is_my_player(player))
             play_non_3d_sample(snd_refusal);

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -239,17 +239,23 @@ void update_local_dig_prediction_cursor_preview(void)
     struct RoomSpace roomspace;
     struct PlayerInfo predicted_player;
     if (!get_local_dig_prediction_roomspace(pckt, &predicted_player, &roomspace)) {
-        if (local_dig_prediction_is_enabled() && update_predicted_build_or_sell_roomspace_preview(&local_dig_render_roomspace, player->id_number, pckt)) {
+        local_dig_render_roomspace_active = false;
+        if (!local_dig_prediction_is_enabled()) {
+            return;
+        }
+        if (update_predicted_build_or_sell_roomspace_preview(&local_dig_render_roomspace, player->id_number, pckt)) {
             local_dig_render_roomspace_active = true;
             box_lag_compensation_x = 0;
             box_lag_compensation_y = 0;
             return;
         }
-        local_dig_render_roomspace_active = false;
-        if (!local_dig_prediction_is_enabled()) {
-            return;
+        TbBool dig_cursor = false;
+        if (player->primary_cursor_state == CSt_PickAxe) {
+            dig_cursor = true;
+        } else if (player->primary_cursor_state == CSt_PowerHand) {
+            dig_cursor = (player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0;
         }
-        if ((pckt != NULL) && ((player->primary_cursor_state == CSt_PickAxe) || ((player->primary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0)))) {
+        if ((pckt != NULL) && (player->work_state == PSt_CtrlDungeon) && dig_cursor) {
             map_volume_box.visible = 0;
             box_lag_compensation_x = 0;
             box_lag_compensation_y = 0;


### PR DESCRIPTION
It's been reported that in multiplayer the trap preview placement box becomes invisible after some play. But I have yet to see this bug for myself.

I'll try again later to try and reproduce it, so we can confirm whether this fix works.