### PR TITLE
17% higher FPS

### DIFF
--- a/src/kfx/renderer/RendererSoftware.cpp
+++ b/src/kfx/renderer/RendererSoftware.cpp
@@ -65,7 +65,6 @@ bool RendererSoftware::ensure_present_target()
     if (m_texture == nullptr || m_tex_w != lbDrawSurface->w || m_tex_h != lbDrawSurface->h)
     {
         if (m_texture != nullptr) { SDL_DestroyTexture(m_texture); m_texture = nullptr; }
-        if (m_rgba != nullptr) { SDL_DestroySurface(m_rgba); m_rgba = nullptr; }
         m_texture = SDL_CreateTexture(m_renderer, SDL_PIXELFORMAT_RGBA32,
                                       SDL_TEXTUREACCESS_STREAMING, lbDrawSurface->w, lbDrawSurface->h);
         if (m_texture == nullptr)
@@ -74,12 +73,6 @@ bool RendererSoftware::ensure_present_target()
             return false;
         }
         SDL_SetTextureScaleMode(m_texture, SDL_SCALEMODE_NEAREST); // crisp pixels
-        m_rgba = SDL_CreateSurface(lbDrawSurface->w, lbDrawSurface->h, SDL_PIXELFORMAT_RGBA32);
-        if (m_rgba == nullptr)
-        {
-            ERRORLOG("SDL_CreateSurface(RGBA staging) failed: %s", SDL_GetError());
-            return false;
-        }
         m_tex_w = lbDrawSurface->w;
         m_tex_h = lbDrawSurface->h;
     }
@@ -89,7 +82,6 @@ bool RendererSoftware::ensure_present_target()
 void RendererSoftware::destroy_present_target()
 {
     if (m_texture != nullptr) { SDL_DestroyTexture(m_texture); m_texture = nullptr; }
-    if (m_rgba != nullptr) { SDL_DestroySurface(m_rgba); m_rgba = nullptr; }
     if (m_renderer != nullptr) { SDL_DestroyRenderer(m_renderer); m_renderer = nullptr; }
     m_tex_w = 0;
     m_tex_h = 0;
@@ -131,11 +123,22 @@ void RendererSoftware::PresentFrame()
 {
     if (lbDrawSurface == NULL || !ensure_present_target())
         return;
+    SDL_Surface* texture_surface;
+    if (!SDL_LockTextureToSurface(m_texture, NULL, &texture_surface))
+    {
+        ERRORLOG("Present texture lock failed: %s", SDL_GetError());
+        return;
+    }
     LbMouseOnBeginSwap();
     // INDEX8 (palette) -> RGBA and present
-    if (!SDL_BlitSurface(lbDrawSurface, NULL, m_rgba, NULL))
+    if (!SDL_BlitSurface(lbDrawSurface, NULL, texture_surface, NULL))
+    {
         ERRORLOG("Present blit failed: %s", SDL_GetError());
-    SDL_UpdateTexture(m_texture, NULL, m_rgba->pixels, m_rgba->pitch);
+        SDL_UnlockTexture(m_texture);
+        LbMouseOnEndSwap();
+        return;
+    }
+    SDL_UnlockTexture(m_texture);
     SDL_RenderClear(m_renderer);
     SDL_RenderTexture(m_renderer, m_texture, NULL, NULL);
     SDL_RenderPresent(m_renderer);

--- a/src/kfx/renderer/RendererSoftware.h
+++ b/src/kfx/renderer/RendererSoftware.h
@@ -26,7 +26,6 @@ private:
 
     SDL_Renderer* m_renderer = nullptr;
     SDL_Texture*  m_texture  = nullptr;
-    SDL_Surface*  m_rgba     = nullptr;
     int           m_tex_w    = 0;
     int           m_tex_h    = 0;
     int           m_vsync    = -1; // SDL_SetRenderVSync value; -1 = unset


### PR DESCRIPTION
Found another CPU renderer optimization. Hopefully this one doesn't have drawbacks, as they often do.

Fully zoomed out while at 3840x2160:

Level 1 of the campaign:
Alpha 5320: 79-84 FPS
This PR: 89-102 FPS

Blaze End:
Alpha 5320: 65-68 FPS
This PR: 75-81 FPS

So ~17% higher FPS.
The importance of these kinds of optimizations is for late game multiplayer, when there's a ton of units on screen and then performance dips for even one player in a 4-player game which slows it down for everybody else.