### PR TITLE
Refactor project_point_helper to prevent overflow

### DIFF
--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -7075,16 +7075,16 @@ static TbBool project_point_helper(struct PlayerInfo *player, int zoom, MapCoord
 {
     int vertical_shift;
     int64_t new_zoom;
-    uint8_t offset;
     short window_width = player->engine_window_width;
     short window_height = player->engine_window_height;
 
     *x_out = (zoom * horizontal_delta >> 16) + (*(uint16_t *)&window_width / 2);
     vertical_shift = zoom * vertical_delta >> 8;
     *z_out = window_height - ((vertical_shift + ((uint16_t)(window_height & PPH_EVEN_ALIGN_MASK) << 7)) >> 8) + 64;
-    new_zoom = (zoom * ((int16_t) pos_z)) << 7;
-    offset = *((uint8_t *)&new_zoom + 4);
-    *y_out = (vertical_shift + ((uint16_t)(window_height & PPH_EVEN_ALIGN_MASK) << 7) - ((offset + (signed int)new_zoom) >> 16)) >> 8;
+    // prevent 32bit int overflow for the big sprites.
+    new_zoom = ((int64_t)zoom * (int16_t)pos_z) << 7;
+    *y_out = (int32_t)((vertical_shift + ((uint16_t)(window_height & PPH_EVEN_ALIGN_MASK) << 7)
+                        - (int32_t)(new_zoom >> 16)) >> 8);
 
     return (*x_out >= 0 && *x_out < window_width && *y_out >= 0 && *y_out < window_height);
 }


### PR DESCRIPTION
Stops dungeon heart from going into the ground when you zoom in, in heathen frontview mode.