### PR TITLE
Sync client clock to host packet receive time

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,6 +225,7 @@ static long double process_frame_time = 0;
 static long double time_since_last_draw = 0;
 static long double average_frame_draw_time = 1;
 static long double multiplayer_clock_adjust = 1;
+long double host_packet_received = 1;
 float interpolate_time = 0;
 /******************************************************************************/
 
@@ -3554,13 +3555,12 @@ static void gameplay_loop_logic()
     {
         if (game.input_lag_turns == 0)
         {
-            // The logic here is: if we are late (process_turn_time > 1.0), we
-            // spent too long waiting for a packet from the host.  Assuming
-            // network lag remains constant, this means we entered
-            // exchange_packet() too early.  So, the scaling factor must reduce
-            // (< 1.0) so that the next turn takes a little longer in real time.
-            // Vice-versa if we are early.
-            multiplayer_clock_adjust = 1 + (1 - game.process_turn_time) / 20;
+            // Adjust the clock rate so that the host packet is received at
+            // process_turn_time == 1.0 (on average).  If it is received later,
+            // reduce the scaling factor (< 1.0) so that the next turn takes a
+            // little longer in real time.  Vice-versa if it is early.
+
+            multiplayer_clock_adjust = 1 + (1 - host_packet_received) / 20;
         }
         else
         {
@@ -3570,7 +3570,8 @@ static void gameplay_loop_logic()
             multiplayer_clock_adjust = tick_ns_one_turn / tick_ns_adjusted_turn;
         }
     }
-    else multiplayer_clock_adjust = 1;
+    else multiplayer_clock_adjust = 1.0;
+    host_packet_received = 1.0;
 
     while (game.process_turn_time < 1.0)
     {

--- a/src/net_exchange_common.c
+++ b/src/net_exchange_common.c
@@ -44,6 +44,7 @@
 
 extern void network_yield_draw_frontend(void);
 extern void network_yield_draw_gameplay(void);
+extern long double host_packet_received;
 
 void send_to_active_peers(int send_count, enum NetworkPeerSendMode send_mode, const char *buffer, size_t msg_size, NetUserId first_skip_id, NetUserId second_skip_id)
 {
@@ -116,6 +117,12 @@ static TbError handle_exchange_message(NetUserId source, void *server_buf, size_
             return Lb_OK;
         }
         const struct Packet *packets = (const struct Packet *)read_pos;
+        if (peer_id == SERVER_ID
+            && packets[0].turn == get_gameturn()
+            && get_history_packet((PlayerNumber)peer_id, packets[0].turn) == NULL)
+        {
+            host_packet_received = game.process_turn_time;
+        }
         for (unsigned char i = 0; i < packet_count; i += 1) {
             if (is_packet_empty(&packets[i])) {
                 MULTIPLAYER_LOG("process_network_message: Skipping empty packet for player %d turn %lu", peer_id, (unsigned long)packets[i].turn);


### PR DESCRIPTION
With `input_lag_turns == 0`, clients sync their clock (`process_turn_time`) to the time point when all packets are received (ie. when `exchange_packets()` returns).  This was added in #4919.

For 3 and 4 player games, this creates a very complex interaction as all clients try to sync to each other, which is very difficult to reason about.  So far, it *seems* to work okay, but I expect it will cause trouble, at some point.

This patch fixes any potential problems, and greatly simplifies the logic, by only using receipt of the *host* packet as the clock sync target.
