### PR TITLE
Label builds that are not made by the release workflows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,13 @@ set(CMAKE_CXX_STANDARD 20)
 find_package(Git REQUIRED)
 execute_process(COMMAND "${GIT_EXECUTABLE}" describe --always OUTPUT_VARIABLE COMMIT_ID OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+set(_kfx_package_suffix "")
 file(STRINGS "${CMAKE_SOURCE_DIR}/version.mk" _kfx_version_lines)
 foreach(_line IN LISTS _kfx_version_lines)
     if(_line MATCHES "^(VER_MAJOR|VER_MINOR|VER_RELEASE|VER_BUILD)=([0-9]+)")
         set(${CMAKE_MATCH_1} "${CMAKE_MATCH_2}")
+    elseif(_line MATCHES "^PACKAGE_SUFFIX=(.*)$")
+        set(_kfx_package_suffix "${CMAKE_MATCH_1}")
     endif()
 endforeach()
 foreach(_v VER_MAJOR VER_MINOR VER_RELEASE VER_BUILD)
@@ -25,8 +28,10 @@ foreach(_v VER_MAJOR VER_MINOR VER_RELEASE VER_BUILD)
     endif()
 endforeach()
 # Override via -DBUILD_NUMBER=<n> -DPACKAGE_SUFFIX=<s>; used for the CPack name.
-set(BUILD_NUMBER   "${VER_BUILD}" CACHE STRING "Monotonic build number")
-set(PACKAGE_SUFFIX ""             CACHE STRING "Distribution suffix (e.g. Alpha, Release)")
+# The suffix defaults to the one in version.mk, the same way the Makefile takes
+# it, so both build systems call an unattended build the same thing.
+set(BUILD_NUMBER   "${VER_BUILD}"           CACHE STRING "Monotonic build number")
+set(PACKAGE_SUFFIX "${_kfx_package_suffix}" CACHE STRING "Distribution suffix (e.g. Alpha, Release)")
 set(VER_STRING     "${VER_MAJOR}.${VER_MINOR}.${VER_RELEASE}.${BUILD_NUMBER} ${PACKAGE_SUFFIX}")
 set(GIT_REVISION   "${COMMIT_ID}")
 

--- a/version.mk
+++ b/version.mk
@@ -3,4 +3,11 @@ VER_MINOR=4
 VER_RELEASE=0
 VER_BUILD=0
 
-PACKAGE_SUFFIX=
+# Appended to the version string the game reports and writes into its log.
+#
+# The default marks a build as not coming from the release workflows: they each
+# pass PACKAGE_SUFFIX on the command line, which wins over this, so an official
+# package is unaffected while anything built from a fork or a working copy says
+# so on its own. That keeps a screenshot or a bug report from being mistaken for
+# an official release.
+PACKAGE_SUFFIX=Unofficial


### PR DESCRIPTION
`PACKAGE_SUFFIX` defaulted to empty, which is exactly what a release build uses, so nothing in the version string distinguished an official package from a fork or from somebody's working copy. A screenshot or a log pasted into a bug report looks the same either way.

It now defaults to `Unofficial`, so anyone who builds from a clone says so without having to do anything.

**The release workflows are unaffected.** All three already pass the value on the command line, which wins over `version.mk` in both build systems:

| Workflow | Passes |
|---|---|
| `build-release-patch-unsigned.yml` | `PACKAGE_SUFFIX=` (explicitly empty) |
| `build-alpha-patch-unsigned.yml` | `PACKAGE_SUFFIX=Alpha` |
| `build-prototype.yml` | `PACKAGE_SUFFIX=Prototype_<sha>` |

The second change is that the CMake build now reads `PACKAGE_SUFFIX` out of `version.mk` the same way it already reads the version numbers. It used to hardcode an empty default, so `make` and `cmake` disagreed about what an unattended build is called — without this the new default would only apply to the Makefile.

Two things left alone deliberately:

- `Makefile:45` still has `PACKAGE_SUFFIX ?= Prototype`, which `include version.mk` has always overridden. It is dead either way and removing it felt out of scope here.
- `MATCHMAKING_VERSION` is built from `VER_MAJOR`/`VER_MINOR`/`VER_RELEASE` only and does not carry the suffix, so the lobby browser keeps matching official clients.

Requested by a maintainer.