### PR TITLE
Multiplayer: reliable slap/power click

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -2055,9 +2055,18 @@ static short get_creature_control_action_inputs(void)
 
 static void set_packet_action_for_thing_under_hand(struct PlayerInfo* player, struct Packet* pckt)
 {
-    if ((player->view_type == PVT_DungeonTop) && ((pckt->control_flags & PCtr_Gui) == 0) && left_button_released && (local_thing_under_hand > 0) && (pckt->action == PckA_None) && (get_gameturn() - hand_pick_pending_turn > game.input_lag_turns)) {
-        int32_t cursor_state = (pckt->additional_packet_values & PCAdV_ContextMask) >> 1;
-        switch (player->work_state) {
+    if ((player->view_type != PVT_DungeonTop) || ((pckt->control_flags & PCtr_Gui) != 0) || (local_thing_under_hand <= 0) || (pckt->action != PckA_None) || (get_gameturn() - hand_pick_pending_turn <= game.input_lag_turns)) {
+        return;
+    }
+    int32_t cursor_state = (pckt->additional_packet_values & PCAdV_ContextMask) >> 1;
+    if (right_button_released && (player->work_state == PSt_CtrlDungeon) && (cursor_state == CSt_PowerHand) && power_hand_is_empty(player) && !player->one_click_lock_cursor && thing_slappable(thing_get(local_thing_under_hand), player->id_number)) {
+        set_packet_action(pckt, PckA_UsePwrOnThing, PwrK_SLAP, local_thing_under_hand, 0, 0);
+        return;
+    }
+    if (!left_button_released) {
+        return;
+    }
+    switch (player->work_state) {
         case PSt_CtrlDungeon:
             if ((pckt->additional_packet_values & PCAdV_CrtrContrlPressed) != 0) {
                 set_packet_action(pckt, PckA_UsePwrOnThing, PwrK_POSSESS, local_thing_under_hand, 0, 0);
@@ -2076,7 +2085,6 @@ static void set_packet_action_for_thing_under_hand(struct PlayerInfo* player, st
         case PST_CastPowerOnTarget:
             set_packet_action(pckt, PckA_UsePwrOnThing, player->chosen_power_kind, local_thing_under_hand, 0, 0);
             break;
-        }
     }
 }
 

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -523,7 +523,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
                 }
             } else
             {
-                if (player->primary_cursor_state == CSt_PowerHand && (!player->one_click_lock_cursor)) {
+                if (!thing_target_action && (player->primary_cursor_state == CSt_PowerHand) && (!player->one_click_lock_cursor)) {
                     thing = get_nearest_thing_for_slap(plyr_idx, subtile_coord_center(stl_x), subtile_coord_center(stl_y));
                     if(!thing_is_invalid(thing))
                         magic_use_available_power_on_thing(plyr_idx, PwrK_SLAP, 0, stl_x, stl_y, thing, PwMod_Default);


### PR DESCRIPTION
At some point throughout all these hand adjustments I either disabled reliable clicking for power/slap or I didn't implement it. Only pickup works reliably.

To test this, you can open Clumsy and set Lag to 250 (this'll give you like 12 `input_lag_turns`) and try slapping a fast moving creature. It is much easier to do with this PR.