### PR TITLE
Multiplayer: Dynamically adjust input lag during gameplay

### DIFF
--- a/src/front_landview_multiplayer.c
+++ b/src/front_landview_multiplayer.c
@@ -39,7 +39,6 @@
 #include "game_legacy.h"
 #include "kjm_input.h"
 #include "net_game.h"
-#include "net_input_lag.h"
 #include "keeperfx.hpp"
 #include "room_list.h"
 #include "vidfade.h"
@@ -99,7 +98,6 @@ const int32_t hand_limp_yoffset[] = { -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, 
 long fe_net_level_selected;
 static struct NetLandLocalState net_map_local;
 static struct NetLandRemoteSlap net_map_remote_slap[MAX_NET_USERS];
-static LevelNumber pending_level_number = SINGLEPLAYER_NOTSTARTED;
 struct ScreenPacket net_screen_packet[MAX_NET_USERS];
 /******************************************************************************/
 #ifdef __cplusplus
@@ -287,7 +285,6 @@ static void get_hand_packet(PlayerNumber plyr_idx, struct ScreenPacket *nspck, i
 
 static void draw_netmap_players_hands(void)
 {
-    static const char *dot_frames[] = {"...", "..", ".", "..", "..."};
     struct ScreenPacket nspck;
     const char *plyr_nam;
     const struct TbSprite *spr;
@@ -313,9 +310,6 @@ static void draw_netmap_players_hands(void)
         }
         get_hand_packet(i, &nspck, slap_frame, now);
         plyr_nam = network_player_name(i);
-        if (pending_level_number > SINGLEPLAYER_NOTSTARTED) {
-            plyr_nam = dot_frames[(now / 125) % 5];
-        }
         colr = net_player_colours[i];
         spr = get_hand_sprite_for_packet(&nspck, anim_frame, &x, &y);
         x -= (long)map_info.screen_shift_x;
@@ -356,9 +350,6 @@ void frontnetmap_input(void)
     TbClockMSec now;
     struct LevelInformation* lvinfo;
 
-    if (pending_level_number > SINGLEPLAYER_NOTSTARTED) {
-        return;
-    }
     if (lbKeyOn[KC_ESCAPE]) {
         fe_net_level_selected = LEVELNUMBER_ERROR;
         lbKeyOn[KC_ESCAPE] = 0;
@@ -451,7 +442,6 @@ TbBool frontnetmap_load(void)
     frontmap_zoom_skip_init(SINGLEPLAYER_NOTSTARTED);
     fe_net_level_selected = SINGLEPLAYER_NOTSTARTED;
     net_level_hilighted = SINGLEPLAYER_NOTSTARTED;
-    pending_level_number = SINGLEPLAYER_NOTSTARTED;
     set_pointer_graphic_none();
     LbMouseSetPosition(lbDisplay.PhysicalScreenWidth/2, lbDisplay.PhysicalScreenHeight/2);
     map_sound_fade = FULL_LOUDNESS;
@@ -517,14 +507,14 @@ static LevelNumber frontnetmap_update_players(void)
         return fe_net_level_selected;
     }
     const PlayerNumber host_player_number = get_host_player_id();
-    const TbBool can_select_level = get_selected_level_number() <= SINGLEPLAYER_NOTSTARTED;
-    LbNetwork_UpdateInputLagIfHost();
-    const TbBool input_lag_ready = !frontnet_is_waiting_for_ping_stabilization();
+    const TbBool is_host = my_player_number == host_player_number;
+    const TbBool level_not_selected = get_selected_level_number() <= SINGLEPLAYER_NOTSTARTED;
+    const TbBool can_start_level = is_host && level_not_selected;
     struct ScreenPacket* my_nspck = &net_screen_packet[my_player_number];
     TbBool slap_hit_confirmed = false;
     int32_t leading_votes = 0;
     LevelNumber selected_level_number = SINGLEPLAYER_NOTSTARTED;
-    if (can_select_level) {
+    if (can_start_level) {
         memset(scratch, 0, PALETTE_SIZE);
     }
     for (int32_t i = 0; i < MAX_NET_USERS; i++) {
@@ -555,7 +545,7 @@ static LevelNumber frontnetmap_update_players(void)
         if ((i == host_player_number) && (action == NetAct_HostStartLevel) && (nspck->action_par1 > SINGLEPLAYER_NOTSTARTED)) {
             return nspck->action_par1;
         }
-        if (can_select_level) {
+        if (can_start_level) {
             if ((action == NetAct_Slapping) || (nspck->action_par1 <= 0)) {
                 selected_level_number = SINGLEPLAYER_NOTSTARTED;
                 leading_votes = -1;
@@ -597,12 +587,8 @@ static LevelNumber frontnetmap_update_players(void)
             }
         }
     }
-    if (can_select_level) {
-        if (pending_level_number != selected_level_number) {
-            pending_level_number = selected_level_number;
-        } else if ((selected_level_number > SINGLEPLAYER_NOTSTARTED) && (my_player_number == host_player_number) && input_lag_ready) {
-            set_selected_level_number(selected_level_number);
-        }
+    if (can_start_level && (selected_level_number > SINGLEPLAYER_NOTSTARTED)) {
+        set_selected_level_number(selected_level_number);
     }
     return SINGLEPLAYER_NOTSTARTED;
 }

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -46,7 +46,6 @@
 #include "game_legacy.h"
 #include "net_matchmaking.h"
 #include "net_lan.h"
-#include "net_input_lag.h"
 #include "config_campaigns.h"
 #include "post_inc.h"
 
@@ -75,8 +74,6 @@ struct ConfigInfo net_config_info;
 char net_service[16][NET_SERVICE_LEN];
 char net_player_name[20];
 char tmp_net_player_name[24];
-static TbClockMSec frontnet_ping_stabilization_end_time;
-static int32_t previous_player_count_for_ping_wait = -1;
 static TbBool attempting_to_join_cancelled = false;
 static int32_t previous_active_players = 0;
 /******************************************************************************/
@@ -113,13 +110,7 @@ static TbBool try_starting_level_from_chat(const char *message, int32_t player_i
     }
     char campaign_filename[80];
     snprintf(campaign_filename, sizeof(campaign_filename), "%.*s", campaign_len, message);
-    if (!frontnet_start_level(campaign_filename, level_num)) {
-        return false;
-    }
-    if (level_num > SINGLEPLAYER_NOTSTARTED) {
-        add_message(player_id, "Waiting before loading...");
-    }
-    return true;
+    return frontnet_start_level(campaign_filename, level_num);
 }
 
 TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
@@ -138,7 +129,6 @@ TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
         return false;
     }
     if (lvnum <= 0) {
-        set_selected_level_number(SINGLEPLAYER_NOTSTARTED);
         return true;
     }
     if (get_level_info(lvnum) == NULL) {
@@ -146,6 +136,8 @@ TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
         return false;
     }
     set_selected_level_number(lvnum);
+    fe_network_active = 1;
+    frontend_set_state(FeSt_START_MPLEVEL);
     return true;
 }
 
@@ -495,7 +487,7 @@ static void process_frontend_packets(void)
             }
             break;
         case NetAct_OpenLandView:
-            if (i != SERVER_ID || version_mismatch_found) {
+            if (version_mismatch_found) {
                 break;
             }
             fe_network_active = 1;
@@ -530,37 +522,6 @@ static void process_frontend_packets(void)
   }
 }
 
-TbBool frontnet_is_waiting_for_ping_stabilization(void)
-{
-    int32_t player_count = 0;
-    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
-        if (IsUserActive(id)) {
-            player_count += 1;
-        }
-    }
-    if (player_count != previous_player_count_for_ping_wait) {
-        frontnet_ping_stabilization_end_time = LbTimerClock() + FRONTNET_PING_STABILIZATION_DELAY_MS;
-        previous_player_count_for_ping_wait = player_count;
-    }
-    if (player_count < 2) {
-        return true;
-    }
-    if (frontnet_ping_stabilization_end_time == 0) {
-        return false;
-    }
-    if (LbTimerClock() < frontnet_ping_stabilization_end_time) {
-        return true;
-    }
-    frontnet_ping_stabilization_end_time = 0;
-    return false;
-}
-
-void frontnet_reset_ping_stabilization(void)
-{
-    frontnet_ping_stabilization_end_time = 0;
-    previous_player_count_for_ping_wait = -1;
-}
-
 void frontnet_send_campaign_change_message(const char* campaign_fname)
 {
     char base_name[64];
@@ -576,7 +537,6 @@ void frontnet_send_campaign_change_message(const char* campaign_fname)
 
     char msg[64];
     snprintf(msg, sizeof(msg), "%s:_", base_name);
-    set_selected_level_number(SINGLEPLAYER_NOTSTARTED);
     send_network_chat_message(my_player_number, msg);
 }
 
@@ -628,7 +588,6 @@ void frontnet_start_update(void)
       player_last_time = LbTimerClock();
     }
 
-    frontnet_is_waiting_for_ping_stabilization();
     handle_autostart_multiplayer_messaging();
 
     if ((net_number_of_messages <= 0) || (net_message_scroll_offset < 0))
@@ -642,11 +601,6 @@ void frontnet_start_update(void)
     process_frontend_packets();
     frontnet_rewite_net_messages();
 
-    LbNetwork_UpdateInputLagIfHost();
-    if (get_selected_level_number() > SINGLEPLAYER_NOTSTARTED && !frontnet_is_waiting_for_ping_stabilization()) {
-        fe_network_active = 1;
-        frontend_set_state(FeSt_START_MPLEVEL);
-    }
     if (frontnet_service_selected(FrontendNetSvc_LAN)) {
         lan_host_update();
     }
@@ -746,7 +700,6 @@ void frontnet_session_setup(void)
 
 void frontnet_start_setup(void)
 {
-    frontnet_reset_ping_stabilization();
     set_selected_level_number(SINGLEPLAYER_NOTSTARTED);
     previous_active_players = 0;
     memset(net_screen_packet, 0, sizeof(net_screen_packet));

--- a/src/front_network.h
+++ b/src/front_network.h
@@ -30,10 +30,6 @@ extern "C" {
 #endif
 
 /******************************************************************************/
-// WAIT_FOR_STABLE_PLAYER waits until we have stable ping readings after any player leaves/joins.
-#define WAIT_FOR_STABLE_PLAYER 3000
-#define AVERAGE_PING_UPDATE_RATE 500
-#define FRONTNET_PING_STABILIZATION_DELAY_MS 8000
 #define NET_SERVICE_LEN 64
 
 enum FrontendNetService {
@@ -82,8 +78,6 @@ void frontnet_session_update(void);
 void frontnet_start_update(void);
 TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum);
 void process_frontend_chat_message(int player_id, const char *message);
-TbBool frontnet_is_waiting_for_ping_stabilization(void);
-void frontnet_reset_ping_stabilization(void);
 TbBool frontnet_service_selected(enum FrontendNetService service);
 void enum_sessions_callback(struct TbNetworkCallbackData *netcdat, void *ptr);
 

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -38,6 +38,7 @@
 #include "gui_frontbtns.h"
 #include "gui_frontmenu.h"
 #include "packets.h"
+#include "net_input_lag.h"
 #include "frontend.h"
 #include "front_input.h"
 #include "vidfade.h"
@@ -869,8 +870,10 @@ void draw_network_stats()
     unsigned int lost_packet_count = GetClientPacketsLost();
     unsigned int outgoing_rate_kb10 = (GetUploadRateBytesPerSecond() * 10) / 1024;
     unsigned int incoming_rate_kb10 = (GetDownloadRateBytesPerSecond() * 10) / 1024;
-    int input_lag = game.input_lag_turns;
-    int input_lag_ms = input_lag * 50;
+    int32_t packet_misses;
+    TbClockMSec increase_countdown;
+    TbClockMSec decrease_countdown;
+    input_lag_get_stats(&packet_misses, &increase_countdown, &decrease_countdown);
     int64_t turn_length_ns = 0;
     if (turns_per_second > 0) {
         turn_length_ns = 1000000000 / turns_per_second;
@@ -884,30 +887,35 @@ void draw_network_stats()
     LbTextDrawResized(0, 0, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Half ping: %lums", half_ping);
     LbTextDrawResized(0, tx_units_per_px, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Input lag: %d turns (%dms)",
-        input_lag, input_lag_ms);
+    snprintf(text, sizeof(text), "Input lag: %d", game.input_lag_turns);
     LbTextDrawResized(0, tx_units_per_px * 2, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Packet waits: %d", packet_misses);
+    LbTextDrawResized(0, tx_units_per_px * 3, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Increase input lag: %dms", increase_countdown);
+    LbTextDrawResized(0, tx_units_per_px * 4, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Decrease input lag: %dms", decrease_countdown);
+    LbTextDrawResized(0, tx_units_per_px * 5, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Download: %u.%u KB/s",
         incoming_rate_kb10 / 10, incoming_rate_kb10 % 10);
-    LbTextDrawResized(0, tx_units_per_px * 3, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 6, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Upload: %u.%u KB/s",
         outgoing_rate_kb10 / 10, outgoing_rate_kb10 % 10);
-    LbTextDrawResized(0, tx_units_per_px * 4, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Congestion: %u bytes", transit);
-    LbTextDrawResized(0, tx_units_per_px * 5, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Loss rate: %u%%", packet_loss_percent);
-    LbTextDrawResized(0, tx_units_per_px * 6, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Lost packets: %u", lost_packet_count);
     LbTextDrawResized(0, tx_units_per_px * 7, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Stutter: %dms", stutter_detection_current);
+    snprintf(text, sizeof(text), "Congestion: %u bytes", transit);
     LbTextDrawResized(0, tx_units_per_px * 8, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Average stutter: %dms", stutter_detection_average);
+    snprintf(text, sizeof(text), "Loss rate: %u%%", packet_loss_percent);
     LbTextDrawResized(0, tx_units_per_px * 9, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Max stutter: %dms", stutter_detection_max);
+    snprintf(text, sizeof(text), "Lost packets: %u", lost_packet_count);
     LbTextDrawResized(0, tx_units_per_px * 10, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
+    snprintf(text, sizeof(text), "Stutter: %dms", stutter_detection_current);
     LbTextDrawResized(0, tx_units_per_px * 11, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
+    snprintf(text, sizeof(text), "Average stutter: %dms", stutter_detection_average);
     LbTextDrawResized(0, tx_units_per_px * 12, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Max stutter: %dms", stutter_detection_max);
+    LbTextDrawResized(0, tx_units_per_px * 13, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
+    LbTextDrawResized(0, tx_units_per_px * 14, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
+    LbTextDrawResized(0, tx_units_per_px * 15, tx_units_per_px, text);
 }
 /******************************************************************************/

--- a/src/net_exchange_common.c
+++ b/src/net_exchange_common.c
@@ -138,12 +138,6 @@ static TbError handle_exchange_message(NetUserId source, void *server_buf, size_
                 (int)message_type, peer_id, (unsigned)payload_size, (unsigned)frame_size);
             return Lb_OK;
         }
-        if (message_type == NETMSG_FRONTEND && frame_size == sizeof(struct ScreenPacket) && netstate.my_id == SERVER_ID && screen_packet_action((struct ScreenPacket *)read_pos) == NetAct_OpenLandView) {
-            if (netstate.frontend_start_pending_end_time == 0) {
-                netstate.frontend_start_pending_end_time = LbTimerClock() + TIMEOUT_JOIN_LOBBY;
-            }
-            screen_packet_set_action((struct ScreenPacket *)read_pos, NetAct_None);
-        }
         memcpy(player_frame, read_pos, frame_size);
     }
     if (frame_peer_id != NULL) {
@@ -240,25 +234,6 @@ TbError exchange_frame_message(void *send_buf, void *server_buf, size_t frame_si
         return Lb_FAIL;
     }
     netstate.sp->update(OnNewUser);
-    if (msg_type == NETMSG_FRONTEND && frame_size == sizeof(struct ScreenPacket) && netstate.my_id == SERVER_ID) {
-        struct ScreenPacket *screen_packet = (struct ScreenPacket *)send_buf;
-        NetUserId user_id;
-        for (user_id = 0; user_id < netstate.max_players; user_id += 1) {
-            if (netstate.users[user_id].progress == USER_CONNECTED) {
-                break;
-            }
-        }
-        if (user_id < netstate.max_players && screen_packet_action(screen_packet) == NetAct_OpenLandView) {
-            if (netstate.frontend_start_pending_end_time == 0) {
-                netstate.frontend_start_pending_end_time = LbTimerClock() + TIMEOUT_JOIN_LOBBY;
-            }
-            screen_packet_set_action(screen_packet, NetAct_None);
-        }
-        if (netstate.frontend_start_pending_end_time != 0 && screen_packet_action(screen_packet) == NetAct_None && (user_id == netstate.max_players || LbTimerClock() >= netstate.frontend_start_pending_end_time)) {
-            screen_packet_set_action(screen_packet, NetAct_OpenLandView);
-            netstate.frontend_start_pending_end_time = 0;
-        }
-    }
     char *my_frame = (char *)server_buf + netstate.my_id * frame_size;
     memcpy(my_frame, send_buf, frame_size);
     char *write_pos = begin_net_message(msg_type);

--- a/src/net_exchange_gameplay.c
+++ b/src/net_exchange_gameplay.c
@@ -206,6 +206,19 @@ const struct Packet *get_history_packet(PlayerNumber player, GameTurn turn)
     return packet;
 }
 
+const struct Packet *get_latest_history_packet(PlayerNumber player)
+{
+    const struct Packet *latest = NULL;
+    const struct PacketHistory *history = &packet_history[player];
+    for (int32_t i = 0; i < PACKET_HISTORY_SIZE; i += 1) {
+        const struct Packet *packet = &history->entries[i];
+        if (!is_packet_empty(packet) && (latest == NULL || (GameTurnDelta)(packet->turn - latest->turn) > 0)) {
+            latest = packet;
+        }
+    }
+    return latest;
+}
+
 TbBool read_repair_packet_history(NetUserId source, const char *buffer, size_t buffer_size)
 {
     size_t header_size = sizeof(struct PacketHistoryHeader);
@@ -269,14 +282,25 @@ void initialize_packet_history(void)
     multiplayer_speed_adjustment_ns = 0;
     last_repair_history_send = 0;
     last_turn_sync_send = 0;
+    input_lag_reset();
+}
+
+static TbBool player_has_required_turn_packets(PlayerNumber player)
+{
+    GameTurn expected_turn = get_gameturn() - game.input_lag_turns;
+    if (get_history_packet(player, expected_turn) == NULL) {
+        return false;
+    }
+    if (!input_lag_needs_lookahead()) {
+        return true;
+    }
+    return get_history_packet(player, expected_turn + 1) != NULL;
 }
 
 static TbBool have_all_turn_packets(PlayerNumber local_packet_player)
 {
-    GameTurn expected_turn = get_gameturn() - game.input_lag_turns;
     for (PlayerNumber player = 0; player < MAX_NET_USERS; player += 1) {
-        const struct Packet *packet = get_history_packet(player, expected_turn);
-        if (player != local_packet_player && network_player_active(player) && packet == NULL) {
+        if (player != local_packet_player && network_player_active(player) && !player_has_required_turn_packets(player)) {
             return false;
         }
     }
@@ -300,22 +324,12 @@ static void send_player_repair_history(PlayerNumber player)
     }
     struct RedundantPacketBundle packet_bundle;
     packet_bundle.valid_count = 0;
-    const struct PacketHistory *history = &packet_history[player];
-    GameTurn latest_turn = 0;
-    TbBool have_turn = false;
-    for (int i = 0; i < PACKET_HISTORY_SIZE; i += 1) {
-        const struct Packet *packet = &history->entries[i];
-        if (is_packet_empty(packet)) {
-            continue;
-        }
-        if (!have_turn || (GameTurnDelta)(packet->turn - latest_turn) > 0) {
-            latest_turn = packet->turn;
-            have_turn = true;
-        }
-    }
-    if (!have_turn) {
+    const struct Packet *latest = get_latest_history_packet(player);
+    if (latest == NULL) {
         return;
     }
+    const struct PacketHistory *history = &packet_history[player];
+    GameTurn latest_turn = latest->turn;
     for (GameTurnDelta offset = 0; offset < PACKET_HISTORY_SIZE; offset += 1) {
         if ((GameTurn)offset > latest_turn) {
             break;
@@ -383,6 +397,7 @@ static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, Pla
     TbClockMSec wait_start_time = LbTimerClock();
     TbBool turn_complete = false;
     TbBool wait_timed_out = false;
+    input_lag_note_packet_wait();
     MULTIPLAYER_LOG("LbNetwork_ExchangeGameplay: Missing packets for turn=%lu, collecting...", (unsigned long)expected_turn);
     while (!turn_complete) {
         send_turn_sync_if_due();
@@ -393,11 +408,10 @@ static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, Pla
         }
         turn_complete = have_all_turn_packets(local_packet_player);
         for (NetUserId peer_id = 0; peer_id < netstate.max_players && !turn_complete; peer_id += 1) {
-            const struct Packet *packet = get_history_packet(peer_id, expected_turn);
             if (!can_send_to_peer(peer_id)) {
                 continue;
             }
-            if (netstate.my_id == SERVER_ID && packet != NULL) {
+            if (netstate.my_id == SERVER_ID && player_has_required_turn_packets(peer_id)) {
                 continue;
             }
             process_peer_msgs(peer_id, server_buf, frame_size);

--- a/src/net_exchange_gameplay.h
+++ b/src/net_exchange_gameplay.h
@@ -32,6 +32,7 @@ struct Packet;
 void initialize_packet_history(void);
 void store_packet_history(PlayerNumber player, const struct Packet *packet);
 const struct Packet *get_history_packet(PlayerNumber player, GameTurn turn);
+const struct Packet *get_latest_history_packet(PlayerNumber player);
 TbBool read_repair_packet_history(NetUserId source, const char *buffer, size_t buffer_size);
 void network_update(void *server_buf, size_t frame_size);
 TbError LbNetwork_ExchangeGameplay(void *send_buf, void *server_buf, size_t frame_size);

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -517,6 +517,7 @@ void process_disconnected_network_players(void)
             }
         }
         if ((player->allocflags & PlaF_CompCtrl) == 0) {
+            input_lag_reset_intervals();
             if (!host_disconnected && player->id_number != get_host_player_id() && player->player_name[0] != '\0') {
                 message_add_fmt(MsgType_Blank, 0, get_string(GUIStr_NetPlayerDisconnected), player->player_name);
                 JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -60,7 +60,6 @@ extern int32_t multiplayer_speed_adjustment_ns;
 struct StartupSyncPacket {
     uint8_t startup_sync_packet_valid;
     int32_t video_rotate_mode;
-    int32_t input_lag_turns;
     TbBigChecksum map_checksums[NETWORK_STARTUP_MAP_FILE_COUNT];
     TbBigChecksum required_sprite_zip_checksums[REQUIRED_SPRITE_ZIP_COUNT];
     uint16_t initial_tendencies;
@@ -68,6 +67,7 @@ struct StartupSyncPacket {
     uint32_t frontview_zoom_level;
     uint32_t zoom_distance_setting;
     uint32_t frontview_zoom_distance_setting;
+    uint8_t initial_input_lag_turns;
 };
 #pragma pack()
 
@@ -76,6 +76,7 @@ short setup_network_service(enum FrontendNetService service)
   struct ServiceInitData *init_data = NULL;
   SYNCMSG("Initializing 4-players type %d network", service);
   memset(net_player_info, 0, sizeof(net_player_info));
+  network_lobby_ping = 0;
   if (service != FrontendNetSvc_Online && service != FrontendNetSvc_LAN) {
     process_network_error(-800);
     return 0;
@@ -195,12 +196,35 @@ static struct StartupSyncPacket s_local_startup_sync;
 static struct StartupSyncPacket s_startup_sync_packets[MAX_NET_USERS];
 static TbBool network_disconnect_victory_enabled;
 
+static uint8_t calculate_initial_input_lag(void)
+{
+    int32_t player_count = 0;
+    for (int32_t i = 0; i < MAX_NET_USERS; i++) {
+        if (net_player_info[i].network_user_active) {
+            player_count++;
+        }
+    }
+    uint64_t ping = network_lobby_ping;
+    if (player_count == 2) {
+        ping /= 2;
+    }
+    uint64_t input_lag_turns = 0;
+    if (turns_per_second > 0) {
+        input_lag_turns = (ping * turns_per_second + 999) / 1000;
+    }
+    uint64_t uncapped_input_lag_turns = input_lag_turns;
+    if (input_lag_turns > MAXIMUM_INPUT_LAG_TURNS) {
+        input_lag_turns = MAXIMUM_INPUT_LAG_TURNS;
+    }
+    JUSTLOG("Initial input lag: (%llu ms * %d turns/s + 999) / 1000 = %llu turns, capped to %llu", (unsigned long long)ping, turns_per_second, (unsigned long long)uncapped_input_lag_turns, (unsigned long long)input_lag_turns);
+    return input_lag_turns;
+}
+
 static void build_local_startup_sync(void)
 {
     memset(&s_local_startup_sync, 0, sizeof(s_local_startup_sync));
     s_local_startup_sync.startup_sync_packet_valid = 1;
     s_local_startup_sync.video_rotate_mode = settings.video_rotate_mode;
-    s_local_startup_sync.input_lag_turns = game.input_lag_turns;
     calculate_network_startup_map_checksums(s_local_startup_sync.map_checksums);
     memcpy(s_local_startup_sync.required_sprite_zip_checksums, required_sprite_zip_checksums, sizeof(s_local_startup_sync.required_sprite_zip_checksums));
     uint16_t initial_tendencies = 0;
@@ -211,6 +235,7 @@ static void build_local_startup_sync(void)
     s_local_startup_sync.frontview_zoom_level = settings.frontview_zoom_level;
     s_local_startup_sync.zoom_distance_setting = zoom_distance_setting;
     s_local_startup_sync.frontview_zoom_distance_setting = frontview_zoom_distance_setting;
+    s_local_startup_sync.initial_input_lag_turns = calculate_initial_input_lag();
 }
 
 static TbBool net_startup_sync_exchange_and_apply(void)
@@ -237,9 +262,10 @@ static TbBool net_startup_sync_exchange_and_apply(void)
         return false;
     }
     const struct StartupSyncPacket *host_sync = &s_startup_sync_packets[get_host_player_id()];
-    game.input_lag_turns = host_sync->input_lag_turns;
+    game.input_lag_turns = host_sync->initial_input_lag_turns;
+    input_lag_reset();
     game.skip_initial_input_turns = calculate_skip_input();
-    NETLOG("Startup input lag synced: input_lag=%d", game.input_lag_turns);
+    NETLOG("Startup input lag: %d", game.input_lag_turns);
     zoom_distance_setting = host_sync->zoom_distance_setting;
     frontview_zoom_distance_setting = host_sync->frontview_zoom_distance_setting;
     setup_players_from_startup_packets(s_startup_sync_packets);
@@ -412,6 +438,7 @@ static void stop_network_game_state(void)
     game.game_kind = GKind_LocalGame;
     game.input_lag_turns = 0;
     game.skip_initial_input_turns = 0;
+    input_lag_reset();
     multiplayer_speed_adjustment_ns = 0;
     setup_count_players();
 }

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -5,26 +5,73 @@
 #include "packets.h"
 #include "player_data.h"
 #include "net_game.h"
+#include "net_exchange_gameplay.h"
 #include "game_legacy.h"
-#include "bflib_enet.h"
 #include "net_main.h"
-#include "bflib_math.h"
 #include "bflib_datetm.h"
-#include "frontend.h"
-#include "front_landview.h"
-#include "front_network.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+// Used for TOLERATE_PACKET_MISS_PERCENT
+#define INPUT_LAG_SAMPLE_WINDOW_TURNS 100
+// Input lag increases when the packet miss percentage exceeds this value within the sample window. [Higher = more choppy FPS but lower input lag, lower = smoother FPS but higher input lag]
+#define TOLERATE_PACKET_MISS_PERCENT 70
+// Starts out low so we can more quickly determine the correct input_lag_turns at the start of the level, but doubles and takes longer to change as the game progresses.
+#define INPUT_LAG_INCREASE_INITIAL_INTERVAL_MS 600
+#define INPUT_LAG_DECREASE_INITIAL_INTERVAL_MS 500
+// When increasing input_lag_turns, cap the interval so that we can always get out of a laggy spot. Decreasing has no cap so that it will do less decreases as the game progresses.
+#define INPUT_LAG_INCREASE_MAX_INTERVAL_MS 5000
 
-enum InputLagMode {
-    INPUT_LAG_MODE_ONE_VS_ONE = 0,
-    INPUT_LAG_MODE_RELAY,
-};
+static int32_t input_lag_sample_count;
+static int32_t input_lag_history_position;
+static int32_t input_lag_missing_turn_count;
+static TbBool input_lag_missing_turn_history[INPUT_LAG_SAMPLE_WINDOW_TURNS];
+static TbClockMSec input_lag_reduction_check_interval;
+static TbClockMSec input_lag_increase_check_interval;
+static TbClockMSec input_lag_last_reduction_check;
+static TbClockMSec input_lag_last_increase_check;
+static int32_t local_input_lag_request;
+static int32_t input_lag_target;
+static int32_t input_lag_increase_turns;
 
-TbBool input_lag_skips_initial_processing(void)
+static void input_lag_reset_history(TbClockMSec now)
+{
+    input_lag_sample_count = 0;
+    input_lag_history_position = -1;
+    input_lag_missing_turn_count = 0;
+    memset(input_lag_missing_turn_history, 0, sizeof(input_lag_missing_turn_history));
+    input_lag_reduction_check_interval = INPUT_LAG_DECREASE_INITIAL_INTERVAL_MS;
+    input_lag_increase_check_interval = INPUT_LAG_INCREASE_INITIAL_INTERVAL_MS;
+    input_lag_last_reduction_check = input_lag_last_increase_check = now;
+}
+
+void input_lag_reset(void)
+{
+    input_lag_reset_history(LbTimerClock());
+    local_input_lag_request = game.input_lag_turns;
+    input_lag_target = game.input_lag_turns;
+    input_lag_increase_turns = 0;
+}
+
+void input_lag_get_stats(int32_t *packet_misses, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown)
+{
+    TbClockMSec now = LbTimerClock();
+    TbClockMSec elapsed = now - input_lag_last_increase_check;
+    *packet_misses = input_lag_missing_turn_count;
+    *increase_countdown = 0;
+    if (elapsed < input_lag_increase_check_interval) {
+        *increase_countdown = input_lag_increase_check_interval - elapsed;
+    }
+    elapsed = now - input_lag_last_reduction_check;
+    *decrease_countdown = 0;
+    if (elapsed < input_lag_reduction_check_interval) {
+        *decrease_countdown = input_lag_reduction_check_interval - elapsed;
+    }
+}
+
+TbBool input_lag_skips_processing(void)
 {
     if (!network_is_active()) {
         return false;
@@ -38,6 +85,15 @@ TbBool input_lag_skips_initial_processing(void)
         MULTIPLAYER_LOG("process_packets: Input lag skip turns remaining: %d, skipping packet processing", game.skip_initial_input_turns);
         return true;
     }
+    if (input_lag_increase_turns > 0) {
+        input_lag_increase_turns -= 1;
+        MULTIPLAYER_LOG("Input lag increase: skipping input turn, remaining=%d", input_lag_increase_turns);
+        return true;
+    }
+    if (input_lag_target < game.input_lag_turns) {
+        MULTIPLAYER_LOG("Input lag decrease forced: discarded_turn=%lu current=%d target=%d", (unsigned long)(get_gameturn() - game.input_lag_turns), game.input_lag_turns - 1, input_lag_target);
+        game.input_lag_turns -= 1;
+    }
     return false;
 }
 
@@ -49,85 +105,94 @@ unsigned short calculate_skip_input(void) {
     return game.input_lag_turns + (turns_per_second * 0.25);
 }
 
-void LbNetwork_UpdateInputLagIfHost(void) {
-    static TbClockMSec last_update_ms = 0;
-    static TbClockMSec player_count_change_time = 0;
-    static int total_ping = 0;
-    static int sample_count = 0;
-    static int previous_remote_player_count = -1;
+void input_lag_update(struct Packet *packet)
+{
+    packet->input_lag_turns = 0;
     if (!network_is_active()) { return; }
-    if (frontend_menu_state == FeSt_START_MPLEVEL) { return; }
-    if (my_player_number != get_host_player_id()) { return; }
-    if (!netstate.sp) { return; }
+    if ((game.operation_flags & GOF_Paused) == 0 && input_lag_increase_turns == 0 && input_lag_target > game.input_lag_turns) {
+        game.input_lag_turns = input_lag_target;
+        MULTIPLAYER_LOG("Input lag increase committed: current=%d", game.input_lag_turns);
+    }
     TbClockMSec now = LbTimerClock();
-    netstate.sp->update(OnNewUser);
-    int remote_player_count = 0;
-    NetUserId id;
-    for (id = 0; id < netstate.max_players; id += 1) {
-        if (id == netstate.my_id) { continue; }
-        if (netstate.users[id].progress == USER_LOGGEDIN) {
-            remote_player_count += 1;
+    if ((game.operation_flags & GOF_Paused) != 0 || game.skip_initial_input_turns > 0) {
+        input_lag_last_reduction_check = input_lag_last_increase_check = now;
+    } else {
+        if (now - input_lag_last_reduction_check >= input_lag_reduction_check_interval) {
+            input_lag_last_reduction_check = now;
+            if (input_lag_reduction_check_interval <= INT32_MAX / 2) {
+                input_lag_reduction_check_interval *= 2;
+            }
+            if (input_lag_sample_count > 0 && input_lag_missing_turn_count == 0 && local_input_lag_request > 0) {
+                local_input_lag_request -= 1;
+                input_lag_last_increase_check = now;
+                MULTIPLAYER_LOG("Input lag request decreased after %d clean turns: request=%d next_check=%dms", input_lag_sample_count, local_input_lag_request, input_lag_reduction_check_interval);
+            }
+        }
+        if (now - input_lag_last_increase_check >= input_lag_increase_check_interval) {
+            input_lag_last_increase_check = now;
+            input_lag_increase_check_interval *= 2;
+            if (input_lag_increase_check_interval > INPUT_LAG_INCREASE_MAX_INTERVAL_MS) {
+                input_lag_increase_check_interval = INPUT_LAG_INCREASE_MAX_INTERVAL_MS;
+            }
+            if (input_lag_missing_turn_count * 100 > TOLERATE_PACKET_MISS_PERCENT * input_lag_sample_count && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS) {
+                local_input_lag_request += 1;
+                MULTIPLAYER_LOG("Input lag request increased after %d waits in %d turns: request=%d next_check=%dms", input_lag_missing_turn_count, input_lag_sample_count, local_input_lag_request, input_lag_increase_check_interval);
+            }
+        }
+        input_lag_history_position = (input_lag_history_position + 1) % INPUT_LAG_SAMPLE_WINDOW_TURNS;
+        input_lag_missing_turn_count -= input_lag_missing_turn_history[input_lag_history_position];
+        input_lag_missing_turn_history[input_lag_history_position] = false;
+        if (input_lag_sample_count < INPUT_LAG_SAMPLE_WINDOW_TURNS) {
+            input_lag_sample_count += 1;
         }
     }
-    if (remote_player_count == 0) {
-        player_count_change_time = 0;
-        sample_count = 0;
-        total_ping = 0;
-        previous_remote_player_count = 0;
-        return;
-    }
-    enum InputLagMode mode = INPUT_LAG_MODE_RELAY;
-    if (remote_player_count == 1) {
-        mode = INPUT_LAG_MODE_ONE_VS_ONE;
-    }
-    if (previous_remote_player_count != remote_player_count) {
-        player_count_change_time = now;
-        sample_count = 0;
-        total_ping = 0;
-        previous_remote_player_count = remote_player_count;
-    }
-    if (player_count_change_time == 0) {
-        player_count_change_time = now;
-    }
-    if (now - player_count_change_time < WAIT_FOR_STABLE_PLAYER) {
-        sample_count = 0;
-        total_ping = 0;
-        return;
-    }
-    if (last_update_ms != 0 && now - last_update_ms < AVERAGE_PING_UPDATE_RATE) { return; }
-    last_update_ms = now;
-    int max_ping = 0;
-    for (id = 0; id < netstate.max_players; id += 1) {
-        if (id == netstate.my_id) { continue; }
-        if (!(netstate.users[id].progress == USER_LOGGEDIN)) { continue; }
-        unsigned long ping = GetPing(id);
-        if (ping <= 0) {
-            MULTIPLAYER_LOG("Player %d (%s) has no RTT data yet", id, netstate.users[id].name);
-            continue;
-        }
-        MULTIPLAYER_LOG("Player %d (%s) Ping: %lums", id, netstate.users[id].name, ping);
-        if ((int)ping > max_ping) {
-            max_ping = (int)ping;
+    packet->input_lag_turns = local_input_lag_request;
+    if (my_player_number != get_host_player_id() || !netstate.sp) { return; }
+    int32_t remote_player_count = 0;
+    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+        if (id == netstate.my_id || netstate.users[id].progress != USER_LOGGEDIN) { continue; }
+        remote_player_count += 1;
+        const struct Packet *peer_packet = get_latest_history_packet((PlayerNumber)id);
+        if (peer_packet != NULL && (uint8_t)peer_packet->input_lag_turns <= MAXIMUM_INPUT_LAG_TURNS && peer_packet->input_lag_turns > packet->input_lag_turns) {
+            packet->input_lag_turns = peer_packet->input_lag_turns;
         }
     }
-    if (max_ping == 0) {
+    if (remote_player_count <= 0) {
+        input_lag_reset_history(now);
+        local_input_lag_request = 0;
+        packet->input_lag_turns = 0;
+    }
+}
+
+void input_lag_note_packet_wait(void)
+{
+    if (!network_is_active() || (game.operation_flags & GOF_Paused) != 0 || input_lag_history_position < 0) { return; }
+    if (!input_lag_missing_turn_history[input_lag_history_position]) {
+        input_lag_missing_turn_history[input_lag_history_position] = true;
+        input_lag_missing_turn_count += 1;
+    }
+}
+
+void input_lag_observe_host_packet(const struct Packet *packet)
+{
+    int32_t target = packet->input_lag_turns;
+    if ((uint32_t)target > MAXIMUM_INPUT_LAG_TURNS) {
+        WARNLOG("Ignoring invalid input lag target %d", target);
         return;
     }
-    total_ping += max_ping;
-    sample_count++;
-    float average_ping = (float)total_ping / sample_count;
-    float turn_time = 1000.0f / turns_per_second;
-    float half_turn_time = (turn_time*0.5);
-    float adjusted_ping = 0;
-    switch (mode) {
-        case INPUT_LAG_MODE_ONE_VS_ONE: adjusted_ping = (average_ping - half_turn_time) * 0.5f; break;
-        case INPUT_LAG_MODE_RELAY:      adjusted_ping = (average_ping); break;
+    if (target == input_lag_target) {
+        return;
     }
-    int input_lag = CEILING(adjusted_ping / turn_time);
-    if (average_ping < 25) {input_lag = 0;} // LAN
-    if (input_lag < 0) {input_lag = 0;} // Input lag cannot be below 0
-    game.input_lag_turns = min(input_lag, MAXIMUM_INPUT_LAG_TURNS);
-    MULTIPLAYER_LOG("Average Ping: %dms (samples: %d), Adjusted Ping: %.2fms, Setting Input Lag: %d", (int)average_ping, sample_count, adjusted_ping, game.input_lag_turns);
+    input_lag_target = target;
+    if (target > game.input_lag_turns) {
+        input_lag_increase_turns = target - game.input_lag_turns;
+    }
+    MULTIPLAYER_LOG("Input lag target synchronized: current=%d target=%d", game.input_lag_turns, input_lag_target);
+}
+
+TbBool input_lag_needs_lookahead(void)
+{
+    return network_is_active() && (game.operation_flags & GOF_Paused) == 0 && game.skip_initial_input_turns == 0 && input_lag_increase_turns == 0 && input_lag_target < game.input_lag_turns;
 }
 
 #ifdef __cplusplus

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -36,20 +36,25 @@ static int32_t local_input_lag_request;
 static int32_t input_lag_target;
 static int32_t input_lag_increase_turns;
 
-static void input_lag_reset_history(TbClockMSec now)
+void input_lag_reset_intervals(void)
+{
+    input_lag_reduction_check_interval = INPUT_LAG_DECREASE_INITIAL_INTERVAL_MS;
+    input_lag_increase_check_interval = INPUT_LAG_INCREASE_INITIAL_INTERVAL_MS;
+    input_lag_last_reduction_check = input_lag_last_increase_check = LbTimerClock();
+}
+
+static void input_lag_reset_history(void)
 {
     input_lag_sample_count = 0;
     input_lag_history_position = -1;
     input_lag_missing_turn_count = 0;
     memset(input_lag_missing_turn_history, 0, sizeof(input_lag_missing_turn_history));
-    input_lag_reduction_check_interval = INPUT_LAG_DECREASE_INITIAL_INTERVAL_MS;
-    input_lag_increase_check_interval = INPUT_LAG_INCREASE_INITIAL_INTERVAL_MS;
-    input_lag_last_reduction_check = input_lag_last_increase_check = now;
+    input_lag_reset_intervals();
 }
 
 void input_lag_reset(void)
 {
-    input_lag_reset_history(LbTimerClock());
+    input_lag_reset_history();
     local_input_lag_request = game.input_lag_turns;
     input_lag_target = game.input_lag_turns;
     input_lag_increase_turns = 0;
@@ -158,7 +163,7 @@ void input_lag_update(struct Packet *packet)
         }
     }
     if (remote_player_count <= 0) {
-        input_lag_reset_history(now);
+        input_lag_reset_history();
         local_input_lag_request = 0;
         packet->input_lag_turns = 0;
     }

--- a/src/net_input_lag.h
+++ b/src/net_input_lag.h
@@ -16,6 +16,7 @@ TbBool input_lag_skips_processing(void);
 unsigned short calculate_skip_input(void);
 void input_lag_update(struct Packet *packet);
 void input_lag_reset(void);
+void input_lag_reset_intervals(void);
 void input_lag_get_stats(int32_t *packet_misses, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown);
 void input_lag_note_packet_wait(void);
 void input_lag_observe_host_packet(const struct Packet *packet);

--- a/src/net_input_lag.h
+++ b/src/net_input_lag.h
@@ -10,9 +10,16 @@
 extern "C" {
 #endif
 
-TbBool input_lag_skips_initial_processing(void);
+struct Packet;
+
+TbBool input_lag_skips_processing(void);
 unsigned short calculate_skip_input(void);
-void LbNetwork_UpdateInputLagIfHost(void);
+void input_lag_update(struct Packet *packet);
+void input_lag_reset(void);
+void input_lag_get_stats(int32_t *packet_misses, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown);
+void input_lag_note_packet_wait(void);
+void input_lag_observe_host_packet(const struct Packet *packet);
+TbBool input_lag_needs_lookahead(void);
 
 #ifdef __cplusplus
 }

--- a/src/net_lobby.c
+++ b/src/net_lobby.c
@@ -39,6 +39,8 @@
 
 static struct TbNetworkSessionNameEntry sessions[SESSION_COUNT];
 static int32_t server_port = 0;
+static TbClockMSec lobby_ping_last_sample;
+uint32_t network_lobby_ping;
 
 struct MatchmakingCreateTask {
     uint16_t ipv4_port;
@@ -226,7 +228,16 @@ TbError LbNetwork_ExchangeFrontend(void *send_buf, void *server_buf, size_t fram
     if ((my_player_number == get_host_player_id()) && frontnet_service_selected(FrontendNetSvc_Online)) {
         enet_matchmaking_host_update();
     }
-    return exchange_frame_block(NETMSG_FRONTEND, send_buf, server_buf, frame_size);
+    TbError result = exchange_frame_block(NETMSG_FRONTEND, send_buf, server_buf, frame_size);
+    TbClockMSec now = LbTimerClock();
+    if (network_lobby_ping == 0 || now - lobby_ping_last_sample >= 1000) {
+        unsigned long ping = GetPing(my_player_number);
+        if (ping > 0) {
+            network_lobby_ping = ping;
+        }
+        lobby_ping_last_sample = now;
+    }
+    return result;
 }
 
 TbError LbNetwork_Create(char *, char *plyr_name, uint32_t *plyr_num, void *optns)

--- a/src/net_lobby.h
+++ b/src/net_lobby.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+extern uint32_t network_lobby_ping;
+
 TbError LbNetwork_ExchangeLogin(char *player_name);
 TbError LbNetwork_ExchangeFrontend(void *send_buf, void *server_buf, size_t frame_size);
 TbError process_login_message(NetUserId source, char *read_pos);

--- a/src/net_main.h
+++ b/src/net_main.h
@@ -121,7 +121,6 @@ struct NetState {
     char msg_buffer[NET_MSG_BUFFER_SIZE];
     char msg_buffer_null;
     TbBool locked;
-    TbClockMSec frontend_start_pending_end_time;
 };
 
 struct TbNetworkPlayerInfo {

--- a/src/packets.c
+++ b/src/packets.c
@@ -36,6 +36,7 @@
 #include "bflib_planar.h"
 #include "bflib_dernc.h"
 #include "net_exchange_gameplay.h"
+#include "net_input_lag.h"
 #include "bflib_sound.h"
 #include "config_sounds.h"
 #include "bflib_sndlib.h"
@@ -145,7 +146,8 @@ TbBool is_packet_empty(const struct Packet *pckt) {
         pckt->control_flags != 0 ||
         pckt->additional_packet_values != 0 ||
         pckt->actn_par3 != 0 ||
-        pckt->actn_par4 != 0) {
+        pckt->actn_par4 != 0 ||
+        pckt->input_lag_turns != 0) {
         return false;
     }
     return true;
@@ -1542,6 +1544,7 @@ static void load_old_packets(void)
             MULTIPLAYER_LOG("load_input_lag_packets: cleared packet[%s] (no stored packet)", player_name);
         }
     }
+    input_lag_observe_host_packet(&game.packets[get_host_player_id()]);
 }
 
 void set_local_packet_turn(void) {
@@ -1560,6 +1563,7 @@ void exchange_packets(void)
     SYNCDBG(5, "Starting");
 
     MULTIPLAYER_LOG("process_packets: === BEGIN turn=%lu ===", (unsigned long)get_gameturn());
+    input_lag_update(get_packet_direct(player->packet_num));
     set_local_packet_turn();
     update_turn_checksums();
     update_local_dig_tag_prediction();
@@ -1582,7 +1586,7 @@ void exchange_packets(void)
             return;
         }
     }
-    if (input_lag_skips_initial_processing()) {
+    if (input_lag_skips_processing()) {
         clear_packets();
         return;
     }

--- a/src/packets.h
+++ b/src/packets.h
@@ -280,15 +280,16 @@ extern float camera_movement_y;
 struct Packet {
     GameTurn turn;
     TbBigChecksum checksum; //! Checksum of the entire game state of the previous turn, used solely for desync detection
-    unsigned char action; //! Action kind performed by the player which owns this packet
+    int8_t input_lag_turns;
+    uint8_t action; //! Action kind performed by the player which owns this packet
     int32_t actn_par1; //! Players action parameter #1
     int32_t actn_par2; //! Players action parameter #2
     int32_t pos_x; //! Mouse Cursor Position X
     int32_t pos_y; //! Mouse Cursor Position Y
     uint32_t control_flags;
-    unsigned char additional_packet_values; // uses the flags and values from TbPacketAddValues
-    int32_t actn_par3; //! Players action parameter #3
-    int32_t actn_par4; //! Players action parameter #4
+    uint8_t additional_packet_values; // uses the flags and values from TbPacketAddValues
+    int16_t actn_par3; //! Players action parameter #3
+    int16_t actn_par4; //! Players action parameter #4
 };
 
 struct PacketSaveHead {


### PR DESCRIPTION
Instead of determining the input lag in the lobby or landview, the input lag is now set during live gameplay, increasing and decreasing it based on whether packets are being waited for. You can see it adjust inside of `!netstats` as well as some new variables.

To make this work I did unfortunately have to throw it into the Packet struct, to have instant and proper synchronization of it. So the struct went from 38 bytes to 39 bytes. But I found two other fields I could reduce, to optimize it down to 35 bytes. (smaller than before, at least)

I've written some comments in `net_input_lag.c` for how the #defines work, but basically it goes like this:
- Every X amount of time interval, decrease the input lag if no packets were "waited for" during the past 100 turns. (so no stutter detected)
- Every X amount of time interval, increase the input lag if packets were waited for on more than 70% of the past 100 turns. (stutter detected)

That 70% is a #define based on feel.

Regarding the time interval, it doubles every increase/decrease attempt, so when the game first starts it changes the input lag at a faster rate, then as the game progresses it changes the input lag at a slower rate. But also the increase and decrease each have their own independent time intervals, and the interval for increasing maxes out at 5 seconds, while the decrease-interval has no maximum. The reason for this is if it's bouncing between two values then we want it to lean towards the higher value so you won't experience (slight) stutter for more than 5 seconds before it recognizes that it needs to increase the input lag value.

In a 4 player game the player who has the worst stuttering determines the shared input lag for everyone, as the host selects the highest value of each player's requested input lag.

There's also still an initial input lag calculated from lobby latency, just to get a basic estimate, to get us to the correct value faster when the game first starts.