### PR TITLE
Fix the text input caret: scale it with the font, make its blinking framerate-independent (and set the original DK frequency) and restore its shadow.

### DIFF
--- a/src/bflib_sprfnt.c
+++ b/src/bflib_sprfnt.c
@@ -136,26 +136,31 @@ static TbBool is_duospace_char(unsigned long chr)
  * @param draw_colr
  * @param shadow_colr
  */
-static void LbDrawCharUnderline(long pos_x, long pos_y, long width, long height, uchar draw_colr, uchar shadow_colr)
+static void LbDrawCharUnderline(long pos_x, long pos_y, long width, long height, int units_per_px, uchar draw_colr, uchar shadow_colr)
 {
+    if (units_per_px < 1)
+        units_per_px = 1;
+    // The bound checks follow the original code, so use the unscaled height for them
+    long base_height = height * 16 / units_per_px;
+    // Stroke thickness scaled the same way the font sprites are
+    long thickness = ((base_height > DOUBLE_UNDERLINE_BOUND) ? 2 : 1) * units_per_px / 16;
+    if (thickness < 1)
+        thickness = 1;
     long h = height;
     long w = width;
     // Draw shadow
     if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLNSHADOW) != 0) {
-        long shadow_x = pos_x + 1;
-        if (height > 2*DOUBLE_UNDERLINE_BOUND)
-            shadow_x++;
-        LbDrawHVLine(shadow_x, pos_y+h, shadow_x+w, pos_y+h, shadow_colr);
-        h--;
-        if (height > DOUBLE_UNDERLINE_BOUND) {
+        long shadow_off = ((base_height > 2*DOUBLE_UNDERLINE_BOUND) ? 2 : 1) * units_per_px / 16;
+        if (shadow_off < 1)
+            shadow_off = 1;
+        long shadow_x = pos_x + shadow_off;
+        for (long i = 0; i < thickness; i++) {
             LbDrawHVLine(shadow_x, pos_y+h, shadow_x+w, pos_y+h, shadow_colr);
             h--;
         }
     }
     // Draw underline
-    LbDrawHVLine(pos_x, pos_y+h, pos_x+w, pos_y+h, draw_colr);
-    h--;
-    if (height > DOUBLE_UNDERLINE_BOUND) {
+    for (long i = 0; i < thickness; i++) {
         LbDrawHVLine(pos_x, pos_y+h, pos_x+w, pos_y+h, draw_colr);
         h--;
     }
@@ -450,7 +455,7 @@ static int8_t draw_dbc_char(uint32_t chr, struct AsianFontWindow *awind, long *p
         if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLINE) != 0)
         {
             int h = adraw.bits_height * units_per_px / 16;
-            LbDrawCharUnderline(*pos_x,pos_y,w,h,colour,lbDisplayEx.ShadowColour);
+            LbDrawCharUnderline(*pos_x,pos_y,w,h,units_per_px,colour,lbDisplayEx.ShadowColour);
         }
         *pos_x += w;
         if (*pos_x >= awind->width)
@@ -476,7 +481,7 @@ static int8_t draw_simpletext_char(uint32_t chr, long *pos_x, long pos_y, int un
         if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLINE) != 0)
         {
             int h = LbTextLineHeight() * units_per_px / 16;
-            LbDrawCharUnderline(*pos_x, pos_y, w, h, lbDisplay.DrawColour, lbDisplayEx.ShadowColour);
+            LbDrawCharUnderline(*pos_x, pos_y, w, h, units_per_px, lbDisplay.DrawColour, lbDisplayEx.ShadowColour);
         }
         *pos_x += w;
         return 1;
@@ -532,7 +537,7 @@ static void put_down_sprites(const char *sbuf, const char *ebuf, long x, long y,
         if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLINE) != 0)
         {
             h = LbTextLineHeight() * units_per_px / 16;
-            LbDrawCharUnderline(x,y,w,h,lbDisplay.DrawColour,lbDisplayEx.ShadowColour);
+            LbDrawCharUnderline(x,y,w,h,units_per_px,lbDisplay.DrawColour,lbDisplayEx.ShadowColour);
         }
         x += w;
     } else
@@ -549,7 +554,7 @@ static void put_down_sprites(const char *sbuf, const char *ebuf, long x, long y,
         if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLINE) != 0)
         {
             h = LbTextLineHeight() * units_per_px / 16;
-            LbDrawCharUnderline(x,y,w,h,lbDisplay.DrawColour,lbDisplayEx.ShadowColour);
+            LbDrawCharUnderline(x,y,w,h,units_per_px,lbDisplay.DrawColour,lbDisplayEx.ShadowColour);
         }
         x += w;
     } else

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -99,7 +99,8 @@ enum TbDrawFlags {
     Lb_TEXT_HALIGN_CENTER  = 0x0100,
     Lb_TEXT_HALIGN_JUSTIFY = 0x0200,
     Lb_TEXT_UNDERLINE      = 0x0400,
-    Lb_TEXT_UNDERLNSHADOW  = 0x0800,
+    Lb_SPRITE_REMAP        = 0x0800,
+    Lb_TEXT_UNDERLNSHADOW  = 0x1000,
 };
 
 enum TbVideoModeFlags {

--- a/src/bflib_vidraw.c
+++ b/src/bflib_vidraw.c
@@ -1553,7 +1553,7 @@ TbResult LbSpriteDrawScaled(long xpos, long ypos, const struct TbSprite *sprite,
     SYNCDBG(19,"At (%ld,%ld) size (%ld,%ld)",xpos,ypos,dest_width,dest_height);
     if ((dest_width <= 0) || (dest_height <= 0))
       return 1;
-    if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLNSHADOW) != 0)
+    if ((lbDisplay.DrawFlags & Lb_SPRITE_REMAP) != 0)
         lbSpriteReMapPtr = lbDisplay.FadeTable + ((lbDisplay.FadeStep & 0x3F) << 8);
     LbSpriteSetScalingData(xpos, ypos, sprite->SWidth, sprite->SHeight, dest_width, dest_height);
     const struct TbSourceBuffer buffer = {
@@ -1570,7 +1570,7 @@ TbResult LbSpriteDrawScaledOneColour(long xpos, long ypos, const struct TbSprite
     SYNCDBG(19,"At (%ld,%ld) size (%ld,%ld)",xpos,ypos,dest_width,dest_height);
     if ((dest_width <= 0) || (dest_height <= 0))
       return 1;
-    if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLNSHADOW) != 0)
+    if ((lbDisplay.DrawFlags & Lb_SPRITE_REMAP) != 0)
         lbSpriteReMapPtr = lbDisplay.FadeTable + ((lbDisplay.FadeStep & 0x3F) << 8);
     LbSpriteSetScalingData(xpos, ypos, sprite->SWidth, sprite->SHeight, dest_width, dest_height);
     return LbSpriteDrawOneColourUsingScalingData(0, 0, sprite, colour);
@@ -1581,7 +1581,7 @@ int LbSpriteDrawScaledRemap(long xpos, long ypos, const struct TbSprite *sprite,
     SYNCDBG(19,"At (%ld,%ld) size (%ld,%ld)",xpos,ypos,dest_width,dest_height);
     if ((dest_width <= 0) || (dest_height <= 0))
       return 1;
-    if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLNSHADOW) != 0)
+    if ((lbDisplay.DrawFlags & Lb_SPRITE_REMAP) != 0)
         lbSpriteReMapPtr = lbDisplay.FadeTable + ((lbDisplay.FadeStep & 0x3F) << 8);
     LbSpriteSetScalingData(xpos, ypos, sprite->SWidth, sprite->SHeight, dest_width, dest_height);
     const struct TbSourceBuffer buffer = {

--- a/src/bflib_vidraw_spr_norm.c
+++ b/src/bflib_vidraw_spr_norm.c
@@ -1250,7 +1250,7 @@ TbResult LbSpriteDrawUsingScalingData(long posx, long posy, const struct TbSourc
 
     if ( scale_up )
     {
-        if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLNSHADOW) != 0)
+        if ((lbDisplay.DrawFlags & Lb_SPRITE_REMAP) != 0)
         {
           if ((lbDisplay.DrawFlags & Lb_SPRITE_FLIP_HORIZ) != 0)
           {
@@ -1299,7 +1299,7 @@ TbResult LbSpriteDrawUsingScalingData(long posx, long posy, const struct TbSourc
     }
     else
     {
-        if ((lbDisplay.DrawFlags & Lb_TEXT_UNDERLNSHADOW) != 0)
+        if ((lbDisplay.DrawFlags & Lb_SPRITE_REMAP) != 0)
         {
           if ((lbDisplay.DrawFlags & Lb_SPRITE_FLIP_HORIZ) != 0)
           {

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4954,16 +4954,16 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
     int size_on_screen = thing->sprite_size * ((camera_zoom << 13) / 0x10000 / pixel_size) / 0x10000;
     if ( thing->rendering_flags & TRF_Tint_Flags )
     {
-        lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+        lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
         lbSpriteReMapPtr = &pixmap.ghost[256 * thing->tint_colour];
     }
     else if ( shade_intensity == 0x2000 )
     {
-        lbDisplay.DrawFlags &= ~Lb_TEXT_UNDERLNSHADOW;
+        lbDisplay.DrawFlags &= ~Lb_SPRITE_REMAP;
     }
     else
     {
-        lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+        lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
         lbSpriteReMapPtr = &pixmap.fade_tables[shade_intensity << 8];
     }
 
@@ -4972,11 +4972,11 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
     {
         case TRF_Transpar_8:
             lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR8;
-            lbDisplay.DrawFlags &= ~Lb_TEXT_UNDERLNSHADOW;
+            lbDisplay.DrawFlags &= ~Lb_SPRITE_REMAP;
             break;
         case TRF_Transpar_4:
             lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR4;
-            lbDisplay.DrawFlags &= ~Lb_TEXT_UNDERLNSHADOW;
+            lbDisplay.DrawFlags &= ~Lb_SPRITE_REMAP;
             break;
         case TRF_Transpar_Alpha:
             EngineSpriteDrawUsingAlpha = 1;
@@ -4989,12 +4989,12 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
         || (player->work_state == PSt_QueryAll))
     {
         if ((local_thing_under_hand == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate)) {
-            lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+            lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
             lbSpriteReMapPtr = white_pal;
         } else {
             if ((thing->rendering_flags & TRF_BeingHit) != 0)
             {
-                lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+                lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
                 lbSpriteReMapPtr = red_pal;
             }
         }
@@ -7904,16 +7904,16 @@ static void prepare_jonty_remap_and_scale(int32_t *scale, const struct BucketKin
     *scale = (thelens * (long)thing->sprite_size) / fade;
     if ((thing->rendering_flags & (TRF_Tint_1|TRF_Tint_2)) != 0)
     {
-        lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+        lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
         shade_factor = thing->tint_colour;
         lbSpriteReMapPtr = &pixmap.ghost[256 * shade_factor];
     } else
     if (shade_factor == 32)
     {
-        lbDisplay.DrawFlags &= ~Lb_TEXT_UNDERLNSHADOW;
+        lbDisplay.DrawFlags &= ~Lb_SPRITE_REMAP;
     } else
     {
-        lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+        lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
         lbSpriteReMapPtr = &pixmap.fade_tables[256 * shade_factor];
     }
 }
@@ -7981,11 +7981,11 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
     {
     case TRF_Transpar_8:
         lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR8;
-        lbDisplay.DrawFlags &= ~Lb_TEXT_UNDERLNSHADOW;
+        lbDisplay.DrawFlags &= ~Lb_SPRITE_REMAP;
         break;
     case TRF_Transpar_4:
         lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR4;
-        lbDisplay.DrawFlags &= ~Lb_TEXT_UNDERLNSHADOW;
+        lbDisplay.DrawFlags &= ~Lb_SPRITE_REMAP;
         break;
     case TRF_Transpar_Alpha:
         EngineSpriteDrawUsingAlpha = 1;
@@ -7998,7 +7998,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
           struct Camera *active_cam = get_player_active_camera(player);
           if ((active_cam != NULL) && (active_cam->view_mode == PVM_IsoWibbleView || active_cam->view_mode == PVM_IsoStraightView))
           {
-              lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+              lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
               lbSpriteReMapPtr = white_pal;
           }
           else if ((active_cam != NULL) && (active_cam->view_mode == PVM_CreatureView))
@@ -8010,7 +8010,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
                   struct Thing *dragtng = thing_get(cctrl->dragtng_idx);
                   if (!thing_exists(dragtng))
                   {
-                    lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+                    lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
                     lbSpriteReMapPtr = white_pal;
                   }
                   else if (thing_is_trap_crate(dragtng))
@@ -8020,7 +8020,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
                       {
                           if (handthing->class_id == TCls_Trap)
                           {
-                              lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+                              lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
                               lbSpriteReMapPtr = white_pal;
                           }
                       }
@@ -8030,7 +8030,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
         } else {
             if ((thing->rendering_flags & TRF_BeingHit) != 0)
             {
-                lbDisplay.DrawFlags |= Lb_TEXT_UNDERLNSHADOW;
+                lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
                 lbSpriteReMapPtr = red_pal;
             }
         }

--- a/src/gui_draw.c
+++ b/src/gui_draw.c
@@ -27,6 +27,7 @@
 #include "bflib_vidraw.h"
 #include "bflib_sprfnt.h"
 #include "bflib_guibtns.h"
+#include "bflib_datetm.h"
 #include "config_strings.h"
 
 #include "player_data.h"
@@ -437,15 +438,14 @@ int simple_frontend_sprite_width_units_per_px(const struct GuiButton *gbtn, long
  */
 void draw_button_string(struct GuiButton *gbtn, int base_width, const char *text)
 {
-    static unsigned char cursor_type = 0;
     unsigned long flgmem = lbDisplay.DrawFlags;
     long cursor_pos = -1;
     static char dtext[TEXT_BUFFER_LENGTH];
     snprintf(dtext, TEXT_BUFFER_LENGTH, "%s", text);
     if ((gbtn->gbtype == LbBtnT_EditBox) && (gbtn == input_button))
     {
-        cursor_type++;
-        if ((cursor_type & 0x02) == 0)
+        // Time-based blink; original DK toggled every 2 frames at 20 fps, so 100ms on/off
+        if ((LbTimerClock() / 100 & 1) == 0)
           cursor_pos = input_field_pos;
         LbLocTextStringConcat(dtext, " ", TEXT_BUFFER_LENGTH);
         lbDisplay.DrawColour = LbTextGetFontFaceColor();
@@ -486,7 +486,7 @@ void draw_button_string(struct GuiButton *gbtn, int base_width, const char *text
     }
     LbTextSetJustifyWindow(x, gbtn->scr_pos_y, width);
     LbTextSetClipWindow(x, gbtn->scr_pos_y, width, gbtn->height);
-    lbDisplay.DrawFlags = Lb_TEXT_HALIGN_CENTER;// | Lb_TEXT_UNDERLNSHADOW;
+    lbDisplay.DrawFlags = Lb_TEXT_HALIGN_CENTER | Lb_TEXT_UNDERLNSHADOW;
     if (cursor_pos >= 0) {
         // Mind the order, 'cause inserting makes positions shift
         LbLocTextStringInsert(dtext, "\x0B", cursor_pos+1, TEXT_BUFFER_LENGTH);

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -649,12 +649,12 @@ void draw_power_hand(void)
                 if (crconf->transparency_flags == TRF_Transpar_8)
                 {
                     lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR8;
-                    lbDisplay.DrawFlags &= ~Lb_TEXT_UNDERLNSHADOW;
+                    lbDisplay.DrawFlags &= ~Lb_SPRITE_REMAP;
                 }
                 else if (crconf->transparency_flags == TRF_Transpar_4)
                 {
                     lbDisplay.DrawFlags |= Lb_SPRITE_TRANSPAR4;
-                    lbDisplay.DrawFlags &= ~Lb_TEXT_UNDERLNSHADOW;
+                    lbDisplay.DrawFlags &= ~Lb_SPRITE_REMAP;
                 }
                 else if(crconf->transparency_flags == TRF_Transpar_Alpha)
                 {


### PR DESCRIPTION
Before this fix:
<img width="1920" height="1080" alt="Caret NOT OK" src="https://github.com/user-attachments/assets/73bc0ab2-5290-414c-bda3-b312a3532d50" />


After:
<img width="1920" height="1080" alt="Caret OK" src="https://github.com/user-attachments/assets/5700bffe-1744-4e12-85cc-952bec03bdb6" />

Note: bit 0x0800 (Lb_TEXT_UNDERLNSHADOW) was used for text drawing and for the underline shadow, and the scaling sprite drawers used it to remap sprite colours through lbSpriteReMapPtr (lighting/tint/hit-flash) — which is why enabling the caret shadow turned the text black (so it was not correct), and why it had been disabled since 2014 i think. Now it is set as two constants: Lb_SPRITE_REMAP (0x0800) for the sprite colour remap and Lb_TEXT_UNDERLNSHADOW (0x1000) for the text underline shadow.