### PR TITLE
Multiplayer: improve lobby status reporting

### DIFF
--- a/src/net_game.c
+++ b/src/net_game.c
@@ -327,12 +327,21 @@ TbBool init_players_network_game(void)
         initialized = false;
         break;
     }
-    if (netstate.my_id == SERVER_ID && frontnet_service_selected(FrontendNetSvc_Online)) {
-        matchmaking_close_lobby();
-    }
     if (initialized) {
         build_local_startup_sync();
         initialized = net_startup_sync_exchange_and_apply();
+    }
+    if (initialized && netstate.my_id == SERVER_ID && frontnet_service_selected(FrontendNetSvc_Online)) {
+        LevelNumber map_number = get_level_number();
+        struct LevelInformation *level_info = get_level_info(map_number);
+        const char *map_name = "";
+        if (level_info) {
+            map_name = level_info->name;
+            if (level_info->name_stridx > 0) {
+                map_name = get_string(level_info->name_stridx);
+            }
+        }
+        matchmaking_finish_lobby(MMLobbyResult_Started, (int)map_number, map_name);
     }
     if (!initialized) {
         LbNetwork_Stop();

--- a/src/net_matchmaking.c
+++ b/src/net_matchmaking.c
@@ -31,15 +31,14 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "net_game.h"
 #include "post_inc.h"
 
-#define STR_(x) #x
-#define STR(x) STR_(x)
-#define MATCHMAKING_VERSION STR(VER_MAJOR) "." STR(VER_MINOR) "." STR(VER_RELEASE)
+#define MATCHMAKING_VERSION VER_STRING
 
 #define WEBSOCKET_BUFFER_SIZE         8192
 #define WEBSOCKET_RECEIVE_TIMEOUT_MS  3000
-#define SEND_BUFFER_SIZE              512
+#define SEND_BUFFER_SIZE              1024
 #define CONNECT_TIMEOUT_MS            5000
 #define JSON_KEY_PATTERN_SIZE         128
 
@@ -58,6 +57,21 @@ struct TbNetworkSessionNameEntry matchmaking_sessions[MATCHMAKING_SESSIONS_MAX];
 int matchmaking_session_count = 0;
 
 static void matchmaking_init(void);
+
+static void json_escape(char *output, size_t output_size, const char *input)
+{
+    size_t output_position = 0;
+    for (size_t input_position = 0; input[input_position] && output_position < output_size - 1; input_position++) {
+        if (input[input_position] == '"' || input[input_position] == '\\') {
+            if (output_position >= output_size - 2) {
+                break;
+            }
+            output[output_position++] = '\\';
+        }
+        output[output_position++] = input[input_position];
+    }
+    output[output_position] = '\0';
+}
 
 static size_t write_to_buffer(char *data, size_t element_size, size_t element_count, void *userdata)
 {
@@ -174,14 +188,24 @@ static void websocket_cleanup(void)
 
 static int websocket_send(const char *request)
 {
-    size_t bytes_sent = 0;
-    CURLcode curl_result = curl_ws_send(curl_handle, request, strlen(request), &bytes_sent, 0, CURLWS_TEXT);
-    if (curl_result != CURLE_OK) {
-        LbNetLog("Matchmaking: websocket_send failed (%s)\n", curl_easy_strerror(curl_result));
-        websocket_cleanup();
-        return -1;
+    size_t remaining = strlen(request);
+    Uint32 timeout_deadline = (Uint32)SDL_GetTicks() + CONNECT_TIMEOUT_MS;
+    CURLcode curl_result = CURLE_OK;
+    while (remaining && (curl_result == CURLE_OK || curl_result == CURLE_AGAIN) && (int)(timeout_deadline - (Uint32)SDL_GetTicks()) > 0) {
+        size_t bytes_sent = 0;
+        curl_result = curl_ws_send(curl_handle, request, remaining, &bytes_sent, 0, CURLWS_TEXT);
+        request += bytes_sent;
+        remaining -= bytes_sent;
+        if (curl_result == CURLE_AGAIN || !bytes_sent)
+            SDL_Delay(1);
     }
-    return 0;
+    if (!remaining && curl_result == CURLE_OK)
+        return 0;
+    if (remaining && (curl_result == CURLE_OK || curl_result == CURLE_AGAIN))
+        curl_result = CURLE_OPERATION_TIMEDOUT;
+    LbNetLog("Matchmaking: websocket_send failed (%s)\n", curl_easy_strerror(curl_result));
+    websocket_cleanup();
+    return -1;
 }
 
 static int websocket_receive(char *response_buffer, size_t buffer_size, int timeout_ms)
@@ -379,7 +403,7 @@ void matchmaking_disconnect(void)
         SDL_Delay(10);
     }
     wait_for_public_ip_resolution();
-    matchmaking_close_lobby();
+    matchmaking_finish_lobby(MMLobbyResult_Closed, 0, "");
     SDL_LockMutex(mutex);
     connect_gave_up = 0;
     SDL_SetAtomicInt(&ips_resolved, 0);
@@ -390,7 +414,7 @@ void matchmaking_disconnect(void)
     SDL_UnlockMutex(mutex);
 }
 
-void matchmaking_close_lobby(void)
+void matchmaking_finish_lobby(enum MatchmakingLobbyResult result, int map_number, const char *map_name)
 {
     if (mutex == NULL) {
         return;
@@ -399,9 +423,25 @@ void matchmaking_close_lobby(void)
     connect_gave_up = 1;
     if (curl_handle) {
         if (hosted_lobby_id[0] != '\0') {
-            char delete_message[SEND_BUFFER_SIZE];
-            snprintf(delete_message, sizeof(delete_message), "{\"action\":\"delete\",\"id\":\"%s\"}", hosted_lobby_id);
-            websocket_send(delete_message);
+            char message[SEND_BUFFER_SIZE];
+            int write_position = snprintf(message, sizeof(message), "{\"action\":\"cancel\",\"id\":\"%s\"}", hosted_lobby_id);
+            if (result == MMLobbyResult_Started) {
+                char escaped_map_name[LINEMSG_SIZE * 2 + 1];
+                json_escape(escaped_map_name, sizeof(escaped_map_name), map_name);
+                write_position = snprintf(message, sizeof(message), "{\"action\":\"game_started\",\"id\":\"%s\",\"mapNumber\":%d,\"mapName\":\"%s\",\"players\":[", hosted_lobby_id, map_number, escaped_map_name);
+                const char *separator = "";
+                for (int i = 0; i < MAX_NET_USERS; i++) {
+                    if (!network_player_active(i)) {
+                        continue;
+                    }
+                    char escaped_name[NETSP_PLAYER_NAME_MAX_LEN * 2 + 1];
+                    json_escape(escaped_name, sizeof(escaped_name), network_player_name(i));
+                    write_position += snprintf(message + write_position, sizeof(message) - write_position, "%s\"%s\"", separator, escaped_name);
+                    separator = ",";
+                }
+                snprintf(message + write_position, sizeof(message) - write_position, "]}");
+            }
+            websocket_send(message);
         }
         if (curl_handle) {
             websocket_cleanup();
@@ -464,15 +504,9 @@ int matchmaking_create(const char *name, int udp_ipv4_port, int udp_ipv6_port)
         SDL_UnlockMutex(mutex);
         return -1;
     }
-    int write_position = 0;
-    for (int i = 0; name[i] && write_position < (int)sizeof(escaped_lobby_name) - 2; i++) {
-        if (name[i] == '"' || name[i] == '\\')
-            escaped_lobby_name[write_position++] = '\\';
-        escaped_lobby_name[write_position++] = name[i];
-    }
-    escaped_lobby_name[write_position] = '\0';
+    json_escape(escaped_lobby_name, sizeof(escaped_lobby_name), name);
     snprintf(request_message, sizeof(request_message),
-        "{\"action\":\"create\",\"name\":\"%s\",\"ipv4Port\":%d,\"ipv6Port\":%d,\"version\":\"%s\",\"ipv4\":\"%s\",\"ipv6\":\"%s\"}",
+        "{\"action\":\"create\",\"name\":\"%s\",\"ipv4Port\":%d,\"ipv6Port\":%d,\"version\":\"%s\",\"ipv4\":\"%s\",\"ipv6\":\"%s\",\"resultActions\":true}",
         escaped_lobby_name, udp_ipv4_port, udp_ipv6_port, MATCHMAKING_VERSION,
         published_addresses.ipv4, published_addresses.ipv6);
     int bytes_received = websocket_exchange(request_message, response_buffer, sizeof(response_buffer));

--- a/src/net_matchmaking.h
+++ b/src/net_matchmaking.h
@@ -33,6 +33,11 @@ extern "C" {
 #define MATCHMAKING_NAME_MAX SESSION_NAME_MAX_LEN
 #define MATCHMAKING_SESSIONS_MAX 32
 
+enum MatchmakingLobbyResult {
+    MMLobbyResult_Closed,
+    MMLobbyResult_Started,
+};
+
 typedef struct {
     char ipv4[MATCHMAKING_IP_MAX];
     char ipv6[MATCHMAKING_IP_MAX];
@@ -48,7 +53,7 @@ void matchmaking_connect_async(void);
 int matchmaking_connect(void);
 int matchmaking_request_list(void);
 void matchmaking_disconnect(void);
-void matchmaking_close_lobby(void);
+void matchmaking_finish_lobby(enum MatchmakingLobbyResult result, int map_number, const char *map_name);
 void matchmaking_refresh_sessions(void);
 int matchmaking_create(const char *name, int udp_ipv4_port, int udp_ipv6_port);
 int matchmaking_punch(const char *lobby_id, int udp_ipv4_port, int udp_ipv6_port, PunchAddresses *output);


### PR DESCRIPTION
Mainly for discord but the code is also becoming more robust which can prevent potential bugs.

- Report the full version number to the server
- Distinguish cancelling a lobby from from starting a match
- Report the map name and player names when starting a match
- WebSocket sends are more reliable
- Fixed the timing of the lobby being closed

All while preserving server compatibility with older KeeperFX versions.