### PR TITLE
Handle camera catchup packets after logic update

### DIFF
--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -725,5 +725,8 @@ void update_all_players_cameras(void)
           update_player_camera(player);
     }
   }
+
+  // Send catchup packets if local camera has drifted too far from packet-based camera
+  send_camera_catchup_packets();
 }
 /******************************************************************************/

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -87,14 +87,14 @@ void send_camera_catchup_packets(void)
     default:
         return;
     }
-    
+
     struct Camera* local_cam = &destination_local_cameras[cam_idx];
     struct Camera* packet_cam = &player->cameras[cam_idx];
     struct Packet* pckt = get_packet(player->id_number);
-    
+
     long diff_map_x = local_cam->mappos.x.val - packet_cam->mappos.x.val;
     long diff_map_y = local_cam->mappos.y.val - packet_cam->mappos.y.val;
-    
+
     long angle = local_cam->rotation_angle_x;
     long cos_angle = LbCosL(angle);
     long sin_angle = LbSinL(angle);

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -61,15 +61,16 @@ static struct Packet* get_packet_for_local_camera_update(void)
     return get_packet_direct(player->packet_num);
 }
 
-void send_camera_catchup_packets(struct PlayerInfo *player)
+void send_camera_catchup_packets(void)
 {
     // Threshold distance before sending catchup packets (in map coordinates)
     #define CAMERA_DESYNC_THRESHOLD 512
 
-    if (!is_my_player(player) || !local_camera_ready) {
+    if (!local_camera_ready) {
         return;
     }
-    
+    struct PlayerInfo* player = get_my_player();
+
     // Determine which camera to compare based on view mode
     int cam_idx = (player->view_mode == PVM_FrontView) ? CamIV_FrontView : CamIV_Isometric;
     
@@ -244,9 +245,7 @@ void update_local_cameras(void)
             process_camera_controls(cam, local_packet, my_player, true);
             view_process_camera_inertia(cam);
         }
-        
-        // Send catchup packets if local camera has drifted too far from packet-based camera
-        send_camera_catchup_packets(my_player);
+
         update_camera_deviations(active_cam_idx);
     }
 }

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -72,7 +72,21 @@ void send_camera_catchup_packets(void)
     struct PlayerInfo* player = get_my_player();
 
     // Determine which camera to compare based on view mode
-    int cam_idx = (player->view_mode == PVM_FrontView) ? CamIV_FrontView : CamIV_Isometric;
+    int cam_idx;
+    switch (player->view_mode)
+    {
+    case PVM_FrontView:
+        cam_idx = CamIV_FrontView;
+        break;
+
+    case PVM_IsoStraightView:
+    case PVM_IsoWibbleView:
+        cam_idx = CamIV_Isometric;
+        break;
+
+    default:
+        return;
+    }
     
     struct Camera* local_cam = &destination_local_cameras[cam_idx];
     struct Camera* packet_cam = &player->cameras[cam_idx];

--- a/src/local_camera.h
+++ b/src/local_camera.h
@@ -45,7 +45,7 @@ void sync_local_camera(struct PlayerInfo *player);
 void set_local_camera_destination(struct PlayerInfo *player);
 void move_local_camera_to_position(MapCoord x, MapCoord y);
 struct Camera* get_local_camera(struct Camera* cam);
-void send_camera_catchup_packets(struct PlayerInfo *player);
+void send_camera_catchup_packets(void);
 
 /******************************************************************************/
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes multiplayer games desyncing, caused by #5067.