### PR TITLE
RFC: Fix straight-view draw order (walls bucket at their visible face)

### DIFF
--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -7071,6 +7071,7 @@ static void display_fast_drawlist(struct Camera *cam) // Draws frontview only. N
  */
 
 #define PPH_EVEN_ALIGN_MASK 0xFFFE
+#define FRONTVIEW_BUCKET_MARGIN 1024
 static TbBool project_point_helper(struct PlayerInfo *player, int zoom, MapCoordDelta vertical_delta, MapCoordDelta horizontal_delta, MapCoord pos_z, int32_t *x_out, int32_t *y_out, int32_t *z_out)
 {
     int vertical_shift;
@@ -7080,7 +7081,7 @@ static TbBool project_point_helper(struct PlayerInfo *player, int zoom, MapCoord
 
     *x_out = (zoom * horizontal_delta >> 16) + (*(uint16_t *)&window_width / 2);
     vertical_shift = zoom * vertical_delta >> 8;
-    *z_out = window_height - ((vertical_shift + ((uint16_t)(window_height & PPH_EVEN_ALIGN_MASK) << 7)) >> 8) + 64;
+    *z_out = window_height - ((vertical_shift + ((uint16_t)(window_height & PPH_EVEN_ALIGN_MASK) << 7)) >> 8) + FRONTVIEW_BUCKET_MARGIN;
     // prevent 32bit int overflow for the big sprites.
     new_zoom = ((int64_t)zoom * (int16_t)pos_z) << 7;
     *y_out = (int32_t)((vertical_shift + ((uint16_t)(window_height & PPH_EVEN_ALIGN_MASK) << 7)
@@ -7365,7 +7366,7 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
     myplyr = get_my_player();
     cube_itm = (qdrant + 2) & 3;
     delta_y = (zoom << 7) / 256;
-    bckt_idx = myplyr->engine_window_height - (pos_y >> 8) + 64;
+    bckt_idx = myplyr->engine_window_height - (pos_y >> 8) + FRONTVIEW_BUCKET_MARGIN;
     // Check if there's enough place to draw
     if (!is_free_space_in_poly_pool(8))
       return;
@@ -7430,6 +7431,23 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
 
     // Draw the columns cubes
 
+    long bckt_face = bckt_idx;
+    long bckt_top = bckt_idx;
+    if (((mapblk->flags & SlbAtFlg_Blocking) != 0)
+     && (get_column_floor_filled_subtiles(col) >= 3))
+    {
+        bckt_face = bckt_idx - (zoom >> 8);
+        bckt_top = bckt_face;
+        MapSubtlCoord sstl_x = stl_x + (qdrant == 3) - (qdrant == 1);
+        MapSubtlCoord sstl_y = stl_y + (qdrant == 0) - (qdrant == 2);
+        struct Map *smapblk = get_map_block_at(sstl_x, sstl_y);
+        if (((smapblk->flags & SlbAtFlg_Blocking) != 0)
+         && (!map_block_revealed(smapblk, my_player_number)
+          || (get_floor_filled_subtiles_at(sstl_x, sstl_y) >= 3))) {
+            bckt_top = bckt_face - 2 * (zoom >> 8);
+        }
+    }
+
     y = zoom + pos_y;
     cube_config_stats = NULL;
     for (tc=0; tc < COLUMN_STACK_HEIGHT; tc++)
@@ -7443,7 +7461,7 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
         *ymax = y;
         textr_idx = engine_remap_texture_blocks(stl_x, stl_y, cube_config_stats->texture_id[cube_itm]);
         add_lgttextrdquad_to_polypool(pos_x, y, textr_idx, zoom, delta_y, 0,
-            lightness_arr[3][tc+1], lightness_arr[2][tc+1], lightness_arr[2][tc], lightness_arr[3][tc], bckt_idx);
+            lightness_arr[3][tc+1], lightness_arr[2][tc+1], lightness_arr[2][tc], lightness_arr[3][tc], bckt_face);
       }
     }
 
@@ -7456,15 +7474,15 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
         textr_idx = engine_remap_texture_blocks(stl_x, stl_y, cube_config_stats->texture_id[4]);
         if ((mapblk->flags & SlbAtFlg_TaggedValuable) != 0)
         {
-          add_textruredquad_to_polypool(pos_x, i, textr_idx, zoom, qdrant, 2097152, 1, bckt_idx);
+          add_textruredquad_to_polypool(pos_x, i, textr_idx, zoom, qdrant, 2097152, 1, bckt_top);
         } else
         if ((mapblk->flags & SlbAtFlg_Unexplored) != 0)
         {
-          add_textruredquad_to_polypool(pos_x, i, textr_idx, zoom, qdrant, 2097152, 0, bckt_idx);
+          add_textruredquad_to_polypool(pos_x, i, textr_idx, zoom, qdrant, 2097152, 0, bckt_top);
         } else
         {
           add_lgttextrdquad_to_polypool(pos_x, i, textr_idx, zoom, zoom, qdrant,
-              lightness_arr[0][tc], lightness_arr[1][tc], lightness_arr[2][tc], lightness_arr[3][tc], bckt_idx);
+              lightness_arr[0][tc], lightness_arr[1][tc], lightness_arr[2][tc], lightness_arr[3][tc], bckt_top);
         }
       }
     }
@@ -7490,7 +7508,7 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
             {
               textr_idx = engine_remap_texture_blocks(stl_x, stl_y, cube_config_stats->texture_id[cube_itm]);
               add_lgttextrdquad_to_polypool(pos_x, y, textr_idx, zoom, delta_y, 0,
-                  lightness_arr[3][tc+1], lightness_arr[2][tc+1], lightness_arr[2][tc], lightness_arr[3][tc], bckt_idx);
+                  lightness_arr[3][tc+1], lightness_arr[2][tc+1], lightness_arr[2][tc], lightness_arr[3][tc], bckt_face);
             }
         }
         if (cube_config_stats != NULL)
@@ -7500,7 +7518,7 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
           {
               textr_idx = engine_remap_texture_blocks(stl_x, stl_y, cube_config_stats->texture_id[4]);
             add_lgttextrdquad_to_polypool(pos_x, i, textr_idx, zoom, zoom, qdrant,
-                lightness_arr[0][tc], lightness_arr[1][tc], lightness_arr[2][tc], lightness_arr[3][tc], bckt_idx);
+                lightness_arr[0][tc], lightness_arr[1][tc], lightness_arr[2][tc], lightness_arr[3][tc], bckt_top);
           }
         }
     }
@@ -8449,7 +8467,7 @@ void create_frontview_map_volume_box(struct Camera *cam, unsigned char stl_width
         coord_x -= box_width;
         break;
     }
-    coord_z -= (stl_width >> 1);
+    coord_z -= (stl_width >> 1) + 3 * (long)stl_width;
     // Draw 4 horizonal line elements
     create_line_element(coord_x,             coord_y,                      coord_x + box_width, coord_y,                      coord_z,                          line_color);
     create_line_element(coord_x,             coord_y + box_height,         coord_x + box_width, coord_y + box_height,         coord_z - box_height,             line_color);
@@ -8542,7 +8560,7 @@ void create_fancy_frontview_map_volume_box(struct RoomSpace roomspace, struct Ca
         }
         break;
     }
-    coord_z -= (stl_width >> 1);
+    coord_z -= (stl_width >> 1) + 3 * (long)stl_width;
     for (int roomspace_y = 0; roomspace_y < room_slab_height; roomspace_y += 1)
     {
         int y_start = (box_height * roomspace_y       / room_slab_height) + ((((box_height * roomspace_y)       % room_slab_height) >= room_slab_height) ? 1 : 0);

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -8467,7 +8467,7 @@ void create_frontview_map_volume_box(struct Camera *cam, unsigned char stl_width
         coord_x -= box_width;
         break;
     }
-    coord_z -= (stl_width >> 1) + 3 * (long)stl_width;
+    coord_z -= (11 * (long)stl_width) >> 2;
     // Draw 4 horizonal line elements
     create_line_element(coord_x,             coord_y,                      coord_x + box_width, coord_y,                      coord_z,                          line_color);
     create_line_element(coord_x,             coord_y + box_height,         coord_x + box_width, coord_y + box_height,         coord_z - box_height,             line_color);
@@ -8560,7 +8560,7 @@ void create_fancy_frontview_map_volume_box(struct RoomSpace roomspace, struct Ca
         }
         break;
     }
-    coord_z -= (stl_width >> 1) + 3 * (long)stl_width;
+    coord_z -= (11 * (long)stl_width) >> 2;
     for (int roomspace_y = 0; roomspace_y < room_slab_height; roomspace_y += 1)
     {
         int y_start = (box_height * roomspace_y       / room_slab_height) + ((((box_height * roomspace_y)       % room_slab_height) >= room_slab_height) ? 1 : 0);


### PR DESCRIPTION
Draft on purpose: this fixes the reported bug in our testing, but it changes 29-year-old draw-order behavior, so we want the reasoning reviewed before it counts as ready. Tear it apart.

### The bug
Community report: creatures visible through the tops of walls they are standing behind in the straight view (reproduces on alpha 1.4.0.5252). Same family as #5060 / #5062 / #5066: draw-order assumptions sized for 320x200 breaking at modern zoom.

### Root cause
The straight view buckets by screen pixels. draw_element buckets the entire column at the tile's NORTH edge, but the visible wall face is the tile's SOUTHERN boundary plane, one tile later in draw order. Any thing bias toward the camera (the #5062 size bias, or even the legacy -3 for a thing standing in the southern strip of its tile) can out-bucket the wall directly south of it, and once the feet cross that line the whole sprite draws over the wall top. Separately, the +64 bucket margin was sized for the legacy -3 bias; at the bottom rows of the screen modern biases overspend it, everything clamps into bucket 0, and ordering collapses there.

### The fix (one file, +45/-8)
- Wall-class columns (tall AND blocking) bucket their faces and caps at the south edge. Walkable columns of any height (dungeon heart pedestal, room floors, lair padding) are floors and keep the early bucket, under their occupants.
- A wall whose screen-south neighbor is also wall-class shows no face at all, so its top draws over everything nearby. This also cuts wide sprites brushing a wall strip sideways instead of letting them spill over the tops.
- The dig/place markers lift three rows so they stay visible on tagged wall strips.
- The shared bucket margin grows 64 -> 1024 in both formulas; it cancels between things and columns, and BUCKETS_COUNT (4098) has headroom at any real window height.

### Testing
4K, straight view, on two builds: this branch applied to current master, and the truecolor fork where it soaked first. Creatures behind walls are buried at every position including pressed against the wall; creatures in front keep their heads; lair rooms full of nests show no tile-boundary cuts; the heart is fully visible on its pedestal; markers stay visible on tagged strips; bottom-edge ordering holds. The max-zoom sprite vanish still present on this branch is #5066, not this change.

### Known residual (pre-existing)
A wide sprite whose feet are south of a wall's EXPOSED end face can still overlap that face. The bucket list sorts on one axis and this case needs the second one; the honest fix for it is per-pixel depth, and it exists in current master too.

### Review questions
1. Wall-class is `SlbAtFlg_Blocking` plus `get_column_floor_filled_subtiles >= 3`. Is there map content this misclassifies (walkable 3+ columns, blocking 2-cube ledges)?
2. Hidden-face tops draw 2 rows late and markers lift 3 rows. Tuned constants, not derived ones; sturdier ideas welcome.
3. The 1024 margin assumes engine windows under roughly 3000px tall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update: volume box depth bias retuned** (addresses the boundbox report below)

The build-room volume box carries a hand-tuned depth bias that ducks its lines under wall faces. It was calibrated against the original north-edge wall bucketing; with walls bucketing at their visible face, the branch's earlier 3.5-subtile compensation overshot and the box's bottom line showed through walls where unrevealed terrain lies beyond. The committed 2.75 subtiles was measured against a test matrix at 4K: box over walls, against walls with dark beyond, over open and unrevealed ground, both box render modes, across zoom levels.

Two things reviewers should know:

1. This interaction has been through two tuning iterations already, and this is as good as it gets from our side short of per-pixel depth, i.e. a renderer rewrite. The remaining artifact is a one-pixel slimming of horizontal lines where covering geometry meets them: the painter's list quantizes the boundary row, and it goes to the occluder.
2. The volume box renders broken at 4K on every official build we tested, including stable 1.4.0 and alpha 5249, because the 1997-sized bucket margin collapses at 4K window heights. The margin raise in this branch is what makes the box tunable at 4K at all. At lower resolutions the old margin may hold. This is unconfirmed since lower resolutions don't work well with my screen. 
