### PR TITLE
Fixed SDL 3 screenshotting

### DIFF
--- a/src/scrcapt.c
+++ b/src/scrcapt.c
@@ -60,12 +60,12 @@ TbBool take_screenshot(char *fname)
     {
         case 1:
         {
-            success = IMG_SavePNG(lbDrawSurface, fname);
+            success = IMG_SavePNG(lbScreenSurface, fname);
             break;
         }
         case 2:
         {
-            success = SDL_SaveBMP(lbDrawSurface, fname);
+            success = SDL_SaveBMP(lbScreenSurface, fname);
             break;
         }
         default:


### PR DESCRIPTION
Fixes #5094

One minor difference: the cursor is now visible in the output. This wasn't the case before.