### PR TITLE
Multiplayer: fixed being unable to chat in lobby

### DIFF
--- a/src/front_network.c
+++ b/src/front_network.c
@@ -31,8 +31,6 @@
 #include "bflib_sprfnt.h"
 #include "bflib_datetm.h"
 #include "bflib_fileio.h"
-#include "bflib_inputctrl.h"
-
 #include "kjm_input.h"
 #include "gui_draw.h"
 #include "front_simple.h"
@@ -713,7 +711,6 @@ void frontnet_start_setup(void)
         struct PlayerInfo* player = get_player(i);
         player->mp_message_text[0] = '\0';
     }
-    LbStartTextInput();
 }
 
 /******************************************************************************/

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2698,6 +2698,7 @@ FrontendMenuState frontend_setup_state(FrontendMenuState nstate)
           turn_on_menu(GMnu_FENET_START);
           if (frontend_menu_state != FeSt_MP_MAPPACK_SELECT)
             frontnet_start_setup();
+          LbStartTextInput();
           set_flag(game.system_flags, GSF_NetworkActive);
           set_pointer_graphic_menu();
           break;


### PR DESCRIPTION
Returning from the mappack selection screen was breaking your text input permanently. Client or host, just whichever player changed the mappack.