### PR TITLE
Fix distorted icons in the in-game panel and possession view

### DIFF
--- a/src/frontmenu_ingame_evnt_data.cpp
+++ b/src/frontmenu_ingame_evnt_data.cpp
@@ -69,7 +69,7 @@ struct GuiButtonInit battle_buttons[] = {
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, gui_get_creature_in_battle,gui_go_to_person_in_battle,gui_setup_enemy_over, 1,260,42,260,42,160,24,gui_area_enemy_battlers,     0,GUIStr_Empty,        0,       {0},            0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, gui_get_creature_in_battle,gui_go_to_person_in_battle,gui_setup_friend_over,2, 42,72, 42,72,160,24,gui_area_friendly_battlers,  0,GUIStr_Empty,        0,       {0},            0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, gui_get_creature_in_battle,gui_go_to_person_in_battle,gui_setup_enemy_over, 2,260,72,260,72,160,24,gui_area_enemy_battlers,     0,GUIStr_Empty,        0,       {0},            0, NULL },
-  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0, 214,  34, 214,  34, 32, 32,                gui_area_null, GBS_guisymbols_sym_fight,GUIStr_Empty,        0,       {0},            0, NULL },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0, 214,  34, 214,  34, 29, 24,                gui_area_null, GBS_guisymbols_sym_fight,GUIStr_Empty,        0,       {0},            0, NULL },
   {-1,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   0,   0,   0,   0,  0,  0,                NULL,                        0,   0,                0,       {0},            0, NULL },
 };
 

--- a/src/frontmenu_ingame_opts_data.cpp
+++ b/src/frontmenu_ingame_opts_data.cpp
@@ -85,10 +85,10 @@ struct GuiButtonInit pause_buttons[] = {
 
 struct GuiButtonInit autopilot_menu_buttons[] = {
   {LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0, 999,  10, 999,  10,155, 32, gui_area_text,                     1, GUIStr_MnuComputer,      0,       {0},            0, NULL },
-  {LbBtnT_RadioBtn,   BID_DEFAULT, 0, 0, gui_set_autopilot,  NULL,        NULL,               0,  12,  36,  12,  36, 46, 64, gui_area_new_normal_button, GPS_options_cassist_btn_orange, GUIStr_AggressiveAssistDesc,  0,{.ptr = &game.comp_player_aggressive},  0, maintain_compsetting_button },
-  {LbBtnT_RadioBtn,   BID_DEFAULT, 0, 0, gui_set_autopilot,  NULL,        NULL,               1,  60,  36,  60,  36, 46, 64, gui_area_new_normal_button, GPS_options_cassist_btn_yellow, GUIStr_DefensiveAssistDesc,   0,{.ptr = &game.comp_player_defensive},   0, maintain_compsetting_button },
-  {LbBtnT_RadioBtn,   BID_DEFAULT, 0, 0, gui_set_autopilot,  NULL,        NULL,               2, 108,  36, 108,  36, 46, 64, gui_area_new_normal_button, GPS_options_cassist_btn_pink,   GUIStr_ConstructionAssistDesc,0,{.ptr = &game.comp_player_construct},   0, maintain_compsetting_button },
-  {LbBtnT_RadioBtn,   BID_DEFAULT, 0, 0, gui_set_autopilot,  NULL,        NULL,               3, 156,  36, 156,  36, 46, 64, gui_area_new_normal_button, GPS_options_cassist_btn_green,  GUIStr_MoveOnlyAssistDesc,    0,{.ptr = &game.comp_player_creatrsonly}, 0, maintain_compsetting_button },
+  {LbBtnT_RadioBtn,   BID_DEFAULT, 0, 0, gui_set_autopilot,  NULL,        NULL,               0,  12,  36,  12,  36, 46, 64, gui_area_new_vertical_button, GPS_options_cassist_btn_orange, GUIStr_AggressiveAssistDesc,  0,{.ptr = &game.comp_player_aggressive},  0, maintain_compsetting_button },
+  {LbBtnT_RadioBtn,   BID_DEFAULT, 0, 0, gui_set_autopilot,  NULL,        NULL,               1,  60,  36,  60,  36, 46, 64, gui_area_new_vertical_button, GPS_options_cassist_btn_yellow, GUIStr_DefensiveAssistDesc,   0,{.ptr = &game.comp_player_defensive},   0, maintain_compsetting_button },
+  {LbBtnT_RadioBtn,   BID_DEFAULT, 0, 0, gui_set_autopilot,  NULL,        NULL,               2, 108,  36, 108,  36, 46, 64, gui_area_new_vertical_button, GPS_options_cassist_btn_pink,   GUIStr_ConstructionAssistDesc,0,{.ptr = &game.comp_player_construct},   0, maintain_compsetting_button },
+  {LbBtnT_RadioBtn,   BID_DEFAULT, 0, 0, gui_set_autopilot,  NULL,        NULL,               3, 156,  36, 156,  36, 46, 64, gui_area_new_vertical_button, GPS_options_cassist_btn_green,  GUIStr_MoveOnlyAssistDesc,    0,{.ptr = &game.comp_player_creatrsonly}, 0, maintain_compsetting_button },
   {              -1,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   0,   0,   0,   0,  0,  0, NULL,                              0,   0,                     0,       {0},            0, NULL },
 };
 

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1875,7 +1875,7 @@ void gui_area_instance_button(struct GuiButton *gbtn)
 {
     struct PlayerInfo* player = get_my_player();
     int units_per_px = (gbtn->width * 16 + 60 / 2) / 60;
-    int ps_units_per_px = simple_gui_panel_sprite_width_units_per_px(gbtn, GPS_rpanel_bar_with_pic_full_blue_down, 100);
+    int ps_units_per_px = simple_gui_panel_sprite_height_units_per_px(gbtn, GPS_rpanel_bar_with_pic_full_blue_down, 100);
     struct Thing* ctrltng = thing_get(player->controlled_thing_idx);
     TRACE_THING(ctrltng);
     if (!thing_is_creature(ctrltng))

--- a/src/frontmenu_ingame_tabs_data.cpp
+++ b/src/frontmenu_ingame_tabs_data.cpp
@@ -314,9 +314,9 @@ struct GuiButtonInit trap_menu2_buttons[] = {
 };
 
 struct GuiButtonInit creature_menu_buttons[] = {
-  {LbBtnT_NormalBtn,BID_CRTR_NXWNDR, 0, 0, pick_up_next_wanderer,gui_go_to_next_wanderer    ,NULL,  0,  26, 192,  26, 192, 38, 24, gui_area_new_normal_button, GPS_rpanel_tab_crtr_wandr_act, GUIStr_CreatureIdleDesc,       0,       {0},            0, NULL },
-  {LbBtnT_NormalBtn,BID_CRTR_NXWRKR, 0, 0, pick_up_next_worker,gui_go_to_next_worker        ,NULL,  0,  62, 192,  62, 192, 38, 24, gui_area_new_normal_button, GPS_rpanel_tab_crtr_work_act, GUIStr_CreatureWorkingDesc,    0,       {0},            0, NULL },
-  {LbBtnT_NormalBtn,BID_CRTR_NXFIGT, 0, 0, pick_up_next_fighter,gui_go_to_next_fighter      ,NULL,  0,  98, 192,  98, 192, 38, 24, gui_area_new_normal_button, GPS_rpanel_tab_crtr_fight_act, GUIStr_CreatureFightingDesc,   0,       {0},            0, NULL },
+  {LbBtnT_NormalBtn,BID_CRTR_NXWNDR, 0, 0, pick_up_next_wanderer,gui_go_to_next_wanderer    ,NULL,  0,  26, 192,  26, 192, 36, 24, gui_area_new_normal_button, GPS_rpanel_tab_crtr_wandr_act, GUIStr_CreatureIdleDesc,       0,       {0},            0, NULL },
+  {LbBtnT_NormalBtn,BID_CRTR_NXWRKR, 0, 0, pick_up_next_worker,gui_go_to_next_worker        ,NULL,  0,  62, 192,  62, 192, 36, 24, gui_area_new_normal_button, GPS_rpanel_tab_crtr_work_act, GUIStr_CreatureWorkingDesc,    0,       {0},            0, NULL },
+  {LbBtnT_NormalBtn,BID_CRTR_NXFIGT, 0, 0, pick_up_next_fighter,gui_go_to_next_fighter      ,NULL,  0,  98, 192,  98, 192, 36, 24, gui_area_new_normal_button, GPS_rpanel_tab_crtr_fight_act, GUIStr_CreatureFightingDesc,   0,       {0},            0, NULL },
   {LbBtnT_HoldableBtn,  BID_DEFAULT, 0, 0, gui_scroll_activity_up,gui_scroll_activity_up    ,NULL,  0,   4, 192,   4, 192, 22, 24, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_up_act, GUIStr_Empty,                  0,       {0},            0, maintain_activity_up },
   {LbBtnT_HoldableBtn,  BID_DEFAULT, 0, 0, gui_scroll_activity_down,gui_scroll_activity_down,NULL,  0,   4, 364,   4, 364, 22, 24, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_down_act, GUIStr_Empty,                  0,       {0},            0, maintain_activity_down },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, pick_up_next_creature,gui_go_to_next_creature,gui_over_creature_button,  0,   0, 196,   0, 218, 22, 22, gui_area_creatrmodel_button,            0, GUIStr_PickCreatrMostExpDesc,  0,       {0},            0, maintain_activity_pic },


### PR DESCRIPTION
Several icons in the in-game GUI were drawn stretched because the button box didn't match the real sprite dimensions or the scale was measured on the wrong axis. All are rendered 1:1 now.

- **Creature panel (Idle/Working/Fighting icons):** button box was 38px wide, sprite is 36px → drew a duplicated row.
- **Battle "swords" icon:** button box was 32x32, sprite is 29x24 → stretched both axes.
- **Autopilot assist buttons:** scale was derived from the button's width instead of height → sprite squashed vertically.
- **Instance/spell bars (possession panel):** same wrong-axis issue as autopilot → sprite cropped.