### PR TITLE
Multiplayer: more reliable clicking on creatures

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -2052,6 +2052,32 @@ static short get_creature_control_action_inputs(void)
     return false;
 }
 
+static void set_packet_action_for_thing_under_hand(struct PlayerInfo* player, struct Packet* pckt)
+{
+    if ((player->view_type == PVT_DungeonTop) && ((pckt->control_flags & PCtr_Gui) == 0) && left_button_released && (local_thing_under_hand > 0) && (pckt->action == PckA_None)) {
+        int32_t cursor_state = (pckt->additional_packet_values & PCAdV_ContextMask) >> 1;
+        switch (player->work_state) {
+        case PSt_CtrlDungeon:
+            if ((pckt->additional_packet_values & PCAdV_CrtrContrlPressed) != 0) {
+                set_packet_action(pckt, PckA_UsePwrOnThing, PwrK_POSSESS, local_thing_under_hand, 0, 0);
+            } else if (((pckt->additional_packet_values & PCAdV_CrtrQueryPressed) == 0) && (cursor_state == CSt_PowerHand)) {
+                set_packet_action(pckt, PckA_UsePwrHandPick, local_thing_under_hand, 0, 0, 0);
+            }
+            break;
+        case PSt_Slap:
+            set_packet_action(pckt, PckA_UsePwrOnThing, PwrK_SLAP, local_thing_under_hand, 0, 0);
+            break;
+        case PSt_CtrlDirect:
+        case PSt_FreeCtrlDirect:
+            set_packet_action(pckt, PckA_UsePwrOnThing, PwrK_POSSESS, local_thing_under_hand, 0, 0);
+            break;
+        case PST_CastPowerOnTarget:
+            set_packet_action(pckt, PckA_UsePwrOnThing, player->chosen_power_kind, local_thing_under_hand, 0, 0);
+            break;
+        }
+    }
+}
+
 static void get_packet_control_mouse_clicks(void)
 {
     SYNCDBG(8,"Starting");
@@ -2062,6 +2088,8 @@ static void get_packet_control_mouse_clicks(void)
     }
 
     struct PlayerInfo* player = get_my_player();
+    struct Packet* pckt = get_packet(my_player_number);
+    set_packet_action_for_thing_under_hand(player, pckt);
 
     if ( left_button_held )
     {

--- a/src/packets.c
+++ b/src/packets.c
@@ -200,7 +200,7 @@ TbBool process_dungeon_control_packet_spell_overcharge(long plyr_idx)
     SYNCDBG(6,"Starting for player %d state %s",(int)plyr_idx,player_state_code_name(player->work_state));
     struct Packet* pckt = get_packet_direct(player->packet_num);
 
-    while (game.conf.rules[plyr_idx].magic.allow_instant_charge_up && is_game_key_pressed(Gkey_SpeedMod, false, true))
+    while (game.conf.rules[plyr_idx].magic.allow_instant_charge_up && (pckt->additional_packet_values & PCAdV_SpeedupPressed))
     {
         struct PowerConfigStats *powerst = get_power_model_stats(player->chosen_power_kind);
 

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -279,6 +279,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
     MapSubtlCoord stl_x = coord_subtile(x);
     MapSubtlCoord stl_y = coord_subtile(y);
     TbBool at_limit = false;
+    TbBool thing_target_action = (pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing);
     unsigned char box_colour;
     if ((pckt->control_flags & PCtr_LBtnAnyAction) == 0)
         player->secondary_cursor_state = CSt_DefaultArrow;
@@ -399,9 +400,8 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         } else
         if (player->cursor_button_down != 0)
         {
-            if ((player->thing_under_hand != 0) && (player->input_crtr_control != 0)
-                && (dungeon->things_in_hand[0] != player->thing_under_hand))
-            {
+            TbBool direct_control_target = !thing_target_action && (player->thing_under_hand != 0) && (player->input_crtr_control != 0);
+            if (direct_control_target && (dungeon->things_in_hand[0] != player->thing_under_hand)) {
                 thing = get_creature_near_for_controlling(player->id_number, x, y);
                 if (!thing_is_invalid(thing))
                 {
@@ -416,9 +416,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
                     set_player_state(player, player->continue_work_state, 0);
                 }
                 unset_packet_control(pckt, PCtr_LBtnRelease);
-            } else
-            if (player->input_crtr_query != 0)
-            {
+            } else if (!thing_target_action && player->input_crtr_query != 0) {
                 thing = get_creature_near(x, y);
                 if (!can_thing_be_queried(thing, plyr_idx))
                 {
@@ -444,9 +442,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
                     }
                     unset_packet_control(pckt, PCtr_LBtnRelease);
                 }
-            } else
-            if (player->secondary_cursor_state == player->primary_cursor_state)
-            {
+            } else if (!thing_target_action && player->secondary_cursor_state == player->primary_cursor_state) {
                 if ( (player->primary_cursor_state == CSt_PickAxe) || (player->primary_cursor_state == CSt_PowerHand) )
                 {
                     if (player->thing_under_hand != 0) 
@@ -698,6 +694,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     struct PlayerInfo* player = get_player(plyr_idx);
     struct Packet* pckt = get_packet_direct(player->packet_num);
     SYNCDBG(6,"Starting for player %d state %s",(int)plyr_idx,player_state_code_name(player->work_state));
+    TbBool thing_target_action = (pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing);
     player->full_slab_cursor = 1;
     packet_left_button_double_clicked[plyr_idx] = 0;
     player->mouse_on_map = is_mouse_on_map(pckt);
@@ -754,9 +751,10 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             }
             break;
         case PSt_Slap:
-            if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
-            {
-                magic_use_available_power_on_thing(plyr_idx, PwrK_SLAP, 0, stl_x, stl_y, thing, PwMod_Default);
+            if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (((pckt->control_flags & PCtr_MapCoordsValid) != 0) || thing_target_action)) {
+                if (!thing_target_action) {
+                    magic_use_available_power_on_thing(plyr_idx, PwrK_SLAP, 0, stl_x, stl_y, thing, PwMod_Default);
+                }
                 unset_packet_control(pckt, PCtr_LBtnRelease);
             }
             break;
@@ -785,8 +783,9 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
         case PSt_FreeCtrlDirect:
             if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
             {
-                if (player->thing_under_hand > 0)
-                {
+                if (thing_target_action) {
+                    unset_packet_control(pckt, PCtr_LBtnRelease);
+                } else if (player->thing_under_hand > 0) {
                     magic_use_available_power_on_thing(plyr_idx, PwrK_POSSESS, 0, stl_x, stl_y, thing, PwMod_Default);
                     unset_packet_control(pckt, PCtr_LBtnRelease);
                 }
@@ -871,14 +870,15 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             break;
         }
         case PST_CastPowerOnTarget:
-            if (thing_is_invalid(thing))
-            {
-                break;
-            }
             if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
             {
-                i = get_power_overcharge_level(player);
-                magic_use_available_power_on_thing(plyr_idx, pwkind, i, stl_x, stl_y, thing, PwMod_Default);
+                if (!thing_target_action) {
+                    if (thing_is_invalid(thing)) {
+                        break;
+                    }
+                    i = get_power_overcharge_level(player);
+                    magic_use_available_power_on_thing(plyr_idx, pwkind, i, stl_x, stl_y, thing, PwMod_Default);
+                }
                 unset_packet_control(pckt, PCtr_LBtnRelease);
             }
             break;

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -608,9 +608,8 @@ void draw_power_hand(void)
     if (player->work_state != PSt_HoldInHand)
     {
       TbBool draw_hand = (local_thing_under_hand > 0);
-      if ((player->work_state == PSt_CtrlDungeon) && !power_hand_is_empty(player))
-      {
-        draw_hand = (player->secondary_cursor_state == CSt_PowerHand) || ((player->secondary_cursor_state == CSt_DefaultArrow) && (player->primary_cursor_state == CSt_PowerHand));
+      if ((player->work_state == PSt_CtrlDungeon) && !power_hand_is_empty(player)) {
+        draw_hand = (player->primary_cursor_state != CSt_DoorKey) && (player->secondary_cursor_state != CSt_DoorKey);
       }
       if ((player->work_state != PSt_CtrlDungeon) || !draw_hand)
       {

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -608,8 +608,9 @@ void draw_power_hand(void)
     if (player->work_state != PSt_HoldInHand)
     {
       TbBool draw_hand = (local_thing_under_hand > 0);
-      if ((player->work_state == PSt_CtrlDungeon) && !power_hand_is_empty(player)) {
-        draw_hand = (player->primary_cursor_state != CSt_DoorKey) && (player->secondary_cursor_state != CSt_DoorKey);
+      if ((player->work_state == PSt_CtrlDungeon) && !power_hand_is_empty(player))
+      {
+        draw_hand = (player->secondary_cursor_state == CSt_PowerHand) || ((player->secondary_cursor_state == CSt_DefaultArrow) && (player->primary_cursor_state == CSt_PowerHand));
       }
       if ((player->work_state != PSt_CtrlDungeon) || !draw_hand)
       {


### PR DESCRIPTION
Instead of relying on the mouse coordinates when clicking on creatures, which fall out of date on high `input_lag_turns`, we now use the packet actions `PckA_UsePwrHandPick` and `PckA_UsePwrOnThing`, these are actually already used in the battle window UI, so we just need to use them on the main isometric gameplay as well. I really should have figured this one out sooner considering how obvious it is.

Also apparently if you were using Shift to move your camera faster that might have been causing some misclicks as well, that's a one-line fix.