### PR TITLE
Add in-game error message for misplaced zip files

### DIFF
--- a/src/custom_sprites.c
+++ b/src/custom_sprites.c
@@ -23,6 +23,7 @@
 #include "engine_render.h"
 #include "bflib_fileio.h"
 #include "gui_draw.h"
+#include "gui_msgs.h"
 #include "frontend.h"
 #include "bflib_dernc.h"
 #include "net_checksums.h"
@@ -337,6 +338,37 @@ static void load_dir_sprites(const char *dir_path, const char *dir_desc)
             LbJustLog("Found %d sprite zip file(s) from %s, loaded %d with animations and %d with icons. Used %d/%d sprite slots.\n", cnt_zip, dir_desc, cnt_sprite, cnt_icon, next_free_sprite, KEEPERSPRITE_ADD_NUM);
         }
     }
+}
+
+void show_ignored_fxdata_zip_messages(void)
+{
+    char *dname = prepare_file_path(FGrp_FxData, NULL);
+    if (dname == NULL || dname[0] == 0) {
+        return;
+    }
+    char full_path[1024] = {0};
+    sprintf(full_path, "%s/%s", dname, "*.zip");
+    struct TbFileEntry fe;
+    struct TbFileFind *ff = LbFileFindFirst(full_path, &fe);
+    if (ff == NULL) {
+        return;
+    }
+    do {
+        int zip_is_required = 0;
+        for (int i = 0; i < REQUIRED_SPRITE_ZIP_COUNT; i++) {
+            if (strcasecmp(fe.Filename, required_sprite_zips[i]) == 0) {
+                zip_is_required = 1;
+                break;
+            }
+        }
+        if (zip_is_required != 0) {
+            continue;
+        }
+        WARNLOG("/fxdata/%s was not loaded. Please install it as a mod inside the /mods/ folder.", fe.Filename);
+        message_add(MsgType_Blank, 0, "Please install it as a mod inside the /mods/ folder.");
+        message_add_fmt(MsgType_Blank, 0, "/fxdata/%.39s was not loaded.", fe.Filename);
+    } while (LbFileFindNext(ff, &fe) >= 0);
+    LbFileFindEnd(ff);
 }
 
 /* @comment

--- a/src/custom_sprites.h
+++ b/src/custom_sprites.h
@@ -44,6 +44,7 @@ static const char * const required_sprite_zips[] = {
 #define REQUIRED_SPRITE_ZIP_COUNT (sizeof(required_sprite_zips) / sizeof(required_sprite_zips[0]))
 
 void init_custom_sprites(LevelNumber level_no);
+void show_ignored_fxdata_zip_messages(void);
 
 extern TbBigChecksum required_sprite_zip_checksums[REQUIRED_SPRITE_ZIP_COUNT];
 

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -223,6 +223,7 @@ static void init_level(void)
     game.armageddon_cast_turn = 0;
     game.armageddon_over_turn = 0;
     clear_messages();
+    show_ignored_fxdata_zip_messages();
     game.creatures_tend_imprison = 0;
     game.creatures_tend_flee = 0;
     memset(game.pay_day_progress, 0, sizeof(game.pay_day_progress));


### PR DESCRIPTION
This needs a very loud message in singleplayer, because there's currently a lot of people who still have the wrong idea that installing zip files in /fxdata/ will work, but it won't.

It won't be long before we update all the documentation and instructions everywhere and then no one ever sees this message again. So don't worry too much about the ugliness of the error.

<img width="1928" height="1153" alt="Untitled" src="https://github.com/user-attachments/assets/8d2ae661-a37a-44c9-aed7-1801807d573b" />
