### PR TITLE
Fix pathfinding lag for unreachable jobs

### DIFF
--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -3229,7 +3229,7 @@ void path_init8_wide_f(struct Path *path, long start_x, long start_y, long end_x
         return;
     }
     NAVIDBG(19,"%s: prepared triangles %ld -> %ld", func_name,tree_triA,tree_triB);
-    if (!regions_connected(tree_triA, tree_triB))
+    if (!navigation_regions_connected(tree_triA, tree_triB, owner_player_navigating))
     {
         NAVIDBG(9,"%s: Regions not connected, cannot trace a path.", func_name);
         return;

--- a/src/ariadne_regions.c
+++ b/src/ariadne_regions.c
@@ -48,48 +48,9 @@ static long ix_RegionQput;
 static long ix_RegionQget;
 static long count_RegionQ;
 static long RegionQueue[REGION_QUEUE_LEN];
-static uint32_t navigation_components[PLAYERS_COUNT][TRIANLGLES_COUNT];
-static PlayerBitFlags navigation_components_valid;
 /******************************************************************************/
 struct RegionT bad_region;
 /******************************************************************************/
-static void rebuild_navigation_regions(PlayerNumber owner)
-{
-    uint32_t *components = navigation_components[owner];
-    NavColour owner_mask = 1 << (NAVMAP_OWNERSELECT_BIT + owner);
-    NavColour blocked_mask = NAVMAP_FLOORHEIGHT_MASK | owner_mask;
-    memset(components, 0, sizeof(navigation_components[owner]));
-    for (int32_t triangle = 0; triangle < ix_Triangles; triangle++) {
-        if (components[triangle]) {
-            continue;
-        }
-        NavColour triangle_alt = get_triangle_tree_alt(triangle);
-        if ((triangle_alt & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
-            continue;
-        }
-        components[triangle] = triangle + 1;
-        tree_val[0] = triangle;
-        for (uint32_t head = 0, tail = 1; head < tail; head++) {
-            for (int32_t edge = 0; edge < 3; edge++) {
-                int32_t next = Triangles[tree_val[head]].tags[edge];
-                if (next < 0) {
-                    continue;
-                }
-                if (components[next]) {
-                    continue;
-                }
-                NavColour next_alt = get_triangle_tree_alt(next);
-                if ((next_alt & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
-                    continue;
-                }
-                components[next] = components[triangle];
-                tree_val[tail++] = next;
-            }
-        }
-    }
-    navigation_components_valid |= to_flag(owner);
-}
-
 TbBool navigation_regions_connected(int32_t first_triangle, int32_t second_triangle, PlayerNumber owner)
 {
     if (!regions_connected(first_triangle, second_triangle)) {
@@ -98,21 +59,33 @@ TbBool navigation_regions_connected(int32_t first_triangle, int32_t second_trian
     if (owner < 0 || owner >= PLAYERS_COUNT) {
         return true;
     }
-    if (!(navigation_components_valid & to_flag(owner))) {
-        rebuild_navigation_regions(owner);
-    }
-    uint32_t *components = navigation_components[owner];
-    uint32_t first_component = components[first_triangle];
-    uint32_t second_component = components[second_triangle];
-    if (!first_component || !second_component) {
+    NavColour blocked_mask = NAVMAP_FLOORHEIGHT_MASK | 1 << (NAVMAP_OWNERSELECT_BIT + owner);
+    if ((get_triangle_tree_alt(first_triangle) & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX || (get_triangle_tree_alt(second_triangle) & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
         return true;
     }
-    return first_component == second_component;
-}
-
-void invalidate_navigation_regions(void)
-{
-    navigation_components_valid = 0;
+    if (first_triangle == second_triangle) {
+        return true;
+    }
+    tags_init();
+    store_current_tag(first_triangle);
+    tree_val[0] = first_triangle;
+    for (uint32_t head = 0, tail = 1; head < tail; head++) {
+        for (int32_t edge = 0; edge < 3; edge++) {
+            int32_t next = Triangles[tree_val[head]].tags[edge];
+            if (next < 0 || is_current_tag(next)) {
+                continue;
+            }
+            if ((get_triangle_tree_alt(next) & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
+                continue;
+            }
+            if (next == second_triangle) {
+                return true;
+            }
+            store_current_tag(next);
+            tree_val[tail++] = next;
+        }
+    }
+    return false;
 }
 
 /**

--- a/src/ariadne_regions.c
+++ b/src/ariadne_regions.c
@@ -56,10 +56,15 @@ struct RegionT bad_region;
 static void rebuild_navigation_regions(PlayerNumber owner)
 {
     uint32_t *components = navigation_components[owner];
-    NavColour blocked_mask = NAVMAP_FLOORHEIGHT_MASK | 1 << (NAVMAP_OWNERSELECT_BIT + owner);
+    NavColour owner_mask = 1 << (NAVMAP_OWNERSELECT_BIT + owner);
+    NavColour blocked_mask = NAVMAP_FLOORHEIGHT_MASK | owner_mask;
     memset(components, 0, sizeof(navigation_components[owner]));
     for (int32_t triangle = 0; triangle < ix_Triangles; triangle++) {
-        if (components[triangle] || (get_triangle_tree_alt(triangle) & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
+        if (components[triangle]) {
+            continue;
+        }
+        NavColour triangle_alt = get_triangle_tree_alt(triangle);
+        if ((triangle_alt & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
             continue;
         }
         components[triangle] = triangle + 1;
@@ -67,10 +72,18 @@ static void rebuild_navigation_regions(PlayerNumber owner)
         for (uint32_t head = 0, tail = 1; head < tail; head++) {
             for (int32_t edge = 0; edge < 3; edge++) {
                 int32_t next = Triangles[tree_val[head]].tags[edge];
-                if (next >= 0 && !components[next] && (get_triangle_tree_alt(next) & blocked_mask) < NAVMAP_FLOORHEIGHT_MAX) {
-                    components[next] = components[triangle];
-                    tree_val[tail++] = next;
+                if (next < 0) {
+                    continue;
                 }
+                if (components[next]) {
+                    continue;
+                }
+                NavColour next_alt = get_triangle_tree_alt(next);
+                if ((next_alt & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
+                    continue;
+                }
+                components[next] = components[triangle];
+                tree_val[tail++] = next;
             }
         }
     }
@@ -79,15 +92,22 @@ static void rebuild_navigation_regions(PlayerNumber owner)
 
 TbBool navigation_regions_connected(int32_t first_triangle, int32_t second_triangle, PlayerNumber owner)
 {
-    TbBool connected = regions_connected(first_triangle, second_triangle);
-    if (!connected || owner < 0 || owner >= PLAYERS_COUNT) {
-        return connected;
+    if (!regions_connected(first_triangle, second_triangle)) {
+        return false;
+    }
+    if (owner < 0 || owner >= PLAYERS_COUNT) {
+        return true;
     }
     if (!(navigation_components_valid & to_flag(owner))) {
         rebuild_navigation_regions(owner);
     }
     uint32_t *components = navigation_components[owner];
-    return !components[first_triangle] || !components[second_triangle] || components[first_triangle] == components[second_triangle];
+    uint32_t first_component = components[first_triangle];
+    uint32_t second_component = components[second_triangle];
+    if (!first_component || !second_component) {
+        return true;
+    }
+    return first_component == second_component;
 }
 
 void invalidate_navigation_regions(void)

--- a/src/ariadne_regions.c
+++ b/src/ariadne_regions.c
@@ -22,7 +22,9 @@
 
 #include "globals.h"
 #include "bflib_basics.h"
+#include "ariadne_navitree.h"
 #include "ariadne_tringls.h"
+#include "player_data.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
@@ -46,9 +48,53 @@ static long ix_RegionQput;
 static long ix_RegionQget;
 static long count_RegionQ;
 static long RegionQueue[REGION_QUEUE_LEN];
+static uint32_t navigation_components[PLAYERS_COUNT][TRIANLGLES_COUNT];
+static PlayerBitFlags navigation_components_valid;
 /******************************************************************************/
 struct RegionT bad_region;
 /******************************************************************************/
+static void rebuild_navigation_regions(PlayerNumber owner)
+{
+    uint32_t *components = navigation_components[owner];
+    NavColour blocked_mask = NAVMAP_FLOORHEIGHT_MASK | 1 << (NAVMAP_OWNERSELECT_BIT + owner);
+    memset(components, 0, sizeof(navigation_components[owner]));
+    for (int32_t triangle = 0; triangle < ix_Triangles; triangle++) {
+        if (components[triangle] || (get_triangle_tree_alt(triangle) & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
+            continue;
+        }
+        components[triangle] = triangle + 1;
+        tree_val[0] = triangle;
+        for (uint32_t head = 0, tail = 1; head < tail; head++) {
+            for (int32_t edge = 0; edge < 3; edge++) {
+                int32_t next = Triangles[tree_val[head]].tags[edge];
+                if (next >= 0 && !components[next] && (get_triangle_tree_alt(next) & blocked_mask) < NAVMAP_FLOORHEIGHT_MAX) {
+                    components[next] = components[triangle];
+                    tree_val[tail++] = next;
+                }
+            }
+        }
+    }
+    navigation_components_valid |= to_flag(owner);
+}
+
+TbBool navigation_regions_connected(int32_t first_triangle, int32_t second_triangle, PlayerNumber owner)
+{
+    TbBool connected = regions_connected(first_triangle, second_triangle);
+    if (!connected || owner < 0 || owner >= PLAYERS_COUNT) {
+        return connected;
+    }
+    if (!(navigation_components_valid & to_flag(owner))) {
+        rebuild_navigation_regions(owner);
+    }
+    uint32_t *components = navigation_components[owner];
+    return !components[first_triangle] || !components[second_triangle] || components[first_triangle] == components[second_triangle];
+}
+
+void invalidate_navigation_regions(void)
+{
+    navigation_components_valid = 0;
+}
+
 /**
  * Allocates region ID.
  * @return The region ID, or 0 on failure.

--- a/src/ariadne_regions.h
+++ b/src/ariadne_regions.h
@@ -32,6 +32,8 @@ extern "C" {
 
 /******************************************************************************/
 TbBool regions_connected(long first_tree_region, long second_tree_region);
+TbBool navigation_regions_connected(int32_t first_triangle, int32_t second_triangle, PlayerNumber owner);
+void invalidate_navigation_regions(void);
 void region_store_init(void);
 long region_get(void);
 void region_put(long nreg);

--- a/src/ariadne_regions.h
+++ b/src/ariadne_regions.h
@@ -33,7 +33,6 @@ extern "C" {
 /******************************************************************************/
 TbBool regions_connected(long first_tree_region, long second_tree_region);
 TbBool navigation_regions_connected(int32_t first_triangle, int32_t second_triangle, PlayerNumber owner);
-void invalidate_navigation_regions(void);
 void region_store_init(void);
 long region_get(void);
 void region_put(long nreg);

--- a/src/ariadne_update.c
+++ b/src/ariadne_update.c
@@ -1598,6 +1598,7 @@ static TbBool triangulate_area(NavColour *imap, long start_x, long start_y, long
     if ( not_whole_map )
         border_unlock(start_x, start_y, end_x, end_y);
     triangulation_border_init();
+    invalidate_navigation_regions();
     NAVIDBG(9,"Done");
     return triangulation_successful;
 }

--- a/src/ariadne_update.c
+++ b/src/ariadne_update.c
@@ -1598,7 +1598,6 @@ static TbBool triangulate_area(NavColour *imap, long start_x, long start_y, long
     if ( not_whole_map )
         border_unlock(start_x, start_y, end_x, end_y);
     triangulation_border_init();
-    invalidate_navigation_regions();
     NAVIDBG(9,"Done");
     return triangulation_successful;
 }


### PR DESCRIPTION
Fixes #5161

Adds `navigation_regions_connected` function which does some basic checks between two navigation triangles and returns true or false as to whether you can walk there. This is just a fast check for terrain blockages, not a definitive pathfinding check.