### PR TITLE
Action Points triggerable by script

### DIFF
--- a/src/actionpt.c
+++ b/src/actionpt.c
@@ -158,6 +158,22 @@ TbBool action_point_reset_idx(ActionPointId apt_idx, PlayerNumber plyr_idx)
     return apt->exists;
 }
 
+TbBool action_point_trigger_idx(ActionPointId apt_idx, PlayerNumber plyr_idx)
+{
+    struct ActionPoint* apt = action_point_get(apt_idx);
+    if (action_point_is_invalid(apt))
+        return false;
+    if (plyr_idx == ALL_PLAYERS)
+    {
+        set_flag(apt->activated, 0x1FF);
+    }
+    else
+    {
+        set_flag(apt->activated, to_flag(plyr_idx));
+    }
+    return apt->exists;
+}
+
 /**
  * Returns if the action point of given index was triggered by given player.
  */

--- a/src/actionpt.h
+++ b/src/actionpt.h
@@ -62,6 +62,7 @@ ActionPointId action_point_number_to_index(ActionPointNumber apt_num);
 TbBool action_point_is_invalid(const struct ActionPoint *apt);
 
 TbBool action_point_reset_idx(ActionPointId apt_idx, PlayerNumber plyr_idx);
+TbBool action_point_trigger_idx(ActionPointId apt_idx, PlayerNumber plyr_idx);
 TbBool action_point_activated_by_player(ActionPointId apt_idx, PlayerNumber plyr_idx);
 
 void clear_action_points(void);

--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -390,6 +390,15 @@ static int lua_Set_next_level(lua_State *L)
     return 0;
 }
 
+static int lua_Trigger_action_point(lua_State *L)
+{
+    ActionPointId apt_idx = luaL_checkActionPoint(L, 1);
+    PlayerNumber player_range = luaL_checkPlayerRangeId(L, 2);
+
+    action_point_trigger_idx(apt_idx, player_range);
+    return 0;
+}
+
 //Adding New Creatures and Parties to the Level
 
 static int lua_Add_creature_to_level(lua_State *L)
@@ -2422,6 +2431,7 @@ static const luaL_Reg global_methods[] = {
    {"AddBonusTime",                     lua_Add_bonus_time                  },
    {"ResetActionPoint",                 lua_Reset_action_point              },
    {"SetNextLevel",                     lua_Set_next_level                  },
+   {"TriggerActionPoint",               lua_Trigger_action_point            },
 
 //Adding New Creatures and Parties to the Level
    {"AddCreatureToLevel",               lua_Add_creature_to_level           },

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -5818,7 +5818,7 @@ static void set_creature_max_level_process(struct ScriptContext* context)
     }
 }
 
-static void reset_action_point_check(const struct ScriptLine* scline)
+static void reset_or_trigger_action_point_check(const struct ScriptLine* scline)
 {
     ALLOCATE_SCRIPT_VALUE(scline->command, 0);
     long apt_idx = action_point_number_to_index(scline->np[0]);
@@ -6758,6 +6758,11 @@ static void tutorial_flash_button_process(struct ScriptContext* context)
     }
 }
 
+static void trigger_action_point_process(struct ScriptContext* context)
+{
+    action_point_trigger_idx(context->value->longs[0], context->value->chars[4]);
+}
+
 /**
  * Descriptions of script commands for parser.
  * Arguments are: A-string, N-integer, C-creature model, P-player, R-room kind, L-location, O-operator, S-slab kind, B-boolean
@@ -6814,7 +6819,7 @@ const struct CommandDesc command_desc[] = {
   {"HEART_LOST_QUICK_OBJECTIVE",        "NAl     ", Cmd_HEART_LOST_QUICK_OBJECTIVE, &heart_lost_quick_objective_check, &heart_lost_quick_objective_process},
   {"ADD_TUNNELLER_PARTY_TO_LEVEL",      "PAAANNN ", Cmd_ADD_TUNNELLER_PARTY_TO_LEVEL, NULL, NULL},
   {"ADD_CREATURE_TO_POOL",              "CN      ", Cmd_ADD_CREATURE_TO_POOL, NULL, NULL},
-  {"RESET_ACTION_POINT",                "Na      ", Cmd_RESET_ACTION_POINT, &reset_action_point_check, &reset_action_point_process},
+  {"RESET_ACTION_POINT",                "Na      ", Cmd_RESET_ACTION_POINT, &reset_or_trigger_action_point_check, &reset_action_point_process},
   {"SET_CREATURE_MAX_LEVEL",            "PC!N    ", Cmd_SET_CREATURE_MAX_LEVEL, &set_creature_max_level_check, &set_creature_max_level_process},
   {"SET_MUSIC",                         "A       ", Cmd_SET_MUSIC, &set_music_check, &set_music_process},
   {"TUTORIAL_FLASH_BUTTON",             "AN      ", Cmd_TUTORIAL_FLASH_BUTTON, &tutorial_flash_button_check, &tutorial_flash_button_process},
@@ -6936,6 +6941,7 @@ const struct CommandDesc command_desc[] = {
   {"LOCK_POSSESSION",                   "PB!     ", Cmd_LOCK_POSSESSION, &lock_possession_check, &lock_possession_process},
   {"SET_DIGGER",                        "PC      ", Cmd_SET_DIGGER , &set_digger_check, &set_digger_process},
   {"RUN_LUA_CODE",                      "A       ", Cmd_RUN_LUA_CODE , &run_lua_code_check, &run_lua_code_process},
+  {"TRIGGER_ACTION_POINT",              "Na      ", Cmd_TRIGGER_ACTION_POINT, &reset_or_trigger_action_point_check, &trigger_action_point_process},
   {NULL,                                "        ", Cmd_NONE, NULL, NULL},
 };
 
@@ -6970,7 +6976,7 @@ const struct CommandDesc dk1_command_desc[] = {
   {"DISPLAY_INFORMATION_WITH_POS", "ANN     ", Cmd_DISPLAY_INFORMATION_WITH_POS, &display_information_check, &display_information_process},
   {"ADD_TUNNELLER_PARTY_TO_LEVEL", "PAAANNN ", Cmd_ADD_TUNNELLER_PARTY_TO_LEVEL, NULL, NULL},
   {"ADD_CREATURE_TO_POOL",         "CN      ", Cmd_ADD_CREATURE_TO_POOL, NULL, NULL},
-  {"RESET_ACTION_POINT",           "N       ", Cmd_RESET_ACTION_POINT, &reset_action_point_check, &reset_action_point_process},
+  {"RESET_ACTION_POINT",           "N       ", Cmd_RESET_ACTION_POINT, &reset_or_trigger_action_point_check, &reset_action_point_process},
   {"SET_CREATURE_MAX_LEVEL",       "PC!N    ", Cmd_SET_CREATURE_MAX_LEVEL, &set_creature_max_level_check, &set_creature_max_level_process},
   {"SET_MUSIC",                    "N       ", Cmd_SET_MUSIC, NULL, NULL},
   {"TUTORIAL_FLASH_BUTTON",        "NN      ", Cmd_TUTORIAL_FLASH_BUTTON, &tutorial_flash_button_check, &tutorial_flash_button_process},

--- a/src/lvl_script_lib.h
+++ b/src/lvl_script_lib.h
@@ -206,6 +206,7 @@ enum TbScriptCommands {
     Cmd_QUICK_PLAYER_OBJECTIVE_WITH_POS    = 194,
     Cmd_QUICK_PLAYER_INFORMATION_WITH_POS  = 195,
     Cmd_COPY_CREATURE_TYPE                 = 196,
+    Cmd_TRIGGER_ACTION_POINT               = 197,
 };
 
 struct ScriptLine {


### PR DESCRIPTION
TRIGGER_ACTION_POINT DKScript command (same parameters as RESET_ACTION_POINT) and TriggerActionPoint Lua command (same parameters as ResetActionPoint)

The effects can be mimicked by using flags, but this makes it easier and uses fewer resources.