### PR TITLE
Clear stale thing lists between levels

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -960,6 +960,9 @@ void clear_things_and_persons_data(void)
 {
     struct Thing *thing;
     long i;
+    memset(game.thing_lists, 0, sizeof(game.thing_lists));
+    game.ambient_sound_thing_idx = 0;
+    game.nodungeon_creatr_list_start = 0;
     for (i=0; i < THINGS_COUNT; i++)
     {
         thing = &game.things_data[i];


### PR DESCRIPTION
Not enough stuff was being cleared between levels, which was causing a lot of different errors. And ultimately leading to a freeze during a multiplayer game.

Fixes https://keeperfx.net/dev/crash-report/564 and https://keeperfx.net/dev/crash-report/563