### PR TITLE
ci: include keeperfx.exe and keeperfx_hvlog.exe in uploaded package artifact

### DIFF
--- a/.github/workflows/build-alpha-patch-unsigned.yml
+++ b/.github/workflows/build-alpha-patch-unsigned.yml
@@ -52,6 +52,12 @@ jobs:
         make BUILD_NUMBER=$BUILD_NUMBER PACKAGE_SUFFIX=$PACKAGE_SUFFIX pkg-assemble
         cmake --build out --target package
         echo "ZIP_NAME=$(basename -s .7z pkg/keeperfx*.7z)" >> $GITHUB_ENV
+        # CPack stages the binaries (keeperfx.exe, keeperfx_hvlog.exe) and the SDL2
+        # runtime DLLs only inside the .7z archive, not into the loose pkg/ tree, so
+        # uploading pkg/** would drop them and leave SignPath with nothing to sign.
+        # Install the full package layout into dist/ so the uploaded artifact holds
+        # the binaries + DLLs + game data.
+        cmake --install out --prefix dist
         rm pkg/keeperfx*.7z
 
     - name: Upload artifact
@@ -59,7 +65,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ZIP_NAME }}
-        path: pkg/**
+        path: dist/**
       
     outputs:
       artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}

--- a/.github/workflows/build-prototype.yml
+++ b/.github/workflows/build-prototype.yml
@@ -38,13 +38,18 @@ jobs:
         make BUILD_NUMBER=$BUILD_NUMBER PACKAGE_SUFFIX=$PACKAGE_SUFFIX pkg-assemble
         cmake --build out --target package
         echo "ZIP_NAME=$(basename -s .7z pkg/keeperfx*.7z)" >> $GITHUB_ENV
+        # CPack stages the binaries (keeperfx.exe, keeperfx_hvlog.exe) and the SDL2
+        # runtime DLLs only inside the .7z archive, not into the loose pkg/ tree, so
+        # uploading pkg/** would drop them. Install the full package layout into
+        # dist/ so the uploaded artifact holds the binaries + DLLs + game data.
+        cmake --install out --prefix dist
         rm pkg/keeperfx*.7z
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ZIP_NAME }}
-        path: pkg/**
+        path: dist/**
 
   build-prototype-linux:
     name: "Build Prototype Linux x86_64"

--- a/.github/workflows/build-release-patch-unsigned.yml
+++ b/.github/workflows/build-release-patch-unsigned.yml
@@ -52,6 +52,12 @@ jobs:
         make BUILD_NUMBER=$BUILD_NUMBER PACKAGE_SUFFIX=$PACKAGE_SUFFIX pkg-assemble
         cmake --build out --target package
         echo "ZIP_NAME=$(basename -s .7z pkg/keeperfx*.7z)" >> $GITHUB_ENV
+        # CPack stages the binaries (keeperfx.exe, keeperfx_hvlog.exe) and the SDL2
+        # runtime DLLs only inside the .7z archive, not into the loose pkg/ tree, so
+        # uploading pkg/** would drop them and leave SignPath with nothing to sign.
+        # Install the full package layout into dist/ so the uploaded artifact holds
+        # the binaries + DLLs + game data.
+        cmake --install out --prefix dist
         rm pkg/keeperfx*.7z
 
     - name: Upload artifact
@@ -59,7 +65,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ZIP_NAME }}
-        path: pkg/**
+        path: dist/**
       
     outputs:
       artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}


### PR DESCRIPTION
## Problem

The **Sign Alpha Patch** job fails with *"nothing to sign"* — the uploaded package artifact is missing `keeperfx.exe` and `keeperfx_hvlog.exe` (and the SDL2 runtime DLLs).

## Root cause

The unsigned build workflows assemble only game **data** into `pkg/` via `make pkg-assemble`. CPack (`--target package`) stages the binaries and SDL2 DLLs **only inside the `.7z` archive**, never into the loose `pkg/` tree. The workflow then deletes the archive and uploads `pkg/**`:

```
cmake --build out --target package   # binaries + DLLs go ONLY into pkg/keeperfx-*.7z
rm pkg/keeperfx*.7z                  # deleted
upload-artifact  path: pkg/**        # data only — no exes, no DLLs
```

So the artifact contains no executable, and SignPath has nothing to sign.

## Fix

Run `cmake --install out --prefix dist` after packaging and upload `dist/**`. This reproduces the exact full package layout (binaries + SDL2 DLLs + game data) as loose files. The existing `install(CODE)` block already skips the `.7z`, so nothing extra is included.

Applied to all three affected unsigned workflows:
- `build-alpha-patch-unsigned.yml`
- `build-release-patch-unsigned.yml`
- `build-prototype.yml`

Signed workflows are unchanged — SignPath writes its signed output back into `pkg/`, which now contains the binaries.