### PR TITLE
Allow loading string subtypes in .tngfx files

### DIFF
--- a/src/thing_factory.c
+++ b/src/thing_factory.c
@@ -40,6 +40,7 @@
 #include "dungeon_data.h"
 #include "gui_topmsg.h"
 #include "config_magic.h"
+#include "game_merge.h"
 #include "game_legacy.h"
 
 #include "keeperfx.hpp"
@@ -230,7 +231,7 @@ TbBool thing_create_thing_adv(VALUE *init_data)
     }
     if (model == -1) {
         if (value_type(subtype) == VALUE_STRING)
-            ERRORLOG("Unrecognized Thing Subtype \"%s\"", value_string(subtype));
+            ERRORMSG("map%05u.tngfx: Tried to load unrecognized Thing subtype \"%s\"", (unsigned int)get_selected_level_number(), value_string(subtype));
         else
             ERRORLOG("Thing Subtype is not set");
         return false;

--- a/src/thing_factory.c
+++ b/src/thing_factory.c
@@ -217,7 +217,8 @@ TbBool thing_create_thing_adv(VALUE *init_data)
 {
     int owner = value_int32(value_dict_get(init_data, "Ownership"));
     int oclass = value_parse_class(value_dict_get(init_data, "ThingType"));
-    ThingModel model = value_parse_model(oclass, value_dict_get(init_data, "Subtype"));
+    VALUE *subtype = value_dict_get(init_data, "Subtype");
+    ThingModel model = value_parse_model(oclass, subtype);
     struct Coord3d mappos;
     mappos.x.val = value_read_stl_coord(value_dict_get(init_data, "SubtileX"));
     mappos.y.val = value_read_stl_coord(value_dict_get(init_data, "SubtileY"));
@@ -227,9 +228,11 @@ TbBool thing_create_thing_adv(VALUE *init_data)
         ERRORLOG("Thing ThingType is not set");
         return false;
     }
-    if (model == -1)
-    {
-        ERRORLOG("Thing Subtype is not set");
+    if (model == -1) {
+        if (value_type(subtype) == VALUE_STRING)
+            ERRORLOG("Unrecognized Thing Subtype \"%s\"", value_string(subtype));
+        else
+            ERRORLOG("Thing Subtype is not set");
         return false;
     }
     if (owner == -1)

--- a/src/value_util.c
+++ b/src/value_util.c
@@ -5,7 +5,11 @@
 #include "pre_inc.h"
 #include "value_util.h"
 #include "config.h"
+#include "config_creature.h"
+#include "config_effects.h"
+#include "config_magic.h"
 #include "config_objects.h"
+#include "config_trapdoor.h"
 #include "bflib_basics.h"
 #include "bflib_fileio.h"
 #include "bflib_dernc.h"
@@ -90,7 +94,30 @@ int value_parse_model(int oclass, VALUE *value)
 {
     if (value_type(value) == VALUE_INT32)
         return value_int32(value);
-    // TODO: model names for different classes
+    if (value_type(value) != VALUE_STRING)
+        return -1;
+    const char *name = value_string(value);
+    switch (oclass)
+    {
+    case TCls_Object:
+    case TCls_AmbientSnd:
+        return get_id(object_desc, name);
+    case TCls_Shot:
+        return get_id(shot_desc, name);
+    case TCls_EffectElem:
+        return get_id(effectelem_desc, name);
+    case TCls_DeadCreature:
+    case TCls_Creature:
+        return get_id(creature_desc, name);
+    case TCls_Effect:
+        return get_id(effect_desc, name);
+    case TCls_EffectGen:
+        return get_id(effectgen_desc, name);
+    case TCls_Trap:
+        return get_id(trap_desc, name);
+    case TCls_Door:
+        return get_id(door_desc, name);
+    }
     return -1;
 }
 


### PR DESCRIPTION
This functions as an alternative, integers can still be used.

I've made the error slightly more informative so it will log the string name that it couldn't find:
`Error: map00045.tngfx: Tried to load unrecognized Thing subtype "BLAH"`