### PR TITLE
Multiplayer: chat improvements

### DIFF
--- a/config/fxdata/sounds.cfg
+++ b/config/fxdata/sounds.cfg
@@ -53,6 +53,12 @@ REFUSAL                = 119
 TAB_CLICK              = 60
 ; Event notification tab falling into position on the panel
 TAB_FALL               = 947
+; Lobby player leaving
+LOBBY_PLAYER_LEAVE     = 9 4
+; Lobby and in-game chat message sent
+SEND_CHAT_MESSAGE      = 62
+; Lobby and in-game chat message received
+RECEIVE_CHAT_MESSAGE   = 175
 ; Event notification tab snapping into final position
 TAB_HIT                = 175
 ; GUI button click

--- a/src/bflib_sprfnt.c
+++ b/src/bflib_sprfnt.c
@@ -403,12 +403,17 @@ static int8_t draw_dbc_char(uint32_t chr, struct AsianFontWindow *awind, long *p
     SYNCDBG(19,"Got needs_draw");
     struct AsianDraw adraw;
     unsigned long colour;
+    unsigned long shadow_colour = dbc_colour1;
     if (dbc_get_sprite_for_char(&adraw, chr) == 0)
     {
         if ((RendererGetDrawFlags() & Lb_TEXT_ONE_COLOR) == 0)
           colour = dbc_colour0;
         else
           colour = RendererGetDrawColour();
+        if ((RendererGetDrawFlags() & Lb_TEXT_REMAP) != 0) {
+            colour = lbSpriteReMapPtr[colour];
+            shadow_colour = lbSpriteReMapPtr[shadow_colour];
+        }
 
         #define MAX_DBC_SPRITE_SIZE 8192
         unsigned char dest_pixel[MAX_DBC_SPRITE_SIZE] = { 0 };
@@ -442,7 +447,7 @@ static int8_t draw_dbc_char(uint32_t chr, struct AsianFontWindow *awind, long *p
             adraw.y_spacing = adraw.y_spacing * units_per_px / 16;
         }
 
-        dbc_draw_font_sprite_text(awind, &adraw, *pos_x, pos_y, colour, -1, dbc_colour1);
+        dbc_draw_font_sprite_text(awind, &adraw, *pos_x, pos_y, colour, -1, shadow_colour);
 
         int w;
         if (adraw.bits_height == 16)
@@ -474,6 +479,9 @@ static int8_t draw_simpletext_char(uint32_t chr, long *pos_x, long pos_y, int un
     {
         if ((RendererGetDrawFlags() & Lb_TEXT_ONE_COLOR) != 0) {
             LbSpriteDrawResizedOneColour(*pos_x, pos_y, units_per_px, spr, RendererGetDrawColour());
+        }
+        else if ((RendererGetDrawFlags() & Lb_TEXT_REMAP) != 0) {
+            LbSpriteDrawResizedRemap(*pos_x, pos_y, units_per_px, spr, lbSpriteReMapPtr);
         }
         else {
             LbSpriteDrawResized(*pos_x, pos_y, units_per_px, spr);

--- a/src/bflib_video.h
+++ b/src/bflib_video.h
@@ -109,6 +109,7 @@ enum TbDrawFlags {
     Lb_TEXT_UNDERLINE      = 0x0400,
     Lb_SPRITE_REMAP        = 0x0800,
     Lb_TEXT_UNDERLNSHADOW  = 0x1000,
+    Lb_TEXT_REMAP          = 0x2000,
 };
 
 enum TbVideoModeFlags {

--- a/src/config_sounds.c
+++ b/src/config_sounds.c
@@ -63,6 +63,7 @@ int            snd_foot_snow_count = 0;
 int            snd_chicken_cluck_count = 0;
 int            snd_strike_wall_count = 0;
 int            snd_reinforce_hit_count = 0;
+int            snd_lobby_player_leave_count = 0;
 
 SoundSmplTblID snd_foot_spur       = 0;
 SoundSmplTblID snd_foot_wet        = 0;
@@ -115,6 +116,8 @@ SoundSmplTblID snd_larg_tile_up    = 0;
 SoundSmplTblID snd_larg_tile_down  = 0;
 
 SoundSmplTblID snd_tab_fall        = 0;
+SoundSmplTblID snd_chat_message[2] = { 0 };
+SoundSmplTblID snd_lobby_player_leave = 0;
 SoundSmplTblID snd_reinforce_hit   = 0;
 
 // Trap trigger sounds
@@ -1042,6 +1045,9 @@ TbBool cache_common_sound_ids(void)
     CACHE_SND(snd_button_click,   "BUTTON_CLICK2")
     CACHE_SND(snd_buzzer,          "BUZZER")
     CACHE_SND(snd_tab_fall,        "TAB_FALL")
+    CACHE_SND(snd_chat_message[0], "RECEIVE_CHAT_MESSAGE")
+    CACHE_SND(snd_chat_message[1], "SEND_CHAT_MESSAGE")
+    CACHE_SND_COUNT(snd_lobby_player_leave, snd_lobby_player_leave_count, "LOBBY_PLAYER_LEAVE")
     CACHE_SND(snd_heart_engine,    "HEART_ENGINE")
     CACHE_SND(snd_scavenge,        "SCAVENGE")
     CACHE_SND(snd_tile_place,      "ROOM_BUILD")

--- a/src/config_sounds.h
+++ b/src/config_sounds.h
@@ -198,6 +198,9 @@ extern int            snd_tunnel_dig_count;
 extern SoundSmplTblID snd_button_click;
 extern SoundSmplTblID snd_buzzer;           /* error buzz */
 extern SoundSmplTblID snd_tab_fall;         /* event notification tab fall */
+extern SoundSmplTblID snd_chat_message[2];
+extern SoundSmplTblID snd_lobby_player_leave;
+extern int            snd_lobby_player_leave_count;
 
 /* Dungeon heart */
 extern SoundSmplTblID snd_heart_engine;     /* heartbeat engine hum (looping) */

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -28,6 +28,7 @@
 #include "bflib_netsession.h"
 #include "bflib_guibtns.h"
 #include "bflib_keybrd.h"
+#include "bflib_sound.h"
 #include "bflib_vidraw.h"
 #include "bflib_sprfnt.h"
 #include "bflib_datetm.h"
@@ -40,6 +41,7 @@
 #include "player_data.h"
 #include "net_game.h"
 #include "config.h"
+#include "config_sounds.h"
 #include "config_strings.h"
 #include "game_merge.h"
 #include "game_legacy.h"
@@ -145,6 +147,7 @@ void process_frontend_chat_message(int player_id, const char *message)
     struct PlayerInfo *player = prepare_network_chat_message(player_id, message);
     if (message[0] != '\0' && !try_starting_level_from_chat(player->mp_message_text, player_id)) {
         add_message(player_id, player->mp_message_text);
+        play_non_3d_sample(snd_chat_message[player_id == my_player_number]);
     }
     memset(player->mp_message_text, 0, PLAYER_MP_MESSAGE_LEN);
 }
@@ -383,27 +386,6 @@ void frontnet_session_update(void)
     }
 }
 
-void frontnet_rewite_net_messages(void)
-{
-    struct NetMessage lmsg[NET_MESSAGES_COUNT];
-    long k = 0;
-    long i = net_number_of_messages;
-    for (i=0; i < NET_MESSAGES_COUNT; i++)
-      memset(&lmsg[i], 0, sizeof(struct NetMessage));
-    for (i=0; i < net_number_of_messages; i++)
-    {
-        struct NetMessage* nmsg = &net_message[i];
-        if (network_player_active(nmsg->plyr_idx))
-        {
-            memcpy(&lmsg[k], nmsg, sizeof(struct NetMessage));
-            k++;
-      }
-    }
-    net_number_of_messages = k;
-    for (i=0; i < NET_MESSAGES_COUNT; i++)
-      memcpy(&net_message[i], &lmsg[i], sizeof(struct NetMessage));
-}
-
 static TbBool check_frontend_version_mismatch(void)
 {
   int32_t active_players = 0;
@@ -425,6 +407,9 @@ static TbBool check_frontend_version_mismatch(void)
     }
   }
   TbBool player_joined = active_players > previous_active_players;
+  if (active_players < previous_active_players && snd_lobby_player_leave_count > 0) {
+    play_non_3d_sample(snd_lobby_player_leave + SOUND_RANDOM(snd_lobby_player_leave_count));
+  }
   previous_active_players = active_players;
   if (remote_id == -1 || (!player_joined && !start_requested)) {
     return remote_id != -1;
@@ -598,7 +583,6 @@ void frontnet_start_update(void)
       net_message_scroll_offset = net_number_of_messages-1;
     }
     process_frontend_packets();
-    frontnet_rewite_net_messages();
 
     if (frontnet_service_selected(FrontendNetSvc_LAN)) {
         lan_host_update();

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -498,6 +498,7 @@ void add_message(long plyr_idx, char *msg)
     }
     nmsg = &net_message[i];
     nmsg->plyr_idx = plyr_idx;
+    nmsg->connection_id = net_player_info[plyr_idx].connection_id;
     snprintf(nmsg->text, NET_MESSAGE_LEN, "%s", msg);
     i++;
     net_number_of_messages = i;

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -242,8 +242,9 @@ struct DemoItem { //sizeof = 5
     };
 };
 
-struct NetMessage { // sizeof = 0x41
+struct NetMessage { // sizeof = 0x45
   unsigned char plyr_idx;
+  uint32_t connection_id;
   char text[NET_MESSAGE_LEN];
 };
 

--- a/src/frontmenu_net.c
+++ b/src/frontmenu_net.c
@@ -40,6 +40,7 @@
 #include "game_merge.h"
 #include "game_legacy.h"
 #include "sprites.h"
+#include "vidfade.h"
 #include "keeperfx.hpp"
 #include "custom_sprites.h"
 #include "bflib_enet.h"
@@ -576,6 +577,15 @@ void frontnet_draw_current_message(struct GuiButton *gbtn)
 
 void frontnet_draw_messages(struct GuiButton *gbtn)
 {
+    static unsigned char player_left_remap[PALETTE_COLORS];
+    static int player_left_remap_initialized;
+    if (!player_left_remap_initialized) {
+        for (int i = 0; i < PALETTE_COLORS; i++) {
+            int intensity = max(frontend_palette[3*i], max(frontend_palette[3*i+1], frontend_palette[3*i+2]));
+            player_left_remap[i] = LbPaletteFindColour(frontend_palette, intensity*5/8, intensity*3/8, intensity/4);
+        }
+        player_left_remap_initialized = 1;
+    }
     int font_idx;
     font_idx = frontend_button_caption_font(gbtn, 0);
     LbTextSetFont(frontend_font[font_idx]);
@@ -598,22 +608,31 @@ void frontnet_draw_messages(struct GuiButton *gbtn)
             break;
         struct NetMessage *nmsg;
         nmsg = &net_message[netmsg_id];
+        TbBool sender_active = nmsg->connection_id == net_player_info[nmsg->plyr_idx].connection_id;
         int num_active;
         num_active = 0;
-        int i;
-        for (i = nmsg->plyr_idx; i > 0; i--)
-        {
-          if ( net_player_info[i].network_user_active)
-            num_active++;
+        if (sender_active) {
+            for (int i = nmsg->plyr_idx; i > 0; i--) {
+                if (net_player_info[i].network_user_active) {
+                    num_active++;
+                }
+            }
         }
 
         spr = get_frontend_sprite(GFS_bullfrog_red_med+num_active);
 
-        i = font_height - spr->SHeight * fs_units_per_px / 16;
-        LbSpriteDrawResized(gbtn->scr_pos_x, y + gbtn->scr_pos_y + (i >> 1), fs_units_per_px, spr);
+        int icon_y = font_height - spr->SHeight * fs_units_per_px / 16;
+        if (sender_active) {
+            LbSpriteDrawResized(gbtn->scr_pos_x, y + gbtn->scr_pos_y + (icon_y >> 1), fs_units_per_px, spr);
+        } else {
+            lbSpriteReMapPtr = player_left_remap;
+            RendererSetDrawFlags(Lb_TEXT_REMAP);
+            LbSpriteDrawResizedRemap(gbtn->scr_pos_x, y + gbtn->scr_pos_y + (icon_y >> 1), fs_units_per_px, spr, player_left_remap);
+        }
 
         LbTextSetWindow(gbtn->scr_pos_x, y + gbtn->scr_pos_y, gbtn->width, min(font_height, gbtn->height-y));
         LbTextDrawResized(spr->SWidth * fs_units_per_px / 16, 0, tx_units_per_px, nmsg->text);
+        RendererSetDrawFlags(0);
 
         y += font_height;
     }

--- a/src/net_exchange_gameplay.c
+++ b/src/net_exchange_gameplay.c
@@ -19,7 +19,9 @@
 #include "net_exchange_gameplay.h"
 #include "bflib_enet.h"
 #include "bflib_datetm.h"
+#include "bflib_sound.h"
 #include "bflib_video.h"
+#include "config_sounds.h"
 #include "config_keeperfx.h"
 #include "console_cmd.h"
 #include "engine_redraw.h"
@@ -158,6 +160,7 @@ void process_gameplay_chat_message(int player_id, const char *message)
         lua_on_chatmsg(player_id, player->mp_message_text);
         if (player->mp_message_text[0] != cmd_char || !cmd_exec(player_id, player->mp_message_text + 1) || network_is_active()) {
             message_add(MsgType_Player, player_id, player->mp_message_text);
+            play_non_3d_sample(snd_chat_message[player_id == my_player_number]);
         }
     }
     memset(player->mp_message_text, 0, PLAYER_MP_MESSAGE_LEN);

--- a/src/net_main.c
+++ b/src/net_main.c
@@ -41,7 +41,11 @@ int32_t GetRemoteUserCount(void)
 
 void UpdateLocalPlayerInfo(NetUserId id)
 {
-    local_player_info[id].network_user_active = (netstate.users[id].progress != USER_UNUSED);
+    TbBool active = netstate.users[id].progress != USER_UNUSED;
+    if (local_player_info[id].network_user_active && !active) {
+        local_player_info[id].connection_id++;
+    }
+    local_player_info[id].network_user_active = active;
     if (!local_player_info[id].network_user_active) {
         memset(local_player_info[id].name, 0, sizeof(local_player_info[id].name));
         return;

--- a/src/net_main.h
+++ b/src/net_main.h
@@ -126,6 +126,7 @@ struct NetState {
 struct TbNetworkPlayerInfo {
     char name[32];
     int32_t network_user_active;
+    uint32_t connection_id;
 };
 
 struct ServiceInitData {


### PR DESCRIPTION
Added sound effects: `SEND_CHAT_MESSAGE` `RECEIVE_CHAT_MESSAGE` `LOBBY_PLAYER_LEAVE`

Send chat message is 62 (`button3.wav`) which was an unused sound. It sounds like a little pop.

Receive chat message is 175 (`tabhit.wav`), same as when an event button clicks into place.

"Lobby player leave" is the imp footstep sound (played for those remaining in the lobby). When you join there's a claim sound so my idea was the imp footstep represents the claimer walking away from the lobby. Also I wanted to keep it subtle, I considered chicken sfx or `man1sad.wav` but those would get obnoxious.

Fixed the issue of a player's text disappearing when they leave the lobby, and it also now turns grey (turning grey is better than keeping it coloured because then you may mistakenly assume the next person who joined was the one who said it):
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/6efd19b4-073a-4880-8b30-bb3233ce8728" />