### PR TITLE
Fix Things not flashing red on taking damage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ crash_log.txt
 debug.log
 .local/
 .vscode/compile_and_copy_files.ps1
+/keeperfx_vs2010

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -4992,7 +4992,7 @@ static void draw_fastview_mapwho(struct Camera *cam, struct BucketKindJontySprit
             lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
             lbSpriteReMapPtr = white_pal;
         } else {
-            if ((thing->rendering_flags & TRF_BeingHit) != 0)
+            if (thing->last_turn_damaged == game.play_gameturn)
             {
                 lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
                 lbSpriteReMapPtr = red_pal;
@@ -8045,7 +8045,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
               }
           }
         } else {
-            if ((thing->rendering_flags & TRF_BeingHit) != 0)
+            if (thing->last_turn_damaged == game.play_gameturn)
             {
                 lbDisplay.DrawFlags |= Lb_SPRITE_REMAP;
                 lbSpriteReMapPtr = red_pal;

--- a/src/thing_data.h
+++ b/src/thing_data.h
@@ -83,7 +83,6 @@ enum ThingRenderingFlags {
     TRF_Transpar_Flags = 0x30,
 
     TRF_AnimateOnce    = 0x40,
-    TRF_BeingHit       = 0x80,    // Being hit (draw red sometimes)
 };
 
  /**
@@ -301,7 +300,8 @@ struct Thing {
     short next_of_class;
     short prev_of_class;
     uint32_t flags; //ThingAddFlags
-    int32_t last_turn_drawn;
+    GameTurn last_turn_drawn;
+    GameTurn last_turn_damaged;
     unsigned short previous_floor_height;
     struct Coord3d previous_mappos;
     uint32_t random_seed;

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -100,9 +100,6 @@ static void update_thing_interpolation(struct Thing *thing)
     thing->previous_mappos = thing->mappos;
     thing->previous_floor_height = thing->floor_height;
 
-    // Originally cleared by the renderer after drawing one frame.
-    clear_flag(thing->rendering_flags, TRF_BeingHit);
-
     // Signal to reset interpolation on attached armour/disease particle effect.
     clear_flag(thing->state_flags, TF1_Teleported);
 }

--- a/src/thing_stats.c
+++ b/src/thing_stats.c
@@ -988,7 +988,7 @@ static HitPoints apply_damage_to_creature(struct Thing *thing, HitPoints dmg)
       cdamage = 1;
     // Apply damage to the thing.
     thing->health -= cdamage;
-    thing->rendering_flags |= TRF_BeingHit;
+    thing->last_turn_damaged = game.play_gameturn + 1;
     // Red palette if the possessed creature is hit very strong.
     if (is_thing_some_way_controlled(thing))
     {
@@ -1017,7 +1017,7 @@ static HitPoints apply_damage_to_object(struct Thing *thing, HitPoints dmg)
 {
     HitPoints cdamage = dmg;
     thing->health -= cdamage;
-    thing->rendering_flags |= TRF_BeingHit;
+    thing->last_turn_damaged = game.play_gameturn + 1;
     return cdamage;
 }
 


### PR DESCRIPTION
In #4919 I removed `float time_spent_displaying_hurt_colour` from `struct Thing`, in order to reduce mixing of interpolation logic and game logic.  I thought clearing `TRF_BeingHit` in thing_list.c would be sufficient.  But this is not reliable, as it depends on the order in which Things are processed (the flag is set by the attacking Thing).

Instead of re-introducing the floating-point variable though, I think it's simpler and cleaner to just store the GameTurn during which the red flash should be displayed.

Fixes: #5102
