### PR TITLE
refactor(platform): move OS-info queries into PlatformX

### DIFF
--- a/src/kfx/platform/IPlatform.h
+++ b/src/kfx/platform/IPlatform.h
@@ -10,6 +10,12 @@ class IPlatform {
 public:
     virtual ~IPlatform() = default;
 
+    // ----- OS information -----
+    virtual const char* GetOSVersion() const = 0;
+    virtual const void* GetImageBase() const = 0;
+    virtual const char* GetWineVersion() const = 0; // nullptr when not running under Wine
+    virtual const char* GetWineHost() const = 0;    // nullptr when not running under Wine
+
     /** Initialise the display subsystem. Per-OS: Windows adjusts SDL hints
      *  before SDL_Init, Linux initialises plainly. Returns false on failure. */
     virtual bool VideoInit() = 0;

--- a/src/kfx/platform/PlatformLinux.cpp
+++ b/src/kfx/platform/PlatformLinux.cpp
@@ -4,6 +4,11 @@
 #include <cstdlib>
 #include "post_inc.h"
 
+const char* PlatformLinux::GetOSVersion() const { return "Linux"; }
+const void* PlatformLinux::GetImageBase() const { return nullptr; }
+const char* PlatformLinux::GetWineVersion() const { return nullptr; } // running native
+const char* PlatformLinux::GetWineHost() const { return nullptr; }    // running native
+
 bool PlatformLinux::VideoInit()
 {
     if (!SDL_Init(SDL_INIT_VIDEO))

--- a/src/kfx/platform/PlatformLinux.h
+++ b/src/kfx/platform/PlatformLinux.h
@@ -6,6 +6,11 @@
 /** Linux desktop platform. */
 class PlatformLinux : public IPlatform {
 public:
+    const char* GetOSVersion() const override;
+    const void* GetImageBase() const override;
+    const char* GetWineVersion() const override;
+    const char* GetWineHost() const override;
+
     bool VideoInit() override;
 };
 

--- a/src/kfx/platform/PlatformManager.cpp
+++ b/src/kfx/platform/PlatformManager.cpp
@@ -12,6 +12,7 @@
 #include "kfx/platform/IPlatform.h"
 #include "kfx/platform/PlatformWindows.h"
 #include "kfx/platform/PlatformLinux.h"
+#include "platform.h"
 #include "post_inc.h"
 
 /******************************************************************************/
@@ -27,6 +28,13 @@ IPlatform* GetPlatform()
 #endif
     return &s_platform;
 }
+
+/******************************************************************************/
+
+extern "C" const char * get_os_version(void)   { return GetPlatform()->GetOSVersion(); }
+extern "C" const void * get_image_base(void)    { return GetPlatform()->GetImageBase(); }
+extern "C" const char * get_wine_version(void)  { return GetPlatform()->GetWineVersion(); }
+extern "C" const char * get_wine_host(void)     { return GetPlatform()->GetWineHost(); }
 
 /******************************************************************************/
 

--- a/src/kfx/platform/PlatformWindows.cpp
+++ b/src/kfx/platform/PlatformWindows.cpp
@@ -2,7 +2,58 @@
 #include "kfx/platform/PlatformWindows.h"
 #include <SDL3/SDL.h>
 #include <cstdlib>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
 #include "post_inc.h"
+
+const char* PlatformWindows::GetOSVersion() const
+{
+    static char buffer[256];
+    OSVERSIONINFO v;
+    v.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+    if (GetVersionEx(&v)) {
+        snprintf(buffer, sizeof(buffer), "%s %ld.%ld.%ld",
+            (v.dwPlatformId == VER_PLATFORM_WIN32_NT) ? "Windows NT" : "Windows",
+            v.dwMajorVersion, v.dwMinorVersion, v.dwBuildNumber);
+        return buffer;
+    }
+    return "unknown";
+}
+
+const void* PlatformWindows::GetImageBase() const
+{
+    return GetModuleHandle(NULL);
+}
+
+const char* PlatformWindows::GetWineVersion() const
+{
+    const auto module = GetModuleHandle("ntdll.dll");
+    if (module) {
+        const auto wine_get_version = (const char* (WINAPI*)()) (void*) GetProcAddress(module, "wine_get_version");
+        if (wine_get_version) {
+            return wine_get_version();
+        }
+    }
+    return nullptr;
+}
+
+const char* PlatformWindows::GetWineHost() const
+{
+    const auto module = GetModuleHandle("ntdll.dll");
+    static char buffer[256];
+    if (module) {
+        const auto wine_get_host_version = (void (WINAPI*)(const char**, const char**)) (void*) GetProcAddress(module, "wine_get_host_version");
+        if (wine_get_host_version) {
+            const char* sys_name = nullptr;
+            const char* release_name = nullptr;
+            wine_get_host_version(&sys_name, &release_name);
+            snprintf(buffer, sizeof(buffer), "%s %s", sys_name ? sys_name : "unknown", release_name ? release_name : "unknown");
+            return buffer;
+        }
+    }
+    return nullptr;
+}
 
 bool PlatformWindows::VideoInit()
 {

--- a/src/kfx/platform/PlatformWindows.cpp
+++ b/src/kfx/platform/PlatformWindows.cpp
@@ -30,7 +30,7 @@ const char* PlatformWindows::GetWineVersion() const
 {
     const auto module = GetModuleHandle("ntdll.dll");
     if (module) {
-        const auto wine_get_version = reinterpret_cast<const char* (WINAPI*)()>(GetProcAddress(module, "wine_get_version"));
+        const auto wine_get_version = (const char* (WINAPI*)()) (void*) GetProcAddress(module, "wine_get_version");
         if (wine_get_version) {
             return wine_get_version();
         }

--- a/src/kfx/platform/PlatformWindows.cpp
+++ b/src/kfx/platform/PlatformWindows.cpp
@@ -30,7 +30,7 @@ const char* PlatformWindows::GetWineVersion() const
 {
     const auto module = GetModuleHandle("ntdll.dll");
     if (module) {
-        const auto wine_get_version = (const char* (WINAPI*)()) (void*) GetProcAddress(module, "wine_get_version");
+        const auto wine_get_version = reinterpret_cast<const char* (WINAPI*)()>(GetProcAddress(module, "wine_get_version"));
         if (wine_get_version) {
             return wine_get_version();
         }

--- a/src/kfx/platform/PlatformWindows.h
+++ b/src/kfx/platform/PlatformWindows.h
@@ -6,6 +6,11 @@
 /** Windows desktop platform. */
 class PlatformWindows : public IPlatform {
 public:
+    const char* GetOSVersion() const override;
+    const void* GetImageBase() const override;
+    const char* GetWineVersion() const override;
+    const char* GetWineHost() const override;
+
     bool VideoInit() override;
 };
 

--- a/src/linux.cpp
+++ b/src/linux.cpp
@@ -15,25 +15,6 @@
 #include <unistd.h>
 #include <fnmatch.h>
 
-extern "C" const char * get_os_version() {
-    return "Linux";
-}
-
-extern "C" const void * get_image_base()
-{
-    return nullptr;
-}
-
-extern "C" const char * get_wine_version()
-{
-    return nullptr; // we're running native
-}
-
-extern "C" const char * get_wine_host()
-{
-    return nullptr; // we're running native
-}
-
 extern "C" void install_exception_handler()
 {
 	LbErrorParachuteInstall();

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -16,56 +16,6 @@
 #include <vector>
 #include "post_inc.h"
 
-extern "C" const char * get_os_version()
-{
-    static char buffer[256];
-    OSVERSIONINFO v;
-    v.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-    if (GetVersionEx(&v)) {
-        snprintf(buffer, sizeof(buffer), "%s %ld.%ld.%ld",
-            (v.dwPlatformId == VER_PLATFORM_WIN32_NT) ? "Windows NT" : "Windows",
-            v.dwMajorVersion, v.dwMinorVersion, v.dwBuildNumber);
-        return buffer;
-    } else {
-        return "unknown";
-    }
-}
-
-extern "C" const void * get_image_base()
-{
-    return GetModuleHandle(NULL);
-}
-
-
-extern "C" const char * get_wine_version()
-{
-    const auto module = GetModuleHandle("ntdll.dll");
-    if (module) {
-        const auto wine_get_version = (const char * (WINAPI *)()) (void *) GetProcAddress(module, "wine_get_version");
-        if (wine_get_version) {
-            return wine_get_version();
-        }
-    }
-    return nullptr;
-}
-
-extern "C" const char * get_wine_host()
-{
-    const auto module = GetModuleHandle("ntdll.dll");
-    static char buffer[256];
-    if (module) {
-        const auto wine_get_host_version = (void (WINAPI *)(const char **, const char **)) (void *) GetProcAddress(module, "wine_get_host_version");
-        if (wine_get_host_version) {
-            const char * sys_name = nullptr;
-            const char * release_name = nullptr;
-            wine_get_host_version(&sys_name, &release_name);
-            snprintf(buffer, sizeof(buffer), "%s %s", sys_name ? sys_name : "unknown", release_name ? release_name : "unknown");
-            return buffer;
-        }
-    }
-    return nullptr;
-}
-
 const char * exception_name(DWORD exception_code)
 {
     switch (exception_code) {


### PR DESCRIPTION
Part of the abstraction layer, this one is for OS info, it eventually deletes windows.cpp and linux.cpp