### PR TITLE
Multiplayer: display version mismatch message when clicking start game

### DIFF
--- a/src/front_network.c
+++ b/src/front_network.c
@@ -411,39 +411,35 @@ void frontnet_rewite_net_messages(void)
 static TbBool check_frontend_version_mismatch(void)
 {
   int32_t active_players = 0;
-  struct NetUser* host_user = &netstate.users[SERVER_ID];
+  const struct NetUser *host_user = &netstate.users[SERVER_ID];
   NetUserId remote_id = -1;
+  TbBool start_requested = false;
 
-  if (netstate.my_id != SERVER_ID) {
-    remote_id = my_player_number;
-  }
-  for (int32_t i = 0; i < MAX_NET_USERS; i++) {
+  for (NetUserId i = 0; i < MAX_NET_USERS; i++) {
     if (!network_player_active(i)) {
       continue;
     }
     active_players++;
-    if (remote_id == -1 && i != SERVER_ID
-        && !net_versions_match(&host_user->version, &netstate.users[i].version)) {
+    unsigned char action = screen_packet_action(&net_screen_packet[i]);
+    if (action == NetAct_OpenLandView || action == NetAct_HostStartLevel) {
+      start_requested = true;
+    }
+    if (i != SERVER_ID && !net_versions_match(&host_user->version, &netstate.users[i].version) && (remote_id == -1 || i == my_player_number)) {
       remote_id = i;
     }
   }
-  TbBool player_joined = (active_players > previous_active_players);
+  TbBool player_joined = active_players > previous_active_players;
   previous_active_players = active_players;
-  if (remote_id == -1) {
-    return false;
+  if (remote_id == -1 || (!player_joined && !start_requested)) {
+    return remote_id != -1;
   }
-  struct NetUser* remote_user = &netstate.users[remote_id];
-  if (net_versions_match(&host_user->version, &remote_user->version)) {
-    return false;
-  }
-  if (player_joined) {
-    char text[MESSAGE_TEXT_LEN];
-    snprintf(text, sizeof(text), "%s\n%s: %d.%d.%d.%d\n%s: %d.%d.%d.%d",
-        get_string(GUIStr_VersionMismatch),
-        network_player_name(SERVER_ID), (int)host_user->version.major, (int)host_user->version.minor, (int)host_user->version.release, (int)host_user->version.build,
-        network_player_name(remote_id), (int)remote_user->version.major, (int)remote_user->version.minor, (int)remote_user->version.release, (int)remote_user->version.build);
-    create_frontend_error_box(10000, text);
-  }
+  const struct NetUser *remote_user = &netstate.users[remote_id];
+  char text[MESSAGE_TEXT_LEN];
+  snprintf(text, sizeof(text), "%s\n%s: %d.%d.%d.%d\n%s: %d.%d.%d.%d",
+      get_string(GUIStr_VersionMismatch),
+      network_player_name(SERVER_ID), (int)host_user->version.major, (int)host_user->version.minor, (int)host_user->version.release, (int)host_user->version.build,
+      network_player_name(remote_id), (int)remote_user->version.major, (int)remote_user->version.minor, (int)remote_user->version.release, (int)remote_user->version.build);
+  create_frontend_error_box(10000, text);
   return true;
 }
 

--- a/src/net_exchange_common.c
+++ b/src/net_exchange_common.c
@@ -279,7 +279,7 @@ TbError process_network_message(NetUserId source, void *server_buf, size_t frame
     case NETMSG_LOGIN:
         return process_login_message(source, read_pos);
     case NETMSG_USERUPDATE:
-        return process_user_update_message(source, read_pos);
+        return process_user_update_message(source, read_pos, netstate.msg_buffer + message_size);
     case NETMSG_FRONTEND:
     case NETMSG_STARTUP_SYNC:
     case NETMSG_GAMEPLAY_UNSEQUENCED:

--- a/src/net_lobby.c
+++ b/src/net_lobby.c
@@ -140,7 +140,7 @@ TbError process_login_message(NetUserId source, char *read_pos)
     return Lb_OK;
 }
 
-TbError process_user_update_message(NetUserId source, char *read_pos)
+TbError process_user_update_message(NetUserId source, char *read_pos, const char *end_pos)
 {
     if (source != SERVER_ID) {
         WARNLOG("Unexpected USERUPDATE");
@@ -161,6 +161,9 @@ TbError process_user_update_message(NetUserId source, char *read_pos)
         abort();
     }
     strcpy(user->name, name);
+    if (read_pos + sizeof(user->version) <= end_pos) {
+        memcpy(&user->version, read_pos, sizeof(user->version));
+    }
     UpdateLocalPlayerInfo(user_id);
     return Lb_OK;
 }

--- a/src/net_lobby.h
+++ b/src/net_lobby.h
@@ -29,7 +29,7 @@ extern "C" {
 TbError LbNetwork_ExchangeLogin(char *player_name);
 TbError LbNetwork_ExchangeFrontend(void *send_buf, void *server_buf, size_t frame_size);
 TbError process_login_message(NetUserId source, char *read_pos);
-TbError process_user_update_message(NetUserId source, char *read_pos);
+TbError process_user_update_message(NetUserId source, char *read_pos, const char *end_pos);
 
 void LbNetwork_SetServerPort(int port);
 void LbNetwork_InitSessionsFromCmdLine(const char *str);

--- a/src/net_main.c
+++ b/src/net_main.c
@@ -77,6 +77,8 @@ void SendUserUpdate(NetUserId dest, NetUserId updated_user)
     write_pos += 1;
     strcpy(write_pos, netstate.users[updated_user].name);
     write_pos += strlen(netstate.users[updated_user].name) + 1;
+    memcpy(write_pos, &netstate.users[updated_user].version, sizeof(netstate.users[updated_user].version));
+    write_pos += sizeof(netstate.users[updated_user].version);
     send_message_buffer(dest, write_pos);
 }
 


### PR DESCRIPTION
also fixes up a situation where some players may start anyway despite the error
and displays the message to all players