### PR TITLE
Multiplayer: dynamic input lag improvements and bandwidth optimization

### DIFF
--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -877,11 +877,11 @@ void draw_network_stats()
     unsigned int lost_packet_count = GetClientPacketsLost();
     unsigned int outgoing_rate_kb10 = (GetUploadRateBytesPerSecond() * 10) / 1024;
     unsigned int incoming_rate_kb10 = (GetDownloadRateBytesPerSecond() * 10) / 1024;
-    int32_t increase_missed_turns;
-    int32_t increase_sampled_turns;
-    int32_t decrease_missed_turns;
-    int32_t decrease_sampled_turns;
-    input_lag_get_stats(&increase_missed_turns, &increase_sampled_turns, &decrease_missed_turns, &decrease_sampled_turns);
+    int32_t increase_wait_time;
+    int32_t increase_turn_time;
+    int32_t decrease_wait_time;
+    int32_t decrease_sample_time;
+    input_lag_get_stats(&increase_wait_time, &increase_turn_time, &decrease_wait_time, &decrease_sample_time);
     int64_t turn_length_ns = 0;
     if (turns_per_second > 0) {
         turn_length_ns = 1000000000 / turns_per_second;
@@ -897,9 +897,10 @@ void draw_network_stats()
     LbTextDrawResized(0, tx_units_per_px, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Input lag: %d", game.input_lag_turns);
     LbTextDrawResized(0, tx_units_per_px * 2, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Recent packet misses: %d/%d", increase_missed_turns, increase_sampled_turns);
+    snprintf(text, sizeof(text), "Packet wait increase: %d/%dms in %dms", increase_wait_time,
+        increase_turn_time, INPUT_LAG_INCREASE_SAMPLE_MS);
     LbTextDrawResized(0, tx_units_per_px * 3, tx_units_per_px, text);
-    snprintf(text, sizeof(text), "Decrease packet misses: %d/%d", decrease_missed_turns, decrease_sampled_turns);
+    snprintf(text, sizeof(text), "Packet wait decrease: %d/%dms", decrease_wait_time, decrease_sample_time);
     LbTextDrawResized(0, tx_units_per_px * 4, tx_units_per_px, text);
     snprintf(text, sizeof(text), "Download: %u.%u KB/s",
         incoming_rate_kb10 / 10, incoming_rate_kb10 % 10);

--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -523,6 +523,16 @@ void gameplay_loop_draw()
     }
 }
 
+void network_yield_waiting_gameplay_packets()
+{
+    poll_inputs();
+    gameplay_loop_draw();
+    update_gameplay_delta_time();
+    // Reduce game speed during lag spikes.
+    if (game.process_turn_time > 2.0)
+        game.process_turn_time = 2.0;
+}
+
 static void gameplay_loop_logic()
 {
     if(flag_is_set(start_params.debug_flags, DFlg_PauseAtGameTurn))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1697,16 +1697,6 @@ extern "C" void network_yield_draw_gameplay()
     gameplay_loop_draw();
 }
 
-extern "C" void network_yield_waiting_gameplay_packets()
-{
-    poll_inputs();
-    gameplay_loop_draw();
-    update_gameplay_delta_time();
-    // Reduce game speed during lag spikes.
-    if (game.process_turn_time > 2.0)
-        game.process_turn_time = 2.0;
-}
-
 extern "C" void update_velocity(void);
 extern "C" void check_mouse_scroll(void);
 extern "C" void fronttorture_update(void);

--- a/src/net_exchange_common.c
+++ b/src/net_exchange_common.c
@@ -98,8 +98,8 @@ static TbError handle_exchange_message(NetUserId source, void *server_buf, size_
         return Lb_OK;
     }
     char *player_frame = (char *)server_buf + peer_id * frame_size;
-    netstate.users[peer_id].ack = seq_nbr;
     size_t payload_size = message_size - (read_pos - netstate.msg_buffer);
+    TbBool relay_message = true;
     if (message_type == NETMSG_GAMEPLAY_UNSEQUENCED) {
         if (frame_size != sizeof(struct Packet)) {
             WARNLOG("Gameplay frame size mismatch (%u != %u)", (unsigned)frame_size, (unsigned)sizeof(struct Packet));
@@ -117,10 +117,8 @@ static TbError handle_exchange_message(NetUserId source, void *server_buf, size_
             return Lb_OK;
         }
         const struct Packet *packets = (const struct Packet *)read_pos;
-        if (peer_id == SERVER_ID
-            && packets[0].turn == get_gameturn()
-            && get_history_packet((PlayerNumber)peer_id, packets[0].turn) == NULL)
-        {
+        relay_message = netstate.users[peer_id].ack != seq_nbr;
+        if (peer_id == SERVER_ID && packets[0].turn == get_gameturn() && get_history_packet((PlayerNumber)peer_id, packets[0].turn) == NULL) {
             host_packet_received = game.process_turn_time;
         }
         for (unsigned char i = 0; i < packet_count; i += 1) {
@@ -140,10 +138,11 @@ static TbError handle_exchange_message(NetUserId source, void *server_buf, size_
         }
         memcpy(player_frame, read_pos, frame_size);
     }
+    netstate.users[peer_id].ack = seq_nbr;
     if (frame_peer_id != NULL) {
         *frame_peer_id = peer_id;
     }
-    if (netstate.my_id == SERVER_ID) {
+    if (netstate.my_id == SERVER_ID && relay_message) {
         send_exchange_message(message_type, message_size, peer_id);
     }
     return Lb_OK;

--- a/src/net_exchange_gameplay.c
+++ b/src/net_exchange_gameplay.c
@@ -75,8 +75,9 @@ struct PacketHistoryHeader {
 static struct PacketHistory packet_history[MAX_NET_USERS];
 static TbClockMSec server_turn_received_at = 0;
 static int64_t server_turn_position_ns = 0;
-static TbClockMSec last_repair_history_send = 0;
+static TbClockMSec last_repair_history_send[MAX_NET_USERS];
 static TbClockMSec last_turn_sync_send = 0;
+static PlayerNumber next_repair_history_player = 0;
 
 static int64_t get_current_turn_position_ns(void)
 {
@@ -287,8 +288,9 @@ void initialize_packet_history(void)
     server_turn_received_at = 0;
     server_turn_position_ns = 0;
     multiplayer_speed_adjustment_ns = 0;
-    last_repair_history_send = 0;
+    memset(last_repair_history_send, 0, sizeof(last_repair_history_send));
     last_turn_sync_send = 0;
+    next_repair_history_player = 0;
     input_lag_reset();
 }
 
@@ -385,17 +387,24 @@ static void send_player_repair_history(PlayerNumber player)
 static void send_repair_history_if_due(void)
 {
     TbClockMSec current_time = LbTimerClock();
-    if (last_repair_history_send != 0 && current_time - last_repair_history_send < REPAIR_HISTORY_RESEND_INTERVAL) {
+    PlayerNumber player = (PlayerNumber)netstate.my_id;
+    if (player == SERVER_ID) {
+        PlayerNumber offset;
+        for (offset = 0; offset < netstate.max_players; offset += 1) {
+            player = (next_repair_history_player + offset) % netstate.max_players;
+            if (network_player_active(player) && (last_repair_history_send[player] == 0 || current_time - last_repair_history_send[player] >= REPAIR_HISTORY_RESEND_INTERVAL)) {
+                break;
+            }
+        }
+        if (offset == netstate.max_players) {
+            return;
+        }
+        next_repair_history_player = (player + 1) % netstate.max_players;
+    } else if (last_repair_history_send[player] != 0 && current_time - last_repair_history_send[player] < REPAIR_HISTORY_RESEND_INTERVAL) {
         return;
     }
-    last_repair_history_send = current_time;
-    if (netstate.my_id != SERVER_ID) {
-        send_player_repair_history((PlayerNumber)netstate.my_id);
-        return;
-    }
-    for (PlayerNumber player = 0; player < netstate.max_players; player += 1) {
-        send_player_repair_history(player);
-    }
+    last_repair_history_send[player] = current_time;
+    send_player_repair_history(player);
 }
 
 static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, PlayerNumber local_packet_player)

--- a/src/net_exchange_gameplay.c
+++ b/src/net_exchange_gameplay.c
@@ -413,7 +413,6 @@ static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, Pla
     TbClockMSec wait_start_time = LbTimerClock();
     TbBool turn_complete = false;
     TbBool wait_timed_out = false;
-    input_lag_note_packet_wait();
     MULTIPLAYER_LOG("LbNetwork_ExchangeGameplay: Missing packets for turn=%lu, collecting...", (unsigned long)expected_turn);
     while (!turn_complete) {
         send_turn_sync_if_due();
@@ -453,6 +452,7 @@ static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, Pla
         }
     }
     TbClockMSec wait_time = LbTimerClock() - wait_start_time;
+    input_lag_note_packet_wait((int32_t)wait_time);
     if (wait_timed_out) {
         WARNLOG("LbNetwork_ExchangeGameplay: Timed out waiting for turn=%lu after %dms; continuing so resync can recover",
             (unsigned long)expected_turn, (int32_t)wait_time);

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -8,28 +8,50 @@
 #include "net_exchange_gameplay.h"
 #include "game_legacy.h"
 #include "net_main.h"
+#include "bflib_datetm.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define INPUT_LAG_SAMPLE_START_TURN 100
+#define INPUT_LAG_SAMPLE_START_TURN 50
 
-static int32_t input_lag_increase_sample_count;
-static int32_t input_lag_decrease_sample_count;
-static int32_t input_lag_decrease_missed_turn_count;
-static uint8_t input_lag_missed_turn_history;
+static int32_t input_lag_decrease_sample_time;
+static int32_t input_lag_decrease_wait_time;
+static uint32_t input_lag_decrease_last_update;
+static int32_t input_lag_time_spent_waiting;
+static unsigned char input_lag_increase_wait_history[INPUT_LAG_INCREASE_SAMPLE_MS];
+static uint32_t input_lag_increase_last_update;
 static int32_t local_input_lag_request;
 static int32_t input_lag_target;
 static int32_t input_lag_increase_turns;
 static GameTurn input_lag_next_increase_turn;
+static int32_t input_lag_adjustment_time = INPUT_LAG_ADJUSTMENT_TIME_1V1_MS;
+
+static void input_lag_update_increase_sample(uint32_t current_time)
+{
+    uint32_t elapsed = current_time - input_lag_increase_last_update;
+    if (elapsed >= INPUT_LAG_INCREASE_SAMPLE_MS) {
+        memset(input_lag_increase_wait_history, 0, sizeof(input_lag_increase_wait_history));
+        input_lag_time_spent_waiting = 0;
+    } else {
+        for (uint32_t offset = 1; offset <= elapsed; offset += 1) {
+            uint32_t index = (input_lag_increase_last_update + offset) % INPUT_LAG_INCREASE_SAMPLE_MS;
+            input_lag_time_spent_waiting -= input_lag_increase_wait_history[index];
+            input_lag_increase_wait_history[index] = 0;
+        }
+    }
+    input_lag_increase_last_update = current_time;
+}
 
 static void input_lag_reset_samples(void)
 {
-    input_lag_increase_sample_count = 0;
-    input_lag_decrease_sample_count = 0;
-    input_lag_decrease_missed_turn_count = 0;
-    input_lag_missed_turn_history = 0;
+    input_lag_decrease_sample_time = 0;
+    input_lag_decrease_wait_time = 0;
+    input_lag_decrease_last_update = LbTimerClock();
+    input_lag_time_spent_waiting = 0;
+    memset(input_lag_increase_wait_history, 0, sizeof(input_lag_increase_wait_history));
+    input_lag_increase_last_update = input_lag_decrease_last_update;
 }
 
 void input_lag_reset_request(int32_t input_lag_turns)
@@ -48,12 +70,12 @@ void input_lag_reset(void)
     input_lag_next_increase_turn = 0;
 }
 
-void input_lag_get_stats(int32_t *increase_missed_turns, int32_t *increase_sampled_turns, int32_t *decrease_missed_turns, int32_t *decrease_sampled_turns)
+void input_lag_get_stats(int32_t *increase_wait_time, int32_t *increase_turn_time, int32_t *decrease_wait_time, int32_t *decrease_sample_time)
 {
-    *increase_missed_turns = __builtin_popcount(input_lag_missed_turn_history);
-    *increase_sampled_turns = input_lag_increase_sample_count;
-    *decrease_missed_turns = input_lag_decrease_missed_turn_count;
-    *decrease_sampled_turns = input_lag_decrease_sample_count;
+    *increase_wait_time = input_lag_time_spent_waiting;
+    *increase_turn_time = INPUT_LAG_INCREASE_WAIT_MS;
+    *decrease_wait_time = input_lag_decrease_wait_time;
+    *decrease_sample_time = input_lag_decrease_sample_time;
 }
 
 TbBool input_lag_skips_processing(void)
@@ -95,39 +117,35 @@ void input_lag_update(struct Packet *packet)
     packet->input_lag_turns = 0;
     if (!network_is_active()) { return; }
     int32_t remote_player_count = GetRemoteUserCount();
+    input_lag_adjustment_time = INPUT_LAG_ADJUSTMENT_TIME_1V1_MS;
+    if (remote_player_count > 1) {
+        input_lag_adjustment_time = INPUT_LAG_ADJUSTMENT_TIME_HOST_RELAY_MS;
+    }
     if ((game.operation_flags & GOF_Paused) == 0 && input_lag_increase_turns == 0 && input_lag_target > game.input_lag_turns) {
         JUSTLOG("Input lag increased from %d to %d", game.input_lag_turns, input_lag_target);
         game.input_lag_turns = input_lag_target;
     }
+    uint32_t current_time = LbTimerClock();
+    input_lag_update_increase_sample(current_time);
     if ((game.operation_flags & GOF_Paused) == 0 && game.skip_initial_input_turns == 0 && get_gameturn() >= INPUT_LAG_SAMPLE_START_TURN) {
-        if (input_lag_increase_sample_count > 0) {
-            input_lag_decrease_sample_count += 1;
-            if ((input_lag_missed_turn_history & 1) != 0) {
-                input_lag_decrease_missed_turn_count += 1;
-            }
+        uint32_t sample_time = current_time - input_lag_decrease_last_update;
+        if (sample_time > input_lag_adjustment_time) {
+            sample_time = input_lag_adjustment_time;
         }
-        int32_t missed_turns = __builtin_popcount(input_lag_missed_turn_history);
-        if (input_lag_increase_sample_count == INPUT_LAG_INCREASE_TURNS && missed_turns >= INPUT_LAG_INCREASE_MISSES && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS && get_gameturn() >= input_lag_next_increase_turn) {
-            local_input_lag_request += 1;
-            input_lag_next_increase_turn = get_gameturn() + INPUT_LAG_INCREASE_COOLDOWN_TURNS;
-            MULTIPLAYER_LOG("Input lag request increased after %d waits in %d turns: request=%d", missed_turns, input_lag_increase_sample_count, local_input_lag_request);
-            input_lag_reset_samples();
-        } else if (input_lag_decrease_sample_count >= INPUT_LAG_DECREASE_SAMPLE_TURNS) {
-            if (input_lag_decrease_missed_turn_count * 100 <= INPUT_LAG_DECREASE_MISS_PERCENT * input_lag_decrease_sample_count && local_input_lag_request > 0) {
+        input_lag_decrease_sample_time += sample_time;
+        if (input_lag_decrease_sample_time >= input_lag_adjustment_time) {
+            if (input_lag_decrease_wait_time * 100 <= INPUT_LAG_DECREASE_WAIT_PERCENT * input_lag_decrease_sample_time && local_input_lag_request > 0) {
                 local_input_lag_request -= 1;
                 input_lag_next_increase_turn = 0;
-                MULTIPLAYER_LOG("Input lag request decreased after %d waits in %d turns: request=%d", input_lag_decrease_missed_turn_count, input_lag_decrease_sample_count, local_input_lag_request);
+                MULTIPLAYER_LOG("Input lag request decreased after %dms spent waiting in %dms: request=%d", input_lag_decrease_wait_time, input_lag_decrease_sample_time, local_input_lag_request);
                 input_lag_reset_samples();
             } else {
-                input_lag_decrease_sample_count = 0;
-                input_lag_decrease_missed_turn_count = 0;
+                input_lag_decrease_sample_time = 0;
+                input_lag_decrease_wait_time = 0;
             }
         }
-        input_lag_missed_turn_history = (input_lag_missed_turn_history << 1) & ((1 << INPUT_LAG_INCREASE_TURNS) - 1);
-        if (input_lag_increase_sample_count < INPUT_LAG_INCREASE_TURNS) {
-            input_lag_increase_sample_count += 1;
-        }
     }
+    input_lag_decrease_last_update = current_time;
     packet->input_lag_turns = local_input_lag_request;
     if (my_player_number != get_host_player_id() || !netstate.sp) { return; }
     for (NetUserId id = 0; id < netstate.max_players; id += 1) {
@@ -144,10 +162,28 @@ void input_lag_update(struct Packet *packet)
     }
 }
 
-void input_lag_note_packet_wait(void)
+void input_lag_note_packet_wait(int32_t wait_time)
 {
-    if (!network_is_active() || (game.operation_flags & GOF_Paused) != 0 || get_gameturn() < INPUT_LAG_SAMPLE_START_TURN || input_lag_increase_sample_count <= 0) { return; }
-    input_lag_missed_turn_history |= 1;
+    if (!network_is_active() || (game.operation_flags & GOF_Paused) != 0 || get_gameturn() < INPUT_LAG_SAMPLE_START_TURN) { return; }
+    uint32_t current_time = LbTimerClock();
+    input_lag_update_increase_sample(current_time);
+    input_lag_decrease_wait_time += wait_time;
+    if (wait_time > INPUT_LAG_INCREASE_SAMPLE_MS) {
+        wait_time = INPUT_LAG_INCREASE_SAMPLE_MS;
+    }
+    for (int32_t offset = 0; offset < wait_time; offset += 1) {
+        uint32_t index = (current_time % INPUT_LAG_INCREASE_SAMPLE_MS + INPUT_LAG_INCREASE_SAMPLE_MS - offset) % INPUT_LAG_INCREASE_SAMPLE_MS;
+        if (input_lag_increase_wait_history[index] == 0) {
+            input_lag_increase_wait_history[index] = 1;
+            input_lag_time_spent_waiting += 1;
+        }
+    }
+    if (input_lag_time_spent_waiting >= INPUT_LAG_INCREASE_WAIT_MS && local_input_lag_request < MAXIMUM_INPUT_LAG_TURNS && get_gameturn() >= input_lag_next_increase_turn) {
+        local_input_lag_request += 1;
+        input_lag_next_increase_turn = get_gameturn() + (int64_t)input_lag_adjustment_time * turns_per_second / 1000;
+        MULTIPLAYER_LOG("Input lag request increased after %dms spent waiting: request=%d", input_lag_time_spent_waiting, local_input_lag_request);
+        input_lag_reset_samples();
+    }
 }
 
 void input_lag_observe_host_packet(const struct Packet *packet)

--- a/src/net_input_lag.h
+++ b/src/net_input_lag.h
@@ -5,11 +5,14 @@
 #include "bflib_basics.h"
 
 #define MAXIMUM_INPUT_LAG_TURNS 12
-#define INPUT_LAG_INCREASE_MISSES 3
-#define INPUT_LAG_INCREASE_TURNS 4
-#define INPUT_LAG_INCREASE_COOLDOWN_TURNS 600
-#define INPUT_LAG_DECREASE_SAMPLE_TURNS 600
-#define INPUT_LAG_DECREASE_MISS_PERCENT 1
+// The minimum amount of time needed to achieve a stable reading
+#define INPUT_LAG_INCREASE_SAMPLE_MS 150
+#define INPUT_LAG_INCREASE_WAIT_MS 75
+// Host relay and 1v1 times are treated differently because the value in 4-player takes much longer to shift (since it requires every player to have the same value).
+#define INPUT_LAG_ADJUSTMENT_TIME_1V1_MS 60000
+#define INPUT_LAG_ADJUSTMENT_TIME_HOST_RELAY_MS 15000
+// Percentage of misses allowed before a decrease, to take noise into consideration
+#define INPUT_LAG_DECREASE_WAIT_PERCENT 1
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,8 +25,8 @@ unsigned short calculate_skip_input(void);
 void input_lag_update(struct Packet *packet);
 void input_lag_reset(void);
 void input_lag_reset_request(int32_t input_lag_turns);
-void input_lag_get_stats(int32_t *increase_missed_turns, int32_t *increase_sampled_turns, int32_t *decrease_missed_turns, int32_t *decrease_sampled_turns);
-void input_lag_note_packet_wait(void);
+void input_lag_get_stats(int32_t *increase_wait_time, int32_t *increase_turn_time, int32_t *decrease_wait_time, int32_t *decrease_sample_time);
+void input_lag_note_packet_wait(int32_t wait_time);
 void input_lag_observe_host_packet(const struct Packet *packet);
 TbBool input_lag_needs_lookahead(void);
 

--- a/src/net_input_lag.h
+++ b/src/net_input_lag.h
@@ -8,7 +8,7 @@
 // The minimum amount of time needed to achieve a stable reading
 #define INPUT_LAG_INCREASE_SAMPLE_MS 150
 #define INPUT_LAG_INCREASE_WAIT_MS 75
-// Host relay and 1v1 times are treated differently because the value in 4-player takes much longer to shift (since it requires every player to have the same value).
+// Host relay and 1v1 times are treated differently because the value in 4-player takes much longer to shift (requires all players to have the same value for a decrease).
 #define INPUT_LAG_ADJUSTMENT_TIME_1V1_MS 60000
 #define INPUT_LAG_ADJUSTMENT_TIME_HOST_RELAY_MS 15000
 // Percentage of misses allowed before a decrease, to take noise into consideration

--- a/src/room_workshop.c
+++ b/src/room_workshop.c
@@ -957,6 +957,9 @@ void send_manufacture_complete_event(struct Dungeon *dungeon, PlayerNumber plyr_
             kind_description = door_code_name(dungeon->manufacture_kind);
             class_description = "Door";
             break;
+        default:
+            ERRORLOG("Invalid manufacture class %d", (int)dungeon->manufacture_class);
+            return;
     }
 
     struct ApiEventData event_data[] = {

--- a/src/room_workshop.c
+++ b/src/room_workshop.c
@@ -944,8 +944,8 @@ void count_crates_in_room(struct Room *room)
 
 void send_manufacture_complete_event(struct Dungeon *dungeon, PlayerNumber plyr_idx)
 {
-    const char* kind_description = NULL;
-    const char* class_description = NULL;
+    const char *kind_description;
+    const char *class_description;
 
     switch (dungeon->manufacture_class)
     {

--- a/src/room_workshop.c
+++ b/src/room_workshop.c
@@ -944,8 +944,8 @@ void count_crates_in_room(struct Room *room)
 
 void send_manufacture_complete_event(struct Dungeon *dungeon, PlayerNumber plyr_idx)
 {
-    const char *kind_description;
-    const char *class_description;
+    const char* kind_description = NULL;
+    const char* class_description = NULL;
 
     switch (dungeon->manufacture_class)
     {


### PR DESCRIPTION
- Switched the dynamic input lag system to use time-based wait detection, it's much more accurate this way. Also it was leaning towards higher input lag than it should have been, so that's fixed too.
- Fixed a silly bug with `SEND_DUPLICATE_PACKETS` which was relaying the duplicates it received when it shouldn't have been. This has halved the host upload rate bandwidth (90KB/s-->45KB/s) and the client download rate bandwidth (30KB/s-->15KB/s).
- Reduced stutter (not sure if felt, but was detected in `!netstats`) by spreading out the `repair_history_send` to multiple turns instead of all on one turn.
- Moved `network_yield_waiting_gameplay_packets()` function.