### PR TITLE
Complete UTF-8: Allow typing non-ASCII characters (ñ, ç, accented vowels, ¿¡ punctuation, etc) in text input fields

### DIFF
--- a/docs/launcher-auto-file-removal.txt
+++ b/docs/launcher-auto-file-removal.txt
@@ -1556,6 +1556,7 @@ fxdata/lanternpost.zip
 fxdata/mushrooms.zip
 fxdata/torches.zip
 fxdata/trapcolors.zip
+fxdata/trapdoors.zip
 fxdata/waterplants.zip
 fxdata/whiteflag.zip
 fxdata/windbanner.zip

--- a/src/bflib_string.c
+++ b/src/bflib_string.c
@@ -42,7 +42,7 @@ TbCharCount LbLocTextStringLength(const TbLocChar *s)
     TbSize i = 0;
     while (s[i] != 0)
     {
-      //if ((s[i] & 0xc0) != 0x80) // enable when/if UTF-8 is supported
+      if ((s[i] & 0xc0) != 0x80) // don't count UTF-8 continuation bytes
       {
           j++;
       }
@@ -76,10 +76,15 @@ TbSize LbLocTextPosToLength(const TbLocChar *s, TbCharCount pos)
     TbSize i = 0;
     while ((s[i] != 0) && (j < pos))
     {
-      //if ((s[i] & 0xc0) != 0x80) // enable when/if UTF-8 is supported
+      if ((s[i] & 0xc0) != 0x80) // don't count UTF-8 continuation bytes
       {
           j++;
       }
+      i++;
+    }
+    // Advance past the continuation bytes of the last counted character
+    while ((s[i] & 0xc0) == 0x80)
+    {
       i++;
     }
     return i;

--- a/src/front_highscore.c
+++ b/src/front_highscore.c
@@ -201,12 +201,15 @@ TbBool frontend_high_score_table_input(void)
         // Delete previous character
         if (high_score_entry_index > 0)
         {
-            i = high_score_entry_index-1;
-            while (high_score_entry[i] != '\0') {
-                high_score_entry[i] = high_score_entry[i+1];
-                i++;
+            // Step back over UTF-8 continuation bytes to the start of the previous character
+            unsigned long start = high_score_entry_index - 1;
+            while ((start > 0) && ((high_score_entry[start] & 0xc0) == 0x80)) {
+                start--;
             }
-            high_score_entry_index--;
+            unsigned long clen = high_score_entry_index - start;
+            unsigned long slen = strlen(high_score_entry);
+            memmove(&high_score_entry[start], &high_score_entry[start+clen], slen - (start+clen) + 1);
+            high_score_entry_index = start;
         }
         clear_key_pressed(KC_BACK);
         return true;
@@ -215,9 +218,14 @@ TbBool frontend_high_score_table_input(void)
     {
         // Delete next character
         i = high_score_entry_index;
-        while (high_score_entry[i] != '\0') {
-            high_score_entry[i] = high_score_entry[i+1];
-            i++;
+        if (high_score_entry[i] != '\0')
+        {
+            unsigned long clen = 1;
+            while ((high_score_entry[i+clen] & 0xc0) == 0x80) {
+                clen++;
+            }
+            unsigned long slen = strlen(high_score_entry);
+            memmove(&high_score_entry[i], &high_score_entry[i+clen], slen - (i+clen) + 1);
         }
         clear_key_pressed(KC_DELETE);
         return true;
@@ -227,6 +235,9 @@ TbBool frontend_high_score_table_input(void)
         // Move cursor left
         if (high_score_entry_index > 0) {
             high_score_entry_index--;
+            while ((high_score_entry_index > 0) && ((high_score_entry[high_score_entry_index] & 0xc0) == 0x80)) {
+                high_score_entry_index--;
+            }
         }
         clear_key_pressed(KC_LEFT);
         return true;
@@ -237,6 +248,9 @@ TbBool frontend_high_score_table_input(void)
         i = high_score_entry_index;
         if (high_score_entry[i] != '\0') {
             high_score_entry_index++;
+            while ((high_score_entry[high_score_entry_index] & 0xc0) == 0x80) {
+                high_score_entry_index++;
+            }
         }
         clear_key_pressed(KC_RIGHT);
         return true;

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -451,6 +451,9 @@ static short get_players_message_inputs(void)
         clear_key_pressed(KC_UP);
     } else if (is_key_pressed(KC_BACK,KMod_DONTCARE)){
         int chpos = strlen(player->mp_message_text);
+        // Skip UTF-8 continuation bytes so the whole last character is removed
+        while ((chpos > 0) && ((player->mp_message_text[chpos-1] & 0xc0) == 0x80))
+            chpos--;
         if (chpos > 0)
             player->mp_message_text[chpos-1] = '\0';
         clear_key_pressed(KC_BACK);

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -618,7 +618,7 @@ TbBool get_button_area_input(struct GuiButton *gbtn, int modifiers)
             if (insert_text[0] != '\0')
             {
                 if (LbLocTextStringInsert(str, insert_text, input_field_pos, gbtn->maxval) != NULL) {
-                    input_field_pos += strlen(insert_text);
+                    input_field_pos += LbLocTextStringLength(insert_text);
                 }
             }
         }

--- a/src/frontmenu_net.c
+++ b/src/frontmenu_net.c
@@ -125,6 +125,9 @@ TbBool frontnet_start_input(void)
         player->mp_message_text[0] = '\0';
     } else if (is_key_pressed(KC_BACK,KMod_DONTCARE)){
         int chpos = strlen(player->mp_message_text);
+        // Skip UTF-8 continuation bytes so the whole last character is removed
+        while ((chpos > 0) && ((player->mp_message_text[chpos-1] & 0xc0) == 0x80))
+            chpos--;
         if (chpos > 0)
             player->mp_message_text[chpos-1] = '\0';
         clear_key_pressed(KC_BACK);

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -30,6 +30,7 @@
 #include "bflib_planar.h"
 #include "bflib_math.h"
 #include "bflib_sprfnt.h"
+#include "bflib_text.h"
 #include "bflib_inputctrl.h"
 #include "bflib_datetm.h"
 
@@ -751,19 +752,31 @@ TbBool add_input_text_to_message(char *message, int max_message_length, struct T
         return false;
 
     int chpos = strlen(message);
-    for (int ti = 0; ti < text_len && chpos < max_message_length - 1; ++ti) {
-        unsigned char c = (unsigned char)text_input[ti];
-        // Limit it to ASCII characters, to ignore codepage differences and multibyte stuff.
-        if (c >= 0x20 && c < 0x7f) {
-            message[chpos++] = (char)c;
+    int ti = 0;
+    while (ti < text_len)
+    {
+        size_t seq_len = 0;
+        uint32_t codepoint = read_utf_8_codepoint(&text_input[ti], &seq_len);
+        TbBool acceptable;
+        if (codepoint < 0x80) {
+            acceptable = (codepoint >= 0x20 && codepoint < 0x7f);
+        } else {
+            // Accept a non-ASCII character only when the current font has a glyph for it.
+            acceptable = (LbFontCharSprite(font, codepoint) != NULL);
+        }
+        if (acceptable && (chpos + (int)seq_len < max_message_length)) {
+            memcpy(&message[chpos], &text_input[ti], seq_len);
+            chpos += seq_len;
             message[chpos] = '\0';
 
             // Enforce max_width even when multiple characters arrive in one frame.
             if (pixel_size * LbTextStringWidth(message) >= max_width) {
-                message[--chpos] = '\0';
+                chpos -= seq_len;
+                message[chpos] = '\0';
                 break;
             }
         }
+        ti += seq_len;
     }
     return true;
 }

--- a/src/kjm_input.c
+++ b/src/kjm_input.c
@@ -757,13 +757,9 @@ TbBool add_input_text_to_message(char *message, int max_message_length, struct T
     {
         size_t seq_len = 0;
         uint32_t codepoint = read_utf_8_codepoint(&text_input[ti], &seq_len);
-        TbBool acceptable;
-        if (codepoint < 0x80) {
-            acceptable = (codepoint >= 0x20 && codepoint < 0x7f);
-        } else {
-            // Accept a non-ASCII character only when the current font has a glyph for it.
-            acceptable = (LbFontCharSprite(font, codepoint) != NULL);
-        }
+        // Accept any printable character; rendering falls back on unifont
+        // for glyphs missing from the sprite fonts.
+        TbBool acceptable = (codepoint >= 0x20 && codepoint != 0x7f);
         if (acceptable && (chpos + (int)seq_len < max_message_length)) {
             memcpy(&message[chpos], &text_input[ti], seq_len);
             chpos += seq_len;


### PR DESCRIPTION
Follow-up to #4920 (Internal utf8).

#4920 made internal strings and rendering UTF-8, but typed input is still limited to printable ASCII by the (previously necessary) filter introduced in #4899 in add_input_text_to_message().
Characters like "ñ", "ç", accented vowels or "¿" or "¡" typed in the save-game name field and what it's more important, in chat, to allow express ourselves correctly in languages different from english don't appear, even though since #4920 the fonts and the whole text pipeline can handle them.

This PR enables UTF-8 in typed input, completing that missing half.

I think this also will make it work for full French and German and other languages too.

I have tested it with a Spanish keyboard layout and now work in save names and render correctly in the load and save menu.

Note: a non-ASCII character is accepted only when the current font has a glyph for it, which keeps the original intent of the ASCII filter (never let undrawable characters in).
