### PR TITLE
Smooth event button drop

### DIFF
--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -396,21 +396,38 @@ void gui_choose_room(struct GuiButton *gbtn)
 
 void gui_area_event_button(struct GuiButton *gbtn)
 {
-    if ((gbtn->flags & LbBtnF_Enabled) != 0)
-    {
-        int ps_units_per_px = simple_gui_panel_sprite_height_units_per_px(gbtn, GPS_message_rpanel_msg_questn_act, 100);
-        if ((gbtn->button_state_left_pressed) || (gbtn->button_state_right_pressed))
-        {
-            draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, gbtn->sprite_idx);
-        } else
-        if (get_my_event_button_index(gbtn->content.lval) == my_visible_event_idx)
-        {
-            draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, gbtn->sprite_idx);
-        } else
-        {
-            draw_gui_panel_sprite_left(gbtn->scr_pos_x, gbtn->scr_pos_y, ps_units_per_px, gbtn->sprite_idx+1);
+    EventIndex evidx = get_my_event_button_index(gbtn->content.lval);
+    if (evidx == 0) {
+        return;
+    }
+    struct Event* event = &game.event[evidx];
+    int spr_idx = event_button_info[event->kind].bttn_sprite;
+    if (get_gameturn() % (2 * gui_blink_rate) >= gui_blink_rate) {
+        switch (event->kind) {
+        case EvKind_Information:
+        case EvKind_QuickInformation:
+            if (!(my_event_button_state[evidx] & EvBtnS_Read)) {
+                spr_idx += 2;
+            }
+            break;
+        case EvKind_FriendlyFight:
+        case EvKind_EnemyFight:
+        case EvKind_HeartAttacked:
+            if (event->mappos_x != 0 || event->mappos_y != 0) {
+                spr_idx += 2;
+            }
+            break;
         }
     }
+    int32_t draw_y = gbtn->scr_pos_y;
+    if (flag_is_set(event->flags, EvF_BtnFalling)) {
+        draw_y = interpolate_synced(gbtn->scr_pos_y - gbtn->height, gbtn->scr_pos_y);
+    }
+    if (!gbtn->button_state_left_pressed && !gbtn->button_state_right_pressed && evidx != my_visible_event_idx) {
+        spr_idx++;
+    }
+    int ps_units_per_px = simple_gui_panel_sprite_height_units_per_px(gbtn, GPS_message_rpanel_msg_questn_act, 100);
+    draw_gui_panel_sprite_left(gbtn->scr_pos_x, draw_y, ps_units_per_px, spr_idx);
 }
 
 #define BAR_FULL_WIDTH 32
@@ -2220,7 +2237,6 @@ void maintain_event_button(struct GuiButton *gbtn)
     if (evidx == 0)
     {
       gbtn->btype_value |= LbBFeF_NoMouseOver;
-      gbtn->sprite_idx = 0;
       gbtn->flags &= ~LbBtnF_Enabled;
       gbtn->button_state_left_pressed = 0;
       gbtn->button_state_right_pressed = 0;
@@ -2231,12 +2247,8 @@ void maintain_event_button(struct GuiButton *gbtn)
     {
         activate_event_box(evidx);
     }
-    gbtn->sprite_idx = event_button_info[event->kind].bttn_sprite;
-    if (((event->kind == EvKind_FriendlyFight) || (event->kind == EvKind_EnemyFight))
-        && ((event->mappos_x != 0) || (event->mappos_y != 0)) && ((get_gameturn() % (2 * gui_blink_rate)) >= gui_blink_rate))
+    if ((event->kind == EvKind_FriendlyFight || event->kind == EvKind_EnemyFight) && (event->mappos_x != 0 || event->mappos_y != 0) && get_gameturn() % (2 * gui_blink_rate) >= gui_blink_rate)
     {
-        // Fight icon flashes when there are fights to show
-        gbtn->sprite_idx += 2;
         if(is_game_key_pressed(Gkey_SpeedMod, false, true) && is_game_key_pressed(Gkey_ZoomToFight, true, true))
         {
             if (evidx == my_visible_event_idx)
@@ -2248,18 +2260,6 @@ void maintain_event_button(struct GuiButton *gbtn)
             activate_event_box(evidx);
             }
         }
-    } else
-    if (((event->kind == EvKind_Information) || (event->kind == EvKind_QuickInformation))
-      && !(my_event_button_state[evidx] & EvBtnS_Read) && ((get_gameturn() % (2 * gui_blink_rate)) >= gui_blink_rate))
-    {
-        // Unread information flashes
-        gbtn->sprite_idx += 2;
-    } else
-    if ((event->kind == EvKind_HeartAttacked)
-        && ((event->mappos_x != 0) || (event->mappos_y != 0)) && ((get_gameturn() % (2 * gui_blink_rate)) >= gui_blink_rate))
-    {
-        // Heart alert icon flashes when heart is being attacked
-        gbtn->sprite_idx += 2;
     }
     gbtn->tooltip_stridx = event_button_info[event->kind].tooltip_stridx;
     gbtn->flags |= LbBtnF_Enabled;

--- a/src/game_update.cpp
+++ b/src/game_update.cpp
@@ -528,6 +528,9 @@ void update(void)
 
     if (!flag_is_set(game.operation_flags,GOF_Paused))
     {
+        for (int i = 1; i < EVENTS_COUNT; i++) {
+            game.event[i].flags &= ~EvF_BtnFalling;
+        }
         if (flag_is_set(player->additional_flags,PlaAF_LightningPaletteIsActive))
         {
             PaletteSetPlayerPalette(player, engine_palette);

--- a/src/map_events.c
+++ b/src/map_events.c
@@ -610,6 +610,7 @@ void maintain_my_event_list(struct Dungeon *dungeon)
                 dungeon->event_button_index[i-1] = curr_ev_idx;
                 dungeon->event_button_index[i] = 0;
                 struct Event* event = &game.event[curr_ev_idx];
+                event->flags |= EvF_BtnFalling;
                 if (flag_is_set(event->flags,EvF_BtnFirstFall))
                 {
                     if ((i == 1) || ((i >= 2) && dungeon->event_button_index[i-2] != 0))
@@ -733,7 +734,7 @@ void event_process_events(void)
 
 void update_all_events(void)
 {
-    for (long i = EVENTS_COUNT; i > 0; i--)
+    for (int32_t i = EVENTS_COUNT - 1; i > 0; i--)
     {
         struct Thing* thing = event_is_attached_to_thing(i);
         if (thing_exists(thing))

--- a/src/map_events.h
+++ b/src/map_events.h
@@ -73,6 +73,7 @@ enum EventKinds {
 enum EventFlags {
     EvF_Exists       = 0x0001,
     EvF_BtnFirstFall = 0x0002, /*< Informs whether the button is falling for a first time. */
+    EvF_BtnFalling   = 0x0004,
 };
 
 /******************************************************************************/


### PR DESCRIPTION
Back when I was doing delta time and making all the various aspects of the game smooth, having the event button drop smoothly was on my list but I couldn't figure it out because it wasn't a typical movement like everything else I had handled, its position cycles through the other potential button positions.

It's smooth now.