### PR TITLE
Multiplayer: fix mismatched version display

### DIFF
--- a/src/front_network.c
+++ b/src/front_network.c
@@ -429,11 +429,14 @@ static TbBool check_frontend_version_mismatch(void)
   if (remote_id == -1 || (!player_joined && !start_requested)) {
     return remote_id != -1;
   }
+  if (my_player_number != SERVER_ID) {
+    remote_id = SERVER_ID;
+  }
   const struct NetUser *remote_user = &netstate.users[remote_id];
   char text[MESSAGE_TEXT_LEN];
-  snprintf(text, sizeof(text), "%s\n%s: %d.%d.%d.%d\n%s: %d.%d.%d.%d",
+  snprintf(text, sizeof(text), "%s\n%s: %s\n%s: %d.%d.%d.%d",
       get_string(GUIStr_VersionMismatch),
-      network_player_name(SERVER_ID), (int)host_user->version.major, (int)host_user->version.minor, (int)host_user->version.release, (int)host_user->version.build,
+      network_player_name(my_player_number), VER_STRING,
       network_player_name(remote_id), (int)remote_user->version.major, (int)remote_user->version.minor, (int)remote_user->version.release, (int)remote_user->version.build);
   create_frontend_error_box(10000, text);
   return true;


### PR DESCRIPTION
previous:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/3335adc7-a826-49d2-bbe3-bacf8f8ab6c0" />
new:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/87535341-97cf-4d05-8899-bafcdc39e006" />

Unfortunately the reason it's slipping by me and breaking is because when you compile the game locally, it labels it as 1.4.0.0 and so it's been difficult for me to notice that it's been broken. Maybe in a separate PR could be a worthwhile feature to tag the version on local compiles.