### PR TITLE
Fix mouse light flickering on GUI menus

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1205,7 +1205,7 @@ TbBool players_cursor_is_at_top_of_view(struct PlayerInfo *player)
         return (player->controlled_thing_idx > 0);
 
     case PSt_CtrlDungeon:
-        switch(player->primary_cursor_state)
+        switch (player->primary_cursor_state)
         {
             case CSt_DefaultArrow:
                 return false;

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -284,7 +284,6 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
     unsigned char box_colour;
     if ((pckt->control_flags & PCtr_LBtnAnyAction) == 0)
         player->secondary_cursor_state = CSt_DefaultArrow;
-    player->primary_cursor_state = (unsigned short)(pckt->additional_packet_values & PCAdV_ContextMask) >> 1; // get current cursor state from pckt->additional_packet_values
     player->render_roomspace.highlight_mode = settings.highlight_mode; // reset one-click highlight mode
     player->render_roomspace.drag_mode = player->one_click_lock_cursor;
     player->pickup_all_gold = (pckt->additional_packet_values & PCAdV_RotatePressed);
@@ -706,6 +705,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     SYNCDBG(6,"Starting for player %d state %s",(int)plyr_idx,player_state_code_name(player->work_state));
     TbBool thing_target_action = (pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing);
     player->full_slab_cursor = 1;
+    player->primary_cursor_state = (pckt->additional_packet_values & PCAdV_ContextMask) >> 1;
     packet_left_button_double_clicked[plyr_idx] = 0;
     player->mouse_on_map = is_mouse_on_map(pckt);
     remember_cursor_subtile(player);


### PR DESCRIPTION
The way this works: `get_player_coords_and_context()` (front_input.c) picks the map coordinates from either `block_pointed_at_{x,y}` or `top_pointed_at_{x,y}` and sets the cursor state (context field).
Then later `players_cursor_is_at_top_of_view()` (main.cpp) reverses this logic to determine which one it picked.  But this breaks if `primary_cursor_state` is not updated from the packet, which will happen when `PCtr_Gui` is set (then `process_dungeon_control_packet_clicks()` (packets_input.c) returns early).
