### PR TITLE
Multiplayer: fix hand of evil briefly disappearing

### DIFF
--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -785,7 +785,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
           i = player->secondary_cursor_state;
         else
           i = player->primary_cursor_state;
-        if ((player->instance_num == PI_Grab) || (player->instance_num == PI_Drop) || (player->instance_num == PI_Whip) || (player->instance_num == PI_WhipEnd) || (local_thing_under_hand > 0)) {
+        if ((player->instance_num == PI_Grab) || (player->instance_num == PI_Drop) || (player->instance_num == PI_Whip) || (player->instance_num == PI_WhipEnd) || (local_thing_under_hand > 0) || (!power_hand_is_empty(player) && (i != CSt_DoorKey))) {
             i = CSt_PowerHand;
         } else
         if ((i == CSt_PowerHand) && power_hand_is_empty(player))

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -99,6 +99,7 @@ struct GuiLayer gui_layer = {GuiLayer_Default};
 TbBool first_person_see_item_desc = false;
 
 static TbBool move_camera_this_turn;
+static GameTurn hand_pick_pending_until;
 
 long old_mx;
 long old_my;
@@ -2054,7 +2055,7 @@ static short get_creature_control_action_inputs(void)
 
 static void set_packet_action_for_thing_under_hand(struct PlayerInfo* player, struct Packet* pckt)
 {
-    if ((player->view_type == PVT_DungeonTop) && ((pckt->control_flags & PCtr_Gui) == 0) && left_button_released && (local_thing_under_hand > 0) && (pckt->action == PckA_None)) {
+    if ((player->view_type == PVT_DungeonTop) && ((pckt->control_flags & PCtr_Gui) == 0) && left_button_released && (local_thing_under_hand > 0) && (pckt->action == PckA_None) && (hand_pick_pending_until <= get_gameturn())) {
         int32_t cursor_state = (pckt->additional_packet_values & PCAdV_ContextMask) >> 1;
         switch (player->work_state) {
         case PSt_CtrlDungeon:
@@ -2062,6 +2063,7 @@ static void set_packet_action_for_thing_under_hand(struct PlayerInfo* player, st
                 set_packet_action(pckt, PckA_UsePwrOnThing, PwrK_POSSESS, local_thing_under_hand, 0, 0);
             } else if (((pckt->additional_packet_values & PCAdV_CrtrQueryPressed) == 0) && (cursor_state == CSt_PowerHand)) {
                 set_packet_action(pckt, PckA_UsePwrHandPick, local_thing_under_hand, 0, 0, 0);
+                hand_pick_pending_until = get_gameturn() + game.input_lag_turns + 1;
             }
             break;
         case PSt_Slap:
@@ -2530,7 +2532,9 @@ static void get_dungeon_control_nonaction_inputs(void)
   my_mouse_y = GetMouseY();
   struct PlayerInfo* player = get_my_player();
   struct Packet* pckt = get_packet(my_player_number);
-  local_thing_under_hand = 0;
+  if (hand_pick_pending_until <= get_gameturn()) {
+    local_thing_under_hand = 0;
+  }
   unset_packet_control(pckt, PCtr_MapCoordsValid);
   if (player->work_state == PSt_CtrlDungeon)
   {

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -608,9 +608,8 @@ void draw_power_hand(void)
     if (player->work_state != PSt_HoldInHand)
     {
       TbBool draw_hand = (local_thing_under_hand > 0);
-      if ((player->work_state == PSt_CtrlDungeon) && !power_hand_is_empty(player))
-      {
-        draw_hand = (player->secondary_cursor_state == CSt_PowerHand) || ((player->secondary_cursor_state == CSt_DefaultArrow) && (player->primary_cursor_state == CSt_PowerHand));
+      if ((player->work_state == PSt_CtrlDungeon) && !power_hand_is_empty(player)) {
+        draw_hand = (player->primary_cursor_state != CSt_DoorKey) && (player->secondary_cursor_state != CSt_DoorKey);
       }
       if ((player->work_state != PSt_CtrlDungeon) || !draw_hand)
       {


### PR DESCRIPTION
When you have high `input_lag_turns` there's a minor visual glitch where the hand of evil disappears for 1 turn after picking up a creature if you move your cursor away from the creature quickly. There's also the hand of evil turning back into a regular cursor briefly. This PR fixes both issues.