### PR TITLE
Transform preserve lair placement, relative health, return new creature

### DIFF
--- a/config/fxdata/lua/classes/Creature.lua
+++ b/config/fxdata/lua/classes/Creature.lua
@@ -13,6 +13,7 @@
 ---@field continue_state creature_state
 ---@field moveto_pos Pos3d should be combined with assigning a state that makes use of it
 ---@field flee_pos Pos3d The position the creature will flee too. For keeper creatures this is their lair
+---@field lair Thing the lair totem of the creature, if it has one
 ---@field max_speed integer the movement speed of the creature after spell modifications
 ---@field gold_held integer gold carried by the creature
 ---@field opponents_count integer number of creatures it is in battle with, combined ranged and melee
@@ -67,6 +68,7 @@ function Creature:transfer() end
 ---Transforms the creature into another model
 ---@param creaturemodel creature_type type of creature to transform into
 ---@param level integer xp level the creature gets. Use 0 for random
+---@return Creature|nil newcreature the newly creature, nil if failed
 function Creature:transform(creaturemodel,level) end
 
 ---Checks if the creature is under enemy custody (e.g. in prison or torture chamber)

--- a/config/fxdata/lua/classes/Creature.lua
+++ b/config/fxdata/lua/classes/Creature.lua
@@ -13,7 +13,7 @@
 ---@field continue_state creature_state
 ---@field moveto_pos Pos3d should be combined with assigning a state that makes use of it
 ---@field flee_pos Pos3d The position the creature will flee too. For keeper creatures this is their lair
----@field lair Thing the lair totem of the creature, if it has one
+---@field lair Thing|nil the lair totem of the creature, if it has one
 ---@field max_speed integer the movement speed of the creature after spell modifications
 ---@field gold_held integer gold carried by the creature
 ---@field opponents_count integer number of creatures it is in battle with, combined ranged and melee
@@ -68,7 +68,7 @@ function Creature:transfer() end
 ---Transforms the creature into another model
 ---@param creaturemodel creature_type type of creature to transform into
 ---@param level integer xp level the creature gets. Use 0 for random
----@return Creature|nil newcreature the newly creature, nil if failed
+---@return Creature|nil newcreature the newly created creature, nil if failed
 function Creature:transform(creaturemodel,level) end
 
 ---Checks if the creature is under enemy custody (e.g. in prison or torture chamber)

--- a/src/creature_states_lair.c
+++ b/src/creature_states_lair.c
@@ -224,6 +224,18 @@ long process_lair_enemy(struct Thing *thing, struct Room *room)
     return 1;
 }
 
+/**
+ * Creates the lair totem for a creature at given position and books the room capacity for it.
+ * The lair the creature had before, if any, is removed.
+ * @param creatng The creature the lair will belong to.
+ * @param room The room to book the lair capacity in.
+ * @param pos Where the totem is placed. Does not have to be the creature's own position.
+ * @return True if the totem was created, false if the creature model has no lair object
+ *     or the object could not be created.
+ * @note The caller has to check that the room has enough free capacity
+ *     (room_has_enough_free_capacity_for_creature_job()) and that no lair totem is
+ *     standing at 'pos' yet (find_creature_lair_totem_at_subtile()).
+ */
 TbBool creature_place_lair_totem(struct Thing *creatng, struct Room *room, const struct Coord3d *pos)
 {
     struct CreatureControl *cctrl = creature_control_get_from_thing(creatng);
@@ -232,20 +244,20 @@ TbBool creature_place_lair_totem(struct Thing *creatng, struct Room *room, const
     {
         return false;
     }
-    room->content_per_model[creatng->model]++;
-    room->used_capacity += get_required_room_capacity_for_object(RoRoF_LairStorage, 0, creatng->model);
-    if ((cctrl->lair_room_id > 0) && (cctrl->lairtng_idx > 0))
-    {
-        struct Room* origroom = room_get(cctrl->lair_room_id);
-        creature_remove_lair_totem_from_room(creatng, origroom);
-    }
-    cctrl->lair_room_id = room->index;
     struct Thing *lairtng = create_object(pos, crconf->lair_object, creatng->owner, -1);
     if (thing_is_invalid(lairtng))
     {
         ERRORLOG("Could not create lair totem");
         return false;
     }
+    room->content_per_model[creatng->model]++;
+    room->used_capacity += get_required_room_capacity_for_object(RoRoF_LairStorage, 0, creatng->model);
+    if ((cctrl->lair_room_id > 0) && (cctrl->lairtng_idx > 0))
+    {
+        struct Room *origroom = room_get(cctrl->lair_room_id);
+        creature_remove_lair_totem_from_room(creatng, origroom);
+    }
+    cctrl->lair_room_id = room->index;
     lairtng->mappos.z.val = get_thing_height_at(lairtng, &lairtng->mappos);
     lairtng->move_angle_xy = THING_RANDOM(creatng, DEGREES_360);
     // Associate creature with the lair

--- a/src/creature_states_lair.c
+++ b/src/creature_states_lair.c
@@ -224,15 +224,14 @@ long process_lair_enemy(struct Thing *thing, struct Room *room)
     return 1;
 }
 
-CrStateRet creature_add_lair_to_room(struct Thing *creatng, struct Room *room)
+TbBool creature_place_lair_totem(struct Thing *creatng, struct Room *room, const struct Coord3d *pos)
 {
-    if (!room_has_enough_free_capacity_for_creature_job(room, creatng, Job_TAKE_SLEEP))
-        return CrStRet_ResetFail;
-    // Make sure we don't already have a lair on that position
-    struct Thing* lairtng = find_creature_lair_totem_at_subtile(creatng->mappos.x.stl.num, creatng->mappos.y.stl.num, 0);
-    if (!thing_is_invalid(lairtng))
-        return CrStRet_Unchanged;
-    struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
+    struct CreatureControl *cctrl = creature_control_get_from_thing(creatng);
+    struct CreatureModelConfig *crconf = creature_stats_get(creatng->model);
+    if (crconf->lair_object == 0)
+    {
+        return false;
+    }
     room->content_per_model[creatng->model]++;
     room->used_capacity += get_required_room_capacity_for_object(RoRoF_LairStorage, 0, creatng->model);
     if ((cctrl->lair_room_id > 0) && (cctrl->lairtng_idx > 0))
@@ -241,34 +240,44 @@ CrStateRet creature_add_lair_to_room(struct Thing *creatng, struct Room *room)
         creature_remove_lair_totem_from_room(creatng, origroom);
     }
     cctrl->lair_room_id = room->index;
-    // Create the lair thing
-    struct Coord3d pos;
-    pos.x.val = creatng->mappos.x.val;
-    pos.y.val = creatng->mappos.y.val;
-    pos.z.val = creatng->mappos.z.val;
-    struct CreatureModelConfig* crconf = creature_stats_get(creatng->model);
-    lairtng = create_object(&pos, crconf->lair_object, creatng->owner, -1);
+    struct Thing *lairtng = create_object(pos, crconf->lair_object, creatng->owner, -1);
     if (thing_is_invalid(lairtng))
     {
         ERRORLOG("Could not create lair totem");
-        remove_thing_from_mapwho(creatng);
-        place_thing_in_mapwho(creatng);
-        return CrStRet_Modified; // Return that so we won't try to redo the action over and over
+        return false;
     }
-    lairtng->move_angle_xy = THING_RANDOM(creatng, DEGREES_360);
     lairtng->mappos.z.val = get_thing_height_at(lairtng, &lairtng->mappos);
+    lairtng->move_angle_xy = THING_RANDOM(creatng, DEGREES_360);
     // Associate creature with the lair
     cctrl->lairtng_idx = lairtng->index;
     lairtng->lair.belongs_to = creatng->index;
     lairtng->lair.cssize = 1;
     // Lair size depends on creature level
     lairtng->lair.spr_size = game.conf.crtr_conf.sprite_size + (game.conf.crtr_conf.sprite_size * game.conf.crtr_conf.exp.size_increase_on_exp * cctrl->exp_level) / 100;
-    lairtng->move_angle_xy = THING_RANDOM(creatng, DEGREES_360);
     struct ObjectConfigStats* objst = get_object_model_stats(lairtng->model);
     set_thing_draw(lairtng, objst->sprite_anim_idx, objst->anim_speed, lairtng->lair.cssize, 0, -1, objst->draw_class);
-    thing_play_sample(creatng, 158, NORMAL_PITCH, 0, 3, 1, 2, FULL_LOUDNESS);
-    create_effect(&pos, imp_spangle_effects[get_player_color_idx(creatng->owner)], creatng->owner);
     anger_set_creature_anger(creatng, 0, AngR_NoLair);
+    return true;
+}
+
+CrStateRet creature_add_lair_to_room(struct Thing *creatng, struct Room *room)
+{
+    if (!room_has_enough_free_capacity_for_creature_job(room, creatng, Job_TAKE_SLEEP))
+        return CrStRet_ResetFail;
+    // Make sure we don't already have a lair on that position
+    struct Thing* lairtng = find_creature_lair_totem_at_subtile(creatng->mappos.x.stl.num, creatng->mappos.y.stl.num, 0);
+    if (!thing_is_invalid(lairtng))
+        return CrStRet_Unchanged;
+
+    if (!creature_place_lair_totem(creatng, room, &creatng->mappos))
+    {
+        remove_thing_from_mapwho(creatng);
+        place_thing_in_mapwho(creatng);
+        return CrStRet_Modified; // Return that so we won't try to redo the action over and over
+    }
+
+    thing_play_sample(creatng, 158, NORMAL_PITCH, 0, 3, 1, 2, FULL_LOUDNESS);
+    create_effect(&creatng->mappos, imp_spangle_effects[get_player_color_idx(creatng->owner)], creatng->owner);
     remove_thing_from_mapwho(creatng);
     place_thing_in_mapwho(creatng);
     return CrStRet_ResetOk;

--- a/src/creature_states_lair.h
+++ b/src/creature_states_lair.h
@@ -39,6 +39,7 @@ TbBool creature_is_doing_lair_activity(const struct Thing *thing);
 TbBool creature_is_sleeping(const struct Thing *thing);
 TbBool creature_is_doing_toking(const struct Thing *thing);
 TbBool creature_requires_healing(const struct Thing *thing);
+TbBool creature_place_lair_totem(struct Thing *creatng, struct Room *room, const struct Coord3d *pos);
 
 CrStateRet creature_at_changed_lair(struct Thing *thing);
 CrStateRet creature_at_new_lair(struct Thing *thing);

--- a/src/lua_api_things.c
+++ b/src/lua_api_things.c
@@ -165,8 +165,9 @@ static int lua_transform_creature(lua_State* L)
         return 0;
     }
 
-    grow_up_creature(thing, crtr_id, crtr_level);
-    return 0;
+    struct Thing* newtng = grow_up_creature(thing, crtr_id, crtr_level);
+    lua_pushThing(L, newtng);
+    return 1;
 }
 
 static int lua_stun_creature(lua_State* L)
@@ -563,6 +564,8 @@ static int thing_get_field(lua_State *L) {
             lua_pushinteger(L, cctrl->hunger_level);
         } else if (strcmp(key, "hunger_loss") == 0) {
             lua_pushinteger(L, cctrl->hunger_loss);
+        } else if (strcmp(key, "lair") == 0) {
+            lua_pushThing(L, thing_get(cctrl->lairtng_idx));
         } else if (strcmp(key, "opponents_melee_count") == 0) {
             lua_pushinteger(L, cctrl->opponents_melee_count);
         } else if (strcmp(key, "opponents_ranged_count") == 0) {

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6319,6 +6319,13 @@ void transfer_creature_data_and_gold(struct Thing *oldtng, struct Thing *newtng)
     struct CreatureModelConfig* ncrconf = creature_stats_get_from_thing(newtng);
 
     strcpy(newcctrl->creature_name, oldcctrl->creature_name);
+    HitPoints health_permil = get_creature_health_permil(oldtng);
+    HitPoints new_health = (HitPoints)(((int64_t)newcctrl->max_health * health_permil) / 1000);
+    if (new_health < 1)
+    {
+        new_health = 1;
+    }
+    newtng->health = new_health;
     newcctrl->blood_type = oldcctrl->blood_type;
     newcctrl->kills_num = oldcctrl->kills_num;
     newcctrl->kills_num_allied = oldcctrl->kills_num_allied;
@@ -7747,7 +7754,7 @@ ThingModel get_random_appropriate_creature_kind(ThingModel original_model)
     return random_model;
 }
 
-TbBool grow_up_creature(struct Thing *thing, ThingModel grow_up_model, CrtrExpLevel grow_up_level)
+struct Thing *grow_up_creature(struct Thing *thing, ThingModel grow_up_model, CrtrExpLevel grow_up_level)
 {
     if (grow_up_model == CREATURE_NOT_A_DIGGER)
     {
@@ -7756,13 +7763,13 @@ TbBool grow_up_creature(struct Thing *thing, ThingModel grow_up_model, CrtrExpLe
     if (!creature_count_below_map_limit(1))
     {
         WARNLOG("Could not create creature to transform %s to due to creature limit", thing_model_name(thing));
-        return false;
+        return INVALID_THING;
     }
     struct Thing *newtng = create_creature(&thing->mappos, grow_up_model, thing->owner);
     if (thing_is_invalid(newtng))
     {
         ERRORLOG("Could not create creature to transform %s to", thing_model_name(thing));
-        return false;
+        return INVALID_THING;
     }
     // Randomise new level if 'grow_up_level' was set to 0 on the creature config.
     if (grow_up_level == 0)
@@ -7773,8 +7780,20 @@ TbBool grow_up_creature(struct Thing *thing, ThingModel grow_up_model, CrtrExpLe
     {
         set_creature_level(newtng, grow_up_level - 1);
     }
-    transfer_creature_data_and_gold(thing, newtng); // Transfer the blood type, creature name, kill count, joined age and carried gold to the new creature.
-    update_creature_health_to_max(newtng);
+    transfer_creature_data_and_gold(thing, newtng); // Transfer health, the blood type, creature name, kill count, joined age and carried gold to the new creature.
+    // Remember the old lair
+    struct CreatureControl *oldcctrl = creature_control_get_from_thing(thing);
+    RoomIndex lair_room_idx = 0;
+    struct Coord3d lairpos = {0};
+    if ((oldcctrl->lairtng_idx > 0) && (oldcctrl->lair_room_id > 0))
+    {
+        struct Thing *oldlairtng = thing_get(oldcctrl->lairtng_idx);
+        if (!thing_is_invalid(oldlairtng))
+        {
+            lair_room_idx = oldcctrl->lair_room_id;
+            lairpos = oldlairtng->mappos;
+        }
+    }
     struct CreatureControl *cctrl = creature_control_get_from_thing(newtng);
     cctrl->countdown = 50;
     external_set_thing_state(newtng, CrSt_CreatureBeHappy);
@@ -7812,7 +7831,20 @@ TbBool grow_up_creature(struct Thing *thing, ThingModel grow_up_model, CrtrExpLe
         }
     }
     kill_creature(thing, INVALID_THING, -1, CrDed_NoEffects | CrDed_NoUnconscious | CrDed_NotReallyDying);
-    return true;
+    // place new lair
+    if (lair_room_idx > 0)
+    {
+        struct Room *lairroom = room_get(lair_room_idx);
+        if (!room_is_invalid(lairroom)
+         && (lairroom->owner == newtng->owner)
+         && room_role_matches(lairroom->kind, get_room_role_for_job(Job_TAKE_SLEEP))
+         && room_has_enough_free_capacity_for_creature_job(lairroom, newtng, Job_TAKE_SLEEP)
+         && thing_is_invalid(find_creature_lair_totem_at_subtile(lairpos.x.stl.num, lairpos.y.stl.num, 0)))
+        {
+            creature_place_lair_totem(newtng, lairroom, &lairpos);
+        }
+    }
+    return newtng;
 }
 
 TbResult script_use_spell_on_creature(PlayerNumber plyr_idx, struct Thing *thing, SpellKind spkind, CrtrExpLevel spell_level)

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6370,7 +6370,7 @@ long update_creature_levels(struct Thing *thing)
     {
         return 0;
     }
-    if (!grow_up_creature(thing, crconf->grow_up, crconf->grow_up_level))
+    if (thing_is_invalid(grow_up_creature(thing, crconf->grow_up, crconf->grow_up_level)))
     {
         return 0;
     }

--- a/src/thing_creature.h
+++ b/src/thing_creature.h
@@ -244,7 +244,7 @@ TbBool script_change_creatures_annoyance(PlayerNumber plyr_idx, ThingModel crmod
 void throw_out_gold(struct Thing* thing, long amount);
 ThingModel get_random_creature_kind_with_model_flags(unsigned long model_flags);
 ThingModel get_random_appropriate_creature_kind(ThingModel original_model);
-TbBool grow_up_creature(struct Thing *thing, ThingModel grow_up_model, CrtrExpLevel grow_up_level);
+struct Thing *grow_up_creature(struct Thing *thing, ThingModel grow_up_model, CrtrExpLevel grow_up_level);
 /******************************************************************************/
 #ifdef __cplusplus
 }


### PR DESCRIPTION

This affects both the Lua Transform function and transformations on level-up:
- Preserve lair placement, so the new creature doesn't have to place a new lair if the new still fits inside the room
- Preserve relative health, so the creature doesn't get fully healed on transformation anymore

- Extracted `creature_place_lair_totem()` as a helper function from `creature_add_lair_to_room()`
- `grow_up_creature()` now returns the new creature instead of a bool
- Return the new creature in Lua
- New Lua `Creature.lair` field for the linked lair object