### PR TITLE
Refactor ariadne

### DIFF
--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -3618,7 +3618,6 @@ static long tri_split3(long btri_id, long pt_x, long pt_y)
     memcpy(tri2,btri,sizeof(struct Triangle));
     long pt_id;
     pt_id = point_set_new_or_reuse(pt_x, pt_y);
-    //pt_id = point_new(); // from before point_set_new_or_reuse()
     if (pt_id < 0) {
         tri_dispose(new_triangle1_id);
         tri_dispose(new_triangle2_id);
@@ -3731,7 +3730,6 @@ static long edge_split(long ntri, long ncor, long pt_x, long pt_y)
     NAVIDBG(19,"Starting");
     // Create and fill new point
     pt_idx = point_set_new_or_reuse(pt_x, pt_y);
-    //pt_idx = point_new(); // from before point_set_new_or_reuse()
     if (pt_idx < 0) {
         return -1;
     }

--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -2356,7 +2356,7 @@ static TbBool blocked_by_door_at(struct Thing *thing, struct Coord3d *pos, unsig
     return false;
 }
 
-long ariadne_push_position_against_wall(struct Thing *thing, const struct Coord3d *pos1, struct Coord3d *pos_out)
+static long ariadne_push_position_against_wall(struct Thing *thing, const struct Coord3d *pos1, struct Coord3d *pos_out)
 {
     struct Coord3d lpos;
     long radius;
@@ -2569,7 +2569,7 @@ static AriadneReturn ariadne_prepare_creature_route_target_reached(const struct 
  * @param func_name
  * @return
  */
-AriadneReturn ariadne_prepare_creature_route_to_target_f(const struct Thing *thing, struct Ariadne *arid,
+static AriadneReturn ariadne_prepare_creature_route_to_target_f(const struct Thing *thing, struct Ariadne *arid,
     const struct Coord3d *srcpos, const struct Coord3d *dstpos, long speed, AriadneRouteFlags flags, const char *func_name)
 {
     struct Path path;

--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -85,6 +85,8 @@ static int32_t Border[BORDER_LENGTH];
 static int32_t route_fwd[ROUTE_LENGTH];
 static int32_t route_bak[ROUTE_LENGTH];
 
+static NavColour *IanMap = NULL;
+
 /******************************************************************************/
 static unsigned char const actual_sizexy_to_nav_block_sizexy_table[] = {
     1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
@@ -187,6 +189,9 @@ static struct Path fwd_path;
 static struct Path bak_path;
 static struct Path best_path;
 /******************************************************************************/
+
+#define navmap_tile_number(stl_x,stl_y) ((stl_y)*game.navigation_map_size_x+(stl_x))
+
 long thing_nav_block_sizexy(const struct Thing *thing)
 {
     long i;
@@ -238,6 +243,14 @@ static void edgelen_init(void);
 static NavColour get_navigation_colour(long stl_x, long stl_y);
 static TbBool triangulate_area(NavColour *imap, long sx, long sy, long ex, long ey);
 /******************************************************************************/
+static void set_navigation_map(MapSubtlCoord stl_x, MapSubtlCoord stl_y, NavColour navcolour)
+{
+  if ((stl_x < 0) || (stl_x > game.map_subtiles_x))
+      return;
+  if ((stl_y < 0) || (stl_y > game.map_subtiles_y))
+      return;
+  game.navigation_map[navmap_tile_number(stl_x,stl_y)] = navcolour;
+}
 
 static unsigned long fits_thro(long tri_idx, long ormask_idx)
 {
@@ -4712,14 +4725,11 @@ static NavColour get_navigation_colour_for_door(long stl_x, long stl_y)
 
 static NavColour get_navigation_colour_for_cube(long stl_x, long stl_y)
 {
-    long tcube;
-    int32_t cube_pos;
     NavColour i;
     i = get_floor_filled_subtiles_at(stl_x, stl_y);
     if (i > NAVMAP_FLOORHEIGHT_MAX)
       i = NAVMAP_FLOORHEIGHT_MAX;
-    tcube = get_top_cube_at(stl_x, stl_y, &cube_pos);
-    if (cube_is_lava(tcube) || (cube_pos<4 && cube_is_sacrificial(tcube)))
+    if (subtile_is_unsafe(stl_x, stl_y))
       i |= NAVMAP_UNSAFE_SURFACE;
     return i;
 }

--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -4816,7 +4816,7 @@ static void triangulation_initxy(long startx, long starty, long endx, long endy)
     triangulation_init_regions();
 }
 
-void triangulation_init(void)
+static void triangulation_init(void)
 {
     if (!tri_initialised)
     {

--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -2269,17 +2269,6 @@ AriadneReturn ariadne_init_wallhug(struct Thing *thing, struct Ariadne *arid, st
     return AridRet_OK;
 }
 
-void initialise_wallhugging_path_from_to(struct Navigation *navi, struct Coord3d *mvstart, struct Coord3d *mvend)
-{
-    navi->navstate = NavS_WallhugInProgress;
-    navi->pos_final.x.val = mvend->x.val;
-    navi->pos_final.y.val = mvend->y.val;
-    navi->pos_final.z.val = mvend->z.val;
-    navi->wallhug_state = WallhugCurrentState_None;
-    navi->wallhug_retry_counter = 0;
-    navi->push_counter = 0;
-}
-
 long ariadne_get_blocked_flags(struct Thing *thing, const struct Coord3d *pos)
 {
     struct Coord3d lpos;

--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -225,19 +225,21 @@ long ix_Points = 0;
 long free_Points = -1;
 */
 /******************************************************************************/
-long route_to_path(long ptfind_x, long ptfind_y, long ptstart_x, long ptstart_y, const int32_t *route, long wp_lim, struct Path *path, int32_t *total_len);
-void path_out_a_bit(struct Path *path, const int32_t *route);
-void gate_navigator_init8(struct Pathway *pway, long trAx, long trAy, long trBx, long trBy, long wp_lim, unsigned char unusedparam);
-void route_through_gates(const struct Pathway *pway, struct Path *path, long subroute);
-long ariadne_push_position_against_wall(struct Thing *thing, const struct Coord3d *pos1, struct Coord3d *pos_out);
+static long route_to_path(long ptfind_x, long ptfind_y, long ptstart_x, long ptstart_y, const int32_t *route, long wp_lim, struct Path *path, int32_t *total_len);
+static void path_out_a_bit(struct Path *path, const int32_t *route);
+static void gate_navigator_init8(struct Pathway *pway, long trAx, long trAy, long trBx, long trBy, long wp_lim, unsigned char unusedparam);
+static void route_through_gates(const struct Pathway *pway, struct Path *path, long subroute);
+static long ariadne_push_position_against_wall(struct Thing *thing, const struct Coord3d *pos1, struct Coord3d *pos_out);
 static TbBool ariadne_check_forward_for_wallhug_gap(struct Thing *thing, struct Ariadne *arid, struct Coord3d *pos, long hug_angle);
-long ariadne_get_blocked_flags(struct Thing *thing, const struct Coord3d *pos);
+static long ariadne_get_blocked_flags(struct Thing *thing, const struct Coord3d *pos);
 static long triangle_findSE8(long ptfind_x, long ptfind_y);
-long ma_triangle_route(long ptfind_x, long ptfind_y, int32_t *ptstart_x);
-void edgelen_init(void);
+static long ma_triangle_route(long ptfind_x, long ptfind_y, int32_t *ptstart_x);
+static void edgelen_init(void);
+static NavColour get_navigation_colour(long stl_x, long stl_y);
+static TbBool triangulate_area(NavColour *imap, long sx, long sy, long ex, long ey);
 /******************************************************************************/
 
-unsigned long fits_thro(long tri_idx, long ormask_idx)
+static unsigned long fits_thro(long tri_idx, long ormask_idx)
 {
     static unsigned long const edgelen_ORmask[] = {60, 51, 15, 0};
     unsigned long eidx;
@@ -280,12 +282,12 @@ unsigned long fits_thro(long tri_idx, long ormask_idx)
     return EdgeFit[eidx];
 }
 
-void triangulate_map(NavColour *imap)
+static void triangulate_map(NavColour *imap)
 {
     triangulate_area(imap, 0, 0, game.navigation_map_size_x, game.navigation_map_size_y);
 }
 
-void init_navigation_map(void)
+static void init_navigation_map(void)
 {
     MapSubtlCoord stl_x;
     MapSubtlCoord stl_y;
@@ -305,7 +307,7 @@ static PlayerBitFlags get_navtree_owner_flags(NavColour treeI)
     return treeI >> NAVMAP_OWNERSELECT_BIT;
 }
 
-long navigation_rule_normal(NavColour treeA, NavColour treeB)
+static long navigation_rule_normal(NavColour treeA, NavColour treeB)
 {
     if ((treeB & NAVMAP_FLOORHEIGHT_MASK) - (treeA & NAVMAP_FLOORHEIGHT_MASK) > 1)
       return NavigationRule_Blocked;
@@ -408,7 +410,7 @@ static void edge_points8(long ntri_src, long ntri_dst, int32_t *tipA_x, int32_t 
     }
 }
 
-long fov_region(long point_x, long point_y, const struct FOV *fov)
+static long fov_region(long point_x, long point_y, const struct FOV *fov)
 {
     long diff_ax;
     long diff_ay;
@@ -431,7 +433,7 @@ long fov_region(long point_x, long point_y, const struct FOV *fov)
     return FieldOfViewRegion_WithinBounds;
 }
 
-long route_to_path(long ptfind_x, long ptfind_y, long ptstart_x, long ptstart_y, const int32_t *route, long wp_lim, struct Path *path, int32_t *total_len)
+static long route_to_path(long ptfind_x, long ptfind_y, long ptstart_x, long ptstart_y, const int32_t *route, long wp_lim, struct Path *path, int32_t *total_len)
 {
     NAVIDBG(19,"Starting");
 
@@ -557,7 +559,7 @@ long route_to_path(long ptfind_x, long ptfind_y, long ptstart_x, long ptstart_y,
     return wp_num;
 }
 
-void waypoint_normal(long tri1_id, long cor1_id, int32_t *norm_x, int32_t *norm_y)
+static void waypoint_normal(long tri1_id, long cor1_id, int32_t *norm_x, int32_t *norm_y)
 {
     int tri2_id;
     int tri3_id;
@@ -648,7 +650,7 @@ void waypoint_normal(long tri1_id, long cor1_id, int32_t *norm_x, int32_t *norm_
     *norm_y = ny;
 }
 
-void path_out_a_bit(struct Path *path, const int32_t *route)
+static void path_out_a_bit(struct Path *path, const int32_t *route)
 {
     struct PathWayPoint *ppoint;
     int32_t *wpoint;
@@ -690,7 +692,7 @@ void path_out_a_bit(struct Path *path, const int32_t *route)
     }
 }
 
-void cull_gate_to_point(struct Gate *gt, long distance_threshold)
+static void cull_gate_to_point(struct Gate *gt, long distance_threshold)
 {
     int diff_a;
     int diff_b;
@@ -747,7 +749,7 @@ void cull_gate_to_point(struct Gate *gt, long distance_threshold)
     }
 }
 
-TbBool calc_intersection(struct Gate *gt, long line_start_x, long line_start_y, long line_end_x, long line_end_y)
+static TbBool calc_intersection(struct Gate *gt, long line_start_x, long line_start_y, long line_end_x, long line_end_y)
 {
     int gate_start_x_delta;
     int line_y_delta;
@@ -808,7 +810,7 @@ TbBool calc_intersection(struct Gate *gt, long line_start_x, long line_start_y, 
     return true;
 }
 
-void cull_gate_to_best_point(struct Gate *gt, long distance_threshold)
+static void cull_gate_to_best_point(struct Gate *gt, long distance_threshold)
 {
     int start_to_intersection_distance;
     int end_to_intersection_distance;
@@ -955,7 +957,7 @@ void cull_gate_to_best_point(struct Gate *gt, long distance_threshold)
     }
 }
 
-long gate_route_to_coords(long trAx, long trAy, long trBx, long trBy, int32_t *route_array, long route_length, struct Pathway *pway, long distance_threshold)
+static long gate_route_to_coords(long trAx, long trAy, long trBx, long trBy, int32_t *route_array, long route_length, struct Pathway *pway, long distance_threshold)
 {
     int32_t total_len;
     best_path.waypoints_num = route_to_path(trAx, trAy, trBx, trBy, route_array, route_length, &best_path, &total_len);
@@ -1159,7 +1161,7 @@ long gate_route_to_coords(long trAx, long trAy, long trBx, long trBy, int32_t *r
     return pt_num;
 }
 
-void gate_navigator_init8(struct Pathway *pway, long trAx, long trAy, long trBx, long trBy, long wp_lim, unsigned char unusedparam)
+static void gate_navigator_init8(struct Pathway *pway, long trAx, long trAy, long trBx, long trBy, long wp_lim, unsigned char unusedparam)
 {
     pway->start_coordinate_x = trAx;
     pway->start_coordinate_y = trAy;
@@ -1184,7 +1186,7 @@ void gate_navigator_init8(struct Pathway *pway, long trAx, long trAy, long trBx,
     }
 }
 
-void route_through_gates(const struct Pathway *pway, struct Path *path, long subroute)
+static void route_through_gates(const struct Pathway *pway, struct Path *path, long subroute)
 {
     const struct Gate *ppoint;
     struct PathWayPoint *wpoint;
@@ -1276,7 +1278,7 @@ void tag_open_closed_init(void)
 
 */
 
-unsigned long nav_same_component(long ptAx, long ptAy, long ptBx, long ptBy)
+static unsigned long nav_same_component(long ptAx, long ptAy, long ptBx, long ptBy)
 {
     NAVIDBG(19,"F=%u Connect %03ld,%03ld %03ld,%03ld", get_gameturn(), ptAx, ptAy, ptBx, ptBy);
     long tri1_id;
@@ -1297,7 +1299,7 @@ TbBool navigation_points_connected(struct Coord3d *pt1, struct Coord3d *pt2)
   return nav_same_component(pt1->x.val, pt1->y.val, pt2->x.val, pt2->y.val);
 }
 
-TbBool triangulation_border_tag(void)
+static TbBool triangulation_border_tag(void)
 {
     if (border_tags_to_current(Border, ix_Border) != ix_Border)
     {
@@ -1307,7 +1309,7 @@ TbBool triangulation_border_tag(void)
     return true;
 }
 
-void creature_radius_set(long radius)
+static void creature_radius_set(long radius)
 {
     edgelen_init();
     if ((radius < CreatureRadius_Small) || (radius >= EDGEOR_COUNT)) {
@@ -1466,7 +1468,7 @@ void nearest_search_f(long sizexy, long srcx, long srcy, long dstx, long dsty, i
     set_nearpoint(seltri_id, selcor_id, dstx, dsty, px, py);
 }
 
-long cost_to_start(long tri_idx)
+static long cost_to_start(long tri_idx)
 {
     long long len_x;
     long long len_y;
@@ -1556,7 +1558,7 @@ long pointed_at8(long pos_x, long pos_y, int32_t *ret_tri, int32_t *ret_pt)
     return -1;
 }
 
-TbBool triangle_check_and_add_navitree_fwd(long ttri)
+static TbBool triangle_check_and_add_navitree_fwd(long ttri)
 {
     struct Triangle *tri;
     tri = get_triangle(ttri);
@@ -1606,7 +1608,7 @@ TbBool triangle_check_and_add_navitree_fwd(long ttri)
     return true;
 }
 
-TbBool triangle_check_and_add_navitree_bak(long ttri)
+static TbBool triangle_check_and_add_navitree_bak(long ttri)
 {
     struct Triangle *tri;
     tri = get_triangle(ttri);
@@ -1658,7 +1660,7 @@ TbBool triangle_check_and_add_navitree_bak(long ttri)
  * @param routecost Output integer where the tree route cost is returned.
  * @return Amount of points copied into the route array, or -1 on routing failure.
  */
-long triangle_route_do_fwd(long ttriA, long ttriB, int32_t *route, int32_t *routecost)
+static long triangle_route_do_fwd(long ttriA, long ttriB, int32_t *route, int32_t *routecost)
 {
     NAVIDBG(19,"Starting");
     tags_init();
@@ -1726,7 +1728,7 @@ long triangle_route_do_fwd(long ttriA, long ttriB, int32_t *route, int32_t *rout
  * @return Amount of points copied into the route array, or -1 on routing failure.
  * @note This function should differ from triangle_route_do_bak() in only one line
  */
-long triangle_route_do_bak(long ttriA, long ttriB, int32_t *route, int32_t *routecost)
+static long triangle_route_do_bak(long ttriA, long ttriB, int32_t *route, int32_t *routecost)
 {
     NAVIDBG(19,"Starting");
     tags_init();
@@ -1792,7 +1794,7 @@ long triangle_route_do_bak(long ttriA, long ttriB, int32_t *route, int32_t *rout
  * @param routecost Pointer where the tree route cost is returned.
  * @return
  */
-long ma_triangle_route(long ttriA, long ttriB, int32_t *routecost)
+static long ma_triangle_route(long ttriA, long ttriB, int32_t *routecost)
 {
     long forward_route_length;
     long backward_route_length;
@@ -1857,7 +1859,7 @@ long ma_triangle_route(long ttriA, long ttriB, int32_t *routecost)
     }
 }
 
-void edgelen_init(void)
+static void edgelen_init(void)
 {
     if (edgelen_initialised)
         return;
@@ -1888,7 +1890,7 @@ void edgelen_init(void)
     EdgeFit = RadiusEdgeFit[1];
 }
 
-TbBool ariadne_creature_reached_position(const struct Thing *thing, const struct Coord3d *pos)
+static TbBool ariadne_creature_reached_position(const struct Thing *thing, const struct Coord3d *pos)
 {
     if (thing->mappos.x.val != pos->x.val)
     return false;
@@ -1897,7 +1899,7 @@ TbBool ariadne_creature_reached_position(const struct Thing *thing, const struct
     return true;
 }
 
-long ariadne_creature_blocked_by_wall_at(struct Thing *thing, const struct Coord3d *pos)
+static long ariadne_creature_blocked_by_wall_at(struct Thing *thing, const struct Coord3d *pos)
 {
     struct Coord3d mvpos;
     long zmem;
@@ -1913,7 +1915,7 @@ long ariadne_creature_blocked_by_wall_at(struct Thing *thing, const struct Coord
     return ret;
 }
 
-void ariadne_pull_out_waypoint(const struct Thing *thing, const struct Ariadne *arid, long wpoint_id, struct Coord3d *pos)
+static void ariadne_pull_out_waypoint(const struct Thing *thing, const struct Ariadne *arid, long wpoint_id, struct Coord3d *pos)
 {
     const struct Coord2d *wp;
     long size_radius;
@@ -1961,7 +1963,7 @@ void ariadne_pull_out_waypoint(const struct Thing *thing, const struct Ariadne *
  * @param thing The thing which is moving.
  * @param arid The Ariadne which is being changed.
  */
-void ariadne_init_current_waypoint(const struct Thing *thing, struct Ariadne *arid)
+static void ariadne_init_current_waypoint(const struct Thing *thing, struct Ariadne *arid)
 {
     ariadne_pull_out_waypoint(thing, arid, arid->current_waypoint, &arid->current_waypoint_pos);
     arid->current_waypoint_pos.z.val = get_thing_height_at(thing, &arid->current_waypoint_pos);
@@ -1973,7 +1975,7 @@ long angle_to_quadrant(long angle)
     return ((angle + DEGREES_45) / DEGREES_90) & 3;
 }
 
-TbBool ariadne_wallhug_angle_valid(struct Thing *thing, struct Ariadne *arid, long angle)
+static TbBool ariadne_wallhug_angle_valid(struct Thing *thing, struct Ariadne *arid, long angle)
 {
     struct Coord3d pos;
     pos.x.val = thing->mappos.x.val + distance_with_angle_to_coord_x(arid->move_speed, angle);
@@ -1982,7 +1984,7 @@ TbBool ariadne_wallhug_angle_valid(struct Thing *thing, struct Ariadne *arid, lo
     return (ariadne_creature_blocked_by_wall_at(thing, &pos) == 0);
 }
 
-long ariadne_get_wallhug_angle(struct Thing *thing, struct Ariadne *arid)
+static long ariadne_get_wallhug_angle(struct Thing *thing, struct Ariadne *arid)
 {
     long whangle;
     if (arid->hug_side == WallhugPreference_Right)
@@ -2018,7 +2020,7 @@ long ariadne_get_wallhug_angle(struct Thing *thing, struct Ariadne *arid)
     return -1;
 }
 
-void ariadne_get_starting_angle_and_side_of_wallhug_for_desireable_move(struct Thing *thing, struct Ariadne *arid, long inangle, short *rangle, unsigned char *rflag)
+static void ariadne_get_starting_angle_and_side_of_wallhug_for_desireable_move(struct Thing *thing, struct Ariadne *arid, long inangle, short *rangle, unsigned char *rflag)
 {
     struct Coord3d bkp_mappos;
     bkp_mappos = thing->mappos;
@@ -2143,7 +2145,7 @@ void ariadne_get_starting_angle_and_side_of_wallhug_for_desireable_move(struct T
     }
 }
 
-TbBool ariadne_get_starting_angle_and_side_of_wallhug(struct Thing *thing, struct Ariadne *arid, struct Coord3d *pos, short *rangle, unsigned char *rflag)
+static TbBool ariadne_get_starting_angle_and_side_of_wallhug(struct Thing *thing, struct Ariadne *arid, struct Coord3d *pos, short *rangle, unsigned char *rflag)
 {
     TbBool nxdelta_x_neg;
     TbBool nxdelta_y_neg;
@@ -2212,7 +2214,7 @@ TbBool ariadne_get_starting_angle_and_side_of_wallhug(struct Thing *thing, struc
     return false;
 }
 
-AriadneReturn ariadne_init_wallhug(struct Thing *thing, struct Ariadne *arid, struct Coord3d *pos)
+static AriadneReturn ariadne_init_wallhug(struct Thing *thing, struct Ariadne *arid, struct Coord3d *pos)
 {
     if (arid->move_speed <= 0) {
         ERRORLOG("Ariadne Speed not positive");
@@ -2269,7 +2271,7 @@ AriadneReturn ariadne_init_wallhug(struct Thing *thing, struct Ariadne *arid, st
     return AridRet_OK;
 }
 
-long ariadne_get_blocked_flags(struct Thing *thing, const struct Coord3d *pos)
+static long ariadne_get_blocked_flags(struct Thing *thing, const struct Coord3d *pos)
 {
     struct Coord3d lpos;
     unsigned long blkflags;
@@ -2295,7 +2297,7 @@ long ariadne_get_blocked_flags(struct Thing *thing, const struct Coord3d *pos)
     return blkflags;
 }
 
-TbBool blocked_by_door_at(struct Thing *thing, struct Coord3d *pos, unsigned long blk_flags)
+static TbBool blocked_by_door_at(struct Thing *thing, struct Coord3d *pos, unsigned long blk_flags)
 {
     long radius;
     long start_x;
@@ -2415,7 +2417,7 @@ long ariadne_push_position_against_wall(struct Thing *thing, const struct Coord3
     return blk_flags;
 }
 
-long ariadne_init_movement_to_current_waypoint(struct Thing *thing, struct Ariadne *arid)
+static long ariadne_init_movement_to_current_waypoint(struct Thing *thing, struct Ariadne *arid)
 {
     struct Coord3d requested_pos;
     struct Coord3d fixed_pos;
@@ -2463,7 +2465,7 @@ long ariadne_init_movement_to_current_waypoint(struct Thing *thing, struct Ariad
     return 1;
 }
 
-long ariadne_creature_can_continue_direct_line_to_waypoint(struct Thing *thing, struct Ariadne *arid, long speed)
+static long ariadne_creature_can_continue_direct_line_to_waypoint(struct Thing *thing, struct Ariadne *arid, long speed)
 {
     long angle;
     angle = get_angle_xy_to(&thing->mappos, &arid->current_waypoint_pos);
@@ -2520,7 +2522,7 @@ long ariadne_creature_can_continue_direct_line_to_waypoint(struct Thing *thing, 
  * @param dstpos
  * @return
  */
-AriadneReturn ariadne_prepare_creature_route_target_reached(const struct Thing *thing, struct Ariadne *arid, const struct Coord3d *srcpos, const struct Coord3d *dstpos)
+static AriadneReturn ariadne_prepare_creature_route_target_reached(const struct Thing *thing, struct Ariadne *arid, const struct Coord3d *srcpos, const struct Coord3d *dstpos)
 {
     arid->startpos.x.val = srcpos->x.val;
     arid->startpos.y.val = srcpos->y.val;
@@ -2702,7 +2704,7 @@ AriadneReturn ariadne_initialise_creature_route_f(struct Thing *thing, const str
     return AridRet_OK;
 }
 
-AriadneReturn ariadne_creature_get_next_waypoint(struct Thing *thing, struct Ariadne *arid)
+static AriadneReturn ariadne_creature_get_next_waypoint(struct Thing *thing, struct Ariadne *arid)
 {
     struct Coord3d pos;
     // Make sure we didn't exceeded the stored waypoints count
@@ -2733,12 +2735,12 @@ AriadneReturn ariadne_creature_get_next_waypoint(struct Thing *thing, struct Ari
     return ariadne_initialise_creature_route(thing, &pos, arid->move_speed, arid->route_flags);
 }
 
-TbBool ariadne_creature_reached_waypoint(const struct Thing *thing, const struct Ariadne *arid)
+static TbBool ariadne_creature_reached_waypoint(const struct Thing *thing, const struct Ariadne *arid)
 {
     return ariadne_creature_reached_position(thing, &arid->current_waypoint_pos);
 }
 
-AriadneReturn ariadne_update_state_manoeuvre_to_position(struct Thing *thing, struct Ariadne *arid)
+static AriadneReturn ariadne_update_state_manoeuvre_to_position(struct Thing *thing, struct Ariadne *arid)
 {
     struct Coord3d pos;
     MapCoord dist;
@@ -2786,7 +2788,7 @@ AriadneReturn ariadne_update_state_manoeuvre_to_position(struct Thing *thing, st
     return AridRet_OK;
 }
 
-AriadneReturn ariadne_update_state_on_line(struct Thing *thing, struct Ariadne *arid)
+static AriadneReturn ariadne_update_state_on_line(struct Thing *thing, struct Ariadne *arid)
 {
     long angle;
     long distance;
@@ -2952,7 +2954,7 @@ static TbBool ariadne_check_forward_for_wallhug_gap(struct Thing *thing, struct 
     return false;
 }
 
-TbBool ariadne_creature_on_circular_hug(const struct Thing *thing, const struct Ariadne *arid)
+static TbBool ariadne_creature_on_circular_hug(const struct Thing *thing, const struct Ariadne *arid)
 {
     long src_x;
     long src_y;
@@ -2984,7 +2986,7 @@ TbBool ariadne_creature_on_circular_hug(const struct Thing *thing, const struct 
     return false;
 }
 
-AriadneReturn ariadne_update_state_wallhug(struct Thing *thing, struct Ariadne *arid)
+static AriadneReturn ariadne_update_state_wallhug(struct Thing *thing, struct Ariadne *arid)
 {
     MapCoordDelta distance;
     NAVIDBG(18,"Route for %s index %d from %3d,%3d to %3d,%3d", thing_model_name(thing),(int)thing->index,
@@ -3133,7 +3135,7 @@ AriadneReturn ariadne_update_state_wallhug(struct Thing *thing, struct Ariadne *
 }
 
 //TODO investigate when we get same coords
-AriadneReturn ariadne_get_next_position_for_route(struct Thing *thing, struct Coord3d *finalpos, long speed, struct Coord3d *nextpos, AriadneRouteFlags flags)
+static AriadneReturn ariadne_get_next_position_for_route(struct Thing *thing, struct Coord3d *finalpos, long speed, struct Coord3d *nextpos, AriadneRouteFlags flags)
 {
     struct CreatureControl *cctrl;
     struct Ariadne *arid;
@@ -3331,7 +3333,7 @@ void path_init8_wide_f(struct Path *path, long start_x, long start_y, long end_x
  * @param pt_cor
  * @return Returns resulted level (3 or 4), or non-positive value on error.
  */
-long make_3or4point(int32_t *pt_tri, int32_t *pt_cor)
+static long make_3or4point(int32_t *pt_tri, int32_t *pt_cor)
 {
     long initial_loop_result;
     long final_loop_result;
@@ -3561,7 +3563,7 @@ static long delete_triangle_point(long tri1_id, long cor1_id)
     return true;
 }
 
-TbBool delete_point(long pt_tri, long pt_cor)
+static TbBool delete_point(long pt_tri, long pt_cor)
 {
     long n;
     int32_t ntri;
@@ -3592,7 +3594,7 @@ TbBool delete_point(long pt_tri, long pt_cor)
     return true;
 }
 
-long tri_split3(long btri_id, long pt_x, long pt_y)
+static long tri_split3(long btri_id, long pt_x, long pt_y)
 {
     NAVIDBG(19,"Starting");
     struct Triangle *btri;
@@ -3674,7 +3676,7 @@ long tri_split3(long btri_id, long pt_x, long pt_y)
     return pt_id;
 }
 
-long tri_split2(long tri_id1, long cor_id1, long pt_x, long pt_y, long pt_id1)
+static long tri_split2(long tri_id1, long cor_id1, long pt_x, long pt_y, long pt_id1)
 {
     long tri_id2;
     tri_id2 = tri_new();
@@ -3719,7 +3721,7 @@ long tri_split2(long tri_id1, long cor_id1, long pt_x, long pt_y, long pt_id1)
     return tri_id2;
 }
 
-long edge_split(long ntri, long ncor, long pt_x, long pt_y)
+static long edge_split(long ntri, long ncor, long pt_x, long pt_y)
 {
     long pt_idx;
     long ntr2;
@@ -3758,7 +3760,7 @@ long edge_split(long ntri, long ncor, long pt_x, long pt_y)
  * @param pt_y Coord Y of the dividing point.
  * @return Zero if areas do not differ; -1 or 1 otherwise.
  */
-char triangle_divide_areas_differ(long ntri, long ncorA, long ncorB, long pt_x, long pt_y)
+static char triangle_divide_areas_differ(long ntri, long ncorA, long ncorB, long pt_x, long pt_y)
 {
     long tipA_x;
     long tipA_y;
@@ -3811,7 +3813,7 @@ static TbBool insert_point(long pt_x, long pt_y)
     return tri_split3(ntri, pt_x, pt_y) >= 0;
 }
 
-long fill_concave(long tri_beg_id, long tag_id, long tri_end_id)
+static long fill_concave(long tri_beg_id, long tag_id, long tri_end_id)
 {
     long tri_id;
     long cor_id;
@@ -3851,7 +3853,7 @@ long fill_concave(long tri_beg_id, long tag_id, long tri_end_id)
     return 1;
 }
 
-void make_edge_sub(long start_tri_id1, long start_cor_id1, long start_tri_id4, long start_cor_id4, long sx, long sy, long ex, long ey)
+static void make_edge_sub(long start_tri_id1, long start_cor_id1, long start_tri_id4, long start_cor_id4, long sx, long sy, long ex, long ey)
 {
     struct Triangle *tri;
     struct Point *pt;
@@ -3987,7 +3989,7 @@ static TbBool make_edge(long start_x, long start_y, long end_x, long end_y)
     return true;
 }
 
-TbBool border_clip_horizontal(const NavColour *imap, long start_x, long end_x, long start_y, long end_y)
+static TbBool border_clip_horizontal(const NavColour *imap, long start_x, long end_x, long start_y, long end_y)
 {
     NavColour map_center;
     NavColour map_up;
@@ -4031,7 +4033,7 @@ TbBool border_clip_horizontal(const NavColour *imap, long start_x, long end_x, l
     return clipping_successful;
 }
 
-TbBool border_clip_vertical(const NavColour *imap, long start_x, long end_x, long start_y, long end_y)
+static TbBool border_clip_vertical(const NavColour *imap, long start_x, long end_x, long start_y, long end_y)
 {
     NavColour map_center;
     NavColour map_left;
@@ -4075,7 +4077,7 @@ TbBool border_clip_vertical(const NavColour *imap, long start_x, long end_x, lon
     return clipping_successful;
 }
 
-TbBool point_redundant(long tri_idx, long cor_idx)
+static TbBool point_redundant(long tri_idx, long cor_idx)
 {
     long tri_first;
     long cor_first;
@@ -4171,7 +4173,8 @@ static long edge_find(long stlstart_x, long stlstart_y, long stlend_x, long stle
     return 0;
 }
 
-TbBool edge_lock_f(long ptend_x, long ptend_y, long ptstart_x, long ptstart_y, const char *func_name)
+#define edge_lock(fin_x, fin_y, bgn_x, bgn_y) edge_lock_f(fin_x, fin_y, bgn_x, bgn_y, __func__)
+static TbBool edge_lock_f(long ptend_x, long ptend_y, long ptstart_x, long ptstart_y, const char *func_name)
 {
     long pt_x;
     long pt_y;
@@ -4209,7 +4212,8 @@ TbBool edge_lock_f(long ptend_x, long ptend_y, long ptstart_x, long ptstart_y, c
     return true;
 }
 
-TbBool edge_unlock_record_and_regions_f(long ptend_x, long ptend_y, long ptstart_x, long ptstart_y, const char *func_name)
+#define edge_unlock_record_and_regions(fin_x, fin_y, bgn_x, bgn_y) edge_unlock_record_and_regions_f(fin_x, fin_y, bgn_x, bgn_y, __func__)
+static TbBool edge_unlock_record_and_regions_f(long ptend_x, long ptend_y, long ptstart_x, long ptstart_y, const char *func_name)
 {
     long pt_x;
     long pt_y;
@@ -4259,7 +4263,7 @@ TbBool edge_unlock_record_and_regions_f(long ptend_x, long ptend_y, long ptstart
     return true;
 }
 
-TbBool border_lock(long start_x, long start_y, long end_x, long end_y)
+static TbBool border_lock(long start_x, long start_y, long end_x, long end_y)
 {
     TbBool lock_successful;
     NAVIDBG(19,"Starting");
@@ -4271,7 +4275,7 @@ TbBool border_lock(long start_x, long start_y, long end_x, long end_y)
     return lock_successful;
 }
 
-void border_internal_points_delete(long start_x, long start_y, long end_x, long end_y)
+static void border_internal_points_delete(long start_x, long start_y, long end_x, long end_y)
 {
     int32_t edge_tri;
     int32_t edge_cor;
@@ -4346,7 +4350,7 @@ void border_internal_points_delete(long start_x, long start_y, long end_x, long 
     }
 }
 
-long triangle_area1(long tri_idx)
+static long triangle_area1(long tri_idx)
 {
     int ptidx0;
     int ptidx1;
@@ -4415,7 +4419,7 @@ static void brute_fill_rectangle(long start_x, long start_y, long end_x, long en
 }
 
 #define fill_rectangle(start_x, start_y, end_x, end_y, nav_colour) fill_rectangle_f(start_x, start_y, end_x, end_y, nav_colour, __func__)
-void fill_rectangle_f(long start_x, long start_y, long end_x, long end_y, NavColour nav_colour, const char *func_name)
+static void fill_rectangle_f(long start_x, long start_y, long end_x, long end_y, NavColour nav_colour, const char *func_name)
 {
     int32_t tri_n0;
     int32_t tri_k0;
@@ -4480,7 +4484,7 @@ void fill_rectangle_f(long start_x, long start_y, long end_x, long end_y, NavCol
     brute_fill_rectangle(start_x, start_y, end_x, end_y, nav_colour);
 }
 
-TbBool tri_set_rectangle(long start_x, long start_y, long end_x, long end_y, NavColour nav_colour)
+static TbBool tri_set_rectangle(long start_x, long start_y, long end_x, long end_y, NavColour nav_colour)
 {
     long sx;
     long sy;
@@ -4521,7 +4525,7 @@ TbBool tri_set_rectangle(long start_x, long start_y, long end_x, long end_y, Nav
     return rectangle_creation_successful;
 }
 
-long fringe_scan(int32_t *outfri_x, int32_t *outfri_y, int32_t *outlen_x, int32_t *outlen_y)
+static long fringe_scan(int32_t *outfri_x, int32_t *outfri_y, int32_t *outlen_x, int32_t *outlen_y)
 {
     long loc_x;
     long sub_y;
@@ -4557,7 +4561,7 @@ long fringe_scan(int32_t *outfri_x, int32_t *outfri_y, int32_t *outlen_x, int32_
     return 1;
 }
 
-long fringe_get_rectangle(int32_t *outfri_x1, int32_t *outfri_y1, int32_t *outfri_x2, int32_t *outfri_y2, NavColour *oval)
+static long fringe_get_rectangle(int32_t *outfri_x1, int32_t *outfri_y1, int32_t *outfri_x2, int32_t *outfri_y2, NavColour *oval)
 {
     NAVIDBG(19,"Starting");
     int32_t fri_x;
@@ -4599,7 +4603,7 @@ long fringe_get_rectangle(int32_t *outfri_x1, int32_t *outfri_y1, int32_t *outfr
     return 1;
 }
 
-void border_unlock(long start_x, long start_y, long end_x, long end_y)
+static void border_unlock(long start_x, long start_y, long end_x, long end_y)
 {
     struct EdgePoint *ept;
     long ept_id;
@@ -4633,7 +4637,7 @@ void border_unlock(long start_x, long start_y, long end_x, long end_y)
     }
 }
 
-TbBool triangulation_border_start(int32_t *border_a, int32_t *border_b)
+static TbBool triangulation_border_start(int32_t *border_a, int32_t *border_b)
 {
     struct Triangle *tri;
     long tri_idx;
@@ -4684,7 +4688,7 @@ TbBool triangulation_border_start(int32_t *border_a, int32_t *border_b)
     return false;
 }
 
-NavColour get_navigation_colour_for_door(long stl_x, long stl_y)
+static NavColour get_navigation_colour_for_door(long stl_x, long stl_y)
 {
     struct Thing *doortng;
     NavColour colour = (1 << NAVMAP_FLOORHEIGHT_BIT);
@@ -4708,7 +4712,7 @@ NavColour get_navigation_colour_for_door(long stl_x, long stl_y)
 
 }
 
-NavColour get_navigation_colour_for_cube(long stl_x, long stl_y)
+static NavColour get_navigation_colour_for_cube(long stl_x, long stl_y)
 {
     long tcube;
     int32_t cube_pos;
@@ -4722,7 +4726,7 @@ NavColour get_navigation_colour_for_cube(long stl_x, long stl_y)
     return i;
 }
 
-NavColour get_navigation_colour(long stl_x, long stl_y)
+static NavColour get_navigation_colour(long stl_x, long stl_y)
 {
     struct Map *mapblk;
     mapblk = get_map_block_at(stl_x, stl_y);
@@ -4737,7 +4741,7 @@ NavColour get_navigation_colour(long stl_x, long stl_y)
     return get_navigation_colour_for_cube(stl_x, stl_y);
 }
 
-NavColour uniform_area_colour(const NavColour *imap, long start_x, long start_y, long end_x, long end_y)
+static NavColour uniform_area_colour(const NavColour *imap, long start_x, long start_y, long end_x, long end_y)
 {
     NavColour uniform;
     long x;
@@ -4756,7 +4760,7 @@ NavColour uniform_area_colour(const NavColour *imap, long start_x, long start_y,
     return uniform;
 }
 
-void triangulation_border_init(void)
+static void triangulation_border_init(void)
 {
     int32_t border_a;
     int32_t border_b;
@@ -4794,7 +4798,7 @@ void triangulation_border_init(void)
     NAVIDBG(19,"Finished");
 }
 
-void triangulation_initxy(long startx, long starty, long endx, long endy)
+static void triangulation_initxy(long startx, long starty, long endx, long endy)
 {
     long i;
     for (i=0; i < TRIANLGLES_COUNT; i++)
@@ -4821,7 +4825,7 @@ void triangulation_init(void)
     }
 }
 
-TbBool triangulate_area(NavColour *imap, long start_x, long start_y, long end_x, long end_y)
+static TbBool triangulate_area(NavColour *imap, long start_x, long start_y, long end_x, long end_y)
 {
     TbBool one_tile;
     TbBool not_whole_map;

--- a/src/ariadne.h
+++ b/src/ariadne.h
@@ -237,14 +237,12 @@ extern const struct HugStart blocked_xy_hug_start[][2][2];
 /******************************************************************************/
 long init_navigation(void);
 long update_navigation_triangulation(long start_x, long start_y, long end_x, long end_y);
-TbBool triangulate_area(NavColour *imap, long sx, long sy, long ex, long ey);
+
 
 AriadneReturn ariadne_initialise_creature_route_f(struct Thing *thing, const struct Coord3d *pos, long speed, AriadneRouteFlags flags, const char *func_name);
 #define ariadne_initialise_creature_route(thing, pos, speed, flags) ariadne_initialise_creature_route_f(thing, pos, speed, flags, __func__)
 AriadneReturn creature_follow_route_to_using_gates(struct Thing *thing, struct Coord3d *finalpos, struct Coord3d *nextpos, long speed, AriadneRouteFlags flags);
-#define ariadne_prepare_creature_route_to_target(thing, arid, srcpos, dstpos, speed, flags) ariadne_prepare_creature_route_to_target_f(thing, arid, srcpos, dstpos, speed, flags, __func__)
-AriadneReturn ariadne_prepare_creature_route_to_target_f(const struct Thing *thing, struct Ariadne *arid,
-    const struct Coord3d *srcpos, const struct Coord3d *dstpos, long speed, AriadneRouteFlags flags, const char *func_name);
+
 long ariadne_count_waypoints_on_creature_route_to_target_f(const struct Thing *thing,
     const struct Coord3d *srcpos, const struct Coord3d *dstpos, AriadneRouteFlags flags, const char *func_name);
 AriadneReturn ariadne_invalidate_creature_route(struct Thing *thing);
@@ -253,21 +251,9 @@ TbBool navigation_points_connected(struct Coord3d *pt1, struct Coord3d *pt2);
 void path_init8_wide_f(struct Path *path, long start_x, long start_y, long end_x, long end_y, long subroute, unsigned char nav_size, const char *func_name);
 void nearest_search_f(long sizexy, long srcx, long srcy, long dstx, long dsty, int32_t *px, int32_t *py, const char *func_name);
 #define nearest_search(sizexy, srcx, srcy, dstx, dsty, px, py) nearest_search_f(sizexy, srcx, srcy, dstx, dsty, px, py, __func__)
-NavColour get_navigation_colour(long stl_x, long stl_y);
-TbBool border_clip_horizontal(const NavColour *imap, long start_x, long end_x, long start_y, long end_y);
-TbBool border_clip_vertical(const NavColour *imap, long start_x, long end_x, long start_y, long end_y);
-#define edge_lock(fin_x, fin_y, bgn_x, bgn_y) edge_lock_f(fin_x, fin_y, bgn_x, bgn_y, __func__)
-TbBool edge_lock_f(long ptend_x, long ptend_y, long ptstart_x, long ptstart_y, const char *func_name);
-#define edge_unlock_record_and_regions(fin_x, fin_y, bgn_x, bgn_y) edge_unlock_record_and_regions_f(fin_x, fin_y, bgn_x, bgn_y, __func__)
-TbBool edge_unlock_record_and_regions_f(long ptend_x, long ptend_y, long ptstart_x, long ptstart_y, const char *func_name);
-void border_internal_points_delete(long start_x, long start_y, long end_x, long end_y);
-TbBool tri_set_rectangle(long start_x, long start_y, long end_x, long end_y, NavColour nav_colour);
-long fringe_get_rectangle(int32_t *outfri_x1, int32_t *outfri_y1, int32_t *outfri_x2, int32_t *outfri_y2, NavColour *oval);
-long delaunay_seeded(long start_x, long start_y, long end_x, long end_y, TbBool keep_edge);
-void border_unlock(long start_x, long start_y, long end_x, long end_y);
-TbBool triangulation_border_start(int32_t *border_a, int32_t *border_b);
+
+
 void triangulation_init(void);
-void triangulation_initxy(long sx, long sy, long ex, long ey);
 long pointed_at8(long pos_x, long pos_y, int32_t *ret_tri, int32_t *ret_pt);
 long angle_to_quadrant(long angle);
 

--- a/src/ariadne.h
+++ b/src/ariadne.h
@@ -213,22 +213,6 @@ struct WayPoints {
   int32_t waypoint_index_array[ARID_PATH_WAYPOINTS_COUNT];
 };
 
-struct Navigation {
-  unsigned char navstate;
-  unsigned char side;
-  unsigned char wallhug_retry_counter;
-  unsigned char wallhug_state;
-  unsigned char push_counter;
-  long dist_to_final_pos;
-  long distance_to_next_pos;
-  int32_t angle;
-  SubtlCodedCoords first_colliding_block;
-  SubtlCodedCoords second_colliding_block;
-  PlayerBitFlags owner_flags[2];
-  struct Coord3d pos_next;
-  struct Coord3d pos_final;
-};
-
 struct FOV { // sizeof=0x18
     struct PathWayPoint tipA;
     struct PathWayPoint tipB;
@@ -289,8 +273,6 @@ long angle_to_quadrant(long angle);
 
 long thing_nav_block_sizexy(const struct Thing *thing);
 long thing_nav_sizexy(const struct Thing *thing);
-
-void initialise_wallhugging_path_from_to(struct Navigation *navi, struct Coord3d *mvstart, struct Coord3d *mvend);
 
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/ariadne.h
+++ b/src/ariadne.h
@@ -253,7 +253,6 @@ void nearest_search_f(long sizexy, long srcx, long srcy, long dstx, long dsty, i
 #define nearest_search(sizexy, srcx, srcy, dstx, dsty, px, py) nearest_search_f(sizexy, srcx, srcy, dstx, dsty, px, py, __func__)
 
 
-void triangulation_init(void);
 long pointed_at8(long pos_x, long pos_y, int32_t *ret_tri, int32_t *ret_pt);
 long angle_to_quadrant(long angle);
 

--- a/src/ariadne_findcache.c
+++ b/src/ariadne_findcache.c
@@ -87,7 +87,7 @@ long triangle_brute_find8_near(long pos_x, long pos_y)
     return tri_id;
 }
 
-long triangle_find_cache_get(long pos_x, long pos_y)
+static long triangle_find_cache_get(long pos_x, long pos_y)
 {
     long cache_x = (pos_x >> 14);
     if (cache_x > 3)
@@ -115,7 +115,7 @@ long triangle_find_cache_get(long pos_x, long pos_y)
 
 }
 
-void triangle_find_cache_put(long pos_x, long pos_y, long ntri)
+static void triangle_find_cache_put(long pos_x, long pos_y, long ntri)
 {
     long cache_x = (pos_x >> 14);
     if (cache_x > 3)

--- a/src/ariadne_findcache.h
+++ b/src/ariadne_findcache.h
@@ -32,8 +32,6 @@ extern "C" {
 
 #pragma pack()
 /******************************************************************************/
-long triangle_find_cache_get(long pos_x, long pos_y);
-void triangle_find_cache_put(long pos_x, long pos_y, long ntri);
 
 void triangulation_init_cache(long tri_idx);
 

--- a/src/ariadne_naviheap.c
+++ b/src/ariadne_naviheap.c
@@ -32,6 +32,8 @@ extern "C" {
 /******************************************************************************/
 static long heap_end;
 static long Heap[PATH_HEAP_LEN];
+
+static long naviheap_item_tree_val(long heapid);
 /******************************************************************************/
 /** Initializes navigation heap for new use.
  */
@@ -65,7 +67,7 @@ long naviheap_top(void)
  * @param heapid
  * @return
  */
-long naviheap_get(long heapid)
+static long naviheap_get(long heapid)
 {
     if ((heapid < 0) || (heapid > heap_end+1))
         return -1;
@@ -163,7 +165,7 @@ TbBool naviheap_add(long heapid)
  * @param heapid
  * @return
  */
-long naviheap_item_tree_val(long heapid)
+static long naviheap_item_tree_val(long heapid)
 {
     long tree_id = naviheap_get(heapid);
     if ((tree_id < 0) || (tree_id >= TREEVALS_COUNT))

--- a/src/ariadne_naviheap.h
+++ b/src/ariadne_naviheap.h
@@ -32,11 +32,9 @@ TbBool naviheap_empty(void);
 void naviheap_init(void);
 
 long naviheap_top(void);
-long naviheap_get(long heapid);
 long naviheap_remove(void);
 TbBool naviheap_add(long heapid);
 
-long naviheap_item_tree_val(long heapid);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/ariadne_navitree.h
+++ b/src/ariadne_navitree.h
@@ -48,6 +48,7 @@ long copy_tree_to_route(long tag_start_id, long tag_end_id, int32_t *route_pts, 
 
 void delaunay_init(void);
 TbBool delaunay_add(long itm_pos);
+long delaunay_seeded(long start_x, long start_y, long end_x, long end_y, TbBool keep_edge);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/ariadne_points.c
+++ b/src/ariadne_points.c
@@ -36,7 +36,7 @@ static long free_Points;
 struct Point ari_Points[POINTS_COUNT];
 /******************************************************************************/
 
-AridPointId point_new(void)
+static AridPointId point_new(void)
 {
     AridPointId i;
     if (free_Points == -1)

--- a/src/ariadne_points.h
+++ b/src/ariadne_points.h
@@ -45,7 +45,6 @@ extern struct Point ari_Points[];
 /******************************************************************************/
 #define INVALID_POINT (&ari_Points[0])
 /******************************************************************************/
-AridPointId point_new(void);
 void point_dispose(AridPointId pt_id);
 TbBool point_set(AridPointId pt_id, long x, long y);
 struct Point *point_get(AridPointId pt_id);

--- a/src/ariadne_regions.c
+++ b/src/ariadne_regions.c
@@ -29,6 +29,12 @@
 extern "C" {
 #endif
 /******************************************************************************/
+
+struct RegionT {
+  unsigned short num_triangles;
+  unsigned char is_connected;
+};
+
 /******************************************************************************/
 /** Array of regions.
  * Note that region[0] is used for storing unused triangles and shouldn't be

--- a/src/ariadne_regions.h
+++ b/src/ariadne_regions.h
@@ -29,18 +29,7 @@
 extern "C" {
 #endif
 
-/******************************************************************************/
-#pragma pack(1)
 
-struct RegionT { // sizeof = 3
-  unsigned short num_triangles;
-  unsigned char is_connected;
-};
-
-#pragma pack()
-/******************************************************************************/
-extern struct RegionT bad_region;
-#define INVALID_REGION &bad_region;
 /******************************************************************************/
 TbBool regions_connected(long first_tree_region, long second_tree_region);
 void region_store_init(void);

--- a/src/ariadne_wallhug.c
+++ b/src/ariadne_wallhug.c
@@ -17,7 +17,6 @@
  */
 /******************************************************************************/
 #include "pre_inc.h"
-#include "ariadne_wallhug.h"
 
 #include "globals.h"
 #include "bflib_basics.h"
@@ -2128,6 +2127,18 @@ short get_hug_side_options(MapSubtlCoord src_stl_x, MapSubtlCoord src_stl_y, Map
     *ostlb_y = stl_b_y;
     return 2;
 }
+
+void initialise_wallhugging_path_from_to(struct Navigation *navi, struct Coord3d *mvstart, struct Coord3d *mvend)
+{
+    navi->navstate = NavS_WallhugInProgress;
+    navi->pos_final.x.val = mvend->x.val;
+    navi->pos_final.y.val = mvend->y.val;
+    navi->pos_final.z.val = mvend->z.val;
+    navi->wallhug_state = WallhugCurrentState_None;
+    navi->wallhug_retry_counter = 0;
+    navi->push_counter = 0;
+}
+
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/ariadne_wallhug.h
+++ b/src/ariadne_wallhug.h
@@ -31,8 +31,23 @@ extern "C" {
 
 struct Thing;
 struct Coord3d;
-struct Navigation;
 struct SlabMap;
+
+struct Navigation {
+  unsigned char navstate;
+  unsigned char side;
+  unsigned char wallhug_retry_counter;
+  unsigned char wallhug_state;
+  unsigned char push_counter;
+  long dist_to_final_pos;
+  long distance_to_next_pos;
+  int32_t angle;
+  SubtlCodedCoords first_colliding_block;
+  SubtlCodedCoords second_colliding_block;
+  PlayerBitFlags owner_flags[2];
+  struct Coord3d pos_next;
+  struct Coord3d pos_final;
+};
 
 enum WallHugSideState {
     WaHSS_Initial = 0,
@@ -51,6 +66,7 @@ SubtlCodedCoords dig_to_position(PlayerNumber plyr_idx, MapSubtlCoord basestl_x,
 TbBool slab_good_for_computer_dig_path(const struct SlabMap *slb);
 short get_hug_side_options(MapSubtlCoord stl1_x, MapSubtlCoord stl1_y, MapSubtlCoord stl2_x, MapSubtlCoord stl2_y, SmallAroundIndex direction, PlayerNumber plyr_idx,
     MapSubtlCoord *ostla_x, MapSubtlCoord *ostla_y, MapSubtlCoord *ostlb_x, MapSubtlCoord *ostlb_y);
+void initialise_wallhugging_path_from_to(struct Navigation *navi, struct Coord3d *mvstart, struct Coord3d *mvend);
 /******************************************************************************/
 #define CHECK_SLAB_OWNER (flag_is_set(crt_owner_flags, to_flag(slabmap_owner(slb)))) // return TRUE if the slab's owner is stored in crt_owner_flags
 #define IGNORE_SLAB_OWNER_CHECK 0 // crt_owner_flags can be set to 0 to nullify the check for the slab's owner

--- a/src/creature_control.h
+++ b/src/creature_control.h
@@ -24,6 +24,7 @@
 #include "bflib_sound.h"
 
 #include "ariadne.h"
+#include "ariadne_wallhug.h"
 #include "creature_graphics.h"
 #include "creature_groups.h"
 #include "thing_creature.h"

--- a/src/creature_groups.c
+++ b/src/creature_groups.c
@@ -32,7 +32,6 @@
 #include "creature_states_hero.h"
 #include "config_creature.h"
 #include "room_jobs.h"
-#include "ariadne_wallhug.h"
 #include "game_legacy.h"
 #include "post_inc.h"
 

--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -43,7 +43,6 @@
 #include "room_util.h"
 #include "map_blocks.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "spdigger_stack.h"
 #include "tasks_list.h"
 #include "config_magic.h"

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -51,7 +51,6 @@
 #include "map_events.h"
 #include "map_blocks.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "power_hand.h"
 #include "gui_topmsg.h"
 #include "gui_soundmsgs.h"

--- a/src/creature_states_combt.c
+++ b/src/creature_states_combt.c
@@ -45,7 +45,6 @@
 #include "room_jobs.h"
 #include "map_blocks.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "gui_soundmsgs.h"
 #include "game_legacy.h"
 #include "engine_redraw.h"

--- a/src/creature_states_hero.c
+++ b/src/creature_states_hero.c
@@ -43,7 +43,6 @@
 #include "room_jobs.h"
 #include "room_list.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "player_utils.h"
 #include "gui_soundmsgs.h"
 #include "gui_topmsg.h"

--- a/src/creature_states_pray.c
+++ b/src/creature_states_pray.c
@@ -805,7 +805,7 @@ TbBool find_random_sacrifice_center(struct Coord3d *pos, const struct Room *room
             pos->z.val = subtile_coord(1,0);
             struct Map* mapblk = get_map_block_at(pos->x.stl.num, pos->y.stl.num);
             if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && ((mapblk->flags & SlbAtFlg_IsDoor) == 0)
-                && (get_navigation_map_floor_height(pos->x.stl.num, pos->y.stl.num) < 4)
+                && (get_floor_filled_subtiles_at(pos->x.stl.num, pos->y.stl.num) < 4)
                 )
             {
                 return true;

--- a/src/creature_states_spdig.c
+++ b/src/creature_states_spdig.c
@@ -47,7 +47,6 @@
 #include "room_graveyard.h"
 #include "room_util.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "spdigger_stack.h"
 #include "tasks_list.h"
 #include "power_hand.h"

--- a/src/creature_states_train.c
+++ b/src/creature_states_train.c
@@ -40,7 +40,6 @@
 #include "room_data.h"
 #include "room_jobs.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "gui_soundmsgs.h"
 #include "game_legacy.h"
 #include "post_inc.h"

--- a/src/creature_states_wrshp.c
+++ b/src/creature_states_wrshp.c
@@ -38,7 +38,6 @@
 #include "room_data.h"
 #include "room_jobs.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "gui_soundmsgs.h"
 
 #include "game_legacy.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3094,7 +3094,7 @@ void update_block_pointed(int i,long x, long x_frac, long y, long y_frac)
           colmn = get_column(k);
           if (colmn->solidmask >= 8)
           {
-            if ( (!visible) || (((get_navigation_map(x,y) & 0x80) == 0) && ((mapblk->flags & SlbAtFlg_IsRoom) == 0)) )
+            if ( (!visible) || (((mapblk->flags & SlbAtFlg_IsRoom) == 0)) )
               smask &= 3;
           }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,7 +120,6 @@
 #include "gui_frontbtns.h"
 #include "frontmenu_ingame_tabs.h"
 #include "frontmenu_ingame_evnt.h"
-#include "ariadne.h"
 #include "sounds.h"
 #include "vidfade.h"
 #include "config_settings.h"

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -34,7 +34,6 @@
 #include "config_creature.h"
 #include "creature_senses.h"
 #include "player_utils.h"
-#include "ariadne_wallhug.h"
 #include "spdigger_stack.h"
 #include "frontmenu_ingame_map.h"
 #include "game_legacy.h"

--- a/src/map_columns.c
+++ b/src/map_columns.c
@@ -475,6 +475,15 @@ void init_top_texture_to_cube_table(void)
     }
 }
 
+TbBool subtile_is_unsafe(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+{
+    long tcube;
+    int32_t cube_pos;
+    tcube = get_top_cube_at(stl_x, stl_y, &cube_pos);
+
+    return cube_is_lava(tcube) || (cube_pos<4 && cube_is_sacrificial(tcube));
+}
+
 /* Returns if given cube is lava.
  * @param cube_id
  * @return */

--- a/src/map_columns.h
+++ b/src/map_columns.h
@@ -94,6 +94,8 @@ TbBool cube_is_water(long cube_id);
 TbBool cube_is_sacrificial(long cube_id);
 TbBool cube_is_unclaimed_path(long cube_id);
 
+TbBool subtile_is_unsafe(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+
 TbBool subtile_has_lava_on_top(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool subtile_has_water_on_top(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool subtile_has_sacrificial_on_top(MapSubtlCoord stl_x, MapSubtlCoord stl_y);

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -109,11 +109,6 @@ void set_navigation_map(MapSubtlCoord stl_x, MapSubtlCoord stl_y, NavColour navc
   game.navigation_map[navmap_tile_number(stl_x,stl_y)] = navcolour;
 }
 
-unsigned long get_navigation_map_floor_height(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
-{
-    return get_navigation_map(stl_x, stl_y) & NAVMAP_FLOORHEIGHT_MASK;
-}
-
 long get_ceiling_height(const struct Coord3d *pos)
 {
     long i = get_subtile_number(pos->x.stl.num, pos->y.stl.num);

--- a/src/map_data.c
+++ b/src/map_data.c
@@ -40,7 +40,6 @@ struct Map bad_map_block;
  */
 MapSubtlCoord map_subtiles_z = 8;
 
-NavColour *IanMap = NULL;
 long nav_map_initialised = 0;
 /******************************************************************************/
 /**
@@ -89,24 +88,6 @@ TbBool map_block_invalid(const struct Map *map)
   if (map == INVALID_MAP_BLOCK)
     return true;
   return (map < &game.map[0]);
-}
-
-NavColour get_navigation_map(MapSubtlCoord stl_x, MapSubtlCoord stl_y)
-{
-  if ((stl_x < 0) || (stl_x > game.map_subtiles_x))
-      return 0;
-  if ((stl_y < 0) || (stl_y > game.map_subtiles_y))
-      return 0;
-  return game.navigation_map[navmap_tile_number(stl_x,stl_y)];
-}
-
-void set_navigation_map(MapSubtlCoord stl_x, MapSubtlCoord stl_y, NavColour navcolour)
-{
-  if ((stl_x < 0) || (stl_x > game.map_subtiles_x))
-      return;
-  if ((stl_y < 0) || (stl_y > game.map_subtiles_y))
-      return;
-  game.navigation_map[navmap_tile_number(stl_x,stl_y)] = navcolour;
 }
 
 long get_ceiling_height(const struct Coord3d *pos)

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -58,7 +58,6 @@ struct Map {
 /******************************************************************************/
 extern struct Map bad_map_block;
 extern MapSubtlCoord map_subtiles_z;
-extern NavColour *IanMap;
 extern long nav_map_initialised;
 /******************************************************************************/
 /** Convert subtile to slab. */
@@ -77,7 +76,6 @@ extern long nav_map_initialised;
 /** Converts slab to coord value. */
 #define slab_coord(slb) ((slb) * (COORD_PER_SLB))
 #define subtile_coord_center(stl) ((stl)*COORD_PER_STL+COORD_PER_STL/2)
-#define navmap_tile_number(stl_x,stl_y) ((stl_y)*game.navigation_map_size_x+(stl_x))
 /******************************************************************************/
 struct Map *get_map_block_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 struct Map *get_map_block_at_pos(SubtlCodedCoords stl_num);
@@ -106,9 +104,6 @@ long get_mapblk_filled_subtiles(const struct Map *mapblk);
 void set_mapblk_filled_subtiles(struct Map *map, long height);
 long get_mapblk_wibble_value(const struct Map *mapblk);
 void set_mapblk_wibble_value(struct Map *mapblk, long wib);
-
-NavColour get_navigation_map(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
-void set_navigation_map(MapSubtlCoord stl_x, MapSubtlCoord stl_y, NavColour navcolour);
 
 TbBool set_coords_with_clip(struct Coord3d *pos, MapCoord cor_x, MapCoord cor_y, MapCoord cor_z);
 TbBool subtile_has_slab(MapSubtlCoord stl_x, MapSubtlCoord stl_y);

--- a/src/map_data.h
+++ b/src/map_data.h
@@ -109,7 +109,6 @@ void set_mapblk_wibble_value(struct Map *mapblk, long wib);
 
 NavColour get_navigation_map(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void set_navigation_map(MapSubtlCoord stl_x, MapSubtlCoord stl_y, NavColour navcolour);
-unsigned long get_navigation_map_floor_height(MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 TbBool set_coords_with_clip(struct Coord3d *pos, MapCoord cor_x, MapCoord cor_y, MapCoord cor_z);
 TbBool subtile_has_slab(MapSubtlCoord stl_x, MapSubtlCoord stl_y);

--- a/src/player_compchecks.c
+++ b/src/player_compchecks.c
@@ -39,7 +39,6 @@
 #include "map_utils.h"
 #include "dungeon_data.h"
 #include "room_data.h"
-#include "ariadne_wallhug.h"
 #include "power_hand.h"
 #include "gui_soundmsgs.h"
 #include "game_legacy.h"

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -53,7 +53,6 @@
 #include "map_blocks.h"
 #include "map_data.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "slab_data.h"
 #include "power_hand.h"
 #include "power_process.h"

--- a/src/player_computer.c
+++ b/src/player_computer.c
@@ -22,7 +22,6 @@
 
 #include <limits.h>
 
-#include "ariadne_wallhug.h"
 #include "bflib_basics.h"
 #include "bflib_dernc.h"
 #include "bflib_fileio.h"

--- a/src/player_computer_data.cpp
+++ b/src/player_computer_data.cpp
@@ -33,7 +33,6 @@
 #include "config_terrain.h"
 #include "config_creature.h"
 #include "creature_states.h"
-#include "ariadne_wallhug.h"
 #include "spdigger_stack.h"
 #include "magic_powers.h"
 #include "thing_traps.h"

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -46,7 +46,6 @@
 #include "config_terrain.h"
 #include "map_blocks.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "game_saves.h"
 #include "game_legacy.h"
 #include "frontend.h"

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -45,6 +45,7 @@
 #include "config_spritecolors.h"
 #include "config_terrain.h"
 #include "map_blocks.h"
+#include "map_columns.h"
 #include "map_utils.h"
 #include "game_saves.h"
 #include "game_legacy.h"

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -898,7 +898,7 @@ TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
         if ((player_is_roaming(wandr->plyr_idx)) || map_block_revealed(mapblk, wandr->plyr_idx))
         {
             slb = get_slabmap_for_subtile(stl_x, stl_y);
-            if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && ((get_navigation_map(stl_x, stl_y) & NAVMAP_UNSAFE_SURFACE) == 0)
+            if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && (!subtile_is_unsafe(stl_x, stl_y))
              && players_creatures_tolerate_each_other(wandr->plyr_idx,slabmap_owner(slb)))
             {
                 heartng = get_player_soul_container(wandr->plyr_idx);
@@ -921,7 +921,7 @@ TbBool wp_check_map_pos_valid(struct Wander *wandr, SubtlCodedCoords stl_num)
         // Add only tiles which are not revealed to the wandering player, unless it's heroes - for them, do nothing
         if (!player_is_roaming(wandr->plyr_idx) && !map_block_revealed(mapblk, wandr->plyr_idx))
         {
-            if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && ((get_navigation_map(stl_x, stl_y) & NAVMAP_UNSAFE_SURFACE) == 0))
+            if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && (!subtile_is_unsafe(stl_x, stl_y)))
             {
                 heartng = get_player_soul_container(wandr->plyr_idx);
                 if (thing_exists(heartng))

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -36,7 +36,6 @@
 #include "creature_instances.h"
 #include "creature_states.h"
 #include "creature_senses.h"
-#include "ariadne_wallhug.h"
 #include "config_terrain.h"
 #include "config_creature.h"
 #include "config_effects.h"

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -42,7 +42,6 @@
 #include "thing_effects.h"
 #include "map_blocks.h"
 #include "map_utils.h"
-#include "ariadne_wallhug.h"
 #include "config_terrain.h"
 #include "config_effects.h"
 #include "creature_states.h"

--- a/src/room_data.c
+++ b/src/room_data.c
@@ -1545,7 +1545,7 @@ TbBool find_random_valid_position_for_thing_in_room(struct Thing *thing, struct 
             MapSubtlCoord stl_x = slab_subtile(slb_x, ssub % 3);
             MapSubtlCoord stl_y = slab_subtile(slb_y, ssub / 3);
             struct Map* mapblk = get_map_block_at(stl_x, stl_y);
-            if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && (get_navigation_map_floor_height(stl_x,stl_y) < 4))
+            if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && (get_floor_filled_subtiles_at(stl_x,stl_y) < 4))
             {
                 if (!terrain_toxic_for_creature_at_position(thing, stl_x, stl_y) && !subtile_has_sacrificial_on_top(stl_x, stl_y))
                 {
@@ -1651,7 +1651,7 @@ TbBool find_random_position_at_area_of_room(struct Coord3d *pos, const struct Ro
                 pos->z.val = subtile_coord(1,0);
                 struct Map* mapblk = get_map_block_at(pos->x.stl.num, pos->y.stl.num);
                 if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && ((mapblk->flags & SlbAtFlg_IsDoor) == 0)
-                    && (get_navigation_map_floor_height(pos->x.stl.num, pos->y.stl.num) < 4)) {
+                    && (get_floor_filled_subtiles_at(pos->x.stl.num, pos->y.stl.num) < 4)) {
                     return true;
                 }
             }
@@ -1918,7 +1918,7 @@ TbBool find_first_valid_position_for_thing_anywhere_in_room(const struct Thing *
                 MapSubtlCoord stl_y = 3 * slb_y + dy;
                 struct Map* mapblk = get_map_block_at(stl_x, stl_y);
                 // Check if the position isn't filled with solid block
-                if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && (get_navigation_map_floor_height(stl_x,stl_y) < 4))
+                if (((mapblk->flags & SlbAtFlg_Blocking) == 0) && (get_floor_filled_subtiles_at(stl_x,stl_y) < 4))
                 {
                     if (!terrain_toxic_for_creature_at_position(thing, stl_x, stl_y) && !subtile_has_sacrificial_on_top(stl_x, stl_y))
                     {

--- a/src/room_util.c
+++ b/src/room_util.c
@@ -35,7 +35,6 @@
 #include "thing_objects.h"
 #include "room_list.h"
 #include "room_workshop.h"
-#include "ariadne_wallhug.h"
 #include "config_terrain.h"
 #include "config_creature.h"
 #include "gui_soundmsgs.h"

--- a/src/slab_data.c
+++ b/src/slab_data.c
@@ -24,8 +24,6 @@
 #include "config_terrain.h"
 #include "map_blocks.h"
 #include "map_ceiling.h"
-#include "ariadne.h"
-#include "ariadne_wallhug.h"
 #include "map_utils.h"
 #include "frontmenu_ingame_map.h"
 #include "game_legacy.h"

--- a/src/spdigger_stack.c
+++ b/src/spdigger_stack.c
@@ -49,7 +49,6 @@
 #include "power_hand.h"
 #include "map_utils.h"
 #include "map_events.h"
-#include "ariadne_wallhug.h"
 #include "gui_soundmsgs.h"
 #include "front_simple.h"
 #include "game_legacy.h"

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6177,8 +6177,8 @@ void process_landscape_affecting_creature(struct Thing *thing)
     cctrl->corpse_to_piss_on = 0;
 
     int stl_idx = get_subtile_number(thing->mappos.x.stl.num, thing->mappos.y.stl.num);
-    unsigned long navheight = get_navigation_map_floor_height(thing->mappos.x.stl.num, thing->mappos.y.stl.num);
-    if (subtile_coord(navheight,0) == thing->mappos.z.val)
+    unsigned long floor_height = get_floor_height_at(thing->mappos);
+    if (subtile_coord(floor_height,0) == thing->mappos.z.val)
     {
         int i = get_top_cube_at_pos(stl_idx);
         if (cube_is_lava(i))

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6177,7 +6177,7 @@ void process_landscape_affecting_creature(struct Thing *thing)
     cctrl->corpse_to_piss_on = 0;
 
     int stl_idx = get_subtile_number(thing->mappos.x.stl.num, thing->mappos.y.stl.num);
-    unsigned long floor_height = get_floor_height_at(thing->mappos);
+    unsigned long floor_height = get_floor_height_at(&thing->mappos);
     if (subtile_coord(floor_height,0) == thing->mappos.z.val)
     {
         int i = get_top_cube_at_pos(stl_idx);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6177,8 +6177,8 @@ void process_landscape_affecting_creature(struct Thing *thing)
     cctrl->corpse_to_piss_on = 0;
 
     int stl_idx = get_subtile_number(thing->mappos.x.stl.num, thing->mappos.y.stl.num);
-    unsigned long floor_height = get_floor_height_at(&thing->mappos);
-    if (subtile_coord(floor_height,0) == thing->mappos.z.val)
+MapCoord floor_height = get_floor_height_at(&thing->mappos);
+if (floor_height == thing->mappos.z.val)
     {
         int i = get_top_cube_at_pos(stl_idx);
         if (cube_is_lava(i))

--- a/src/thing_doors.c
+++ b/src/thing_doors.c
@@ -31,8 +31,6 @@
 #include "thing_effects.h"
 #include "config_terrain.h"
 #include "creature_senses.h"
-#include "ariadne.h"
-#include "ariadne_wallhug.h"
 #include "map_blocks.h"
 #include "map_ceiling.h"
 #include "map_utils.h"


### PR DESCRIPTION
mostly moves some stuff around,
makes sure non of the non ariadne code makes use of the navmap for cleaner seperation
scrapped the headers where they're not used
marked more as static

functionally should be no different