### PR TITLE
Load default campaign when no campaign is active

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2661,6 +2661,9 @@ FrontendMenuState frontend_setup_state(FrontendMenuState nstate)
               char* fname = prepare_file_path(FGrp_Save, continue_game_filename);
               LbFileDelete(fname);
           }
+          if (!is_campaign_loaded()) {
+              change_campaign(CampgnT_Default,"");
+          }
           turn_on_menu(GMnu_FEMAIN);
           last_mouse_x = GetMouseX();
           last_mouse_y = GetMouseY();


### PR DESCRIPTION
Fixes issues that can occur when there's no active campaign.