### PR TITLE
Share packet-action logic between local and packet cameras

### DIFF
--- a/src/engine_camera.c
+++ b/src/engine_camera.c
@@ -729,14 +729,4 @@ void update_all_players_cameras(void)
   // Send catchup packets if local camera has drifted too far from packet-based camera
   send_camera_catchup_packets();
 }
-
-void set_player_cameras_position(struct PlayerInfo *player, int32_t pos_x, int32_t pos_y)
-{
-    player->cameras[CamIV_Parchment].mappos.x.val = pos_x;
-    player->cameras[CamIV_FrontView].mappos.x.val = pos_x;
-    player->cameras[CamIV_Isometric].mappos.x.val = pos_x;
-    player->cameras[CamIV_Parchment].mappos.y.val = pos_y;
-    player->cameras[CamIV_FrontView].mappos.y.val = pos_y;
-    player->cameras[CamIV_Isometric].mappos.y.val = pos_y;
-}
 /******************************************************************************/

--- a/src/engine_camera.h
+++ b/src/engine_camera.h
@@ -126,7 +126,6 @@ TbBool view_move_camera_to_position(struct Camera *cam, MapCoord x, MapCoord y, 
 void update_all_players_cameras(void);
 void init_player_cameras(struct PlayerInfo *player);
 void update_first_person_position(struct Camera *cam, struct Thing *thing, int eye_height);
-void set_player_cameras_position(struct PlayerInfo *player, int32_t pos_x, int32_t pos_y);
 
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -221,8 +221,9 @@ void update_local_cameras(void)
     destination_deviation_x = 0;
     destination_deviation_y = 0;
 
-    process_camera_action(destination_local_cameras, pckt);
-
+    if (pckt != NULL) {
+        process_camera_action(destination_local_cameras, pckt);
+    }
     if (player->view_mode == PVM_CreatureView && thing_exists(ctrltng)) {
         update_local_first_person_camera(ctrltng, pckt);
         return;

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -165,20 +165,7 @@ void move_local_camera_to_position(MapCoord x, MapCoord y)
     local_camera_move_active = true;
 }
 
-void process_local_minimap_click(const struct Packet* packet) {
-    if (packet != NULL && packet->action == PckA_BookmarkLoad) {
-        const MapCoord pos_x = packet->actn_par1;
-        const MapCoord pos_y = packet->actn_par2;
-        for (int i = CamIV_Isometric; i <= CamIV_FrontView; i++) {
-            if (i != CamIV_FirstPerson) {
-                destination_local_cameras[i].mappos.x.val = pos_x;
-                destination_local_cameras[i].mappos.y.val = pos_y;
-            }
-        }
-    }
-}
-
-void update_local_first_person_camera(struct Thing *ctrltng)
+static void update_local_first_person_camera(struct Thing *ctrltng, const struct Packet *pckt)
 {
     struct Camera* cam = &destination_local_cameras[CamIV_FirstPerson];
     int eye_height = get_creature_eye_height(ctrltng);
@@ -192,15 +179,14 @@ void update_local_first_person_camera(struct Thing *ctrltng)
         return;
     }
 
-    const struct Packet* latest_packet = get_packet_for_local_camera_update();
-    if (latest_packet == NULL) {
+    if (pckt == NULL) {
         return;
     }
 
     const long current_horizontal = cam->rotation_angle_x;
     const long current_vertical = cam->rotation_angle_y;
     long new_horizontal, new_vertical, new_roll;
-    process_first_person_look(ctrltng, latest_packet, current_horizontal, current_vertical, &new_horizontal, &new_vertical, &new_roll);
+    process_first_person_look(ctrltng, pckt, current_horizontal, current_vertical, &new_horizontal, &new_vertical, &new_roll);
     cam->rotation_angle_x = new_horizontal;
     cam->rotation_angle_y = new_vertical;
     if ((ctrltng->movement_flags & TMvF_Flying) != 0) {
@@ -229,31 +215,33 @@ void update_local_cameras(void)
     if (!local_camera_ready) {
         return;
     }
-    struct PlayerInfo* my_player = get_my_player();
-    struct Thing *ctrltng = thing_get(my_player->controlled_thing_idx);
+    struct PlayerInfo *player = get_my_player();
+    struct Thing *ctrltng = thing_get(player->controlled_thing_idx);
+    const struct Packet *pckt = get_packet_for_local_camera_update();
     destination_deviation_x = 0;
     destination_deviation_y = 0;
-    TbBool in_first_person = ( (thing_exists(ctrltng)) && (my_player->view_mode == PVM_CreatureView) );
-    if (in_first_person) {
-        update_local_first_person_camera(ctrltng);
-    } else {
-        const struct Packet* local_packet = get_packet_for_local_camera_update();
-        if (local_packet == NULL) {
-            return;
-        }
-        process_local_minimap_click(local_packet);
-        // Only process camera controls for the currently active camera view
-        int active_cam_idx = (my_player->view_mode == PVM_FrontView) ? CamIV_FrontView : CamIV_Isometric;
-        struct Camera *cam = &destination_local_cameras[active_cam_idx];
-        if (local_camera_move_active) {
-            local_camera_move_active = !view_move_camera_to_position(cam, local_camera_move_target[0], local_camera_move_target[1], local_camera_move_delta[0], local_camera_move_delta[1]);
-        } else {
-            process_camera_controls(cam, local_packet, my_player, true);
-            view_process_camera_inertia(cam);
-        }
 
-        update_camera_deviations(active_cam_idx);
+    process_camera_action(destination_local_cameras, pckt);
+
+    if (player->view_mode == PVM_CreatureView && thing_exists(ctrltng)) {
+        update_local_first_person_camera(ctrltng, pckt);
+        return;
     }
+    if (pckt == NULL) {
+        return;
+    }
+
+    // Only process camera controls for the currently active camera view
+    int active_cam_idx = (player->view_mode == PVM_FrontView) ? CamIV_FrontView : CamIV_Isometric;
+    struct Camera *cam = &destination_local_cameras[active_cam_idx];
+    if (local_camera_move_active) {
+        local_camera_move_active = !view_move_camera_to_position(cam, local_camera_move_target[0], local_camera_move_target[1], local_camera_move_delta[0], local_camera_move_delta[1]);
+    } else {
+        process_camera_controls(cam, pckt, player, true);
+        view_process_camera_inertia(cam);
+    }
+
+    update_camera_deviations(active_cam_idx);
 }
 
 void interpolate_camera_deviations(void)

--- a/src/packets.c
+++ b/src/packets.c
@@ -594,6 +594,42 @@ void process_players_dungeon_control_packet_control(long plyr_idx)
     update_mouse_light(player);
 }
 
+static void set_all_cameras_position(struct Camera cams[], int32_t pos_x, int32_t pos_y)
+{
+    cams[CamIV_Parchment].mappos.x.val = pos_x;
+    cams[CamIV_FrontView].mappos.x.val = pos_x;
+    cams[CamIV_Isometric].mappos.x.val = pos_x;
+    cams[CamIV_Parchment].mappos.y.val = pos_y;
+    cams[CamIV_FrontView].mappos.y.val = pos_y;
+    cams[CamIV_Isometric].mappos.y.val = pos_y;
+}
+
+static void set_all_cameras_rotation(struct Camera cams[], int32_t angle)
+{
+    cams[CamIV_Parchment].rotation_angle_x = angle;
+    cams[CamIV_FrontView].rotation_angle_x = angle;
+    cams[CamIV_Isometric].rotation_angle_x = angle;
+}
+
+void process_camera_action(struct Camera cams[], const struct Packet *pckt)
+{
+    switch (pckt->action)
+    {
+    case PckA_BookmarkLoad:
+        set_all_cameras_position(cams, pckt->actn_par1, pckt->actn_par2);
+        break;
+
+    case PckA_SetMapRotation:
+        set_all_cameras_rotation(cams, pckt->actn_par1);
+        break;
+
+    case PckA_ZoomFromMap:
+        set_all_cameras_position(cams, subtile_coord_center(pckt->actn_par1), subtile_coord_center(pckt->actn_par2));
+        set_all_cameras_rotation(cams, 0);
+        break;
+    }
+}
+
 TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
 {
   //TODO PACKET add commands from beta
@@ -603,6 +639,9 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
   struct Dungeon *dungeon;
   struct Thing *thing;
   int i;
+
+  process_camera_action(player->cameras, pckt);
+
   switch (pckt->action)
   {
   case PckA_QuitToMainMenu:
@@ -720,9 +759,6 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         centre_engine_window();
       }
       return 0;
-  case PckA_BookmarkLoad:
-      set_player_cameras_position(player, pckt->actn_par1, pckt->actn_par2);
-      return 0;
   case PckA_SetGammaLevel:
       if (is_my_player(player))
       {
@@ -737,12 +773,6 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         settings.minimap_zoom = player->minimap_zoom;
         save_settings();
       }
-      return 0;
-  case PckA_SetMapRotation:
-      player->cameras[CamIV_Parchment].rotation_angle_x = pckt->actn_par1;
-      player->cameras[CamIV_FrontView].rotation_angle_x = pckt->actn_par1;
-      player->cameras[CamIV_Isometric].rotation_angle_x = pckt->actn_par1;
-      set_local_camera_destination(player);
       return 0;
   case PckA_SetPlyrState:
       set_player_state(player, pckt->actn_par1, pckt->actn_par2);
@@ -771,10 +801,6 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       set_player_mode(player, pckt->actn_par1);
       return 0;
   case PckA_ZoomFromMap:
-      set_player_cameras_position(player, subtile_coord_center(pckt->actn_par1), subtile_coord_center(pckt->actn_par2));
-      player->cameras[CamIV_Parchment].rotation_angle_x = 0;
-      player->cameras[CamIV_FrontView].rotation_angle_x = 0;
-      player->cameras[CamIV_Isometric].rotation_angle_x = 0;
       if (network_is_active()
           || (lbDisplay.PhysicalScreenWidth > 320))
       {

--- a/src/packets.h
+++ b/src/packets.h
@@ -342,6 +342,7 @@ void process_players_creature_control_packet_action(long idx);
 void process_map_packet_clicks(long idx);
 void process_pause_packet(long a1, long a2);
 void process_camera_controls(struct Camera* cam, const struct Packet* pckt, struct PlayerInfo* player, TbBool is_local_camera);
+void process_camera_action(struct Camera cams[], const struct Packet* pckt);
 void process_first_person_look(struct Thing *thing, const struct Packet *pckt, long current_horizontal, long current_vertical, long *out_horizontal, long *out_vertical, long *out_roll);
 TbBool can_process_creature_input(struct Thing *thing);
 void exchange_packets(void);


### PR DESCRIPTION
Simpler alternative to #5117.

I'm not even sure if it is necessary to update all cameras at the same time, I think they already get synced somewhere else.  But let's not introduce too many changes at once.
