### PR TITLE
Multiplayer: Fix network crash

### DIFF
--- a/src/net_exchange_gameplay.c
+++ b/src/net_exchange_gameplay.c
@@ -435,6 +435,9 @@ static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, Pla
 
 void network_update(void *server_buf, size_t frame_size)
 {
+    if (netstate.sp == NULL) {
+        return;
+    }
     netstate.sp->update(OnNewUser);
     for (NetUserId peer_id = 0; peer_id < netstate.max_players; peer_id += 1) {
         if (can_send_to_peer(peer_id)) {

--- a/src/net_lobby.c
+++ b/src/net_lobby.c
@@ -17,6 +17,7 @@
 #include "pre_inc.h"
 #include "net_lobby.h"
 
+#include "game_legacy.h"
 #include "bflib_enet.h"
 #include "bflib_datetm.h"
 #include "net_exchange_common.h"
@@ -320,6 +321,7 @@ TbError LbNetwork_Stop(void)
     if (netstate.sp) {
         netstate.sp->exit();
     }
+    clear_flag(game.system_flags, GSF_NetworkActive);
     memset(&netstate, 0, sizeof(netstate));
     netstate.my_id = INVALID_USER_ID;
     return Lb_OK;

--- a/src/packets.c
+++ b/src/packets.c
@@ -1358,7 +1358,6 @@ void process_players_creature_control_packet_control(long idx)
             // Button is held down - check whether the instance has auto-repeat
             i = ccctrl->active_instance_id;
             inst_inf = creature_instance_info_get(i);
-            target_idx = get_human_controlled_creature_target(cctng, i, pckt);
             if ((inst_inf->instance_property_flags & InstPF_RepeatTrigger) != 0)
             {
                 if (ccctrl->instance_id == CrInst_NULL)


### PR DESCRIPTION
Fixes https://keeperfx.net/dev/crash-report/449

Plus solves some log spam. The `target_idx = get_human_controlled_creature_target(cctng, i, pckt);` line is being called twice for no reason.