### PR TITLE
Fix door key symbol hidden behind walls in straight view

### DIFF
--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -8968,7 +8968,7 @@ static void draw_frontview_thing_on_element(struct Thing *thing, struct Map *map
         convert_world_coord_to_front_view_screen_coord(&interp.mappos, cam, &cx, &cy, &cz);
         if (is_free_space_in_poly_pool(1))
         {
-            add_spinning_key_to_polypool(thing, cx, cy, cy, cz-3);
+            add_spinning_key_to_polypool(thing, cx, cy, cy, cz - 3 - 4 * (camera_zoom >> 11));
         }
         break;
     default:


### PR DESCRIPTION
Follow-up to #5068. Wall tops now draw later in straight view, and the spinning key over locked doors kept its legacy depth bucket, so nearby walls bury it. This lifts the key four rows so it draws above wall tops, same treatment as the dig markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
