### PR TITLE
Multiplayer: use local camera for tagging

### DIFF
--- a/src/packets.c
+++ b/src/packets.c
@@ -989,10 +989,11 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         }
     }
     // fall through
+    case PckA_ApplyRoomspaceDigTag:
     case PckA_SetRoomspaceHighlight:
     {
         player->roomspace_mode = pckt->actn_par1;
-        if ( (pckt->actn_par2 == 1) || (pckt->actn_par1 == roomspace_detection_mode) )
+        if ((pckt->actn_par2 == 1) || (pckt->actn_par1 == roomspace_detection_mode))
         {
             // exit out of click and drag mode
             if (player->render_roomspace.drag_mode)
@@ -1013,6 +1014,11 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
             {
                 reset_dungeon_build_room_ui_variables(plyr_idx);
                 player->roomspace_width = player->roomspace_height = pckt->actn_par2;
+                break;
+            }
+            case roomspace_detection_mode:
+            {
+                set_player_roomspace_size(player, pckt->actn_par2);
                 break;
             }
             case drag_placement_mode: // drag
@@ -1556,8 +1562,8 @@ void exchange_packets(void)
     MULTIPLAYER_LOG("process_packets: === BEGIN turn=%lu ===", (unsigned long)get_gameturn());
     set_local_packet_turn();
     update_turn_checksums();
-    store_packet_history(player->packet_num, get_packet_direct(player->packet_num));
     update_local_dig_tag_prediction();
+    store_packet_history(player->packet_num, get_packet_direct(player->packet_num));
     if (game.game_kind != GKind_LocalGame)
     {
         if (!game.packet_load_enable || game.packet_load_initialized)

--- a/src/packets.c
+++ b/src/packets.c
@@ -993,7 +993,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
     case PckA_SetRoomspaceHighlight:
     {
         player->roomspace_mode = pckt->actn_par1;
-        if ((pckt->actn_par2 == 1) || (pckt->actn_par1 == roomspace_detection_mode))
+        if ( (pckt->actn_par2 == 1) || (pckt->actn_par1 == roomspace_detection_mode) )
         {
             // exit out of click and drag mode
             if (player->render_roomspace.drag_mode)

--- a/src/packets.h
+++ b/src/packets.h
@@ -193,7 +193,7 @@ enum TbPacketAction {
         PckA_PlyrQueryCreature,
         PckA_CheatGiveDoorTrap,
         PckA_RoomspaceHighlightToggle,
-        PckA_UnusedSlot157,
+        PckA_ApplyRoomspaceDigTag,
 		PckA_CheatWinLevel,
 		PckA_CheatLoseLevel,
 		PckA_CheatLevelUp,

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -279,7 +279,8 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
     MapSubtlCoord stl_x = coord_subtile(x);
     MapSubtlCoord stl_y = coord_subtile(y);
     TbBool at_limit = false;
-    TbBool thing_target_action = (pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing);
+    TbBool apply_roomspace_tag = pckt->action == PckA_ApplyRoomspaceDigTag;
+    TbBool thing_target_action = apply_roomspace_tag || (pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing);
     unsigned char box_colour;
     if ((pckt->control_flags & PCtr_LBtnAnyAction) == 0)
         player->secondary_cursor_state = CSt_DefaultArrow;
@@ -293,9 +294,16 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         if ( (player->primary_cursor_state == CSt_PickAxe) || ( (player->primary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0) ) )
         {
             player->thing_under_hand = 0;
-            get_dungeon_highlight_user_roomspace(&player->render_roomspace, player, pckt, stl_x, stl_y, NULL);
+            if (apply_roomspace_tag) {
+                get_roomspace_dig_tag_packet(&player->render_roomspace, player, pckt, plyr_idx, NULL);
+            } else {
+                get_dungeon_highlight_user_roomspace(&player->render_roomspace, player, pckt, stl_x, stl_y, NULL);
+            }
             box_colour = tag_cursor_blocks_dig(player, pckt, &player->render_roomspace, stl_x, stl_y, player->full_slab_cursor);
             at_limit = (box_colour == SLC_REDYELLOW) || (box_colour == SLC_REDFLASH);
+            if (apply_roomspace_tag) {
+                apply_roomspace_dig_tag_selection(plyr_idx, &player->render_roomspace, player->render_roomspace.drag_start_x, player->render_roomspace.drag_start_y, player->roomspace_highlight_mode, NULL, NULL);
+            }
         }
         if ((pckt->control_flags & PCtr_LBtnClick) != 0)
         {
@@ -371,7 +379,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
             {
                 if (player->primary_cursor_state == player->secondary_cursor_state)
                 {
-                    if ( (player->secondary_cursor_state == CSt_PickAxe) || ((player->secondary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_NoThingUnderPowerHand) != 0)) )
+                    if (!apply_roomspace_tag && ((player->secondary_cursor_state == CSt_PickAxe) || ((player->secondary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_NoThingUnderPowerHand) != 0))))
                     {
                         keeper_highlight_roomspace(plyr_idx, &player->render_roomspace);
                     }

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -294,15 +294,17 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
         if ( (player->primary_cursor_state == CSt_PickAxe) || ( (player->primary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0) ) )
         {
             player->thing_under_hand = 0;
+            get_dungeon_highlight_user_roomspace(&player->render_roomspace, player, pckt, stl_x, stl_y, NULL);
             if (apply_roomspace_tag) {
-                get_roomspace_dig_tag_packet(&player->render_roomspace, player, pckt, plyr_idx, NULL);
-            } else {
-                get_dungeon_highlight_user_roomspace(&player->render_roomspace, player, pckt, stl_x, stl_y, NULL);
+                player->render_roomspace.untag_mode = pckt->actn_par4;
+                player->render_roomspace = check_roomspace_for_diggable_slabs(player->render_roomspace, plyr_idx, NULL);
             }
             box_colour = tag_cursor_blocks_dig(player, pckt, &player->render_roomspace, stl_x, stl_y, player->full_slab_cursor);
             at_limit = (box_colour == SLC_REDYELLOW) || (box_colour == SLC_REDFLASH);
             if (apply_roomspace_tag) {
-                apply_roomspace_dig_tag_selection(plyr_idx, &player->render_roomspace, player->render_roomspace.drag_start_x, player->render_roomspace.drag_start_y, player->roomspace_highlight_mode, NULL, NULL);
+                MapSlabCoord previous_slb_x = (uint16_t)pckt->actn_par3 & 0xFF;
+                MapSlabCoord previous_slb_y = (uint16_t)pckt->actn_par3 >> 8;
+                apply_roomspace_dig_tag_selection(plyr_idx, &player->render_roomspace, previous_slb_x, previous_slb_y, player->roomspace_highlight_mode, NULL, NULL, NULL, NULL);
             }
         }
         if ((pckt->control_flags & PCtr_LBtnClick) != 0)

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -1052,6 +1052,20 @@ static void find_next_point(struct RoomSpace *roomspace, unsigned char mode)
     }
 }
 
+void get_roomspace_dig_tag_packet(struct RoomSpace *roomspace, struct PlayerInfo *player, const struct Packet *pckt, PlayerNumber plyr_idx, const unsigned char *predicted_slab_tag_modes)
+{
+    player->roomspace_highlight_mode = pckt->actn_par1;
+    set_player_roomspace_size(player, pckt->actn_par2);
+    player->render_roomspace.drag_start_x = (uint16_t)pckt->actn_par3 & 0xFF;
+    player->render_roomspace.drag_start_y = (uint16_t)pckt->actn_par3 >> 8;
+    if (player->roomspace_highlight_mode == drag_placement_mode) {
+        player->render_roomspace.drag_mode = true;
+    }
+    get_dungeon_highlight_user_roomspace(roomspace, player, pckt, coord_subtile(pckt->pos_x), coord_subtile(pckt->pos_y), predicted_slab_tag_modes);
+    roomspace->untag_mode = pckt->actn_par4;
+    *roomspace = check_roomspace_for_diggable_slabs(*roomspace, plyr_idx, predicted_slab_tag_modes);
+}
+
 int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count)
 {
     int dig_change_count = 0;

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -1052,24 +1052,10 @@ static void find_next_point(struct RoomSpace *roomspace, unsigned char mode)
     }
 }
 
-void get_roomspace_dig_tag_packet(struct RoomSpace *roomspace, struct PlayerInfo *player, const struct Packet *pckt, PlayerNumber plyr_idx, const unsigned char *predicted_slab_tag_modes)
-{
-    player->roomspace_highlight_mode = pckt->actn_par1;
-    set_player_roomspace_size(player, pckt->actn_par2);
-    player->render_roomspace.drag_start_x = (uint16_t)pckt->actn_par3 & 0xFF;
-    player->render_roomspace.drag_start_y = (uint16_t)pckt->actn_par3 >> 8;
-    if (player->roomspace_highlight_mode == drag_placement_mode) {
-        player->render_roomspace.drag_mode = true;
-    }
-    get_dungeon_highlight_user_roomspace(roomspace, player, pckt, coord_subtile(pckt->pos_x), coord_subtile(pckt->pos_y), predicted_slab_tag_modes);
-    roomspace->untag_mode = pckt->actn_par4;
-    *roomspace = check_roomspace_for_diggable_slabs(*roomspace, plyr_idx, predicted_slab_tag_modes);
-}
-
-int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count)
+int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, SlabCodedCoords *predicted_slabs, int *predicted_slab_count, int *predicted_task_count)
 {
     int dig_change_count = 0;
-    if ((predicted_slab_tag_modes == NULL) != (predicted_task_count == NULL)) {
+    if ((predicted_slab_tag_modes == NULL) != (predicted_slabs == NULL) || (predicted_slabs == NULL) != (predicted_slab_count == NULL) || (predicted_slab_count == NULL) != (predicted_task_count == NULL)) {
         ERRORLOG("Prediction slab tag modes and task count must be supplied together");
         return dig_change_count;
     }
@@ -1103,6 +1089,9 @@ int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *r
                             return dig_change_count;
                         }
                         int32_t slb_num = get_slab_number(path_slb_x, path_slb_y);
+                        if (predicted_slab_tag_modes[slb_num] == 0) {
+                            predicted_slabs[(*predicted_slab_count)++] = slb_num;
+                        }
                         predicted_slab_tag_modes[slb_num] = dig_tag_mode;
                         dig_change_count++;
                         if (dig_tag_mode == DigTagMode_Tag) {
@@ -1150,7 +1139,7 @@ int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *r
 void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
-    int dig_change_count = apply_roomspace_dig_tag_selection(plyr_idx, roomspace, player->previous_cursor_subtile_x / STL_PER_SLB, player->previous_cursor_subtile_y / STL_PER_SLB, player->roomspace_highlight_mode, NULL, NULL);
+    int dig_change_count = apply_roomspace_dig_tag_selection(plyr_idx, roomspace, player->previous_cursor_subtile_x / STL_PER_SLB, player->previous_cursor_subtile_y / STL_PER_SLB, player->roomspace_highlight_mode, NULL, NULL, NULL, NULL);
     if (is_my_player(player))
     {
         if ((dig_change_count > 0) && !local_dig_prediction_is_enabled()) {

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -141,6 +141,7 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
 TbBool update_dungeon_build_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool update_dungeon_sell_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void apply_roomspace_packet_action(struct PlayerInfo *player, const struct Packet *pckt);
+void get_roomspace_dig_tag_packet(struct RoomSpace *roomspace, struct PlayerInfo *player, const struct Packet *pckt, PlayerNumber plyr_idx, const unsigned char *predicted_slab_tag_modes);
 
 void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace);
 int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count);

--- a/src/roomspace.h
+++ b/src/roomspace.h
@@ -141,10 +141,9 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
 TbBool update_dungeon_build_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool update_dungeon_sell_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 void apply_roomspace_packet_action(struct PlayerInfo *player, const struct Packet *pckt);
-void get_roomspace_dig_tag_packet(struct RoomSpace *roomspace, struct PlayerInfo *player, const struct Packet *pckt, PlayerNumber plyr_idx, const unsigned char *predicted_slab_tag_modes);
 
 void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace);
-int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, int *predicted_task_count);
+int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *roomspace, MapSlabCoord previous_slb_x, MapSlabCoord previous_slb_y, unsigned char highlight_mode, unsigned char *predicted_slab_tag_modes, SlabCodedCoords *predicted_slabs, int *predicted_slab_count, int *predicted_task_count);
 void keeper_sell_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace);
 void keeper_build_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace);
 

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -31,14 +31,11 @@ extern "C" {
 
 static struct {
     unsigned char slab_tag_modes[MAX_TILES_X * MAX_TILES_Y];
-    unsigned char drag_base_slab_tag_modes[MAX_TILES_X * MAX_TILES_Y];
     GameTurn last_packet_turn;
     MapSlabCoord drag_start_slb_x;
     MapSlabCoord drag_start_slb_y;
     MapSlabCoord previous_slb_x;
     MapSlabCoord previous_slb_y;
-    int predicted_task_count;
-    int drag_base_task_count;
     TbBool untag_mode;
 } local_dig_tag_prediction;
 
@@ -46,6 +43,23 @@ static struct Packet local_dig_roomspace_prediction;
 
 static struct RoomSpace local_dig_render_roomspace;
 static TbBool local_dig_render_roomspace_active;
+
+static int rebuild_local_dig_predictions(void)
+{
+    int task_count = get_players_dungeon(get_my_player())->task_count;
+    memset(local_dig_tag_prediction.slab_tag_modes, 0, sizeof(local_dig_tag_prediction.slab_tag_modes));
+    for (GameTurn turn = get_gameturn() - game.input_lag_turns; turn < get_gameturn(); turn++) {
+        const struct Packet *pckt = get_history_packet(get_my_player()->packet_num, turn);
+        if ((pckt == NULL) || (pckt->action != PckA_ApplyRoomspaceDigTag)) {
+            continue;
+        }
+        struct PlayerInfo player = *get_my_player();
+        struct RoomSpace roomspace;
+        get_roomspace_dig_tag_packet(&roomspace, &player, pckt, my_player_number, local_dig_tag_prediction.slab_tag_modes);
+        apply_roomspace_dig_tag_selection(my_player_number, &roomspace, player.render_roomspace.drag_start_x, player.render_roomspace.drag_start_y, player.roomspace_highlight_mode, local_dig_tag_prediction.slab_tag_modes, &task_count);
+    }
+    return task_count;
+}
 
 static TbBool prevent_local_dig_prediction(const struct Packet *pckt)
 {
@@ -150,6 +164,7 @@ void update_local_dig_tag_prediction(void)
         memset(&local_dig_roomspace_prediction, 0, sizeof(local_dig_roomspace_prediction));
         return;
     }
+    int predicted_task_count = rebuild_local_dig_predictions();
     if ((pckt->action == PckA_SetRoomspaceHighlight) || (pckt->action == PckA_RoomspaceHighlightToggle)) {
         local_dig_roomspace_prediction = *pckt;
     }
@@ -161,6 +176,9 @@ void update_local_dig_tag_prediction(void)
         if ((local_dig_tag_prediction.last_packet_turn != 0) && (get_gameturn() - local_dig_tag_prediction.last_packet_turn > game.input_lag_turns + LOCAL_DIG_TAG_EXPIRY)) {
             memset(&local_dig_tag_prediction, 0, sizeof(local_dig_tag_prediction));
         }
+        return;
+    }
+    if ((pckt->action != PckA_None) && (pckt->action != PckA_SetRoomspaceHighlight)) {
         return;
     }
     MapSlabCoord slb_x = subtile_slab(coord_subtile(pckt->pos_x));
@@ -178,31 +196,22 @@ void update_local_dig_tag_prediction(void)
         memset(&local_dig_tag_prediction, 0, sizeof(local_dig_tag_prediction));
         return;
     }
-    if (local_dig_tag_prediction.last_packet_turn == 0) {
-        local_dig_tag_prediction.predicted_task_count = get_players_dungeon(get_my_player())->task_count;
-    }
     local_dig_tag_prediction.untag_mode = roomspace.untag_mode;
     if (start_selection) {
         local_dig_tag_prediction.last_packet_turn = pckt->turn;
     }
-    if ((predicted_player.roomspace_highlight_mode == drag_placement_mode) && start_selection) {
-        memcpy(local_dig_tag_prediction.drag_base_slab_tag_modes, local_dig_tag_prediction.slab_tag_modes, sizeof(local_dig_tag_prediction.slab_tag_modes));
-        local_dig_tag_prediction.drag_base_task_count = local_dig_tag_prediction.predicted_task_count;
-    }
-    if (predicted_player.roomspace_highlight_mode == drag_placement_mode) {
-        memcpy(local_dig_tag_prediction.slab_tag_modes, local_dig_tag_prediction.drag_base_slab_tag_modes, sizeof(local_dig_tag_prediction.slab_tag_modes));
-        local_dig_tag_prediction.predicted_task_count = local_dig_tag_prediction.drag_base_task_count;
-    }
     if ((predicted_player.roomspace_highlight_mode == drag_placement_mode) && ((pckt->control_flags & PCtr_LBtnRelease) == 0)) {
         return;
     }
-    int changed_slab_count = apply_roomspace_dig_tag_selection(my_player_number, &roomspace, local_dig_tag_prediction.previous_slb_x, local_dig_tag_prediction.previous_slb_y, predicted_player.roomspace_highlight_mode, local_dig_tag_prediction.slab_tag_modes, &local_dig_tag_prediction.predicted_task_count);
-    local_dig_tag_prediction.previous_slb_x = slb_x;
-    local_dig_tag_prediction.previous_slb_y = slb_y;
+    int changed_slab_count = apply_roomspace_dig_tag_selection(my_player_number, &roomspace, local_dig_tag_prediction.previous_slb_x, local_dig_tag_prediction.previous_slb_y, predicted_player.roomspace_highlight_mode, local_dig_tag_prediction.slab_tag_modes, &predicted_task_count);
     if (changed_slab_count > 0) {
+        uint16_t previous_slb = (uint16_t)local_dig_tag_prediction.previous_slb_x | ((uint16_t)local_dig_tag_prediction.previous_slb_y << 8);
         local_dig_tag_prediction.last_packet_turn = pckt->turn;
+        set_packet_action(pckt, PckA_ApplyRoomspaceDigTag, predicted_player.roomspace_highlight_mode, predicted_player.roomspace_width, previous_slb, roomspace.untag_mode);
         play_non_3d_sample(snd_tile_dig);
     }
+    local_dig_tag_prediction.previous_slb_x = slb_x;
+    local_dig_tag_prediction.previous_slb_y = slb_y;
 }
 
 unsigned char get_local_dig_prediction_render_flags(MapSubtlCoord stl_x, MapSubtlCoord stl_y, unsigned char base_map_flags)

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -15,6 +15,7 @@
 #include "player_data.h"
 #include "player_utils.h"
 #include "slab_data.h"
+#include "tasks_list.h"
 #include "packets.h"
 #include "net_exchange_gameplay.h"
 #include "roomspace.h"
@@ -31,6 +32,8 @@ extern "C" {
 
 static struct {
     unsigned char slab_tag_modes[MAX_TILES_X * MAX_TILES_Y];
+    SlabCodedCoords slabs[MAX_TILES_X * MAX_TILES_Y];
+    int slab_count;
     GameTurn last_packet_turn;
     MapSlabCoord drag_start_slb_x;
     MapSlabCoord drag_start_slb_y;
@@ -44,19 +47,21 @@ static struct Packet local_dig_roomspace_prediction;
 static struct RoomSpace local_dig_render_roomspace;
 static TbBool local_dig_render_roomspace_active;
 
-static int rebuild_local_dig_predictions(void)
+static int reconcile_local_dig_predictions(void)
 {
     int task_count = get_players_dungeon(get_my_player())->task_count;
-    memset(local_dig_tag_prediction.slab_tag_modes, 0, sizeof(local_dig_tag_prediction.slab_tag_modes));
-    for (GameTurn turn = get_gameturn() - game.input_lag_turns; turn < get_gameturn(); turn++) {
-        const struct Packet *pckt = get_history_packet(get_my_player()->packet_num, turn);
-        if ((pckt == NULL) || (pckt->action != PckA_ApplyRoomspaceDigTag)) {
+    for (int i = 0; i < local_dig_tag_prediction.slab_count;) {
+        SlabCodedCoords slb_num = local_dig_tag_prediction.slabs[i];
+        unsigned char mode = local_dig_tag_prediction.slab_tag_modes[slb_num];
+        TbBool tagged = find_from_task_list_by_slab(my_player_number, slb_num_decode_x(slb_num), slb_num_decode_y(slb_num)) != -1;
+        if (tagged == (mode == DigTagMode_Tag)) {
+            local_dig_tag_prediction.slab_tag_modes[slb_num] = 0;
+            local_dig_tag_prediction.slabs[i] = local_dig_tag_prediction.slabs[--local_dig_tag_prediction.slab_count];
             continue;
         }
-        struct PlayerInfo player = *get_my_player();
-        struct RoomSpace roomspace;
-        get_roomspace_dig_tag_packet(&roomspace, &player, pckt, my_player_number, local_dig_tag_prediction.slab_tag_modes);
-        apply_roomspace_dig_tag_selection(my_player_number, &roomspace, player.render_roomspace.drag_start_x, player.render_roomspace.drag_start_y, player.roomspace_highlight_mode, local_dig_tag_prediction.slab_tag_modes, &task_count);
+        task_count += mode == DigTagMode_Tag;
+        task_count -= mode == DigTagMode_Untag;
+        i++;
     }
     return task_count;
 }
@@ -164,7 +169,6 @@ void update_local_dig_tag_prediction(void)
         memset(&local_dig_roomspace_prediction, 0, sizeof(local_dig_roomspace_prediction));
         return;
     }
-    int predicted_task_count = rebuild_local_dig_predictions();
     if ((pckt->action == PckA_SetRoomspaceHighlight) || (pckt->action == PckA_RoomspaceHighlightToggle)) {
         local_dig_roomspace_prediction = *pckt;
     }
@@ -196,6 +200,7 @@ void update_local_dig_tag_prediction(void)
         memset(&local_dig_tag_prediction, 0, sizeof(local_dig_tag_prediction));
         return;
     }
+    int predicted_task_count = reconcile_local_dig_predictions();
     local_dig_tag_prediction.untag_mode = roomspace.untag_mode;
     if (start_selection) {
         local_dig_tag_prediction.last_packet_turn = pckt->turn;
@@ -203,7 +208,7 @@ void update_local_dig_tag_prediction(void)
     if ((predicted_player.roomspace_highlight_mode == drag_placement_mode) && ((pckt->control_flags & PCtr_LBtnRelease) == 0)) {
         return;
     }
-    int changed_slab_count = apply_roomspace_dig_tag_selection(my_player_number, &roomspace, local_dig_tag_prediction.previous_slb_x, local_dig_tag_prediction.previous_slb_y, predicted_player.roomspace_highlight_mode, local_dig_tag_prediction.slab_tag_modes, &predicted_task_count);
+    int changed_slab_count = apply_roomspace_dig_tag_selection(my_player_number, &roomspace, local_dig_tag_prediction.previous_slb_x, local_dig_tag_prediction.previous_slb_y, predicted_player.roomspace_highlight_mode, local_dig_tag_prediction.slab_tag_modes, local_dig_tag_prediction.slabs, &local_dig_tag_prediction.slab_count, &predicted_task_count);
     if (changed_slab_count > 0) {
         uint16_t previous_slb = (uint16_t)local_dig_tag_prediction.previous_slb_x | ((uint16_t)local_dig_tag_prediction.previous_slb_y << 8);
         local_dig_tag_prediction.last_packet_turn = pckt->turn;


### PR DESCRIPTION
This should hopefully help with those misclicks. Instead of relying on stale coordinates when handling tagging clicks, we now use the local camera directly to send slab coordinates and the roomspace action in a packet, bypassing the authoritative camera's position and rotation.