### PR TITLE
Multiplayer: Improve stutter tracking

### DIFF
--- a/src/bflib_datetm.cpp
+++ b/src/bflib_datetm.cpp
@@ -379,27 +379,33 @@ TbResult LbTimerInit(void)
 
 int get_current_stutter_percentage()
 {
-    static TbClockMSec last_frame_timestamp = 0;
+    static TbClockMSec last_turn_timestamp = 0;
     static int stutter_detection_history[50] = {0};
+    static TbClockMSec stutter_detection_history_timestamp[50] = {0};
     static int history_index = 0;
     TbClockMSec current_timestamp = LbTimerClock();
-    TbClockMSec frame_time_ms = 0;
     int stutter_detection_pct = 0;
-    if (last_frame_timestamp != 0) {
-        frame_time_ms = current_timestamp - last_frame_timestamp;
-        int expected_frame_time = 1000 / turns_per_second;
-        if (frame_time_ms > expected_frame_time) {
-            stutter_detection_pct = ((frame_time_ms - expected_frame_time) * 100) / expected_frame_time;
+    TbClockMSec expected_turn_time = 1000 / turns_per_second;
+    if (last_turn_timestamp != 0) {
+        TbClockMSec turn_time_ms = current_timestamp - last_turn_timestamp;
+        if (turn_time_ms > expected_turn_time) {
+            stutter_detection_pct = ((turn_time_ms - expected_turn_time) * 100) / expected_turn_time;
+            stutter_detection_history[history_index] = stutter_detection_pct;
+            stutter_detection_history_timestamp[history_index] = current_timestamp;
+            history_index = (history_index + 1) % 50;
         }
     }
-    last_frame_timestamp = current_timestamp;
+    last_turn_timestamp = current_timestamp;
     stutter_detection_current = stutter_detection_pct;
-    stutter_detection_history[history_index] = stutter_detection_pct;
-    history_index = (history_index + 1) % 50;
     int sum = 0;
     int max = 0;
     int i;
     for (i = 0; i < 50; i++) {
+        if (stutter_detection_history_timestamp[i] == 0 || current_timestamp - stutter_detection_history_timestamp[i] >= expected_turn_time * 50) {
+            stutter_detection_history[i] = 0;
+            stutter_detection_history_timestamp[i] = 0;
+            continue;
+        }
         sum += stutter_detection_history[i];
         if (stutter_detection_history[i] > max) {
             max = stutter_detection_history[i];

--- a/src/bflib_datetm.cpp
+++ b/src/bflib_datetm.cpp
@@ -377,26 +377,26 @@ TbResult LbTimerInit(void)
   return Lb_SUCCESS;
 }
 
-int get_current_stutter_percentage()
+int get_current_stutter_milliseconds()
 {
     static TbClockMSec last_turn_timestamp = 0;
     static int stutter_detection_history[50] = {0};
     static TbClockMSec stutter_detection_history_timestamp[50] = {0};
     static int history_index = 0;
     TbClockMSec current_timestamp = LbTimerClock();
-    int stutter_detection_pct = 0;
+    int stutter_detection_ms = 0;
     TbClockMSec expected_turn_time = 1000 / turns_per_second;
     if (last_turn_timestamp != 0) {
         TbClockMSec turn_time_ms = current_timestamp - last_turn_timestamp;
         if (turn_time_ms > expected_turn_time) {
-            stutter_detection_pct = ((turn_time_ms - expected_turn_time) * 100) / expected_turn_time;
-            stutter_detection_history[history_index] = stutter_detection_pct;
+            stutter_detection_ms = turn_time_ms - expected_turn_time;
+            stutter_detection_history[history_index] = stutter_detection_ms;
             stutter_detection_history_timestamp[history_index] = current_timestamp;
             history_index = (history_index + 1) % 50;
         }
     }
     last_turn_timestamp = current_timestamp;
-    stutter_detection_current = stutter_detection_pct;
+    stutter_detection_current = stutter_detection_ms;
     int sum = 0;
     int max = 0;
     int i;
@@ -413,7 +413,7 @@ int get_current_stutter_percentage()
     }
     stutter_detection_average = sum / 50;
     stutter_detection_max = max;
-    return stutter_detection_pct;
+    return stutter_detection_ms;
 }
 
 /******************************************************************************/

--- a/src/bflib_datetm.h
+++ b/src/bflib_datetm.h
@@ -102,7 +102,7 @@ extern void framerate_measurement_capture(int framerate_kind);
 
 extern struct FrametimeMeasurements frametime_measurements;
 
-int get_current_stutter_percentage(void);
+int get_current_stutter_milliseconds(void);
 
 extern int stutter_detection_current;
 extern int stutter_detection_average;

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -899,11 +899,13 @@ void draw_network_stats()
     LbTextDrawResized(0, tx_units_per_px * 6, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Lost packets: %u", lost_packet_count);
     LbTextDrawResized(0, tx_units_per_px * 7, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Micro stutters: %d%%", stutter_detection_average);
+    snprintf(text, sizeof(text), "Average stutter: %d%%", stutter_detection_average);
     LbTextDrawResized(0, tx_units_per_px * 8, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
+    snprintf(text, sizeof(text), "Max stutter: %d%%", stutter_detection_max);
     LbTextDrawResized(0, tx_units_per_px * 9, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
+    snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
     LbTextDrawResized(0, tx_units_per_px * 10, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
+    LbTextDrawResized(0, tx_units_per_px * 11, tx_units_per_px, text);
 }
 /******************************************************************************/

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -899,13 +899,15 @@ void draw_network_stats()
     LbTextDrawResized(0, tx_units_per_px * 6, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Lost packets: %u", lost_packet_count);
     LbTextDrawResized(0, tx_units_per_px * 7, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Average stutter: %d%%", stutter_detection_average);
+    snprintf(text, sizeof(text), "Stutter: %dms", stutter_detection_current);
     LbTextDrawResized(0, tx_units_per_px * 8, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Max stutter: %d%%", stutter_detection_max);
+    snprintf(text, sizeof(text), "Average stutter: %dms", stutter_detection_average);
     LbTextDrawResized(0, tx_units_per_px * 9, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
+    snprintf(text, sizeof(text), "Max stutter: %dms", stutter_detection_max);
     LbTextDrawResized(0, tx_units_per_px * 10, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
+    snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
     LbTextDrawResized(0, tx_units_per_px * 11, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
+    LbTextDrawResized(0, tx_units_per_px * 12, tx_units_per_px, text);
 }
 /******************************************************************************/

--- a/src/packets.c
+++ b/src/packets.c
@@ -1626,7 +1626,7 @@ void process_packets(void)
             resync_game();
         }
     }
-    get_current_stutter_percentage();
+    get_current_stutter_milliseconds();
     MULTIPLAYER_LOG("process_packets: === END turn=%lu ===", (unsigned long)get_gameturn());
     SYNCDBG(7,"Finished");
 }


### PR DESCRIPTION
I saw a situation where the game was stuttering but the microstutters display wasn't displaying it (it was continuing to show 0-1%). This fixes that.

Stutter detection is now more based on time elapsed, I changed it to measure in milliseconds instead of a percentage and it now displays max and current.