### PR TITLE
Multiplayer: desync fixes and logging improvements

### DIFF
--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -239,7 +239,7 @@ void update_local_cameras_post(void)
 void interpolate_camera_deviations(void)
 {
     struct PlayerInfo* my_player = get_my_player();
-    if (my_player->view_mode == PVM_CreatureView || my_player->view_mode == PVM_FrontView) {
+    if (!player_exists(my_player) || my_player->view_mode == PVM_CreatureView || my_player->view_mode == PVM_FrontView) {
         return;
     }
     const float interpolated_deviation_x = interpolate(previous_deviation_x, destination_deviation_x);

--- a/src/net_checksums.c
+++ b/src/net_checksums.c
@@ -115,13 +115,14 @@ static TbBigChecksum compute_player_checksum(struct PlayerInfo *player) {
     if ((player->allocflags & PlaF_CompCtrl) != 0 || camera == NULL) {
         return 0;
     }
-    struct Coord3d* mappos = &(camera->mappos);
     TbBigChecksum checksum = 0;
     CHECKSUM_ADD(checksum, player->instance_remain_turns);
     CHECKSUM_ADD(checksum, player->instance_num);
-    CHECKSUM_ADD(checksum, mappos->x.val);
-    CHECKSUM_ADD(checksum, mappos->y.val);
-    CHECKSUM_ADD(checksum, mappos->z.val);
+    if (player->victory_state == VicS_Undecided) {
+        CHECKSUM_ADD(checksum, camera->mappos.x.val);
+        CHECKSUM_ADD(checksum, camera->mappos.y.val);
+        CHECKSUM_ADD(checksum, camera->mappos.z.val);
+    }
     return checksum;
 }
 
@@ -327,7 +328,11 @@ void update_turn_checksums(void) {
             player_snapshot->id = i;
             player_snapshot->instance_num = player->instance_num;
             player_snapshot->instance_remain_turns = player->instance_remain_turns;
-            player_snapshot->mappos = camera->mappos;
+            if (player->victory_state == VicS_Undecided) {
+                player_snapshot->mappos = camera->mappos;
+            } else {
+                memset(&player_snapshot->mappos, 0, sizeof(player_snapshot->mappos));
+            }
             player_snapshot->checksum = compute_player_checksum(player);
         }
         for (struct Room* room = start_rooms; room < end_rooms; room++) {

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -96,7 +96,7 @@ TbBool input_lag_skips_processing(void)
         return true;
     }
     if (input_lag_target < game.input_lag_turns) {
-        MULTIPLAYER_LOG("Input lag decrease forced: discarded_turn=%lu current=%d target=%d", (unsigned long)(get_gameturn() - game.input_lag_turns), game.input_lag_turns - 1, input_lag_target);
+        JUSTLOG("Input lag decreased from %d to %d; discarded_turn=%lu target=%d", game.input_lag_turns, game.input_lag_turns - 1, (unsigned long)(get_gameturn() - game.input_lag_turns), input_lag_target);
         game.input_lag_turns -= 1;
     }
     return false;
@@ -115,8 +115,8 @@ void input_lag_update(struct Packet *packet)
     packet->input_lag_turns = 0;
     if (!network_is_active()) { return; }
     if ((game.operation_flags & GOF_Paused) == 0 && input_lag_increase_turns == 0 && input_lag_target > game.input_lag_turns) {
+        JUSTLOG("Input lag increased from %d to %d", game.input_lag_turns, input_lag_target);
         game.input_lag_turns = input_lag_target;
-        MULTIPLAYER_LOG("Input lag increase committed: current=%d", game.input_lag_turns);
     }
     TbClockMSec now = LbTimerClock();
     if ((game.operation_flags & GOF_Paused) != 0 || game.skip_initial_input_turns > 0) {

--- a/src/net_resync.cpp
+++ b/src/net_resync.cpp
@@ -223,7 +223,11 @@ static TbBool receive_resync_data(char ** data_buffer, size_t * data_length)
 
         received_size = netstate.sp->readmsg(SERVER_ID, message_buffer, received_size);
         if (received_size < sizeof(ResyncHeader)) {
-            ERRORLOG("Received message too small: %u bytes", (uint32_t)received_size);
+            if (received_size > 0 && message_buffer[0] == NETMSG_RESYNC_DATA) {
+                ERRORLOG("Received incomplete resync data: %u bytes", (uint32_t)received_size);
+            } else {
+                ERRORLOG("Ignoring message too small for resync data: %u bytes", (uint32_t)received_size);
+            }
             free(message_buffer);
             continue;
         }

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -204,7 +204,6 @@ void set_room_playing_ambient_sound(struct Coord3d *pos, long sample_idx)
     }
     if (sample_idx != 0)
     {
-        remove_thing_from_mapwho(thing);
         thing->mappos = *pos;
         thing->previous_mappos = *pos;
         i = thing->snd_emitter_id;

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -35,6 +35,7 @@
 #include "front_landview.h"
 #include "frontmenu_ingame_evnt.h"
 #include "thing_data.h"
+#include "thing_list.h"
 #include "thing_navigate.h"
 #include "config_creature.h"
 #include "config_terrain.h"
@@ -203,7 +204,9 @@ void set_room_playing_ambient_sound(struct Coord3d *pos, long sample_idx)
     }
     if (sample_idx != 0)
     {
-        move_thing_in_map(thing, pos);
+        remove_thing_from_mapwho(thing);
+        thing->mappos = *pos;
+        thing->previous_mappos = *pos;
         i = thing->snd_emitter_id;
         if (i != 0)
         {


### PR DESCRIPTION
Solves issues from some multiplayer logs that were reported.

Fixes a desync when starting without a dungeon heart (so as a spectator in a 3 player game), improved error logs during resync, log all input lag adjustments (necessary because bad FPS performance increases input lag), keep ambient sound object out of mapwho lists (this will prevent a 10MB log from being created).