### PR TITLE
CAPTURE_CURSOR config variable

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -44,6 +44,9 @@ MUSIC_FROM_DISK=ON
 ; Mouse pointer movement speed, 0 is normal OS speed. Dungeon Keeper default was 100. 50 is half speed.
 POINTER_SENSITIVITY=0
 
+; Lock mouse to the window upon startup and in general
+CAPTURE_CURSOR=ON
+
 ; The camera moves when you push the edges of the screen with the mouse.
 CURSOR_EDGE_CAMERA_PANNING=ON
 

--- a/src/config_keeperfx.c
+++ b/src/config_keeperfx.c
@@ -163,6 +163,7 @@ const struct NamedCommand conf_commands[] = {
   {"ROTATE_AROUND_MOUSE"           , 43},
   {"VSYNC"                         , 44},
   {"RELATIVE_MOUSE_MODE"           , 45},
+  {"CAPTURE_CURSOR"                , 46},
   {NULL,                   0},
   };
 
@@ -1016,6 +1017,16 @@ static void load_file_configuration(const char *fname, const char *sname, const 
               features_enabled |= Ft_RelativeMouseMode;
           else
               features_enabled &= ~Ft_RelativeMouseMode;
+          break;
+      case 46: // CAPTURE_CURSOR
+          i = recognize_conf_parameter(buf,&pos,len,logicval_type);
+          if (i <= 0)
+          {
+              CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
+                COMMAND_TEXT(cmd_num),config_textname);
+            break;
+          }
+          if (i!=1) lbMouseGrab = false;
           break;
       case ccr_comment:
           break;

--- a/src/config_keeperfx.h
+++ b/src/config_keeperfx.h
@@ -52,7 +52,7 @@ enum TbFeature {
     Ft_DisableCursorCameraPanning   = 0x20000,
     Ft_DeltaTime                    = 0x40000,
     Ft_NoCdMusic                    = 0x80000,
-    Ft_RelativeMouseMode            = 0x100000
+    Ft_RelativeMouseMode            = 0x100000,
 };
 
 enum TbLanguage {

--- a/src/config_keeperfx.h
+++ b/src/config_keeperfx.h
@@ -52,7 +52,7 @@ enum TbFeature {
     Ft_DisableCursorCameraPanning   = 0x20000,
     Ft_DeltaTime                    = 0x40000,
     Ft_NoCdMusic                    = 0x80000,
-    Ft_RelativeMouseMode            = 0x100000,
+    Ft_RelativeMouseMode            = 0x100000
 };
 
 enum TbLanguage {


### PR DESCRIPTION
Can now add `CAPTURE_CURSOR=OFF` to the .cfg; has the same effect as `-altinput` in the cli.

Minor QoL feature for my ongoing attempt at "archon mode"