### PR TITLE
Multiplayer: more responsive dynamic input lag

### DIFF
--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -877,10 +877,19 @@ void draw_network_stats()
     unsigned int lost_packet_count = GetClientPacketsLost();
     unsigned int outgoing_rate_kb10 = (GetUploadRateBytesPerSecond() * 10) / 1024;
     unsigned int incoming_rate_kb10 = (GetDownloadRateBytesPerSecond() * 10) / 1024;
-    int32_t packet_misses;
+    int32_t increase_miss_percent;
+    int32_t decrease_miss_percent;
     TbClockMSec increase_countdown;
     TbClockMSec decrease_countdown;
-    input_lag_get_stats(&packet_misses, &increase_countdown, &decrease_countdown);
+    input_lag_get_stats(&increase_miss_percent, &decrease_miss_percent, &increase_countdown, &decrease_countdown);
+    const char *increase_miss_alert = "";
+    const char *decrease_miss_alert = "";
+    if (increase_miss_percent > MISS_PERCENT_INC_THRESHOLD) {
+        increase_miss_alert = " (!)";
+    }
+    if (decrease_miss_percent < MISS_PERCENT_DEC_THRESHOLD) {
+        decrease_miss_alert = " (!)";
+    }
     int64_t turn_length_ns = 0;
     if (turns_per_second > 0) {
         turn_length_ns = 1000000000 / turns_per_second;
@@ -896,33 +905,35 @@ void draw_network_stats()
     LbTextDrawResized(0, tx_units_per_px, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Input lag: %d", game.input_lag_turns);
     LbTextDrawResized(0, tx_units_per_px * 2, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Packet waits: %d", packet_misses);
+    snprintf(text, sizeof(text), "Packet misses inc: %d%%%s", increase_miss_percent, increase_miss_alert);
     LbTextDrawResized(0, tx_units_per_px * 3, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Increase input lag: %dms", increase_countdown);
+    snprintf(text, sizeof(text), "Packet misses dec: %d%%%s", decrease_miss_percent, decrease_miss_alert);
     LbTextDrawResized(0, tx_units_per_px * 4, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Decrease input lag: %dms", decrease_countdown);
+    snprintf(text, sizeof(text), "Increase input lag: %dms", increase_countdown);
     LbTextDrawResized(0, tx_units_per_px * 5, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Decrease input lag: %dms", decrease_countdown);
+    LbTextDrawResized(0, tx_units_per_px * 6, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Download: %u.%u KB/s",
         incoming_rate_kb10 / 10, incoming_rate_kb10 % 10);
-    LbTextDrawResized(0, tx_units_per_px * 6, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 7, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Upload: %u.%u KB/s",
         outgoing_rate_kb10 / 10, outgoing_rate_kb10 % 10);
-    LbTextDrawResized(0, tx_units_per_px * 7, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Congestion: %u bytes", transit);
     LbTextDrawResized(0, tx_units_per_px * 8, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Loss rate: %u%%", packet_loss_percent);
+    snprintf(text, sizeof(text), "Congestion: %u bytes", transit);
     LbTextDrawResized(0, tx_units_per_px * 9, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Lost packets: %u", lost_packet_count);
+    snprintf(text, sizeof(text), "Loss rate: %u%%", packet_loss_percent);
     LbTextDrawResized(0, tx_units_per_px * 10, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Stutter: %dms", stutter_detection_current);
+    snprintf(text, sizeof(text), "Lost packets: %u", lost_packet_count);
     LbTextDrawResized(0, tx_units_per_px * 11, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Average stutter: %dms", stutter_detection_average);
+    snprintf(text, sizeof(text), "Stutter: %dms", stutter_detection_current);
     LbTextDrawResized(0, tx_units_per_px * 12, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Max stutter: %dms", stutter_detection_max);
+    snprintf(text, sizeof(text), "Average stutter: %dms", stutter_detection_average);
     LbTextDrawResized(0, tx_units_per_px * 13, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
+    snprintf(text, sizeof(text), "Max stutter: %dms", stutter_detection_max);
     LbTextDrawResized(0, tx_units_per_px * 14, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
+    snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
     LbTextDrawResized(0, tx_units_per_px * 15, tx_units_per_px, text);
+    snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
+    LbTextDrawResized(0, tx_units_per_px * 16, tx_units_per_px, text);
 }
 /******************************************************************************/

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -887,7 +887,7 @@ void draw_network_stats()
     if (increase_miss_percent > MISS_PERCENT_INC_THRESHOLD) {
         increase_miss_alert = " (!)";
     }
-    if (decrease_miss_percent < MISS_PERCENT_DEC_THRESHOLD) {
+    if (decrease_miss_percent <= MISS_PERCENT_DEC_THRESHOLD) {
         decrease_miss_alert = " (!)";
     }
     int64_t turn_length_ns = 0;

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -877,19 +877,11 @@ void draw_network_stats()
     unsigned int lost_packet_count = GetClientPacketsLost();
     unsigned int outgoing_rate_kb10 = (GetUploadRateBytesPerSecond() * 10) / 1024;
     unsigned int incoming_rate_kb10 = (GetDownloadRateBytesPerSecond() * 10) / 1024;
-    int32_t increase_miss_percent;
-    int32_t decrease_miss_percent;
-    TbClockMSec increase_countdown;
-    TbClockMSec decrease_countdown;
-    input_lag_get_stats(&increase_miss_percent, &decrease_miss_percent, &increase_countdown, &decrease_countdown);
-    const char *increase_miss_alert = "";
-    const char *decrease_miss_alert = "";
-    if (increase_miss_percent > MISS_PERCENT_INC_THRESHOLD) {
-        increase_miss_alert = " (!)";
-    }
-    if (decrease_miss_percent <= MISS_PERCENT_DEC_THRESHOLD) {
-        decrease_miss_alert = " (!)";
-    }
+    int32_t increase_missed_turns;
+    int32_t increase_sampled_turns;
+    int32_t decrease_missed_turns;
+    int32_t decrease_sampled_turns;
+    input_lag_get_stats(&increase_missed_turns, &increase_sampled_turns, &decrease_missed_turns, &decrease_sampled_turns);
     int64_t turn_length_ns = 0;
     if (turns_per_second > 0) {
         turn_length_ns = 1000000000 / turns_per_second;
@@ -905,35 +897,31 @@ void draw_network_stats()
     LbTextDrawResized(0, tx_units_per_px, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Input lag: %d", game.input_lag_turns);
     LbTextDrawResized(0, tx_units_per_px * 2, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Packet misses inc: %d%%%s", increase_miss_percent, increase_miss_alert);
+    snprintf(text, sizeof(text), "Recent packet misses: %d/%d", increase_missed_turns, increase_sampled_turns);
     LbTextDrawResized(0, tx_units_per_px * 3, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Packet misses dec: %d%%%s", decrease_miss_percent, decrease_miss_alert);
+    snprintf(text, sizeof(text), "Decrease packet misses: %d/%d", decrease_missed_turns, decrease_sampled_turns);
     LbTextDrawResized(0, tx_units_per_px * 4, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Increase input lag: %dms", increase_countdown);
-    LbTextDrawResized(0, tx_units_per_px * 5, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Decrease input lag: %dms", decrease_countdown);
-    LbTextDrawResized(0, tx_units_per_px * 6, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Download: %u.%u KB/s",
         incoming_rate_kb10 / 10, incoming_rate_kb10 % 10);
-    LbTextDrawResized(0, tx_units_per_px * 7, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 5, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Upload: %u.%u KB/s",
         outgoing_rate_kb10 / 10, outgoing_rate_kb10 % 10);
-    LbTextDrawResized(0, tx_units_per_px * 8, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 6, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Congestion: %u bytes", transit);
-    LbTextDrawResized(0, tx_units_per_px * 9, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 7, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Loss rate: %u%%", packet_loss_percent);
-    LbTextDrawResized(0, tx_units_per_px * 10, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 8, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Lost packets: %u", lost_packet_count);
-    LbTextDrawResized(0, tx_units_per_px * 11, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 9, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Stutter: %dms", stutter_detection_current);
-    LbTextDrawResized(0, tx_units_per_px * 12, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 10, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Average stutter: %dms", stutter_detection_average);
-    LbTextDrawResized(0, tx_units_per_px * 13, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 11, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Max stutter: %dms", stutter_detection_max);
-    LbTextDrawResized(0, tx_units_per_px * 14, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 12, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Turn length: %" PRId64, turn_length_ns);
-    LbTextDrawResized(0, tx_units_per_px * 15, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 13, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Gameturn: %u", get_gameturn());
-    LbTextDrawResized(0, tx_units_per_px * 16, tx_units_per_px, text);
+    LbTextDrawResized(0, tx_units_per_px * 14, tx_units_per_px, text);
 }
 /******************************************************************************/

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -24,6 +24,7 @@
 #include "bflib_basics.h"
 #include "bflib_coroutine.h"
 #include "bflib_datetm.h"
+#include "bflib_enet.h"
 #include "net_exchange_common.h"
 #include "net_lobby.h"
 #include "net_main.h"
@@ -213,10 +214,13 @@ static uint8_t calculate_initial_input_lag(void)
         input_lag_turns = (ping * turns_per_second + 999) / 1000;
     }
     uint64_t uncapped_input_lag_turns = input_lag_turns;
+    if (input_lag_turns > 0) {
+        input_lag_turns -= 1;
+    }
     if (input_lag_turns > MAXIMUM_INPUT_LAG_TURNS) {
         input_lag_turns = MAXIMUM_INPUT_LAG_TURNS;
     }
-    JUSTLOG("Initial input lag: (%llu ms * %d turns/s + 999) / 1000 = %llu turns, capped to %llu", (unsigned long long)ping, turns_per_second, (unsigned long long)uncapped_input_lag_turns, (unsigned long long)input_lag_turns);
+    JUSTLOG("Initial input lag: (%llu ms * %d turns/s + 999) / 1000 = %llu turns, adjusted to %llu", (unsigned long long)ping, turns_per_second, (unsigned long long)uncapped_input_lag_turns, (unsigned long long)input_lag_turns);
     return input_lag_turns;
 }
 
@@ -526,7 +530,8 @@ void process_disconnected_network_players(void)
             }
         }
         if ((player->allocflags & PlaF_CompCtrl) == 0) {
-            input_lag_reset_intervals();
+            network_lobby_ping = GetPing(my_player_number);
+            input_lag_reset_request(calculate_initial_input_lag());
             if (!host_disconnected && player->id_number != get_host_player_id() && player->player_name[0] != '\0') {
                 message_add_fmt(MsgType_Blank, 0, get_string(GUIStr_NetPlayerDisconnected), player->player_name);
                 JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -214,9 +214,6 @@ static uint8_t calculate_initial_input_lag(void)
         input_lag_turns = (ping * turns_per_second + 999) / 1000;
     }
     uint64_t uncapped_input_lag_turns = input_lag_turns;
-    if (input_lag_turns > 0) {
-        input_lag_turns -= 1;
-    }
     if (input_lag_turns > MAXIMUM_INPUT_LAG_TURNS) {
         input_lag_turns = MAXIMUM_INPUT_LAG_TURNS;
     }

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -214,6 +214,9 @@ static uint8_t calculate_initial_input_lag(void)
         input_lag_turns = (ping * turns_per_second + 999) / 1000;
     }
     uint64_t uncapped_input_lag_turns = input_lag_turns;
+    if (input_lag_turns > 0) {
+        input_lag_turns -= 1;
+    }
     if (input_lag_turns > MAXIMUM_INPUT_LAG_TURNS) {
         input_lag_turns = MAXIMUM_INPUT_LAG_TURNS;
     }

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -8,79 +8,52 @@
 #include "net_exchange_gameplay.h"
 #include "game_legacy.h"
 #include "net_main.h"
-#include "bflib_datetm.h"
-#include "kfx_memory.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-// Increase quickly to prevent stutter, but decrease slowly to avoid oscillation.
-#define INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS 30
-#define INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS 6000
 #define INPUT_LAG_SAMPLE_START_TURN 100
 
 static int32_t input_lag_increase_sample_count;
 static int32_t input_lag_decrease_sample_count;
-static int32_t input_lag_history_position;
-static int32_t input_lag_increase_missing_turn_count;
-static int32_t input_lag_decrease_missing_turn_count;
-static TbBool *input_lag_missing_turn_history;
-static TbClockMSec input_lag_last_decrease_check;
-static TbClockMSec input_lag_last_increase_check;
+static int32_t input_lag_decrease_missed_turn_count;
+static uint8_t input_lag_missed_turn_history;
 static int32_t local_input_lag_request;
 static int32_t input_lag_target;
 static int32_t input_lag_increase_turns;
+static GameTurn input_lag_next_increase_turn;
 
-static void input_lag_reset_history(void)
+static void input_lag_reset_samples(void)
 {
-    input_lag_missing_turn_history = KfxRealloc(input_lag_missing_turn_history, INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS * sizeof(*input_lag_missing_turn_history));
     input_lag_increase_sample_count = 0;
     input_lag_decrease_sample_count = 0;
-    input_lag_history_position = -1;
-    input_lag_increase_missing_turn_count = 0;
-    input_lag_decrease_missing_turn_count = 0;
-    memset(input_lag_missing_turn_history, 0, INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS * sizeof(*input_lag_missing_turn_history));
-    input_lag_last_decrease_check = input_lag_last_increase_check = LbTimerClock();
+    input_lag_decrease_missed_turn_count = 0;
+    input_lag_missed_turn_history = 0;
 }
 
 void input_lag_reset_request(int32_t input_lag_turns)
 {
-    input_lag_reset_history();
+    input_lag_reset_samples();
     local_input_lag_request = input_lag_turns;
+    input_lag_next_increase_turn = 0;
 }
 
 void input_lag_reset(void)
 {
-    input_lag_reset_history();
+    input_lag_reset_samples();
     local_input_lag_request = game.input_lag_turns;
     input_lag_target = game.input_lag_turns;
     input_lag_increase_turns = 0;
+    input_lag_next_increase_turn = 0;
 }
 
-void input_lag_get_stats(int32_t *increase_miss_percent, int32_t *decrease_miss_percent, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown)
+void input_lag_get_stats(int32_t *increase_missed_turns, int32_t *increase_sampled_turns, int32_t *decrease_missed_turns, int32_t *decrease_sampled_turns)
 {
-    TbClockMSec now = LbTimerClock();
-    TbClockMSec increase_window = INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS * 1000 / turns_per_second;
-    TbClockMSec decrease_window = INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS * 1000 / turns_per_second / max(GetRemoteUserCount(), 1);
-    TbClockMSec elapsed = now - input_lag_last_increase_check;
-    *increase_miss_percent = 0;
-    if (input_lag_increase_sample_count > 0) {
-        *increase_miss_percent = (input_lag_increase_missing_turn_count * 100 + input_lag_increase_sample_count - 1) / input_lag_increase_sample_count;
-    }
-    *decrease_miss_percent = 0;
-    if (input_lag_decrease_sample_count > 0) {
-        *decrease_miss_percent = input_lag_decrease_missing_turn_count * 100 / input_lag_decrease_sample_count;
-    }
-    *increase_countdown = 0;
-    if (elapsed < increase_window) {
-        *increase_countdown = increase_window - elapsed;
-    }
-    elapsed = now - input_lag_last_decrease_check;
-    *decrease_countdown = 0;
-    if (elapsed < decrease_window) {
-        *decrease_countdown = decrease_window - elapsed;
-    }
+    *increase_missed_turns = __builtin_popcount(input_lag_missed_turn_history);
+    *increase_sampled_turns = input_lag_increase_sample_count;
+    *decrease_missed_turns = input_lag_decrease_missed_turn_count;
+    *decrease_sampled_turns = input_lag_decrease_sample_count;
 }
 
 TbBool input_lag_skips_processing(void)
@@ -126,39 +99,32 @@ void input_lag_update(struct Packet *packet)
         JUSTLOG("Input lag increased from %d to %d", game.input_lag_turns, input_lag_target);
         game.input_lag_turns = input_lag_target;
     }
-    TbClockMSec now = LbTimerClock();
-    if ((game.operation_flags & GOF_Paused) != 0 || game.skip_initial_input_turns > 0) {
-        input_lag_last_decrease_check = input_lag_last_increase_check = now;
-    } else {
-        int32_t decrease_sample_window_turns = INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS / max(remote_player_count, 1);
-        TbClockMSec decrease_window = decrease_sample_window_turns * 1000 / turns_per_second;
-        if (now - input_lag_last_decrease_check >= decrease_window) {
-            input_lag_last_decrease_check = now;
-            if (input_lag_decrease_sample_count > 0 && input_lag_decrease_missing_turn_count * 100 <= MISS_PERCENT_DEC_THRESHOLD * input_lag_decrease_sample_count && local_input_lag_request > 0) {
-                local_input_lag_request -= 1;
-                MULTIPLAYER_LOG("Input lag request decreased after %d waits in %d turns: request=%d next_check=%dms", input_lag_decrease_missing_turn_count, input_lag_decrease_sample_count, local_input_lag_request, decrease_window);
-                input_lag_reset_history();
-            }
-        }
-        TbClockMSec increase_window = INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS * 1000 / turns_per_second;
-        if (now - input_lag_last_increase_check >= increase_window) {
-            input_lag_last_increase_check = now;
-            if (get_gameturn() >= INPUT_LAG_SAMPLE_START_TURN && input_lag_increase_missing_turn_count * 100 > MISS_PERCENT_INC_THRESHOLD * input_lag_increase_sample_count && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS) {
-                local_input_lag_request += 1;
-                MULTIPLAYER_LOG("Input lag request increased after %d waits in %d turns: request=%d next_check=%dms", input_lag_increase_missing_turn_count, input_lag_increase_sample_count, local_input_lag_request, increase_window);
-                input_lag_reset_history();
-            }
-        }
-        input_lag_history_position = (input_lag_history_position + 1) % decrease_sample_window_turns;
-        input_lag_decrease_missing_turn_count -= input_lag_missing_turn_history[input_lag_history_position];
-        int32_t increase_history_position = (input_lag_history_position + decrease_sample_window_turns - INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS) % decrease_sample_window_turns;
-        input_lag_increase_missing_turn_count -= input_lag_missing_turn_history[increase_history_position];
-        input_lag_missing_turn_history[input_lag_history_position] = false;
-        if (input_lag_increase_sample_count < INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS) {
-            input_lag_increase_sample_count += 1;
-        }
-        if (input_lag_decrease_sample_count < decrease_sample_window_turns) {
+    if ((game.operation_flags & GOF_Paused) == 0 && game.skip_initial_input_turns == 0 && get_gameturn() >= INPUT_LAG_SAMPLE_START_TURN) {
+        if (input_lag_increase_sample_count > 0) {
             input_lag_decrease_sample_count += 1;
+            if ((input_lag_missed_turn_history & 1) != 0) {
+                input_lag_decrease_missed_turn_count += 1;
+            }
+        }
+        int32_t missed_turns = __builtin_popcount(input_lag_missed_turn_history);
+        if (input_lag_increase_sample_count == INPUT_LAG_INCREASE_TURNS && missed_turns >= INPUT_LAG_INCREASE_MISSES && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS && get_gameturn() >= input_lag_next_increase_turn) {
+            local_input_lag_request += 1;
+            input_lag_next_increase_turn = get_gameturn() + INPUT_LAG_INCREASE_COOLDOWN_TURNS;
+            MULTIPLAYER_LOG("Input lag request increased after %d waits in %d turns: request=%d", missed_turns, input_lag_increase_sample_count, local_input_lag_request);
+            input_lag_reset_samples();
+        } else if (input_lag_decrease_sample_count >= INPUT_LAG_DECREASE_SAMPLE_TURNS) {
+            if (input_lag_decrease_missed_turn_count * 100 <= INPUT_LAG_DECREASE_MISS_PERCENT * input_lag_decrease_sample_count && local_input_lag_request > 0) {
+                local_input_lag_request -= 1;
+                MULTIPLAYER_LOG("Input lag request decreased after %d waits in %d turns: request=%d", input_lag_decrease_missed_turn_count, input_lag_decrease_sample_count, local_input_lag_request);
+                input_lag_reset_samples();
+            } else {
+                input_lag_decrease_sample_count = 0;
+                input_lag_decrease_missed_turn_count = 0;
+            }
+        }
+        input_lag_missed_turn_history = (input_lag_missed_turn_history << 1) & ((1 << INPUT_LAG_INCREASE_TURNS) - 1);
+        if (input_lag_increase_sample_count < INPUT_LAG_INCREASE_TURNS) {
+            input_lag_increase_sample_count += 1;
         }
     }
     packet->input_lag_turns = local_input_lag_request;
@@ -171,7 +137,7 @@ void input_lag_update(struct Packet *packet)
         }
     }
     if (remote_player_count <= 0) {
-        input_lag_reset_history();
+        input_lag_reset_samples();
         local_input_lag_request = 0;
         packet->input_lag_turns = 0;
     }
@@ -179,12 +145,8 @@ void input_lag_update(struct Packet *packet)
 
 void input_lag_note_packet_wait(void)
 {
-    if (!network_is_active() || (game.operation_flags & GOF_Paused) != 0 || get_gameturn() < INPUT_LAG_SAMPLE_START_TURN || input_lag_history_position < 0) { return; }
-    if (!input_lag_missing_turn_history[input_lag_history_position]) {
-        input_lag_missing_turn_history[input_lag_history_position] = true;
-        input_lag_increase_missing_turn_count += 1;
-        input_lag_decrease_missing_turn_count += 1;
-    }
+    if (!network_is_active() || (game.operation_flags & GOF_Paused) != 0 || get_gameturn() < INPUT_LAG_SAMPLE_START_TURN || input_lag_increase_sample_count <= 0) { return; }
+    input_lag_missed_turn_history |= 1;
 }
 
 void input_lag_observe_host_packet(const struct Packet *packet)

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -18,6 +18,7 @@ extern "C" {
 // Increase quickly to prevent stutter, but decrease slowly to avoid oscillation.
 #define INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS 30
 #define INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS 6000
+#define INPUT_LAG_INCREASE_START_TURN 100
 
 static int32_t input_lag_increase_sample_count;
 static int32_t input_lag_decrease_sample_count;
@@ -142,7 +143,7 @@ void input_lag_update(struct Packet *packet)
         TbClockMSec increase_window = INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS * 1000 / turns_per_second;
         if (now - input_lag_last_increase_check >= increase_window) {
             input_lag_last_increase_check = now;
-            if (input_lag_increase_missing_turn_count * 100 > MISS_PERCENT_INC_THRESHOLD * input_lag_increase_sample_count && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS) {
+            if (get_gameturn() >= INPUT_LAG_INCREASE_START_TURN && input_lag_increase_missing_turn_count * 100 > MISS_PERCENT_INC_THRESHOLD * input_lag_increase_sample_count && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS) {
                 local_input_lag_request += 1;
                 MULTIPLAYER_LOG("Input lag request increased after %d waits in %d turns: request=%d next_check=%dms", input_lag_increase_missing_turn_count, input_lag_increase_sample_count, local_input_lag_request, increase_window);
             }

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -9,47 +9,44 @@
 #include "game_legacy.h"
 #include "net_main.h"
 #include "bflib_datetm.h"
+#include "kfx_memory.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-// Used for TOLERATE_PACKET_MISS_PERCENT
-#define INPUT_LAG_SAMPLE_WINDOW_TURNS 100
-// Input lag increases when the packet miss percentage exceeds this value within the sample window. [Higher = more choppy FPS but lower input lag, lower = smoother FPS but higher input lag]
-#define TOLERATE_PACKET_MISS_PERCENT 70
-// Starts out low so we can more quickly determine the correct input_lag_turns at the start of the level, but doubles and takes longer to change as the game progresses.
-#define INPUT_LAG_INCREASE_INITIAL_INTERVAL_MS 600
-#define INPUT_LAG_DECREASE_INITIAL_INTERVAL_MS 500
-// When increasing input_lag_turns, cap the interval so that we can always get out of a laggy spot. Decreasing has no cap so that it will do less decreases as the game progresses.
-#define INPUT_LAG_INCREASE_MAX_INTERVAL_MS 5000
+// Increase quickly to prevent stutter, but decrease slowly to avoid oscillation.
+#define INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS 30
+#define INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS 6000
 
-static int32_t input_lag_sample_count;
+static int32_t input_lag_increase_sample_count;
+static int32_t input_lag_decrease_sample_count;
 static int32_t input_lag_history_position;
-static int32_t input_lag_missing_turn_count;
-static TbBool input_lag_missing_turn_history[INPUT_LAG_SAMPLE_WINDOW_TURNS];
-static TbClockMSec input_lag_reduction_check_interval;
-static TbClockMSec input_lag_increase_check_interval;
-static TbClockMSec input_lag_last_reduction_check;
+static int32_t input_lag_increase_missing_turn_count;
+static int32_t input_lag_decrease_missing_turn_count;
+static TbBool *input_lag_missing_turn_history;
+static TbClockMSec input_lag_last_decrease_check;
 static TbClockMSec input_lag_last_increase_check;
 static int32_t local_input_lag_request;
 static int32_t input_lag_target;
 static int32_t input_lag_increase_turns;
 
-void input_lag_reset_intervals(void)
-{
-    input_lag_reduction_check_interval = INPUT_LAG_DECREASE_INITIAL_INTERVAL_MS;
-    input_lag_increase_check_interval = INPUT_LAG_INCREASE_INITIAL_INTERVAL_MS;
-    input_lag_last_reduction_check = input_lag_last_increase_check = LbTimerClock();
-}
-
 static void input_lag_reset_history(void)
 {
-    input_lag_sample_count = 0;
+    input_lag_missing_turn_history = KfxRealloc(input_lag_missing_turn_history, INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS * sizeof(*input_lag_missing_turn_history));
+    input_lag_increase_sample_count = 0;
+    input_lag_decrease_sample_count = 0;
     input_lag_history_position = -1;
-    input_lag_missing_turn_count = 0;
-    memset(input_lag_missing_turn_history, 0, sizeof(input_lag_missing_turn_history));
-    input_lag_reset_intervals();
+    input_lag_increase_missing_turn_count = 0;
+    input_lag_decrease_missing_turn_count = 0;
+    memset(input_lag_missing_turn_history, 0, INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS * sizeof(*input_lag_missing_turn_history));
+    input_lag_last_decrease_check = input_lag_last_increase_check = LbTimerClock();
+}
+
+void input_lag_reset_request(int32_t input_lag_turns)
+{
+    input_lag_reset_history();
+    local_input_lag_request = input_lag_turns;
 }
 
 void input_lag_reset(void)
@@ -60,19 +57,28 @@ void input_lag_reset(void)
     input_lag_increase_turns = 0;
 }
 
-void input_lag_get_stats(int32_t *packet_misses, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown)
+void input_lag_get_stats(int32_t *increase_miss_percent, int32_t *decrease_miss_percent, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown)
 {
     TbClockMSec now = LbTimerClock();
+    TbClockMSec increase_window = INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS * 1000 / turns_per_second;
+    TbClockMSec decrease_window = INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS * 1000 / turns_per_second / max(GetRemoteUserCount(), 1);
     TbClockMSec elapsed = now - input_lag_last_increase_check;
-    *packet_misses = input_lag_missing_turn_count;
-    *increase_countdown = 0;
-    if (elapsed < input_lag_increase_check_interval) {
-        *increase_countdown = input_lag_increase_check_interval - elapsed;
+    *increase_miss_percent = 0;
+    if (input_lag_increase_sample_count > 0) {
+        *increase_miss_percent = (input_lag_increase_missing_turn_count * 100 + input_lag_increase_sample_count - 1) / input_lag_increase_sample_count;
     }
-    elapsed = now - input_lag_last_reduction_check;
+    *decrease_miss_percent = 0;
+    if (input_lag_decrease_sample_count > 0) {
+        *decrease_miss_percent = input_lag_decrease_missing_turn_count * 100 / input_lag_decrease_sample_count;
+    }
+    *increase_countdown = 0;
+    if (elapsed < increase_window) {
+        *increase_countdown = increase_window - elapsed;
+    }
+    elapsed = now - input_lag_last_decrease_check;
     *decrease_countdown = 0;
-    if (elapsed < input_lag_reduction_check_interval) {
-        *decrease_countdown = input_lag_reduction_check_interval - elapsed;
+    if (elapsed < decrease_window) {
+        *decrease_countdown = decrease_window - elapsed;
     }
 }
 
@@ -114,49 +120,49 @@ void input_lag_update(struct Packet *packet)
 {
     packet->input_lag_turns = 0;
     if (!network_is_active()) { return; }
+    int32_t remote_player_count = GetRemoteUserCount();
     if ((game.operation_flags & GOF_Paused) == 0 && input_lag_increase_turns == 0 && input_lag_target > game.input_lag_turns) {
         JUSTLOG("Input lag increased from %d to %d", game.input_lag_turns, input_lag_target);
         game.input_lag_turns = input_lag_target;
     }
     TbClockMSec now = LbTimerClock();
     if ((game.operation_flags & GOF_Paused) != 0 || game.skip_initial_input_turns > 0) {
-        input_lag_last_reduction_check = input_lag_last_increase_check = now;
+        input_lag_last_decrease_check = input_lag_last_increase_check = now;
     } else {
-        if (now - input_lag_last_reduction_check >= input_lag_reduction_check_interval) {
-            input_lag_last_reduction_check = now;
-            if (input_lag_reduction_check_interval <= INT32_MAX / 2) {
-                input_lag_reduction_check_interval *= 2;
-            }
-            if (input_lag_sample_count > 0 && input_lag_missing_turn_count == 0 && local_input_lag_request > 0) {
+        int32_t decrease_sample_window_turns = INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS / max(remote_player_count, 1);
+        TbClockMSec decrease_window = decrease_sample_window_turns * 1000 / turns_per_second;
+        if (now - input_lag_last_decrease_check >= decrease_window) {
+            input_lag_last_decrease_check = now;
+            if (input_lag_decrease_sample_count > 0 && input_lag_decrease_missing_turn_count * 100 < MISS_PERCENT_DEC_THRESHOLD * input_lag_decrease_sample_count && local_input_lag_request > 0) {
                 local_input_lag_request -= 1;
                 input_lag_last_increase_check = now;
-                MULTIPLAYER_LOG("Input lag request decreased after %d clean turns: request=%d next_check=%dms", input_lag_sample_count, local_input_lag_request, input_lag_reduction_check_interval);
+                MULTIPLAYER_LOG("Input lag request decreased after %d waits in %d turns: request=%d next_check=%dms", input_lag_decrease_missing_turn_count, input_lag_decrease_sample_count, local_input_lag_request, decrease_window);
             }
         }
-        if (now - input_lag_last_increase_check >= input_lag_increase_check_interval) {
+        TbClockMSec increase_window = INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS * 1000 / turns_per_second;
+        if (now - input_lag_last_increase_check >= increase_window) {
             input_lag_last_increase_check = now;
-            input_lag_increase_check_interval *= 2;
-            if (input_lag_increase_check_interval > INPUT_LAG_INCREASE_MAX_INTERVAL_MS) {
-                input_lag_increase_check_interval = INPUT_LAG_INCREASE_MAX_INTERVAL_MS;
-            }
-            if (input_lag_missing_turn_count * 100 > TOLERATE_PACKET_MISS_PERCENT * input_lag_sample_count && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS) {
+            if (input_lag_increase_missing_turn_count * 100 > MISS_PERCENT_INC_THRESHOLD * input_lag_increase_sample_count && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS) {
                 local_input_lag_request += 1;
-                MULTIPLAYER_LOG("Input lag request increased after %d waits in %d turns: request=%d next_check=%dms", input_lag_missing_turn_count, input_lag_sample_count, local_input_lag_request, input_lag_increase_check_interval);
+                MULTIPLAYER_LOG("Input lag request increased after %d waits in %d turns: request=%d next_check=%dms", input_lag_increase_missing_turn_count, input_lag_increase_sample_count, local_input_lag_request, increase_window);
             }
         }
-        input_lag_history_position = (input_lag_history_position + 1) % INPUT_LAG_SAMPLE_WINDOW_TURNS;
-        input_lag_missing_turn_count -= input_lag_missing_turn_history[input_lag_history_position];
+        input_lag_history_position = (input_lag_history_position + 1) % decrease_sample_window_turns;
+        input_lag_decrease_missing_turn_count -= input_lag_missing_turn_history[input_lag_history_position];
+        int32_t increase_history_position = (input_lag_history_position + decrease_sample_window_turns - INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS) % decrease_sample_window_turns;
+        input_lag_increase_missing_turn_count -= input_lag_missing_turn_history[increase_history_position];
         input_lag_missing_turn_history[input_lag_history_position] = false;
-        if (input_lag_sample_count < INPUT_LAG_SAMPLE_WINDOW_TURNS) {
-            input_lag_sample_count += 1;
+        if (input_lag_increase_sample_count < INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS) {
+            input_lag_increase_sample_count += 1;
+        }
+        if (input_lag_decrease_sample_count < decrease_sample_window_turns) {
+            input_lag_decrease_sample_count += 1;
         }
     }
     packet->input_lag_turns = local_input_lag_request;
     if (my_player_number != get_host_player_id() || !netstate.sp) { return; }
-    int32_t remote_player_count = 0;
     for (NetUserId id = 0; id < netstate.max_players; id += 1) {
         if (id == netstate.my_id || netstate.users[id].progress != USER_LOGGEDIN) { continue; }
-        remote_player_count += 1;
         const struct Packet *peer_packet = get_latest_history_packet((PlayerNumber)id);
         if (peer_packet != NULL && (uint8_t)peer_packet->input_lag_turns <= MAXIMUM_INPUT_LAG_TURNS && peer_packet->input_lag_turns > packet->input_lag_turns) {
             packet->input_lag_turns = peer_packet->input_lag_turns;
@@ -174,7 +180,8 @@ void input_lag_note_packet_wait(void)
     if (!network_is_active() || (game.operation_flags & GOF_Paused) != 0 || input_lag_history_position < 0) { return; }
     if (!input_lag_missing_turn_history[input_lag_history_position]) {
         input_lag_missing_turn_history[input_lag_history_position] = true;
-        input_lag_missing_turn_count += 1;
+        input_lag_increase_missing_turn_count += 1;
+        input_lag_decrease_missing_turn_count += 1;
     }
 }
 

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -18,7 +18,7 @@ extern "C" {
 // Increase quickly to prevent stutter, but decrease slowly to avoid oscillation.
 #define INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS 30
 #define INPUT_LAG_DECREASE_MAX_SAMPLE_WINDOW_TURNS 6000
-#define INPUT_LAG_INCREASE_START_TURN 100
+#define INPUT_LAG_SAMPLE_START_TURN 100
 
 static int32_t input_lag_increase_sample_count;
 static int32_t input_lag_decrease_sample_count;
@@ -134,18 +134,19 @@ void input_lag_update(struct Packet *packet)
         TbClockMSec decrease_window = decrease_sample_window_turns * 1000 / turns_per_second;
         if (now - input_lag_last_decrease_check >= decrease_window) {
             input_lag_last_decrease_check = now;
-            if (input_lag_decrease_sample_count > 0 && input_lag_decrease_missing_turn_count * 100 < MISS_PERCENT_DEC_THRESHOLD * input_lag_decrease_sample_count && local_input_lag_request > 0) {
+            if (input_lag_decrease_sample_count > 0 && input_lag_decrease_missing_turn_count * 100 <= MISS_PERCENT_DEC_THRESHOLD * input_lag_decrease_sample_count && local_input_lag_request > 0) {
                 local_input_lag_request -= 1;
-                input_lag_last_increase_check = now;
                 MULTIPLAYER_LOG("Input lag request decreased after %d waits in %d turns: request=%d next_check=%dms", input_lag_decrease_missing_turn_count, input_lag_decrease_sample_count, local_input_lag_request, decrease_window);
+                input_lag_reset_history();
             }
         }
         TbClockMSec increase_window = INPUT_LAG_INCREASE_SAMPLE_WINDOW_TURNS * 1000 / turns_per_second;
         if (now - input_lag_last_increase_check >= increase_window) {
             input_lag_last_increase_check = now;
-            if (get_gameturn() >= INPUT_LAG_INCREASE_START_TURN && input_lag_increase_missing_turn_count * 100 > MISS_PERCENT_INC_THRESHOLD * input_lag_increase_sample_count && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS) {
+            if (get_gameturn() >= INPUT_LAG_SAMPLE_START_TURN && input_lag_increase_missing_turn_count * 100 > MISS_PERCENT_INC_THRESHOLD * input_lag_increase_sample_count && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS) {
                 local_input_lag_request += 1;
                 MULTIPLAYER_LOG("Input lag request increased after %d waits in %d turns: request=%d next_check=%dms", input_lag_increase_missing_turn_count, input_lag_increase_sample_count, local_input_lag_request, increase_window);
+                input_lag_reset_history();
             }
         }
         input_lag_history_position = (input_lag_history_position + 1) % decrease_sample_window_turns;
@@ -178,7 +179,7 @@ void input_lag_update(struct Packet *packet)
 
 void input_lag_note_packet_wait(void)
 {
-    if (!network_is_active() || (game.operation_flags & GOF_Paused) != 0 || input_lag_history_position < 0) { return; }
+    if (!network_is_active() || (game.operation_flags & GOF_Paused) != 0 || get_gameturn() < INPUT_LAG_SAMPLE_START_TURN || input_lag_history_position < 0) { return; }
     if (!input_lag_missing_turn_history[input_lag_history_position]) {
         input_lag_missing_turn_history[input_lag_history_position] = true;
         input_lag_increase_missing_turn_count += 1;

--- a/src/net_input_lag.h
+++ b/src/net_input_lag.h
@@ -6,7 +6,7 @@
 
 #define MAXIMUM_INPUT_LAG_TURNS 12
 #define MISS_PERCENT_INC_THRESHOLD 65
-#define MISS_PERCENT_DEC_THRESHOLD 4
+#define MISS_PERCENT_DEC_THRESHOLD 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/net_input_lag.h
+++ b/src/net_input_lag.h
@@ -5,8 +5,11 @@
 #include "bflib_basics.h"
 
 #define MAXIMUM_INPUT_LAG_TURNS 12
-#define MISS_PERCENT_INC_THRESHOLD 65
-#define MISS_PERCENT_DEC_THRESHOLD 1
+#define INPUT_LAG_INCREASE_MISSES 3
+#define INPUT_LAG_INCREASE_TURNS 4
+#define INPUT_LAG_INCREASE_COOLDOWN_TURNS 600
+#define INPUT_LAG_DECREASE_SAMPLE_TURNS 600
+#define INPUT_LAG_DECREASE_MISS_PERCENT 1
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,7 +22,7 @@ unsigned short calculate_skip_input(void);
 void input_lag_update(struct Packet *packet);
 void input_lag_reset(void);
 void input_lag_reset_request(int32_t input_lag_turns);
-void input_lag_get_stats(int32_t *increase_miss_percent, int32_t *decrease_miss_percent, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown);
+void input_lag_get_stats(int32_t *increase_missed_turns, int32_t *increase_sampled_turns, int32_t *decrease_missed_turns, int32_t *decrease_sampled_turns);
 void input_lag_note_packet_wait(void);
 void input_lag_observe_host_packet(const struct Packet *packet);
 TbBool input_lag_needs_lookahead(void);

--- a/src/net_input_lag.h
+++ b/src/net_input_lag.h
@@ -5,6 +5,8 @@
 #include "bflib_basics.h"
 
 #define MAXIMUM_INPUT_LAG_TURNS 12
+#define MISS_PERCENT_INC_THRESHOLD 65
+#define MISS_PERCENT_DEC_THRESHOLD 4
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,8 +18,8 @@ TbBool input_lag_skips_processing(void);
 unsigned short calculate_skip_input(void);
 void input_lag_update(struct Packet *packet);
 void input_lag_reset(void);
-void input_lag_reset_intervals(void);
-void input_lag_get_stats(int32_t *packet_misses, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown);
+void input_lag_reset_request(int32_t input_lag_turns);
+void input_lag_get_stats(int32_t *increase_miss_percent, int32_t *decrease_miss_percent, TbClockMSec *increase_countdown, TbClockMSec *decrease_countdown);
 void input_lag_note_packet_wait(void);
 void input_lag_observe_host_packet(const struct Packet *packet);
 TbBool input_lag_needs_lookahead(void);

--- a/src/net_main.c
+++ b/src/net_main.c
@@ -28,6 +28,17 @@ TbBool IsUserActive(NetUserId id)
     return (netstate.users[id].progress == USER_LOGGEDIN);
 }
 
+int32_t GetRemoteUserCount(void)
+{
+    int32_t count = 0;
+    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+        if (id != netstate.my_id && IsUserActive(id)) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
 void UpdateLocalPlayerInfo(NetUserId id)
 {
     local_player_info[id].network_user_active = (netstate.users[id].progress != USER_UNUSED);

--- a/src/net_main.h
+++ b/src/net_main.h
@@ -155,6 +155,7 @@ TbError LbNetwork_Init(uint32_t srvcindex, uint32_t maxplayrs, struct TbNetworkP
 TbBool OnNewUser(NetUserId *assigned_id);
 void OnDroppedUser(NetUserId id, enum NetDropReason reason);
 TbBool IsUserActive(NetUserId id);
+int32_t GetRemoteUserCount(void);
 void UpdateLocalPlayerInfo(NetUserId id);
 char *begin_net_message(enum NetMessageType msg_type);
 void send_message_buffer(NetUserId dest, const char *end_ptr);


### PR DESCRIPTION
Refactored the dynamic input lag system to be way more responsive:
- If the past 3 out of 4 packets were waited on, then increase input lag. (then put a cooldown on it so it can't be increased for a while)
- If only 1% or less of the past 600 packets were waited on, then decrease input lag.
- Don't adjust input lag for at least 100 turns at the start of the game, to let the game stabilize.
- The initial input lag calculation is decreased by 1, for more accuracy.
- When a player disconnects, recalculate input lag.