### PR TITLE
Multiplayer: wait for input lag calculation on landview

### DIFF
--- a/src/front_landview_multiplayer.c
+++ b/src/front_landview_multiplayer.c
@@ -39,6 +39,7 @@
 #include "game_legacy.h"
 #include "kjm_input.h"
 #include "net_game.h"
+#include "net_input_lag.h"
 #include "keeperfx.hpp"
 #include "room_list.h"
 #include "vidfade.h"
@@ -98,6 +99,7 @@ const int32_t hand_limp_yoffset[] = { -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, 
 long fe_net_level_selected;
 static struct NetLandLocalState net_map_local;
 static struct NetLandRemoteSlap net_map_remote_slap[MAX_NET_USERS];
+static LevelNumber pending_level_number = SINGLEPLAYER_NOTSTARTED;
 struct ScreenPacket net_screen_packet[MAX_NET_USERS];
 /******************************************************************************/
 #ifdef __cplusplus
@@ -285,6 +287,7 @@ static void get_hand_packet(PlayerNumber plyr_idx, struct ScreenPacket *nspck, i
 
 static void draw_netmap_players_hands(void)
 {
+    static const char *dot_frames[] = {"...", "..", ".", "..", "..."};
     struct ScreenPacket nspck;
     const char *plyr_nam;
     const struct TbSprite *spr;
@@ -310,6 +313,9 @@ static void draw_netmap_players_hands(void)
         }
         get_hand_packet(i, &nspck, slap_frame, now);
         plyr_nam = network_player_name(i);
+        if (pending_level_number > SINGLEPLAYER_NOTSTARTED) {
+            plyr_nam = dot_frames[(now / 125) % 5];
+        }
         colr = net_player_colours[i];
         spr = get_hand_sprite_for_packet(&nspck, anim_frame, &x, &y);
         x -= (long)map_info.screen_shift_x;
@@ -350,6 +356,9 @@ void frontnetmap_input(void)
     TbClockMSec now;
     struct LevelInformation* lvinfo;
 
+    if (pending_level_number > SINGLEPLAYER_NOTSTARTED) {
+        return;
+    }
     if (lbKeyOn[KC_ESCAPE]) {
         fe_net_level_selected = LEVELNUMBER_ERROR;
         lbKeyOn[KC_ESCAPE] = 0;
@@ -442,6 +451,7 @@ TbBool frontnetmap_load(void)
     frontmap_zoom_skip_init(SINGLEPLAYER_NOTSTARTED);
     fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
     net_level_hilighted = SINGLEPLAYER_NOTSTARTED;
+    pending_level_number = SINGLEPLAYER_NOTSTARTED;
     set_pointer_graphic_none();
     LbMouseSetPosition(lbDisplay.PhysicalScreenWidth/2, lbDisplay.PhysicalScreenHeight/2);
     map_sound_fade = FULL_LOUDNESS;
@@ -507,12 +517,14 @@ static LevelNumber frontnetmap_update_players(void)
         return fe_net_level_selected;
     }
     const PlayerNumber host_player_number = get_host_player_id();
-    const TbBool can_start_level = (my_player_number == host_player_number) && (get_selected_level_number() <= SINGLEPLAYER_NOTSTARTED);
+    const TbBool can_select_level = get_selected_level_number() <= SINGLEPLAYER_NOTSTARTED;
+    LbNetwork_UpdateInputLagIfHost();
+    const TbBool input_lag_ready = !frontnet_is_waiting_for_ping_stabilization();
     struct ScreenPacket* my_nspck = &net_screen_packet[my_player_number];
     TbBool slap_hit_confirmed = false;
     int32_t leading_votes = 0;
     LevelNumber selected_level_number = SINGLEPLAYER_NOTSTARTED;
-    if (can_start_level) {
+    if (can_select_level) {
         memset(scratch, 0, PALETTE_SIZE);
     }
     for (int32_t i = 0; i < MAX_NET_USERS; i++) {
@@ -543,7 +555,7 @@ static LevelNumber frontnetmap_update_players(void)
         if ((i == host_player_number) && (action == NetAct_HostStartLevel) && (nspck->action_par1 > SINGLEPLAYER_NOTSTARTED)) {
             return nspck->action_par1;
         }
-        if (can_start_level) {
+        if (can_select_level) {
             if ((action == NetAct_Slapping) || (nspck->action_par1 <= 0)) {
                 selected_level_number = SINGLEPLAYER_NOTSTARTED;
                 leading_votes = -1;
@@ -585,8 +597,12 @@ static LevelNumber frontnetmap_update_players(void)
             }
         }
     }
-    if (can_start_level && (selected_level_number > SINGLEPLAYER_NOTSTARTED)) {
-        set_selected_level_number(selected_level_number);
+    if (can_select_level) {
+        if (pending_level_number != selected_level_number) {
+            pending_level_number = selected_level_number;
+        } else if ((selected_level_number > SINGLEPLAYER_NOTSTARTED) && (my_player_number == host_player_number) && input_lag_ready) {
+            set_selected_level_number(selected_level_number);
+        }
     }
     return SINGLEPLAYER_NOTSTARTED;
 }

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -113,7 +113,13 @@ static TbBool try_starting_level_from_chat(const char *message, int32_t player_i
     }
     char campaign_filename[80];
     snprintf(campaign_filename, sizeof(campaign_filename), "%.*s", campaign_len, message);
-    return frontnet_start_level(campaign_filename, level_num);
+    if (!frontnet_start_level(campaign_filename, level_num)) {
+        return false;
+    }
+    if (level_num > SINGLEPLAYER_NOTSTARTED) {
+        add_message(player_id, "Waiting before loading...");
+    }
+    return true;
 }
 
 TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
@@ -132,6 +138,7 @@ TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
         return false;
     }
     if (lvnum <= 0) {
+        set_selected_level_number(SINGLEPLAYER_NOTSTARTED);
         return true;
     }
     if (get_level_info(lvnum) == NULL) {
@@ -139,8 +146,6 @@ TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
         return false;
     }
     set_selected_level_number(lvnum);
-    fe_network_active = 1;
-    frontend_set_state(FeSt_START_MPLEVEL);
     return true;
 }
 
@@ -571,43 +576,40 @@ void frontnet_send_campaign_change_message(const char* campaign_fname)
 
     char msg[64];
     snprintf(msg, sizeof(msg), "%s:_", base_name);
+    set_selected_level_number(SINGLEPLAYER_NOTSTARTED);
     send_network_chat_message(my_player_number, msg);
 }
 
 void handle_autostart_multiplayer_messaging(void)
 {
-    static TbBool send_pending = false;
     static int previous_enum_players = 0;
     TbBool player_joined = (net_number_of_enum_players > previous_enum_players);
     previous_enum_players = net_number_of_enum_players;
 
     if (net_number_of_enum_players < 2) {
-        send_pending = false;
         return;
     }
 
     if (player_joined && my_player_number == get_host_player_id()) {
         frontnet_send_campaign_change_message(campaign.fname);
     }
-
-    if (!send_pending && my_player_number == get_host_player_id() &&
-        (autostart_multiplayer_campaign[0] != '\0' || autostart_multiplayer_level > 0)) {
-        send_pending = true;
+    if (my_player_number != get_host_player_id() || get_selected_level_number() > SINGLEPLAYER_NOTSTARTED) {
+        return;
     }
-    if (send_pending && !frontnet_is_waiting_for_ping_stabilization()) {
-        struct PlayerInfo *player = get_my_player();
-        const char* camp = "keeporig";
-        int level = 1;
-        if (autostart_multiplayer_campaign[0]) {
-            camp = autostart_multiplayer_campaign;
-        }
-        if (autostart_multiplayer_level > 0) {
-            level = autostart_multiplayer_level;
-        }
-        snprintf(player->mp_message_text, PLAYER_MP_MESSAGE_LEN, "%s:%d", camp, level);
-        lbInkey = KC_RETURN;
-        send_pending = false;
+    if (autostart_multiplayer_campaign[0] == '\0' && autostart_multiplayer_level <= 0) {
+        return;
     }
+    struct PlayerInfo *player = get_my_player();
+    const char* camp = "keeporig";
+    int level = 1;
+    if (autostart_multiplayer_campaign[0]) {
+        camp = autostart_multiplayer_campaign;
+    }
+    if (autostart_multiplayer_level > 0) {
+        level = autostart_multiplayer_level;
+    }
+    snprintf(player->mp_message_text, PLAYER_MP_MESSAGE_LEN, "%s:%d", camp, level);
+    lbInkey = KC_RETURN;
 }
 
 void frontnet_start_update(void)
@@ -641,6 +643,10 @@ void frontnet_start_update(void)
     frontnet_rewite_net_messages();
 
     LbNetwork_UpdateInputLagIfHost();
+    if (get_selected_level_number() > SINGLEPLAYER_NOTSTARTED && !frontnet_is_waiting_for_ping_stabilization()) {
+        fe_network_active = 1;
+        frontend_set_state(FeSt_START_MPLEVEL);
+    }
     if (frontnet_service_selected(FrontendNetSvc_LAN)) {
         lan_host_update();
     }
@@ -741,6 +747,7 @@ void frontnet_session_setup(void)
 void frontnet_start_setup(void)
 {
     frontnet_reset_ping_stabilization();
+    set_selected_level_number(SINGLEPLAYER_NOTSTARTED);
     previous_active_players = 0;
     memset(net_screen_packet, 0, sizeof(net_screen_packet));
     frontend_alliances = -1;

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -75,8 +75,8 @@ struct ConfigInfo net_config_info;
 char net_service[16][NET_SERVICE_LEN];
 char net_player_name[20];
 char tmp_net_player_name[24];
-static TbClockMSec frontnet_ping_stabilization_end_time = 0;
-static int previous_player_count_for_ping_wait = -1;
+static TbClockMSec frontnet_ping_stabilization_end_time;
+static int32_t previous_player_count_for_ping_wait = -1;
 static TbBool attempting_to_join_cancelled = false;
 static int32_t previous_active_players = 0;
 /******************************************************************************/
@@ -490,7 +490,7 @@ static void process_frontend_packets(void)
             }
             break;
         case NetAct_OpenLandView:
-            if (version_mismatch_found) {
+            if (i != SERVER_ID || version_mismatch_found) {
                 break;
             }
             fe_network_active = 1;
@@ -527,23 +527,27 @@ static void process_frontend_packets(void)
 
 TbBool frontnet_is_waiting_for_ping_stabilization(void)
 {
-    TbClockMSec now;
-    if (net_number_of_enum_players != previous_player_count_for_ping_wait) {
-        frontnet_ping_stabilization_end_time = LbTimerClock() + FRONTNET_PING_STABILIZATION_DELAY_MS;
-        previous_player_count_for_ping_wait = net_number_of_enum_players;
+    int32_t player_count = 0;
+    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+        if (IsUserActive(id)) {
+            player_count += 1;
+        }
     }
-    if (net_number_of_enum_players < 2) {
+    if (player_count != previous_player_count_for_ping_wait) {
+        frontnet_ping_stabilization_end_time = LbTimerClock() + FRONTNET_PING_STABILIZATION_DELAY_MS;
+        previous_player_count_for_ping_wait = player_count;
+    }
+    if (player_count < 2) {
         return true;
     }
     if (frontnet_ping_stabilization_end_time == 0) {
         return false;
     }
-    now = LbTimerClock();
-    if (now >= frontnet_ping_stabilization_end_time) {
-        frontnet_ping_stabilization_end_time = 0;
-        return false;
+    if (LbTimerClock() < frontnet_ping_stabilization_end_time) {
+        return true;
     }
-    return true;
+    frontnet_ping_stabilization_end_time = 0;
+    return false;
 }
 
 void frontnet_reset_ping_stabilization(void)
@@ -551,7 +555,6 @@ void frontnet_reset_ping_stabilization(void)
     frontnet_ping_stabilization_end_time = 0;
     previous_player_count_for_ping_wait = -1;
 }
-
 
 void frontnet_send_campaign_change_message(const char* campaign_fname)
 {

--- a/src/front_network.h
+++ b/src/front_network.h
@@ -30,10 +30,10 @@ extern "C" {
 #endif
 
 /******************************************************************************/
-// 1500 is good enough about 90% of the time, to have stable readings of ping and ping variance
-#define WAIT_FOR_STABLE_PLAYER 1500
+// WAIT_FOR_STABLE_PLAYER waits until we have stable ping readings after any player leaves/joins.
+#define WAIT_FOR_STABLE_PLAYER 3000
 #define AVERAGE_PING_UPDATE_RATE 500
-#define FRONTNET_PING_STABILIZATION_DELAY_MS 3000
+#define FRONTNET_PING_STABILIZATION_DELAY_MS 10000
 #define NET_SERVICE_LEN 64
 
 enum FrontendNetService {

--- a/src/front_network.h
+++ b/src/front_network.h
@@ -33,7 +33,7 @@ extern "C" {
 // WAIT_FOR_STABLE_PLAYER waits until we have stable ping readings after any player leaves/joins.
 #define WAIT_FOR_STABLE_PLAYER 3000
 #define AVERAGE_PING_UPDATE_RATE 500
-#define FRONTNET_PING_STABILIZATION_DELAY_MS 10000
+#define FRONTNET_PING_STABILIZATION_DELAY_MS 8000
 #define NET_SERVICE_LEN 64
 
 enum FrontendNetService {

--- a/src/frontmenu_net.c
+++ b/src/frontmenu_net.c
@@ -109,8 +109,7 @@ void frontnet_messages_down_maintain(struct GuiButton *gbtn)
 
 void frontnet_start_game_maintain(struct GuiButton *gbtn)
 {
-    TbBool enabled;
-    enabled = (net_number_of_enum_players > 1) && !frontnet_is_waiting_for_ping_stabilization();
+    TbBool enabled = net_number_of_enum_players > 1;
     gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * enabled) & LbBtnF_Enabled;
 }
 
@@ -711,26 +710,6 @@ void frontnet_service_select(struct GuiButton *gbtn)
   {
       setup_network_service(srvidx);
   }
-}
-
-void frontnet_draw_start_game_button(struct GuiButton *gbtn)
-{
-    static TbClockMSec last_anim_time = 0;
-    static int anim_frame = 0;
-    static const char *dot_frames[] = {"...", "..", ".", "..", "..."};
-    const char *text;
-
-    if (net_number_of_enum_players >= 2 && frontnet_is_waiting_for_ping_stabilization()) {
-        if (LbTimerClock() >= last_anim_time + 125) {
-            anim_frame = (anim_frame + 1) % 5;
-            last_anim_time = LbTimerClock();
-        }
-        text = dot_frames[anim_frame];
-    } else {
-        text = frontend_button_caption_text(gbtn);
-    }
-
-    frontend_draw_button(gbtn, 0, text, Lb_TEXT_HALIGN_CENTER);
 }
 
 /******************************************************************************/

--- a/src/frontmenu_net.h
+++ b/src/frontmenu_net.h
@@ -98,7 +98,6 @@ void frontnet_draw_bottom_scroll_box_tab(struct GuiButton *gbtn);
 void frontnet_draw_messages_scroll_tab(struct GuiButton *gbtn);
 void frontnet_draw_current_message(struct GuiButton *gbtn);
 void frontnet_draw_messages(struct GuiButton *gbtn);
-void frontnet_draw_start_game_button(struct GuiButton *gbtn);
 void frontnet_start_game_maintain(struct GuiButton *gbtn);
 void frontnet_return_to_session_menu(struct GuiButton *gbtn);
 void frontnet_service_select(struct GuiButton *gbtn);

--- a/src/frontmenu_net_data.cpp
+++ b/src/frontmenu_net_data.cpp
@@ -131,7 +131,7 @@ struct GuiButtonInit frontend_net_start_buttons[] = {
   { LbBtnT_HoldableBtn,BID_DEFAULT, 0, 0, NULL,               NULL,   NULL,                    0, 536, 285, 536, 285,  20, 88, frontnet_draw_messages_scroll_tab, 0, GUIStr_Empty, 0,  {40},    0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,   NULL,                    0,  82, 386,  82, 386, 459, 28, frontnet_draw_current_message,     0, GUIStr_Empty, 0,  {43},    0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,   NULL,                    0,  89, 273,  89, 273, 438,104, frontnet_draw_messages,            0, GUIStr_Empty, 0,  {44},    0, NULL },
-  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, set_packet_start,   NULL,   frontend_over_button,    0,  49, 412,  49, 412, 247, 46, frontnet_draw_start_game_button,   0, GUIStr_Empty, 0,  {15},    0, frontnet_start_game_maintain },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, set_packet_start,   NULL,   frontend_over_button,    0,  49, 412,  49, 412, 247, 46, frontend_draw_small_menu_button,   0, GUIStr_Empty, 0,  {15},    0, frontnet_start_game_maintain },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, frontnet_return_to_session_menu,NULL,frontend_over_button,1, 345,412,345,412,247,46, frontend_draw_small_menu_button,   0, GUIStr_Empty, 0,  {16},    0, NULL },
   {-1,  BID_DEFAULT, 0, 0, NULL,               NULL,   NULL,                    0,   0,   0,   0,   0,   0,  0, NULL,                              0,           0,  0,   {0},    0, NULL },
 };

--- a/src/net_exchange_common.c
+++ b/src/net_exchange_common.c
@@ -131,6 +131,12 @@ static TbError handle_exchange_message(NetUserId source, void *server_buf, size_
                 (int)message_type, peer_id, (unsigned)payload_size, (unsigned)frame_size);
             return Lb_OK;
         }
+        if (message_type == NETMSG_FRONTEND && frame_size == sizeof(struct ScreenPacket) && netstate.my_id == SERVER_ID && screen_packet_action((struct ScreenPacket *)read_pos) == NetAct_OpenLandView) {
+            if (netstate.frontend_start_pending_end_time == 0) {
+                netstate.frontend_start_pending_end_time = LbTimerClock() + TIMEOUT_JOIN_LOBBY;
+            }
+            screen_packet_set_action((struct ScreenPacket *)read_pos, NetAct_None);
+        }
         memcpy(player_frame, read_pos, frame_size);
     }
     if (frame_peer_id != NULL) {
@@ -227,6 +233,25 @@ TbError exchange_frame_message(void *send_buf, void *server_buf, size_t frame_si
         return Lb_FAIL;
     }
     netstate.sp->update(OnNewUser);
+    if (msg_type == NETMSG_FRONTEND && frame_size == sizeof(struct ScreenPacket) && netstate.my_id == SERVER_ID) {
+        struct ScreenPacket *screen_packet = (struct ScreenPacket *)send_buf;
+        NetUserId user_id;
+        for (user_id = 0; user_id < netstate.max_players; user_id += 1) {
+            if (netstate.users[user_id].progress == USER_CONNECTED) {
+                break;
+            }
+        }
+        if (user_id < netstate.max_players && screen_packet_action(screen_packet) == NetAct_OpenLandView) {
+            if (netstate.frontend_start_pending_end_time == 0) {
+                netstate.frontend_start_pending_end_time = LbTimerClock() + TIMEOUT_JOIN_LOBBY;
+            }
+            screen_packet_set_action(screen_packet, NetAct_None);
+        }
+        if (netstate.frontend_start_pending_end_time != 0 && screen_packet_action(screen_packet) == NetAct_None && (user_id == netstate.max_players || LbTimerClock() >= netstate.frontend_start_pending_end_time)) {
+            screen_packet_set_action(screen_packet, NetAct_OpenLandView);
+            netstate.frontend_start_pending_end_time = 0;
+        }
+    }
     char *my_frame = (char *)server_buf + netstate.my_id * frame_size;
     memcpy(my_frame, send_buf, frame_size);
     char *write_pos = begin_net_message(msg_type);

--- a/src/net_main.h
+++ b/src/net_main.h
@@ -121,6 +121,7 @@ struct NetState {
     char msg_buffer[NET_MSG_BUFFER_SIZE];
     char msg_buffer_null;
     TbBool locked;
+    TbClockMSec frontend_start_pending_end_time;
 };
 
 struct TbNetworkPlayerInfo {


### PR DESCRIPTION
Instead of the Start Game button being blocked while waiting for `input_lag_turns` to be calculated, now the block has been moved to the landview, after all players select a level it'll wait out the remaining time if there is any remaining time. If you're slow enough in the lobby/landview you will never see this waiting period.

I've increased the amount of waiting time as well so we can get more accurate readings. Going from 3 seconds total to 8 seconds total. (Warcraft 3 had a countdown timer too if you recall!)

Also fixed a bug where you can start the game while someone is in the process of joining and they get into a stuck-state.

I'll be adjusting the `input_lag_turns` calculation in the next PR.