### PR TITLE
optimize room recalculations

### DIFF
--- a/src/power_specials.c
+++ b/src/power_specials.c
@@ -361,6 +361,9 @@ void make_safe(struct PlayerInfo *player)
     SlabCodedCoords* slblist = (SlabCodedCoords*)(big_scratch + game.map_tiles_x * game.map_tiles_y);
     unsigned int list_len = 0;
     unsigned int list_cur = 0;
+    struct Room* room_list[ROOMS_COUNT + 1];
+    memset(room_list, 0, sizeof(room_list));
+
     while (list_cur <= list_len)
     {
         SlabCodedCoords slb_num;
@@ -377,7 +380,7 @@ void make_safe(struct PlayerInfo *player)
                 {
                     unsigned char pretty_type = choose_pretty_type(plyr_idx, slb_x - 1, slb_y);
                     place_slab_type_on_map(pretty_type, slab_subtile(slb_x-1,0), slab_subtile(slb_y,0), plyr_idx, 0);
-                    do_slab_efficiency_alteration(slb_x-1, slb_y);
+                    collect_rooms_around_slab(slb_x-1, slb_y, room_list);
                     fill_in_reinforced_corners(plyr_idx, slb_x-1, slb_y);
                 }
             } else
@@ -400,7 +403,7 @@ void make_safe(struct PlayerInfo *player)
                 {
                     unsigned char pretty_type = choose_pretty_type(plyr_idx, slb_x + 1, slb_y);
                     place_slab_type_on_map(pretty_type, slab_subtile(slb_x+1,0), slab_subtile(slb_y,0), plyr_idx, 0);
-                    do_slab_efficiency_alteration(slb_x+1, slb_y);
+                    collect_rooms_around_slab(slb_x+1, slb_y, room_list);
                     fill_in_reinforced_corners(plyr_idx, slb_x+1, slb_y);
                 }
             } else
@@ -423,7 +426,7 @@ void make_safe(struct PlayerInfo *player)
                 {
                     unsigned char pretty_type = choose_pretty_type(plyr_idx, slb_x, slb_y - 1);
                     place_slab_type_on_map(pretty_type, slab_subtile(slb_x,0), slab_subtile(slb_y-1,0), plyr_idx, 0);
-                    do_slab_efficiency_alteration(slb_x, slb_y-1);
+                    collect_rooms_around_slab(slb_x, slb_y-1, room_list);
                     fill_in_reinforced_corners(plyr_idx, slb_x, slb_y-1);
                 }
             } else
@@ -446,7 +449,7 @@ void make_safe(struct PlayerInfo *player)
                 {
                     unsigned char pretty_type = choose_pretty_type(plyr_idx, slb_x, slb_y + 1);
                     place_slab_type_on_map(pretty_type, slab_subtile(slb_x,0), slab_subtile(slb_y+1,0), plyr_idx, 0);
-                    do_slab_efficiency_alteration(slb_x, slb_y+1);
+                    collect_rooms_around_slab(slb_x, slb_y+1, room_list);
                     fill_in_reinforced_corners(plyr_idx, slb_x, slb_y+1);
                 }
             } else
@@ -462,6 +465,7 @@ void make_safe(struct PlayerInfo *player)
         slb_y = slb_num_decode_y(slblist[list_cur]);
         list_cur++;
     }
+    recalculate_rooms_in_list(room_list);
     panel_map_update(0, 0, game.map_subtiles_x+1, game.map_subtiles_y+1);
 }
 
@@ -475,6 +479,9 @@ void make_unsafe(PlayerNumber plyr_idx)
     struct PowerConfigStats* powerst;
     struct Dungeon* dungeon;
     struct Coord3d pos;
+    struct Room* room_list[ROOMS_COUNT + 1];
+    memset(room_list, 0, sizeof(room_list));
+
     for (slb_y = 0; slb_y < game.map_tiles_y; slb_y++)
     {
         for (slb_x = 0; slb_x < game.map_tiles_x; slb_x++)
@@ -495,11 +502,12 @@ void make_unsafe(PlayerNumber plyr_idx)
                     powerst = get_power_model_stats(PwrK_DESTRWALLS);
                     play_sound_if_close_to_receiver(&pos, powerst->select_sound_idx);
                     place_slab_type_on_map(newslab, slab_subtile_center(slb_x), slab_subtile_center(slb_y), game.neutral_player_num, 0);
-                    do_slab_efficiency_alteration(slb_x, slb_y);
+                    collect_rooms_around_slab(slb_x, slb_y, room_list);
                 }
             }
         }
     }
+    recalculate_rooms_in_list(room_list);
     panel_map_update(0, 0, game.map_subtiles_x + 1, game.map_subtiles_y + 1);
 }
 

--- a/src/power_specials.c
+++ b/src/power_specials.c
@@ -380,7 +380,7 @@ void make_safe(struct PlayerInfo *player)
                 {
                     unsigned char pretty_type = choose_pretty_type(plyr_idx, slb_x - 1, slb_y);
                     place_slab_type_on_map(pretty_type, slab_subtile(slb_x-1,0), slab_subtile(slb_y,0), plyr_idx, 0);
-                    collect_rooms_around_slab(slb_x-1, slb_y, room_list);
+                    collect_rooms_around_slab(slb_x-1, slb_y, room_list, sizeof(room_list)/sizeof(room_list[0]));
                     fill_in_reinforced_corners(plyr_idx, slb_x-1, slb_y);
                 }
             } else
@@ -403,7 +403,7 @@ void make_safe(struct PlayerInfo *player)
                 {
                     unsigned char pretty_type = choose_pretty_type(plyr_idx, slb_x + 1, slb_y);
                     place_slab_type_on_map(pretty_type, slab_subtile(slb_x+1,0), slab_subtile(slb_y,0), plyr_idx, 0);
-                    collect_rooms_around_slab(slb_x+1, slb_y, room_list);
+                    collect_rooms_around_slab(slb_x+1, slb_y, room_list, sizeof(room_list)/sizeof(room_list[0]));
                     fill_in_reinforced_corners(plyr_idx, slb_x+1, slb_y);
                 }
             } else
@@ -426,7 +426,7 @@ void make_safe(struct PlayerInfo *player)
                 {
                     unsigned char pretty_type = choose_pretty_type(plyr_idx, slb_x, slb_y - 1);
                     place_slab_type_on_map(pretty_type, slab_subtile(slb_x,0), slab_subtile(slb_y-1,0), plyr_idx, 0);
-                    collect_rooms_around_slab(slb_x, slb_y-1, room_list);
+                    collect_rooms_around_slab(slb_x, slb_y-1, room_list, sizeof(room_list)/sizeof(room_list[0]));
                     fill_in_reinforced_corners(plyr_idx, slb_x, slb_y-1);
                 }
             } else
@@ -449,7 +449,7 @@ void make_safe(struct PlayerInfo *player)
                 {
                     unsigned char pretty_type = choose_pretty_type(plyr_idx, slb_x, slb_y + 1);
                     place_slab_type_on_map(pretty_type, slab_subtile(slb_x,0), slab_subtile(slb_y+1,0), plyr_idx, 0);
-                    collect_rooms_around_slab(slb_x, slb_y+1, room_list);
+                    collect_rooms_around_slab(slb_x, slb_y+1, room_list, sizeof(room_list)/sizeof(room_list[0]));
                     fill_in_reinforced_corners(plyr_idx, slb_x, slb_y+1);
                 }
             } else
@@ -465,7 +465,7 @@ void make_safe(struct PlayerInfo *player)
         slb_y = slb_num_decode_y(slblist[list_cur]);
         list_cur++;
     }
-    recalculate_rooms_in_list(room_list);
+    recalculate_rooms_in_list(room_list, sizeof(room_list)/sizeof(room_list[0]));
     panel_map_update(0, 0, game.map_subtiles_x+1, game.map_subtiles_y+1);
 }
 
@@ -502,12 +502,12 @@ void make_unsafe(PlayerNumber plyr_idx)
                     powerst = get_power_model_stats(PwrK_DESTRWALLS);
                     play_sound_if_close_to_receiver(&pos, powerst->select_sound_idx);
                     place_slab_type_on_map(newslab, slab_subtile_center(slb_x), slab_subtile_center(slb_y), game.neutral_player_num, 0);
-                    collect_rooms_around_slab(slb_x, slb_y, room_list);
+                    collect_rooms_around_slab(slb_x, slb_y, room_list, sizeof(room_list)/sizeof(room_list[0]));
                 }
             }
         }
     }
-    recalculate_rooms_in_list(room_list);
+    recalculate_rooms_in_list(room_list, sizeof(room_list)/sizeof(room_list[0]));
     panel_map_update(0, 0, game.map_subtiles_x + 1, game.map_subtiles_y + 1);
 }
 

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -611,7 +611,7 @@ void update_map_collide(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl
     mapblk->flags |= nflags;
 }
 
-void collect_rooms_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, struct Room** room_list)
+void collect_rooms_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, struct Room** room_list, int room_list_len)
 {
     for (long n = 0; n < SMALL_AROUND_SLAB_LENGTH; n++)
     {
@@ -625,8 +625,7 @@ void collect_rooms_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, struct Ro
         if (slabst->category == SlbAtCtg_RoomInterior)
         {
             struct Room* room = slab_room_get(sslb_x, sslb_y);
-            int i = 0;
-            while (true)
+            for (int i = 0; i < room_list_len; i++)
             {
                 if (room_list[i] == room) {
                     break;
@@ -635,23 +634,20 @@ void collect_rooms_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, struct Ro
                     room_list[i] = room;
                     break;
                 }
-                i++;
             }
         }
     }
 }
 
-void recalculate_rooms_in_list(struct Room** room_list)
+void recalculate_rooms_in_list(struct Room** room_list, int room_list_len)
 {
-    while (true)
+    for (int i = 0; i < room_list_len; i++)
     {
-        struct Room* room = *room_list;
+        struct Room* room = room_list[i];
         if (room == NULL) {
             break;
         }
-
         do_room_recalculation(room);
-        room_list++;
     }
 }
 
@@ -659,9 +655,9 @@ void do_slab_efficiency_alteration(MapSlabCoord slb_x, MapSlabCoord slb_y)
 {
     struct Room* room_list[SMALL_AROUND_SLAB_LENGTH + 1];
     memset(room_list, 0, sizeof(room_list));
-    collect_rooms_around_slab(slb_x, slb_y, room_list);
+    collect_rooms_around_slab(slb_x, slb_y, room_list, sizeof(room_list)/sizeof(room_list[0]));
 
-    recalculate_rooms_in_list(room_list);
+    recalculate_rooms_in_list(room_list, sizeof(room_list)/sizeof(room_list[0]));
 }
 
 SlabKind choose_rock_type(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y)

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -611,7 +611,7 @@ void update_map_collide(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl
     mapblk->flags |= nflags;
 }
 
-void do_slab_efficiency_alteration(MapSlabCoord slb_x, MapSlabCoord slb_y)
+void collect_rooms_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, struct Room** room_list)
 {
     for (long n = 0; n < SMALL_AROUND_SLAB_LENGTH; n++)
     {
@@ -625,9 +625,43 @@ void do_slab_efficiency_alteration(MapSlabCoord slb_x, MapSlabCoord slb_y)
         if (slabst->category == SlbAtCtg_RoomInterior)
         {
             struct Room* room = slab_room_get(sslb_x, sslb_y);
-            do_room_recalculation(room);
+            int i = 0;
+            while (true)
+            {
+                if (room_list[i] == room) {
+                    break;
+                }
+                else if (room_list[i] == NULL) {
+                    room_list[i] = room;
+                    break;
+                }
+                i++;
+            }
         }
     }
+}
+
+void recalculate_rooms_in_list(struct Room** room_list)
+{
+    while (true)
+    {
+        struct Room* room = *room_list;
+        if (room == NULL) {
+            break;
+        }
+
+        do_room_recalculation(room);
+        room_list++;
+    }
+}
+
+void do_slab_efficiency_alteration(MapSlabCoord slb_x, MapSlabCoord slb_y)
+{
+    struct Room* room_list[SMALL_AROUND_SLAB_LENGTH + 1];
+    memset(room_list, 0, sizeof(room_list));
+    collect_rooms_around_slab(slb_x, slb_y, room_list);
+
+    recalculate_rooms_in_list(room_list);
 }
 
 SlabKind choose_rock_type(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y)

--- a/src/slab_data.h
+++ b/src/slab_data.h
@@ -182,8 +182,8 @@ void update_blocks_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y);
 void update_map_collide(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void copy_block_with_cube_groups(short itm_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void do_slab_efficiency_alteration(MapSlabCoord slb_x, MapSlabCoord slb_y);
-void collect_rooms_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, struct Room** room_list);
-void recalculate_rooms_in_list(struct Room** room_list);
+void collect_rooms_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, struct Room** room_list, int room_list_len);
+void recalculate_rooms_in_list(struct Room** room_list, int room_list_len);
 void do_unprettying(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y);
 
 TbBool slab_kind_has_no_ownership(SlabKind slbkind);

--- a/src/slab_data.h
+++ b/src/slab_data.h
@@ -182,6 +182,8 @@ void update_blocks_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y);
 void update_map_collide(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void copy_block_with_cube_groups(short itm_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void do_slab_efficiency_alteration(MapSlabCoord slb_x, MapSlabCoord slb_y);
+void collect_rooms_around_slab(MapSlabCoord slb_x, MapSlabCoord slb_y, struct Room** room_list);
+void recalculate_rooms_in_list(struct Room** room_list);
 void do_unprettying(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y);
 
 TbBool slab_kind_has_no_ownership(SlabKind slbkind);


### PR DESCRIPTION
reduces redundant calls to do_room_recalculation

on my benchmark testmap with a make safe it made it go from 27.33s to 20.5,
update_navigation_triangulation can still be looked into, as that one is a remaining 19s if the 20.5