### PR TITLE
Add a previous-page arrow to the possession and passenger creature panel

### DIFF
--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1458,14 +1458,14 @@ static short get_creature_passenger_action_inputs(void)
           {
             turn_off_menu(GMnu_CREATURE_QUERY1);
             turn_on_menu(GMnu_CREATURE_QUERY2);
-            fake_button_click(0);
+            fake_button_click(BID_CRTR_NXPAGE);
             update_wheel_scrolled();
           }
           else if (wheel_scrolled_up)
           {
             turn_off_menu(GMnu_CREATURE_QUERY1);
             turn_on_menu(GMnu_CREATURE_QUERY4);
-            fake_button_click(0);
+            fake_button_click(BID_CRTR_PVPAGE);
             update_wheel_scrolled();
           }
         }
@@ -1475,14 +1475,14 @@ static short get_creature_passenger_action_inputs(void)
           {
             turn_off_menu(GMnu_CREATURE_QUERY2);
             turn_on_menu(GMnu_CREATURE_QUERY3);
-            fake_button_click(0);
+            fake_button_click(BID_CRTR_NXPAGE);
             update_wheel_scrolled();
           }
           else if (wheel_scrolled_up)
           {
             turn_off_menu(GMnu_CREATURE_QUERY2);
             turn_on_menu(GMnu_CREATURE_QUERY1);
-            fake_button_click(0);
+            fake_button_click(BID_CRTR_PVPAGE);
             update_wheel_scrolled();
           }
         }
@@ -1492,14 +1492,14 @@ static short get_creature_passenger_action_inputs(void)
           {
             turn_off_menu(GMnu_CREATURE_QUERY3);
             turn_on_menu(GMnu_CREATURE_QUERY4);
-            fake_button_click(0);
+            fake_button_click(BID_CRTR_NXPAGE);
             update_wheel_scrolled();
           }
           else if (wheel_scrolled_up)
           {
             turn_off_menu(GMnu_CREATURE_QUERY3);
             turn_on_menu(GMnu_CREATURE_QUERY2);
-            fake_button_click(0);
+            fake_button_click(BID_CRTR_PVPAGE);
             update_wheel_scrolled();
           }
         }
@@ -1509,14 +1509,14 @@ static short get_creature_passenger_action_inputs(void)
           {
             turn_off_menu(GMnu_CREATURE_QUERY4);
             turn_on_menu(GMnu_CREATURE_QUERY1);
-            fake_button_click(0);
+            fake_button_click(BID_CRTR_NXPAGE);
             update_wheel_scrolled();
           }
           else if (wheel_scrolled_up)
           {
             turn_off_menu(GMnu_CREATURE_QUERY4);
             turn_on_menu(GMnu_CREATURE_QUERY3);
-            fake_button_click(0);
+            fake_button_click(BID_CRTR_PVPAGE);
             update_wheel_scrolled();
           }
         }
@@ -1688,14 +1688,14 @@ static short get_creature_control_action_inputs(void)
         {
             turn_on_menu(GMnu_CREATURE_QUERY3);
         }
-        fake_button_click(0);
+        fake_button_click(BID_CRTR_NXPAGE);
         update_wheel_scrolled();
       }
       if (is_game_key_pressed(Gkey_CrtrQueryMod, true, false) || wheel_scrolled_up)
       {
         turn_off_menu(GMnu_CREATURE_QUERY1);
         turn_on_menu(GMnu_CREATURE_QUERY4);
-        fake_button_click(0);
+        fake_button_click(BID_CRTR_PVPAGE);
         update_wheel_scrolled();
       }
     }
@@ -1713,14 +1713,14 @@ static short get_creature_control_action_inputs(void)
       {
         turn_off_menu(GMnu_CREATURE_QUERY2);
         turn_on_menu(GMnu_CREATURE_QUERY3);
-        fake_button_click(0);
+        fake_button_click(BID_CRTR_NXPAGE);
         update_wheel_scrolled();
       }
       if (is_game_key_pressed(Gkey_CrtrQueryMod, true, false) || wheel_scrolled_up)
       {
         turn_off_menu(GMnu_CREATURE_QUERY2);
         turn_on_menu(GMnu_CREATURE_QUERY1);
-        fake_button_click(0);
+        fake_button_click(BID_CRTR_PVPAGE);
         update_wheel_scrolled();
       }
     }
@@ -1746,7 +1746,7 @@ static short get_creature_control_action_inputs(void)
       {
         turn_off_menu(GMnu_CREATURE_QUERY3);
         turn_on_menu(GMnu_CREATURE_QUERY4);
-        fake_button_click(0);
+        fake_button_click(BID_CRTR_NXPAGE);
         update_wheel_scrolled();
       }
       if (is_game_key_pressed(Gkey_CrtrQueryMod, true, false) || wheel_scrolled_up)
@@ -1759,7 +1759,7 @@ static short get_creature_control_action_inputs(void)
         {
             turn_on_menu(GMnu_CREATURE_QUERY1);
         }
-        fake_button_click(0);
+        fake_button_click(BID_CRTR_PVPAGE);
         update_wheel_scrolled();
       }
     }
@@ -1785,14 +1785,14 @@ static short get_creature_control_action_inputs(void)
       {
         turn_off_menu(GMnu_CREATURE_QUERY4);
         turn_on_menu(GMnu_CREATURE_QUERY1);
-        fake_button_click(0);
+        fake_button_click(BID_CRTR_NXPAGE);
         update_wheel_scrolled();
       }
       if (is_game_key_pressed(Gkey_CrtrQueryMod, true, false) || wheel_scrolled_up)
       {
         turn_off_menu(GMnu_CREATURE_QUERY4);
         turn_on_menu(GMnu_CREATURE_QUERY3);
-        fake_button_click(0);
+        fake_button_click(BID_CRTR_PVPAGE);
         update_wheel_scrolled();
       }
     }

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -227,7 +227,9 @@ enum IngameButtonDesignationIDs {
     BID_MNFCT_TD32,
     BID_MNFCT_NXPG,
     BID_QUERY_2,
-    BID_ASSIST
+    BID_ASSIST,
+    BID_CRTR_PVPAGE,
+    BID_CRTR_NXPAGE
 };
 
 struct GuiMenu;

--- a/src/frontmenu_ingame_tabs_data.cpp
+++ b/src/frontmenu_ingame_tabs_data.cpp
@@ -374,7 +374,8 @@ struct GuiButtonInit event_menu_buttons[] = {
 };
 
 struct GuiButtonInit creature_query_buttons1[] = {
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 1, NULL,                                NULL,                                               NULL,               0,  44, 374,  44, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_nxpage_act, GUIStr_MoreInformation,&creature_query_menu2,{0},    0, NULL },
+  {LbBtnT_NormalBtn, BID_CRTR_PVPAGE, 0, 1, NULL,                                NULL,                                               NULL,               0,  14, 374,  14, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_pvpage_act, GUIStr_MoreInformation,&creature_query_menu4,{0},    0, NULL },
+  {LbBtnT_NormalBtn,    BID_CRTR_NXPAGE, 0, 1, NULL,                                NULL,                                               NULL,               0,  72, 374,  72, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_nxpage_act, GUIStr_MoreInformation,&creature_query_menu2,{0},    0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,                                NULL,                                               NULL,               0,  80, 200,  80, 200, 56, 24, gui_area_smiley_anger_button, GPS_rpanel_bar_rounded_empty, GUIStr_CreatureAngerDesc,0,       {0},               0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,                                NULL,                                               NULL,               0,  80, 230,  80, 230, 56, 24, gui_area_experience_button, GPS_rpanel_bar_rounded_full, GUIStr_ExperienceDesc,   0,       {0},               0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, gui_query_next_creature_of_owner,    gui_query_next_creature_of_owner_and_model,         NULL,               0,   4, 266,   4, 266,126, 14, NULL,                              0, GUIStr_NameAndHealthDesc,0,       {0},               0, NULL },
@@ -388,7 +389,8 @@ struct GuiButtonInit creature_query_buttons1[] = {
 };
 
 struct GuiButtonInit creature_query_buttons2[] = {
-  {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 1, NULL,                                NULL,                                               NULL,               0,  44, 374,  44, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_nxpage_act, GUIStr_MoreInformation,&creature_query_menu3,{0},    0, NULL },
+  {LbBtnT_NormalBtn, BID_CRTR_PVPAGE, 0, 1, NULL,                                NULL,                                               NULL,               0,  14, 374,  14, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_pvpage_act, GUIStr_MoreInformation,&creature_query_menu1,{0},    0, NULL },
+  {LbBtnT_NormalBtn,    BID_CRTR_NXPAGE, 0, 1, NULL,                                NULL,                                               NULL,               0,  72, 374,  72, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_nxpage_act, GUIStr_MoreInformation,&creature_query_menu3,{0},    0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,                                NULL,                                               NULL,               0,  80, 200,  80, 200, 56, 24, gui_area_smiley_anger_button, GPS_rpanel_bar_rounded_empty, GUIStr_CreatureAngerDesc,0,       {0},               0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, NULL,                                NULL,                                               NULL,               0,  80, 230,  80, 230, 56, 24, gui_area_experience_button, GPS_rpanel_bar_rounded_full, GUIStr_ExperienceDesc,   0,       {0},               0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT, 0, 0, gui_query_next_creature_of_owner,    gui_query_next_creature_of_owner_and_model,         NULL,               0,   4, 266,   4, 266,126, 14, NULL,                              0, GUIStr_NameAndHealthDesc,0,       {0},               0, NULL },
@@ -402,7 +404,8 @@ struct GuiButtonInit creature_query_buttons2[] = {
 };
 
 struct GuiButtonInit creature_query_buttons3[] = {
-  {LbBtnT_NormalBtn,    BID_DEFAULT,    0, 1, NULL,                                NULL,                                               NULL,               0,  44, 374,  44, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_nxpage_act, GUIStr_MoreInformation,&creature_query_menu4,          {0}, 0, NULL },
+  {LbBtnT_NormalBtn, BID_CRTR_PVPAGE, 0, 1, NULL,                                NULL,                                               NULL,               0,  14, 374,  14, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_pvpage_act, GUIStr_MoreInformation,&creature_query_menu2,{0},    0, NULL },
+  {LbBtnT_NormalBtn,    BID_CRTR_NXPAGE,    0, 1, NULL,                                NULL,                                               NULL,               0,  72, 374,  72, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_nxpage_act, GUIStr_MoreInformation,&creature_query_menu4,          {0}, 0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT,    0, 0, gui_query_next_creature_of_owner,    gui_query_next_creature_of_owner_and_model,         NULL,               0,   4, 204,   4, 204,126, 14, NULL,                              0, GUIStr_NameAndHealthDesc,0,       {0},               0, NULL },
   {LbBtnT_NormalBtn,    BID_QUERY_INFO, 0, 0, NULL,                                NULL,                                               NULL,               0,   4, 226,   4, 226, 60, 24, gui_area_stat_button, GPS_crspell_heal_std_s, GUIStr_CreatureHealthDesc,     0,         {CrLStat_Health}, 0, NULL },
   {LbBtnT_NormalBtn,    BID_QUERY_INFO, 0, 0, NULL,                                NULL,                                               NULL,               0,  72, 226,  72, 226, 60, 24, gui_area_stat_button, GPS_symbols_creatr_stat_strength_std, GUIStr_CreatureStrengthDesc,   0,       {CrLStat_Strength}, 0, NULL },
@@ -418,7 +421,8 @@ struct GuiButtonInit creature_query_buttons3[] = {
 };
 
 struct GuiButtonInit creature_query_buttons4[] = {
-  {LbBtnT_NormalBtn,    BID_DEFAULT,    0, 1, NULL,                                NULL,                                               NULL,               0,  44, 374,  44, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_nxpage_act, GUIStr_MoreInformation,&creature_query_menu1,           {0}, 0, NULL },
+  {LbBtnT_NormalBtn, BID_CRTR_PVPAGE, 0, 1, NULL,                                NULL,                                               NULL,               0,  14, 374,  14, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_pvpage_act, GUIStr_MoreInformation,&creature_query_menu3,{0},    0, NULL },
+  {LbBtnT_NormalBtn,    BID_CRTR_NXPAGE,    0, 1, NULL,                                NULL,                                               NULL,               0,  72, 374,  72, 374, 52, 20, gui_area_new_normal_button, GPS_rpanel_rpanel_btn_nxpage_act, GUIStr_MoreInformation,&creature_query_menu1,           {0}, 0, NULL },
   {LbBtnT_NormalBtn,    BID_DEFAULT,    0, 0, gui_query_next_creature_of_owner,    gui_query_next_creature_of_owner_and_model,         NULL,               0,   4, 204,   4, 204,126, 14, NULL,                              0, GUIStr_NameAndHealthDesc,0,       {0},               0, NULL },
   {LbBtnT_NormalBtn,    BID_QUERY_INFO, 0, 0, NULL,                                NULL,                                               NULL,               0,   4, 226,   4, 226, 60, 24, gui_area_stat_button, GPS_crspell_speedup_dis_s, GUIStr_CreatureSpeedDesc,       0,          {CrLStat_Speed}, 0, NULL },
   {LbBtnT_NormalBtn,    BID_QUERY_INFO, 0, 0, NULL,                                NULL,                                               NULL,               0,  72, 226,  72, 226, 60, 24, gui_area_stat_button, GPS_crspell_whip_std_s, GUIStr_CreatureLoyaltyDesc,     0,        {CrLStat_Loyalty}, 0, NULL },

--- a/src/sprites.h
+++ b/src/sprites.h
@@ -762,6 +762,8 @@ enum GUIPanelSprite {
     GPS_rpanel_manufacture_dis = 838,
     GPS_rpanel_manufacture_cant = 839,
     GPS_portrt_qmark = 840,
+    GPS_rpanel_rpanel_btn_pvpage_act = 849,
+    GPS_rpanel_rpanel_btn_pvpage_std = 850,
 
     GUI_PANEL_SPRITES_COUNT = 900,
     GUI_PANEL_SPRITES_NEW = 512,


### PR DESCRIPTION
In possession mode there are several pages. Back in 2019 the ability to go to the previous page was added, but the corresponding graphic (the up arrow) never was.

In fact, right now pressing Q or scrolling the mouse wheel backwards lights up the *down* arrow, which it shouldn't: the down arrow lights up regardless of whether you go a page back or a page forward.

This adds the missing graphic and makes the arrows light up in their corresponding direction.

On top of that, I fixed a yellow pixel that was missing for symmetry. It can be seen in the image attached below (scaled 4x here so it can be appreciated properly):
<img width="942" height="268" alt="pvpage_rows_64_4x" src="https://github.com/user-attachments/assets/88827645-53eb-459a-a329-914949f24f5b" />

Now:
<img width="1920" height="1080" alt="OLD" src="https://github.com/user-attachments/assets/0a62b53d-f326-4314-984a-b015cd993030" />

Fixed:
<img width="1920" height="1080" alt="NEW" src="https://github.com/user-attachments/assets/de809622-9b3d-419d-8279-734483f3cc5c" />


Note on sprite indices: this PR assumes the new sprites land at 849 and 850, which is simply the end of the sheet today. The code change and the graphics change need to go in together, or the index agreed beforehand; otherwise sprites.h and gui2-*.dat drift apart with no build error to warn you.