### PR TITLE
`-waitusers N` (wait for N users to join before starting)

### DIFF
--- a/src/front_network.c
+++ b/src/front_network.c
@@ -58,6 +58,7 @@ extern "C" {
 
 extern char autostart_multiplayer_campaign[80];
 extern int autostart_multiplayer_level;
+extern int autostart_multiplayer_users_expected;
 
 /******************************************************************************/
 const char *keeper_netconf_file = "fxconfig.net";
@@ -545,7 +546,7 @@ void handle_autostart_multiplayer_messaging(void)
     TbBool player_joined = (net_number_of_enum_players > previous_enum_players);
     previous_enum_players = net_number_of_enum_players;
 
-    if (net_number_of_enum_players < 2) {
+    if (net_number_of_enum_players < autostart_multiplayer_users_expected) {
         return;
     }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -64,6 +64,7 @@
 #include <algorithm>
 using std::min;
 using std::max;
+using std::clamp;
 extern "C" {
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,7 @@ short default_loc_player = 0;
 struct StartupParameters start_params;
 char autostart_multiplayer_campaign[80] = "";
 int autostart_multiplayer_level = 0;
+int autostart_multiplayer_users_expected = 2;
 int32_t turns_per_second;
 unsigned char *blue_palette;
 unsigned char *red_palette;
@@ -1934,6 +1935,11 @@ static short process_command_line(unsigned short argc, char *argv[])
           narg++;
           LbNetwork_InitSessionsFromCmdLine(pr2str);
           game_flags2 |= GF2_Connect;
+      }
+      else if (strcasecmp(parstr,"waitusers") == 0)
+      {
+          autostart_multiplayer_users_expected = clamp(atoi(pr2str), MIN_NET_USERS, MAX_NET_USERS);
+          narg++;
       }
       else if (strcasecmp(parstr,"server") == 0)
       {

--- a/src/net_main.h
+++ b/src/net_main.h
@@ -36,6 +36,7 @@ extern "C" {
 #define PEER_TIMEOUT_MIN_MS 5000
 #define PEER_TIMEOUT_MAX_MS 30000
 
+#define MIN_NET_USERS 2
 #define MAX_NET_USERS 4
 #define MAX_NET_PEERS (MAX_NET_USERS - 1)
 #define SERVER_ID 0


### PR DESCRIPTION
Adds a cli arg to specify how many users the host should wait for before starting the match, when starting a netplay match from the cli.

QoL feature for future work on "archon mode."