### PR TITLE
Fix camera jumping bug + smoother middle-mouse rotation

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1242,9 +1242,11 @@ static TbBool get_dungeon_control_pausable_action_inputs(void)
       // Middle mouse camera actions for IsometricView
       if (is_game_key_pressed(Gkey_SnapCamera, true, true))
       {
-          struct Camera* cam = get_local_camera(&player->cameras[CamIV_Isometric]);
           struct Packet* pckt = get_packet(my_player_number);
-          int angle = cam->rotation_angle_x;
+          int angle = destination_local_cameras[CamIV_Isometric].rotation_angle_x;
+          if (local_camera_snap_target >= 0) {
+              angle = local_camera_snap_target;
+          }
           if (key_modifiers & KMod_CONTROL)
           {
               if ((angle >= ANGLE_NORTH && angle < ANGLE_NORTHEAST) || angle == DEGREES_360)
@@ -1328,9 +1330,11 @@ static TbBool get_dungeon_control_pausable_action_inputs(void)
       // Middle mouse camera actions for FrontView
       if (is_game_key_pressed(Gkey_SnapCamera, true, true))
       {
-          struct Camera* cam = get_local_camera(&player->cameras[CamIV_FrontView]);
           struct Packet* pckt = get_packet(my_player_number);
-          int angle = cam->rotation_angle_x;
+          int angle = destination_local_cameras[CamIV_FrontView].rotation_angle_x;
+          if (local_camera_snap_target >= 0) {
+              angle = local_camera_snap_target;
+          }
           if (key_modifiers & KMod_CONTROL)
           {
               set_packet_control(pckt, PCtr_ViewRotateCW);

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1242,7 +1242,7 @@ static TbBool get_dungeon_control_pausable_action_inputs(void)
       // Middle mouse camera actions for IsometricView
       if (is_game_key_pressed(Gkey_SnapCamera, true, true))
       {
-          struct Camera* cam = &player->cameras[CamIV_Isometric];
+          struct Camera* cam = get_local_camera(&player->cameras[CamIV_Isometric]);
           struct Packet* pckt = get_packet(my_player_number);
           int angle = cam->rotation_angle_x;
           if (key_modifiers & KMod_CONTROL)
@@ -1328,7 +1328,7 @@ static TbBool get_dungeon_control_pausable_action_inputs(void)
       // Middle mouse camera actions for FrontView
       if (is_game_key_pressed(Gkey_SnapCamera, true, true))
       {
-          struct Camera* cam = &player->cameras[CamIV_FrontView];
+          struct Camera* cam = get_local_camera(&player->cameras[CamIV_FrontView]);
           struct Packet* pckt = get_packet(my_player_number);
           int angle = cam->rotation_angle_x;
           if (key_modifiers & KMod_CONTROL)

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -39,7 +39,7 @@
 extern "C" {
 #endif
 /******************************************************************************/
-#define CAMERA_180_SPEED 0.4f
+#define CAMERA_SNAPPING_SPEED 0.4f
 
 struct Camera local_cameras[4];
 struct Camera previous_local_cameras[4];
@@ -52,7 +52,7 @@ TbBool local_camera_ready;
 static MapCoord local_camera_move_target[2];
 static MapCoordDelta local_camera_move_delta[2];
 static TbBool local_camera_move_active;
-static int32_t local_camera_180_target = -1;
+int32_t local_camera_snap_target = -1;
 /******************************************************************************/
 
 static const struct Packet* get_packet_for_local_camera_update(void)
@@ -150,7 +150,7 @@ void init_local_cameras(struct PlayerInfo *player)
         sync_camera_state(i, &player->cameras[i]);
     }
     local_camera_move_active = false;
-    local_camera_180_target = -1;
+    local_camera_snap_target = -1;
     local_camera_ready = true;
 }
 
@@ -223,22 +223,22 @@ void update_camera_deviations(int active_cam_idx)
     }
 }
 
-static void update_local_camera_180(struct Camera *cam, const struct Packet *packet)
+static void update_local_camera_snap(struct Camera *cam, const struct Packet *packet)
 {
     if (packet->action == PckA_SetMapRotation) {
-        local_camera_180_target = packet->actn_par1 & ANGLE_MASK;
+        local_camera_snap_target = packet->actn_par1 & ANGLE_MASK;
         cam->inertia_rotation = 0;
     } else if (packet->control_flags & (PCtr_ViewRotateCW | PCtr_ViewRotateCCW)) {
-        local_camera_180_target = -1;
+        local_camera_snap_target = -1;
     }
-    if (local_camera_180_target >= 0) {
-        int angle = lroundf(lerp_angle(cam->rotation_angle_x, local_camera_180_target, CAMERA_180_SPEED)) & ANGLE_MASK;
+    if (local_camera_snap_target >= 0) {
+        int angle = lroundf(lerp_angle(cam->rotation_angle_x, local_camera_snap_target, CAMERA_SNAPPING_SPEED)) & ANGLE_MASK;
         if (angle == cam->rotation_angle_x) {
-            angle = local_camera_180_target;
+            angle = local_camera_snap_target;
         }
         cam->rotation_angle_x = angle;
-        if (cam->rotation_angle_x == local_camera_180_target) {
-            local_camera_180_target = -1;
+        if (cam->rotation_angle_x == local_camera_snap_target) {
+            local_camera_snap_target = -1;
         }
     }
 }
@@ -270,7 +270,7 @@ void update_local_cameras(void)
         // Only process camera controls for the currently active camera view
         int active_cam_idx = (my_player->view_mode == PVM_FrontView) ? CamIV_FrontView : CamIV_Isometric;
         struct Camera *cam = &destination_local_cameras[active_cam_idx];
-        update_local_camera_180(cam, local_packet);
+        update_local_camera_snap(cam, local_packet);
         if (local_camera_move_active) {
             local_camera_move_active = !view_move_camera_to_position(cam, local_camera_move_target[0], local_camera_move_target[1], local_camera_move_delta[0], local_camera_move_delta[1]);
         } else {

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -39,6 +39,8 @@
 extern "C" {
 #endif
 /******************************************************************************/
+#define CAMERA_180_SPEED 0.4f
+
 struct Camera local_cameras[4];
 struct Camera previous_local_cameras[4];
 struct Camera destination_local_cameras[4];
@@ -50,6 +52,7 @@ TbBool local_camera_ready;
 static MapCoord local_camera_move_target[2];
 static MapCoordDelta local_camera_move_delta[2];
 static TbBool local_camera_move_active;
+static int32_t local_camera_180_target = -1;
 /******************************************************************************/
 
 static const struct Packet* get_packet_for_local_camera_update(void)
@@ -147,6 +150,7 @@ void init_local_cameras(struct PlayerInfo *player)
         sync_camera_state(i, &player->cameras[i]);
     }
     local_camera_move_active = false;
+    local_camera_180_target = -1;
     local_camera_ready = true;
 }
 
@@ -165,7 +169,8 @@ void move_local_camera_to_position(MapCoord x, MapCoord y)
     local_camera_move_active = true;
 }
 
-void process_local_minimap_click(const struct Packet* packet) {
+static void process_local_minimap_click(const struct Packet *packet)
+{
     if (packet != NULL && packet->action == PckA_BookmarkLoad) {
         const MapCoord pos_x = packet->actn_par1;
         const MapCoord pos_y = packet->actn_par2;
@@ -218,6 +223,26 @@ void update_camera_deviations(int active_cam_idx)
     }
 }
 
+static void update_local_camera_180(struct Camera *cam, const struct Packet *packet)
+{
+    if (packet->action == PckA_SetMapRotation) {
+        local_camera_180_target = packet->actn_par1 & ANGLE_MASK;
+        cam->inertia_rotation = 0;
+    } else if (packet->control_flags & (PCtr_ViewRotateCW | PCtr_ViewRotateCCW)) {
+        local_camera_180_target = -1;
+    }
+    if (local_camera_180_target >= 0) {
+        int angle = lroundf(lerp_angle(cam->rotation_angle_x, local_camera_180_target, CAMERA_180_SPEED)) & ANGLE_MASK;
+        if (angle == cam->rotation_angle_x) {
+            angle = local_camera_180_target;
+        }
+        cam->rotation_angle_x = angle;
+        if (cam->rotation_angle_x == local_camera_180_target) {
+            local_camera_180_target = -1;
+        }
+    }
+}
+
 void update_local_cameras(void)
 {
     for (int i = 0; i < 4; i++) {
@@ -245,6 +270,7 @@ void update_local_cameras(void)
         // Only process camera controls for the currently active camera view
         int active_cam_idx = (my_player->view_mode == PVM_FrontView) ? CamIV_FrontView : CamIV_Isometric;
         struct Camera *cam = &destination_local_cameras[active_cam_idx];
+        update_local_camera_180(cam, local_packet);
         if (local_camera_move_active) {
             local_camera_move_active = !view_move_camera_to_position(cam, local_camera_move_target[0], local_camera_move_target[1], local_camera_move_delta[0], local_camera_move_delta[1]);
         } else {

--- a/src/local_camera.h
+++ b/src/local_camera.h
@@ -36,6 +36,7 @@ struct PlayerInfo;
 extern struct Camera local_cameras[4];
 extern struct Camera previous_local_cameras[4];
 extern struct Camera destination_local_cameras[4];
+extern int32_t local_camera_snap_target;
 extern TbBool local_camera_ready;
 /******************************************************************************/
 void init_local_cameras(struct PlayerInfo *player);

--- a/src/packets.c
+++ b/src/packets.c
@@ -742,7 +742,6 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       player->cameras[CamIV_Parchment].rotation_angle_x = pckt->actn_par1;
       player->cameras[CamIV_FrontView].rotation_angle_x = pckt->actn_par1;
       player->cameras[CamIV_Isometric].rotation_angle_x = pckt->actn_par1;
-      set_local_camera_destination(player);
       return 0;
   case PckA_SetPlyrState:
       set_player_state(player, pckt->actn_par1, pckt->actn_par2);


### PR DESCRIPTION
Fixes #5113

I had to add more explicit code for the smooth rotation when pressing middle-mouse-button to continue working. I've also slowed it down a little to make it feel more like an intentional effect.