### PR TITLE
Fix side menus becoming hidden and unclickable

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -935,10 +935,6 @@ static TbBool get_level_lost_inputs(void)
           if (network_is_active()
             || (lbDisplay.PhysicalScreenWidth > 320))
           {
-                if (toggle_status_menu(0))
-                  set_flag(game.operation_flags, GOF_ShowPanel);
-                else
-                  clear_flag(game.operation_flags, GOF_ShowPanel);
                 set_players_packet_action(player, PckA_SaveViewType, PVT_MapScreen, 0,0,0);
           } else
           {

--- a/src/gui_parchment.c
+++ b/src/gui_parchment.c
@@ -1194,8 +1194,6 @@ void zoom_to_parchment_map(void)
     if (network_is_active()
         || (lbDisplay.PhysicalScreenWidth > 320))
     {
-      if (!toggle_status_menu(0))
-        clear_flag(game.operation_flags, GOF_ShowPanel);
       set_players_packet_action(player, PckA_SaveViewType, PVT_MapScreen, 0, 0, 0);
       turn_off_roaming_menus();
     } else

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -490,6 +490,9 @@ void set_player_mode(struct PlayerInfo *player, unsigned short nview)
       setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
       break;
   case PVT_MapScreen:
+      if (is_my_player(player)) {
+        toggle_status_menu(0);
+      }
       player->continue_work_state = player->work_state;
       set_engine_view(player, PVM_ParchmentView);
       break;


### PR DESCRIPTION
Inputs were creating a race condition when opening the parchment map, mostly in multiplayer but possibly also in singleplayer, which broke things.