### PR TITLE
Fix all sprites vanishing in straight view at max zoom

### DIFF
--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4951,7 +4951,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
         shade_intensity = get_thing_shade(thing);
     shade_intensity >>= 8;
 
-    int size_on_screen = thing->sprite_size * ((camera_zoom << 13) / 0x10000 / pixel_size) / 0x10000;
+    int size_on_screen = thing->sprite_size * (int)((((int64_t)camera_zoom << 13) / 0x10000) / pixel_size) / 0x10000;
     if ( thing->rendering_flags & TRF_Tint_Flags )
     {
         lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
@@ -8896,7 +8896,7 @@ static void draw_frontview_thing_on_element(struct Thing *thing, struct Map *map
         convert_world_coord_to_front_view_screen_coord(&interp.mappos, cam, &cx, &cy, &cz);
         if (is_free_space_in_poly_pool(1))
         {
-            int size_on_screen = thing->sprite_size * ((camera_zoom << 13) / 0x10000 / pixel_size) / 0x10000;
+            int size_on_screen = thing->sprite_size * (int)((((int64_t)camera_zoom << 13) / 0x10000) / pixel_size) / 0x10000;
             add_thing_sprite_to_polypool(thing, cx, cy, cy, cz - 3 - (size_on_screen >> 1));
             if ((thing->class_id == TCls_Creature) && is_free_space_in_poly_pool(1))
             {


### PR DESCRIPTION
### The bug
In the straight view, zooming to the last two zoom stages at high resolution makes every thing sprite disappear: creatures, lair totems, the dungeon heart. Floors and walls keep rendering, the inhabitants vanish.

### Mechanism
draw_fastview_mapwho sizes sprites with (camera_zoom << 13) in 32-bit math. Resolution-scaled zoom reaches camera_zoom >= 262144 at 4K, the shift wraps negative, and the negative size culls every sprite. Same overflow family as #5060, which fixed the sibling term in project_point_helper.

### The fix
Widen the intermediate to 64-bit, identical math otherwise. The depth bias merged in #5062 computes the same expression in draw_frontview_thing_on_element, so it gets the same widening and stays correct at the zoom levels this fix makes reachable again.

### Testing
Reproduced the vanish on the official alpha 1.4.0.5252 build, then A/B tested a local build of master with this patch on the same machine: every sprite stays visible through max zoom and lair totems render whole there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
