### PR TITLE
Refactor: User/Player distinction

### DIFF
--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -72,6 +72,7 @@
 #include <math.h>
 #include "lua_base.h"
 #include "net_resync.h"
+#include "net_game.h"
 #include "kjm_input.h"
 #include "timer.h"
 #include "post_inc.h"
@@ -129,7 +130,7 @@ void do_param1_completion_for_name_command(PlayerNumber plyr_idx, char *args_str
 
 
 extern void render_set_sprite_debug(int level);
-extern TbBool process_players_global_packet_action(PlayerNumber plyr_idx);
+extern TbBool process_user_global_packet_action(NetUserId user);
 
 static struct GuiBoxOption cmd_comp_procs_data[COMPUTER_PROCESSES_COUNT + 3] = {
   {"!", 1, NULL, NULL, 0, 0, 0, 0, 0, 0, 0, 0 }
@@ -825,7 +826,7 @@ TbBool cmd_reveal(PlayerNumber plyr_idx, char * args)
     }
     if (r > 0) {
         int radius_offset = r / 2;
-        struct Packet * pckt = get_packet_direct(player->packet_num);
+        struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
         MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
         MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
         clear_dig_for_map_rect(player->id_number,
@@ -856,7 +857,7 @@ TbBool cmd_conceal(PlayerNumber plyr_idx, char * args)
     }
     if (r > 0) {
         int radius_offset = r / 2;
-        struct Packet * pckt = get_packet_direct(player->packet_num);
+        struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
         MapSubtlCoord stl_x = coord_subtile((pckt->pos_x));
         MapSubtlCoord stl_y = coord_subtile((pckt->pos_y));
         conceal_map_area(player->id_number, stl_x - radius_offset, stl_x + r - radius_offset, stl_y - radius_offset, stl_y + r - radius_offset, false);
@@ -1045,8 +1046,7 @@ TbBool cmd_create_gold(PlayerNumber plyr_idx, char * args)
             targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "parameter 1 requires a number");
         return false;
     }
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     struct Thing * thing = create_gold_pot_at(pckt->pos_x, pckt->pos_y, plyr_idx);
     if (thing_is_invalid(thing)) {
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "coordinate thing is invalid");
@@ -1087,13 +1087,13 @@ TbBool cmd_look(PlayerNumber plyr_idx, char * args)
     long room_id = get_id(room_desc, pr1str);
     if (room_id != -1) {
         go_to_my_next_room_of_type(room_id);
-        process_players_global_packet_action(plyr_idx); // Dirty hack
+        process_user_global_packet_action(get_player(plyr_idx)->user_id); // Dirty hack
         return true;
     }
     long crmodel = get_id(creature_desc, pr1str);
     if(crmodel != -1) {
         go_to_next_creature_of_model_and_gui_job(crmodel, CrGUIJob_Any, TPF_OrderedPick);
-        process_players_global_packet_action(plyr_idx); // Dirty hack
+        process_user_global_packet_action(get_player(plyr_idx)->user_id); // Dirty hack
         return true;
     }
     TbMapLocation loc = {0};
@@ -1109,7 +1109,7 @@ TbBool cmd_look(PlayerNumber plyr_idx, char * args)
         return false;
     }
     set_players_packet_action(player, PckA_ZoomToPosition, subtile_coord_center(stl_x), subtile_coord_center(stl_y), 0, 0);
-    process_players_global_packet_action(plyr_idx); // Dirty hack
+    process_user_global_packet_action(get_player(plyr_idx)->user_id); // Dirty hack
     return true;
 }
 
@@ -1124,8 +1124,7 @@ TbBool cmd_create_object(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require parameter 1 as object model");
         return false;
     }
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     struct Coord3d pos = {0};
     pos.x.stl.num = coord_subtile(pckt->pos_x);
     pos.y.stl.num = coord_subtile(pckt->pos_y);
@@ -1207,8 +1206,7 @@ TbBool cmd_create_creature(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "creature model [%d] exceeds (%d, %d)", crmodel, 0, game.conf.crtr_conf.model_count);
         return false;
     }
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
     if (subtile_coords_invalid(stl_x, stl_y)) {
@@ -1300,8 +1298,7 @@ TbBool cmd_create_thing(PlayerNumber plyr_idx, char * args)
             targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "model is invalid");
         return false;
     }
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     struct Coord3d pos = {0};
     pos.x.stl.num = coord_subtile(pckt->pos_x);
     pos.y.stl.num = coord_subtile(pckt->pos_y);
@@ -1549,8 +1546,7 @@ TbBool cmd_place_slab(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require parameter 1 as slbkind");
         return false;
     }
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
     MapSlabCoord slb_x = subtile_slab(stl_x);
@@ -1902,8 +1898,7 @@ TbBool cmd_mapwho_info(PlayerNumber plyr_idx, char * args)
     char * pr1str = strsep_param_with_space(&args);
     struct Coord3d pos = {0};
     if (pr1str == NULL) {
-        struct PlayerInfo * player = get_player(plyr_idx);
-        struct Packet * pckt = get_packet_direct(player->packet_num);
+        struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
         pos.x.val = pckt->pos_x;
         pos.y.val = pckt->pos_y;
     } else {
@@ -2011,8 +2006,7 @@ TbBool cmd_cursor_pos(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require 'cheat mode'");
         return false;
     }
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     struct Coord3d pos = {0};
     pos.x.val = pckt->pos_x;
     pos.y.val = pckt->pos_y;
@@ -2024,13 +2018,13 @@ TbBool cmd_cursor_pos(PlayerNumber plyr_idx, char * args)
 
 TbBool cmd_get_thing(PlayerNumber plyr_idx, char * args)
 {
+    struct PlayerInfo * player = get_player(plyr_idx);
     if (game.easter_eggs_enabled == false) {
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require 'cheat mode'");
         return false;
     }
     char * pr1str = strsep_param_with_space(&args);
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
     struct Thing * thing = (pr1str != NULL) ? thing_get(atoi(pr1str)) : get_nearest_thing_at_position(stl_x, stl_y);
@@ -2107,7 +2101,7 @@ TbBool cmd_move_thing(PlayerNumber plyr_idx, char * args)
             pos.z.val = get_floor_height_at(&pos);
         }
     } else {
-        struct Packet * pckt = get_packet_direct(player->packet_num);
+        struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
         pos.x.val = pckt->pos_x;
         pos.y.val = pckt->pos_y;
         pos.z.val = get_floor_height_at(&pos);
@@ -2134,13 +2128,13 @@ TbBool cmd_destroy_thing(PlayerNumber plyr_idx, char * args)
 
 TbBool cmd_get_room(PlayerNumber plyr_idx, char * args)
 {
+    struct PlayerInfo * player = get_player(plyr_idx);
     if (game.easter_eggs_enabled == false) {
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require 'cheat mode'");
         return false;
     }
     char * pr1str = strsep_param_with_space(&args);
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     MapSubtlCoord stl_x = coord_subtile((pckt->pos_x));
     MapSubtlCoord stl_y = coord_subtile((pckt->pos_y));
     struct Room * room = (pr1str != NULL) ? room_get(atoi(pr1str)) : subtile_room_get(stl_x, stl_y);
@@ -2181,8 +2175,7 @@ TbBool cmd_slab_health(PlayerNumber plyr_idx, char * args)
         return false;
     }
     char * pr1str = strsep_param_with_space(&args);
-    struct PlayerInfo * player = get_player(plyr_idx);
-    struct Packet * pckt = get_packet_direct(player->packet_num);
+    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
     MapSubtlCoord stl_x = coord_subtile((pckt->pos_x));
     MapSubtlCoord stl_y = coord_subtile((pckt->pos_y));
     struct SlabMap * slb = get_slabmap_for_subtile(stl_x, stl_y);
@@ -3147,7 +3140,11 @@ void cmd_auto_completion(PlayerNumber plyr_idx, char *cmd_str, size_t cmd_size)
 
 TbBool cmd_exec(PlayerNumber plyr_idx, char * args)
 {
-    SYNCDBG(2, "Command %d: %s",(int)plyr_idx, args);
+    SYNCDBG(2, "Command (player %d): %s",(int)plyr_idx, args);
+    if (!player_exists(get_player(plyr_idx))) {
+        WARNLOG("Command for non-existent player %d ignored: %s", (int)plyr_idx, args);
+        return false;
+    }
     const char * command = strsep_param_with_space(&args);
     if (command == NULL) {
         if (game.easter_eggs_enabled == true) {

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -427,7 +427,7 @@ static short get_players_message_inputs(void)
         memcpy(player->mp_pending_message, player->mp_message_text, PLAYER_MP_MESSAGE_LEN);
         set_players_packet_action(player, PckA_PlyrMsgEnd, 0, 0, 0, 0);
         if (network_is_active()) {
-            send_network_chat_message(player->id_number, player->mp_message_text);
+            send_network_chat_message(get_local_user(), player->mp_message_text);
         }
         player->allocflags &= ~PlaF_NewMPMessage;
         memset(player->mp_message_text, 0, PLAYER_MP_MESSAGE_LEN);
@@ -827,7 +827,7 @@ static short get_global_inputs(void)
       return true;
   if (player->victory_state != VicS_Undecided && is_game_key_pressed(Gkey_FinishLevel, true, false))
       {
-        if ((player->victory_state == VicS_LostLevel) && network_is_active() && (player->id_number == get_host_player_id()) && network_human_contenders_remain())
+        if ((player->victory_state == VicS_LostLevel) && network_is_active() && (player->id_number == get_net_user_player_number(SERVER_ID)) && network_human_contenders_remain())
         {
             return true;
         }
@@ -1240,7 +1240,7 @@ static TbBool get_dungeon_control_pausable_action_inputs(void)
         if (is_game_key_pressed(Gkey_SnapCamera, true, true))
         {
             struct Camera* cam = &player->cameras[CamIV_Isometric];
-            struct Packet* pckt = get_packet(my_player_number);
+            struct Packet* pckt = get_local_packet();
             int angle = cam->rotation_angle_x;
             if (key_modifiers & KMod_CONTROL)
             {
@@ -1280,7 +1280,7 @@ static TbBool get_dungeon_control_pausable_action_inputs(void)
         if (is_game_key_pressed(Gkey_SnapCamera, true, true))
         {
             struct Camera* cam = &player->cameras[CamIV_FrontView];
-            struct Packet* pckt = get_packet(my_player_number);
+            struct Packet* pckt = get_local_packet();
             int angle = cam->rotation_angle_x;
             if (key_modifiers & KMod_CONTROL)
             {
@@ -1986,8 +1986,10 @@ static short get_creature_control_action_inputs(void)
     return false;
 }
 
-static void set_packet_action_for_thing_under_hand(struct PlayerInfo* player, struct Packet* pckt)
+static void set_packet_action_for_thing_under_hand(struct Packet* pckt)
 {
+    NetUserId user = get_local_user();
+    struct PlayerInfo* player = get_my_player();
     if ((player->view_type != PVT_DungeonTop) || ((pckt->control_flags & PCtr_Gui) != 0) || (local_thing_under_hand <= 0) || (pckt->action != PckA_None) || (get_gameturn() - hand_pick_pending_turn <= game.input_lag_turns)) {
         return;
     }
@@ -2002,7 +2004,7 @@ static void set_packet_action_for_thing_under_hand(struct PlayerInfo* player, st
     PowerKind pwkind = player->chosen_power_kind;
     PlayerState work_state = player->work_state;
     for (GameTurnDelta i = 1; i <= game.input_lag_turns; i += 1) {
-        const struct Packet* delayed_pckt = get_history_packet(player->packet_num, get_gameturn() - i);
+        const struct Packet* delayed_pckt = get_history_packet(user, get_gameturn() - i);
         if ((delayed_pckt != NULL) && (delayed_pckt->action == PckA_SetPlyrState)) {
             work_state = delayed_pckt->actn_par1;
             pwkind = delayed_pckt->actn_par2;
@@ -2041,8 +2043,8 @@ static void get_packet_control_mouse_clicks(void)
     }
 
     struct PlayerInfo* player = get_my_player();
-    struct Packet* pckt = get_packet(my_player_number);
-    set_packet_action_for_thing_under_hand(player, pckt);
+    struct Packet* pckt = get_local_packet();
+    set_packet_action_for_thing_under_hand(pckt);
 
     if ( left_button_held )
     {
@@ -2222,7 +2224,7 @@ static void get_isometric_or_front_view_mouse_inputs(struct Packet *pckt,int rot
 static void get_isometric_view_nonaction_inputs(void)
 {
     struct PlayerInfo* player = get_my_player();
-    struct Packet* packet = get_packet(my_player_number);
+    struct Packet* packet = get_local_packet();
     int rotate_pressed = is_game_key_pressed(Gkey_RotateMod, false, true);
     int speed_pressed = is_game_key_pressed(Gkey_SpeedMod, false, true);
     if ((player->allocflags & PlaF_KeyboardInputDisabled) != 0)
@@ -2297,7 +2299,7 @@ static void get_overhead_view_nonaction_inputs(void)
 {
     SYNCDBG(19,"Starting");
     struct PlayerInfo* player = get_my_player();
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     long my = my_mouse_y;
     long mx = my_mouse_x;
     int rotate_pressed = is_game_key_pressed(Gkey_RotateMod, false, true);
@@ -2330,7 +2332,7 @@ static void get_front_view_nonaction_inputs(void)
     static TbClockMSec last_rotate_left_time = 0;
     static TbClockMSec last_rotate_right_time = 0;
     struct PlayerInfo* player = get_my_player();
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     int rotate_pressed = is_game_key_pressed(Gkey_RotateMod, false, true);
     int speed_pressed = is_game_key_pressed(Gkey_SpeedMod, false, true);
     TbBool no_mods = ((rotate_pressed != 0) || (speed_pressed != 0) || (check_current_gui_layer(GuiLayer_OneClick)));
@@ -2484,7 +2486,7 @@ static void get_dungeon_control_nonaction_inputs(void)
   my_mouse_x = GetMouseX();
   my_mouse_y = GetMouseY();
   struct PlayerInfo* player = get_my_player();
-  struct Packet* pckt = get_packet(my_player_number);
+  struct Packet* pckt = get_local_packet();
   if (get_gameturn() - hand_pick_pending_turn > game.input_lag_turns) {
     local_thing_under_hand = 0;
   }
@@ -2572,8 +2574,8 @@ static void get_map_nonaction_inputs(void)
     pos.z.val = 0;
     struct PlayerInfo* player = get_my_player();
     TbBool coords_valid = screen_to_map(get_local_camera(get_player_active_camera(player)), GetMouseX(), GetMouseY(), &pos);
-    set_players_packet_position(get_packet(my_player_number), pos.x.val, pos.y.val, 0);
-    struct Packet* pckt = get_packet(my_player_number);
+    set_players_packet_position(get_local_packet(), pos.x.val, pos.y.val, 0);
+    struct Packet* pckt = get_local_packet();
     if (coords_valid) {
         set_packet_control(pckt, PCtr_MapCoordsValid);
     } else {
@@ -2628,7 +2630,7 @@ static void get_creature_control_nonaction_inputs(void)
     {
         return;
     }
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     long x = GetMouseX();
     long y = GetMouseY();
     struct Thing* thing = thing_get(player->controlled_thing_idx);
@@ -2696,7 +2698,7 @@ static void get_creature_control_nonaction_inputs(void)
             right_button_released = 0;
         }
 
-        struct Packet* packet = get_packet(my_player_number);
+        struct Packet* packet = get_local_packet();
         static float creature_movement_accum_x = 0.0f;
         static float creature_movement_accum_y = 0.0f;
         float movement_delta_x = 0.0f;
@@ -2881,7 +2883,7 @@ static short get_inputs(void)
     if ((player->allocflags & PlaF_MouseInputDisabled) != 0)
     {
         SYNCDBG(5,"Starting for creature fade");
-        set_players_packet_position(get_packet(my_player_number), 0, 0 , 0);
+        set_players_packet_position(get_local_packet(), 0, 0 , 0);
         if ((!game_is_busy_doing_gui_string_input()) && ((game.operation_flags & GOF_Paused) != 0))
         {
             if (is_game_key_pressed(Gkey_PauseMenu, true, false) || is_game_key_pressed(Gkey_TogglePause, true, false))
@@ -2998,7 +3000,7 @@ void input(void)
     {
       lbKeyOn[lbInkey] = 0;
     }
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     if (is_game_key_pressed(Gkey_CrtrContrlMod, false, false) != 0)
       pckt->additional_packet_values |= PCAdV_CrtrContrlPressed;
     else

--- a/src/front_landview_multiplayer.c
+++ b/src/front_landview_multiplayer.c
@@ -260,7 +260,7 @@ static void get_hand_packet(PlayerNumber plyr_idx, struct ScreenPacket *nspck, i
     nspck->action_par1 = fe_net_level_selected;
     set_screen_packet_position(nspck, GetMouseX()*16/units_per_pixel_landview + map_info.screen_shift_x, GetMouseY()*16/units_per_pixel_landview + map_info.screen_shift_y);
     LevelNumber selected_level_number = get_selected_level_number();
-    if ((my_player_number == get_host_player_id()) && (selected_level_number > SINGLEPLAYER_NOTSTARTED)) {
+    if (network_is_host() && (selected_level_number > SINGLEPLAYER_NOTSTARTED)) {
         screen_packet_set_action(nspck, NetAct_HostStartLevel);
         nspck->action_par1 = selected_level_number;
         return;
@@ -311,7 +311,7 @@ static void draw_netmap_players_hands(void)
             slap_frame = get_slap_anim_frame(net_map_local.local_slap_anim_start, now);
         }
         get_hand_packet(i, &nspck, slap_frame, now);
-        plyr_nam = network_player_name(i);
+        plyr_nam = network_user_name(i);
         colr = net_player_colours[i];
         spr = get_hand_sprite_for_packet(&nspck, anim_frame, &x, &y);
         x -= (long)map_info.screen_shift_x;
@@ -510,10 +510,8 @@ static LevelNumber frontnetmap_update_players(void)
     if (!fe_network_active && (fe_net_level_selected > SINGLEPLAYER_NOTSTARTED)) {
         return fe_net_level_selected;
     }
-    const PlayerNumber host_player_number = get_host_player_id();
-    const TbBool is_host = my_player_number == host_player_number;
     const TbBool level_not_selected = get_selected_level_number() <= SINGLEPLAYER_NOTSTARTED;
-    const TbBool can_start_level = is_host && level_not_selected;
+    const TbBool can_start_level = network_is_host() && level_not_selected;
     struct ScreenPacket* my_nspck = &net_screen_packet[my_player_number];
     TbBool slap_hit_confirmed = false;
     int32_t leading_votes = 0;
@@ -521,15 +519,17 @@ static LevelNumber frontnetmap_update_players(void)
     if (can_start_level) {
         memset(scratch, 0, PALETTE_SIZE);
     }
-    for (int32_t i = 0; i < MAX_NET_USERS; i++) {
+    for (NetUserId i = 0; i < MAX_NET_USERS; i++) {
         struct ScreenPacket* nspck = &net_screen_packet[i];
         unsigned char action;
         TbBool remote_player;
+        TbBool host_player;
         if (!is_connected_screen_packet(nspck)) {
             continue;
         }
         remote_player = i != my_player_number;
-        if (remote_player && !network_player_active(i)) {
+        host_player = i == SERVER_ID;
+        if (remote_player && !network_user_active(i)) {
             LbNetwork_EnableNewPlayers(1);
             frontend_set_state(FeSt_NET_START);
             return SINGLEPLAYER_NOTSTARTED;
@@ -546,7 +546,7 @@ static LevelNumber frontnetmap_update_players(void)
             return SINGLEPLAYER_NOTSTARTED;
         }
         action = screen_packet_action(nspck);
-        if ((i == host_player_number) && (action == NetAct_HostStartLevel) && (nspck->action_par1 > SINGLEPLAYER_NOTSTARTED)) {
+        if (host_player && (action == NetAct_HostStartLevel) && (nspck->action_par1 > SINGLEPLAYER_NOTSTARTED)) {
             return nspck->action_par1;
         }
         if (can_start_level) {

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -147,12 +147,15 @@ TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
 
 void process_frontend_chat_message(NetUserId user, const char *message)
 {
-    struct PlayerInfo *player = prepare_network_chat_message(user, message);
-    if (message[0] != '\0' && !try_starting_level_from_chat(player->mp_message_text, user)) {
-        add_message(user, player->mp_message_text);
+    if (message[0] == '\0') {
+        return;
+    }
+    char text[PLAYER_MP_MESSAGE_LEN];
+    snprintf(text, sizeof(text), "%s", message);
+    if (!try_starting_level_from_chat(text, user)) {
+        add_message(user, text);
         play_non_3d_sample(snd_chat_message[user == netstate.my_id]);
     }
-    memset(player->mp_message_text, 0, PLAYER_MP_MESSAGE_LEN);
 }
 
 TbBool frontnet_service_selected(enum FrontendNetService service)

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -85,7 +85,7 @@ static int32_t previous_active_players = 0;
 }
 #endif
 /******************************************************************************/
-static TbBool try_starting_level_from_chat(const char *message, int32_t player_id)
+static TbBool try_starting_level_from_chat(const char *message, NetUserId user_id)
 {
     const char *separator_pos = strchr(message, ':');
     if (separator_pos == NULL) {
@@ -104,7 +104,7 @@ static TbBool try_starting_level_from_chat(const char *message, int32_t player_i
     }
     LevelNumber level_num = -1;
     if (level_str[0] != '_') {
-        if (!isdigit(level_str[0]) || (player_id != get_host_player_id())) {
+        if (!isdigit(level_str[0]) || (user_id != SERVER_ID)) {
             return false;
         }
         level_num = atoi(level_str);
@@ -145,12 +145,12 @@ TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum)
     return true;
 }
 
-void process_frontend_chat_message(int player_id, const char *message)
+void process_frontend_chat_message(NetUserId user, const char *message)
 {
-    struct PlayerInfo *player = prepare_network_chat_message(player_id, message);
-    if (message[0] != '\0' && !try_starting_level_from_chat(player->mp_message_text, player_id)) {
-        add_message(player_id, player->mp_message_text);
-        play_non_3d_sample(snd_chat_message[player_id == my_player_number]);
+    struct PlayerInfo *player = prepare_network_chat_message(user, message);
+    if (message[0] != '\0' && !try_starting_level_from_chat(player->mp_message_text, user)) {
+        add_message(user, player->mp_message_text);
+        play_non_3d_sample(snd_chat_message[user == netstate.my_id]);
     }
     memset(player->mp_message_text, 0, PLAYER_MP_MESSAGE_LEN);
 }
@@ -397,7 +397,7 @@ static TbBool check_frontend_version_mismatch(void)
   TbBool start_requested = false;
 
   for (NetUserId i = 0; i < MAX_NET_USERS; i++) {
-    if (!network_player_active(i)) {
+    if (!network_user_active(i)) {
       continue;
     }
     active_players++;
@@ -421,8 +421,8 @@ static TbBool check_frontend_version_mismatch(void)
   char text[MESSAGE_TEXT_LEN];
   snprintf(text, sizeof(text), "%s\n%s: %d.%d.%d.%d\n%s: %d.%d.%d.%d",
       get_string(GUIStr_VersionMismatch),
-      network_player_name(SERVER_ID), (int)host_user->version.major, (int)host_user->version.minor, (int)host_user->version.release, (int)host_user->version.build,
-      network_player_name(remote_id), (int)remote_user->version.major, (int)remote_user->version.minor, (int)remote_user->version.release, (int)remote_user->version.build);
+      network_user_name(SERVER_ID), (int)host_user->version.major, (int)host_user->version.minor, (int)host_user->version.release, (int)host_user->version.build,
+      network_user_name(remote_id), (int)remote_user->version.major, (int)remote_user->version.minor, (int)remote_user->version.release, (int)remote_user->version.build);
   create_frontend_error_box(10000, text);
   return true;
 }
@@ -432,7 +432,7 @@ static void process_frontend_packets(void)
   if (!frontnet_matchmaking_update()) {
     return;
   }
-  int32_t i;
+  NetUserId i;
   for (i = 0; i < MAX_NET_USERS; i++) {
     net_screen_packet[i].networkstatus_flags &= ~NetStat_PlayerConnected;
   }
@@ -505,7 +505,7 @@ static void process_frontend_packets(void)
     frontend_alliances = 0;
   }
   for (i = 0; i < MAX_NET_USERS; i++) {
-    if (!network_player_active(i)) {
+    if (!network_user_active(i)) {
       const int32_t alliances_to_clear = alliance_grid[i][0] | alliance_grid[i][1] | alliance_grid[i][2] | alliance_grid[i][3];
       frontend_alliances = frontend_alliances & ~alliances_to_clear;
     }
@@ -514,7 +514,7 @@ static void process_frontend_packets(void)
 
 TbBool frontnet_matchmaking_update(void)
 {
-    if (my_player_number == get_host_player_id() && frontnet_service_selected(FrontendNetSvc_Online) && enet_matchmaking_host_update() < 0) {
+    if (network_is_host() && frontnet_service_selected(FrontendNetSvc_Online) && enet_matchmaking_host_update() < 0) {
         frontnet_return_to_session_menu(NULL);
         create_frontend_error_box(0, get_string(GUIStr_NetLobbyConnectionLost));
         return false;
@@ -537,7 +537,7 @@ void frontnet_send_campaign_change_message(const char* campaign_fname)
 
     char msg[64];
     snprintf(msg, sizeof(msg), "%s:_", base_name);
-    send_network_chat_message(my_player_number, msg);
+    send_network_chat_message(netstate.my_id, msg);
 }
 
 void handle_autostart_multiplayer_messaging(void)
@@ -550,10 +550,10 @@ void handle_autostart_multiplayer_messaging(void)
         return;
     }
 
-    if (player_joined && my_player_number == get_host_player_id()) {
+    if (player_joined && network_is_host()) {
         frontnet_send_campaign_change_message(campaign.fname);
     }
-    if (my_player_number != get_host_player_id() || get_selected_level_number() > SINGLEPLAYER_NOTSTARTED) {
+    if (!network_is_host() || get_selected_level_number() > SINGLEPLAYER_NOTSTARTED) {
         return;
     }
     if (autostart_multiplayer_campaign[0] == '\0' && autostart_multiplayer_level <= 0) {

--- a/src/front_network.h
+++ b/src/front_network.h
@@ -78,7 +78,7 @@ void frontnet_session_update(void);
 void frontnet_start_update(void);
 TbBool frontnet_matchmaking_update(void);
 TbBool frontnet_start_level(const char *campaign_fname, LevelNumber lvnum);
-void process_frontend_chat_message(int player_id, const char *message);
+void process_frontend_chat_message(NetUserId user, const char *message);
 TbBool frontnet_service_selected(enum FrontendNetService service);
 void enum_sessions_callback(struct TbNetworkCallbackData *netcdat, void *ptr);
 

--- a/src/front_torture.c
+++ b/src/front_torture.c
@@ -217,10 +217,10 @@ void fronttorture_input(void)
 {
     long x;
     long y;
-    PlayerNumber plyr_idx;
+    NetUserId user;
     clear_packets();
     struct PlayerInfo* player = get_my_player();
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     // Get inputs and create packet
     if (player->victory_state == VicS_WonLevel)
     {
@@ -261,24 +261,21 @@ void fronttorture_input(void)
         if (LbNetwork_ExchangeFrontend(pckt, game.packets, sizeof(struct Packet)))
             ERRORLOG("LbNetwork_Exchange failed");
     }
-    // Determine the controlling player and get his mouse coords
-    for (plyr_idx=0; plyr_idx < PLAYERS_COUNT; plyr_idx++)
+    // Determine the controlling user's mouse coords
+    for (user = 0; user < MAX_NET_USERS; user++)
     {
-        player = get_player(plyr_idx);
-        pckt = get_packet(plyr_idx);
+        pckt = get_packet(user);
         if (pckt->action != 0)
             break;
     }
-    if (plyr_idx < PLAYERS_COUNT)
+    if (user < MAX_NET_USERS)
     {
         x = pckt->actn_par1;
         y = pckt->actn_par2;
         torture_idle_start = LbTimerClock();
     } else
     {
-        plyr_idx = my_player_number;
-        player = get_player(plyr_idx);
-        pckt = get_packet(plyr_idx);
+        pckt = get_local_packet();
         x = 0;
         y = 0;
     }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -498,7 +498,7 @@ void add_message(long plyr_idx, char *msg)
     }
     nmsg = &net_message[i];
     nmsg->plyr_idx = plyr_idx;
-    nmsg->connection_id = net_player_info[plyr_idx].connection_id;
+    nmsg->connection_id = net_user_info[plyr_idx].connection_id;
     snprintf(nmsg->text, NET_MESSAGE_LEN, "%s", msg);
     i++;
     net_number_of_messages = i;
@@ -3454,7 +3454,7 @@ void update_player_objectives(PlayerNumber plyr_idx)
           break;
       case VicS_LostLevel:
           TextStringId msg_idx = CpgStr_LevelLost;
-          if (network_is_active() && (player->id_number == get_host_player_id()) && network_human_contenders_remain()) {
+          if (network_is_active() && (player->id_number == get_net_user_player_number(SERVER_ID)) && network_human_contenders_remain()) {
               msg_idx = GUIStr_NetHostLostWaitingForPlayers;
           }
           set_level_objective(player->id_number, get_string(msg_idx));

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -166,13 +166,13 @@ void gui_get_creature_in_battle(struct GuiButton *gbtn)
     if (pwkind > 0)
     {
         if (can_cast_spell(my_player_number, pwkind, thing->mappos.x.stl.num, thing->mappos.y.stl.num, thing, CastChk_Default)) {
-            struct Packet* pckt = get_packet(my_player_number);
+            struct Packet* pckt = get_local_packet();
             set_packet_action(pckt, PckA_UsePwrOnThing, pwkind, battle_creature_over, 0, 0);
         }
     } else
     {
         if (can_cast_spell(my_player_number, PwrK_HAND, thing->mappos.x.stl.num, thing->mappos.y.stl.num, thing, CastChk_Default)) {
-            struct Packet* pckt = get_packet(my_player_number);
+            struct Packet* pckt = get_local_packet();
             set_packet_action(pckt, PckA_UsePwrHandPick, battle_creature_over, 0, 0, 0);
         }
     }

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -563,7 +563,7 @@ void gui_remove_area_for_rooms(struct GuiButton *gbtn)
     game.chosen_room_kind = 0;
     game.chosen_room_spridx = 0;
     game.chosen_room_tooltip = 0;
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     set_packet_action(pckt, PckA_SetPlyrState, PSt_Sell, 0, 0, 0);
 }
 
@@ -725,17 +725,16 @@ void gui_choose_spell(struct GuiButton *gbtn)
     choose_spell(gbtn->content.lval, gbtn->tooltip_stridx);
 }
 
-void go_to_next_spell_of_type(PowerKind pwkind, PlayerNumber plyr_idx)
+void go_to_next_spell_of_type(PowerKind pwkind)
 {
-    struct Packet* pckt = get_packet(plyr_idx);
+    struct Packet* pckt = get_local_packet();
     set_packet_action(pckt, PckA_ZoomToSpell, pwkind, 0, 0, 0);
 }
 
 void gui_go_to_next_spell(struct GuiButton *gbtn)
 {
     PowerKind pwkind = gbtn->content.lval;
-    struct PlayerInfo* player = get_my_player();
-    go_to_next_spell_of_type(pwkind, player->id_number);
+    go_to_next_spell_of_type(pwkind);
     set_chosen_power(pwkind, gbtn->tooltip_stridx);
 }
 
@@ -937,7 +936,7 @@ void go_to_next_trap_of_type(ThingModel tngmodel, PlayerNumber plyr_idx)
     }
     i = seltrap[tngmodel];
     if (i > 0) {
-        struct Packet* pckt = get_packet(plyr_idx);
+        struct Packet* pckt = get_local_packet();
         set_packet_action(pckt, PckA_ZoomToTrap, i, 0, 0, 0);
     }
 }
@@ -992,7 +991,7 @@ void go_to_next_door_of_type(ThingModel tngmodel, PlayerNumber plyr_idx)
     }
     i = seldoor[tngmodel];
     if (i > 0) {
-        struct Packet* pckt = get_packet(plyr_idx);
+        struct Packet* pckt = get_local_packet();
         set_packet_action(pckt, PckA_ZoomToDoor, i, 0, 0, 0);
     }
 }
@@ -2288,7 +2287,7 @@ void gui_toggle_ally(struct GuiButton *gbtn)
     if(plyr_idx == -1)
         return;
     if ((gbtn->flags & LbBtnF_Enabled) != 0) {
-        struct Packet* pckt = get_packet(my_player_number);
+        struct Packet* pckt = get_local_packet();
         set_packet_action(pckt, PckA_PlyrToggleAlly, plyr_idx, 0, 0, 0);
     }
 }
@@ -2905,7 +2904,7 @@ void gui_query_next_creature_of_owner_and_model(struct GuiButton *gbtn)
     ThingIndex next_creature = get_index_of_next_creature_of_owner_and_model(creatng, creatng->owner, creatng->model, player);
     if (next_creature != player->influenced_thing_idx)
     {
-        struct Packet* pckt = get_packet(player->id_number);
+        struct Packet* pckt = get_local_packet();
         set_packet_action(pckt, PckA_PlyrQueryCreature, next_creature, 0, 1, 0);
         play_non_3d_sample(snd_tab_click);
     }
@@ -2918,7 +2917,7 @@ void gui_query_next_creature_of_owner(struct GuiButton *gbtn)
     ThingIndex next_creature = get_index_of_next_creature_of_owner_and_model(creatng, creatng->owner, 0, player);
     if (next_creature != player->influenced_thing_idx)
     {
-        struct Packet* pckt = get_packet(player->id_number);
+        struct Packet* pckt = get_local_packet();
         set_packet_action(pckt, PckA_PlyrQueryCreature, next_creature, 0, 1, 0);
         play_non_3d_sample(snd_tab_click);
     }

--- a/src/frontmenu_net.c
+++ b/src/frontmenu_net.c
@@ -123,6 +123,7 @@ TbBool frontnet_start_input(void)
             send_network_chat_message(netstate.my_id, player->mp_message_text);
         }
         process_frontend_chat_message(netstate.my_id, player->mp_message_text);
+        memset(player->mp_message_text, 0, PLAYER_MP_MESSAGE_LEN);
     } else if (lbInkey == KC_ESCAPE) {
         player->mp_message_text[0] = '\0';
     } else if (is_key_pressed(KC_BACK,KMod_DONTCARE)){

--- a/src/frontmenu_net.c
+++ b/src/frontmenu_net.c
@@ -120,9 +120,9 @@ TbBool frontnet_start_input(void)
     struct PlayerInfo *player = get_my_player();
     if (lbInkey == KC_RETURN) {
         if (player->mp_message_text[0] != '\0') {
-            send_network_chat_message(my_player_number, player->mp_message_text);
+            send_network_chat_message(netstate.my_id, player->mp_message_text);
         }
-        process_frontend_chat_message(my_player_number, player->mp_message_text);
+        process_frontend_chat_message(netstate.my_id, player->mp_message_text);
     } else if (lbInkey == KC_ESCAPE) {
         player->mp_message_text[0] = '\0';
     } else if (is_key_pressed(KC_BACK,KMod_DONTCARE)){
@@ -360,12 +360,12 @@ void frontnet_draw_net_start_players(struct GuiButton *gbtn)
         if (netplyr_idx >= net_number_of_enum_players)
             break;
 
-        long subplyr_idx;
+        NetUserId subplyr_idx;
         for (subplyr_idx = 0; subplyr_idx < net_number_of_enum_players; subplyr_idx++)
         {
             if (subplyr_idx >= MAX_NET_USERS)
                 break;
-            if (net_player_info[subplyr_idx].network_user_active)
+            if (net_user_info[subplyr_idx].network_user_active)
             {
                 if (subplyr_idx == netplyr_idx)
                     break;
@@ -608,12 +608,12 @@ void frontnet_draw_messages(struct GuiButton *gbtn)
             break;
         struct NetMessage *nmsg;
         nmsg = &net_message[netmsg_id];
-        TbBool sender_active = nmsg->connection_id == net_player_info[nmsg->plyr_idx].connection_id;
+        TbBool sender_active = nmsg->connection_id == net_user_info[nmsg->plyr_idx].connection_id;
         int num_active;
         num_active = 0;
         if (sender_active) {
             for (int i = nmsg->plyr_idx; i > 0; i--) {
-                if (net_player_info[i].network_user_active) {
+                if (net_user_info[i].network_user_active) {
                     num_active++;
                 }
             }

--- a/src/frontmenu_options.c
+++ b/src/frontmenu_options.c
@@ -239,14 +239,14 @@ void gui_video_view_distance_level(struct GuiButton *gbtn)
 
 void gui_video_rotate_mode(struct GuiButton *gbtn)
 {
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     set_packet_action(pckt, PckA_SwitchView, rotate_mode_to_view_mode(settings.video_rotate_mode), 0, 0, 0);
     save_settings();
 }
 
 void gui_video_cluedo_mode(struct GuiButton *gbtn)
 {
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     set_packet_action(pckt, PckA_SetCluedo, video_cluedo_mode, 0, 0, 0);
 }
 

--- a/src/frontmenu_specials.c
+++ b/src/frontmenu_specials.c
@@ -136,7 +136,7 @@ void select_resurrect_creature(struct GuiButton *gbtn)
     if (i != -1)
     {
         struct CreatureStorage* cstore = &dungeon->dead_creatures[i];
-        struct Packet* pckt = get_packet(my_player_number);
+        struct Packet* pckt = get_local_packet();
         set_packet_action(pckt, PckA_ResurrectCrtr, dungeon_special_selected, dungeon->owner | (cstore->model << 4) | (cstore->exp_level << 12), 0, 0);
         turn_off_menu(GMnu_RESURRECT_CREATURE);
     }
@@ -218,7 +218,7 @@ void select_transfer_creature(struct GuiButton *gbtn)
     }
     if (thing_exists(thing))
     {
-        struct Packet* pckt = get_packet(my_player_number);
+        struct Packet* pckt = get_local_packet();
         set_packet_action(pckt, PckA_TransferCreatr, dungeon_special_selected, thing->index, 0, 0);
         turn_off_menu(GMnu_TRANSFER_CREATURE);
     }

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -58,7 +58,7 @@ static const struct Packet* get_packet_for_local_camera_update(void)
     if (player_invalid(player)) {
         return NULL;
     }
-    return get_history_packet(player->packet_num, get_gameturn());
+    return get_history_packet(get_local_user(), get_gameturn());
 }
 
 void send_camera_catchup_packets(void)
@@ -90,7 +90,7 @@ void send_camera_catchup_packets(void)
 
     struct Camera* local_cam = &destination_local_cameras[cam_idx];
     struct Camera* packet_cam = &player->cameras[cam_idx];
-    struct Packet* pckt = get_packet(player->id_number);
+    struct Packet* pckt = get_local_packet();
 
     long diff_map_x = local_cam->mappos.x.val - packet_cam->mappos.x.val;
     long diff_map_y = local_cam->mappos.y.val - packet_cam->mappos.y.val;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "bflib_mshandler.hpp"
 #include "bflib_filelst.h"
 #include "net_exchange_gameplay.h"
+#include "net_game.h"
 #include "net_lobby.h"
 #include "net_resync.h"
 #include "bflib_planar.h"
@@ -1465,9 +1466,9 @@ void update_mouse_light(struct PlayerInfo *player)
     const struct Packet *pckt = nullptr;
 
     if (is_my_player(player))
-        pckt = get_history_packet(player->packet_num, get_gameturn());
+        pckt = get_history_packet(player->user_id, get_gameturn());
     if (pckt == nullptr)
-        pckt = get_packet_direct(player->packet_num);
+        pckt = get_packet(player->user_id);
 
     const TbBool valid = (pckt->control_flags & PCtr_MapCoordsValid) != 0;
     struct Coord3d pos;

--- a/src/net_checksums.c
+++ b/src/net_checksums.c
@@ -197,28 +197,25 @@ static struct ChecksumSnapshot* find_snapshot(GameTurn turn) {
 
 short checksums_different(void)
 {
-    int host_player_id = get_host_player_id();
-    struct Packet* host_packet = get_packet(host_player_id);
+    const NetUserId host_user_id = SERVER_ID;
+    struct Packet* host_packet = get_packet(host_user_id);
     TbBigChecksum host_checksum = host_packet->checksum;
     TbBool mismatch = false;
 
-    for (int i = 0; i < PLAYERS_COUNT; i++) {
-        struct PlayerInfo* player = get_player(i);
-        if (i == host_player_id) {
+    for (NetUserId i = 0; i < MAX_NET_USERS; i++) {
+        if (i == host_user_id) {
             continue;
         }
+        if (!network_user_active(i)) {
+            continue;
+        }
+        struct PlayerInfo* player = get_player(get_net_user_player_number(i));
         if (!player_exists(player)) {
             continue;
         }
-        if ((player->allocflags & PlaF_CompCtrl) != 0) {
-            continue;
-        }
-        if (!network_player_active(player->packet_num)) {
-            continue;
-        }
-        struct Packet* packet = get_packet_direct(player->packet_num);
+        struct Packet* packet = get_packet(i);
         if (is_packet_empty(packet)) {
-            ERRORLOG("Missing checksum packet for player %d packet %d; host turn: %d", i, player->packet_num, host_packet->turn);
+            ERRORLOG("Missing checksum packet for user %d; host turn: %d", i, host_packet->turn);
             desync_turn = host_packet->turn;
             mismatch = true;
             continue;
@@ -362,7 +359,7 @@ void update_turn_checksums(void) {
     things_sum += checksums->effect_gens;
     things_sum += checksums->doors;
 
-    struct Packet* packet = get_packet(my_player_number);
+    struct Packet* packet = get_local_packet();
     packet->checksum = 0;
     packet->checksum += things_sum;
     packet->checksum += checksums->rooms;

--- a/src/net_exchange_common.c
+++ b/src/net_exchange_common.c
@@ -48,7 +48,7 @@ extern long double host_packet_received;
 
 void send_to_active_peers(int send_count, enum NetworkPeerSendMode send_mode, const char *buffer, size_t msg_size, NetUserId first_skip_id, NetUserId second_skip_id)
 {
-    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+    for (NetUserId id = 0; id < netstate.max_users; id += 1) {
         if (id == first_skip_id || id == second_skip_id || !can_send_to_peer(id)) {
             continue;
         }
@@ -87,7 +87,7 @@ static TbError handle_exchange_message(NetUserId source, void *server_buf, size_
     }
     peer_id = (NetUserId)(uint8_t)read_pos[0];
     read_pos += 1;
-    if (peer_id >= netstate.max_players) {
+    if (peer_id >= netstate.max_users) {
         ERRORLOG("Critical error: Out of range peer ID %i received, could be used for buffer overflow attack", peer_id);
         abort();
     }
@@ -150,7 +150,7 @@ static TbError handle_exchange_message(NetUserId source, void *server_buf, size_
 
 static TbError handle_chat_message(NetUserId source, char *read_pos, size_t message_size, enum NetMessageType expected_frame_type)
 {
-    int player_id = (int)read_pos[0];
+    NetUserId sender = (NetUserId)read_pos[0];
     read_pos += 1;
     const char *message;
     if (!read_network_message_text(&read_pos, &message, sizeof(netstate.msg_buffer) - 1)) {
@@ -158,9 +158,9 @@ static TbError handle_chat_message(NetUserId source, char *read_pos, size_t mess
         return Lb_OK;
     }
     if (expected_frame_type == NETMSG_GAMEPLAY_UNSEQUENCED) {
-        process_gameplay_chat_message(player_id, message);
+        process_gameplay_chat_message(sender, message);
     } else {
-        process_frontend_chat_message(player_id, message);
+        process_frontend_chat_message(sender, message);
     }
     if (netstate.my_id == SERVER_ID && source != SERVER_ID) {
         send_to_active_peers(1, NetSend_Reliable, netstate.msg_buffer, message_size, netstate.my_id, source);
@@ -180,10 +180,10 @@ TbBool read_network_message_text(char **read_pos, const char **text, size_t max_
     return true;
 }
 
-void send_network_chat_message(int player_id, const char *message)
+void send_network_chat_message(NetUserId sender, const char *message)
 {
     char *write_pos = begin_net_message(NETMSG_CHATMESSAGE);
-    *write_pos = player_id;
+    *write_pos = sender;
     write_pos += 1;
     strcpy(write_pos, message);
     write_pos += strlen(message) + 1;
@@ -207,12 +207,12 @@ TbBool can_send_to_peer(NetUserId peer_id)
 {
     return (peer_id != netstate.my_id) &&
         (netstate.users[peer_id].progress != USER_UNUSED) &&
-        (my_player_number == get_host_player_id() || peer_id == SERVER_ID);
+        (network_is_host() || peer_id == SERVER_ID);
 }
 
 TbBool all_expected_exchange_frames_received(const TbBool has_received_frame[MAX_NET_USERS], TbBool is_host)
 {
-    for (NetUserId peer_id = 0; peer_id < netstate.max_players; peer_id += 1) {
+    for (NetUserId peer_id = 0; peer_id < netstate.max_users; peer_id += 1) {
         if (is_host && !can_send_to_peer(peer_id)) {
             continue;
         }
@@ -228,7 +228,7 @@ TbBool all_expected_exchange_frames_received(const TbBool has_received_frame[MAX
 
 TbError exchange_frame_message(void *send_buf, void *server_buf, size_t frame_size, enum NetMessageType msg_type)
 {
-    if (netstate.my_id < 0 || netstate.my_id >= netstate.max_players) {
+    if (netstate.my_id < 0 || netstate.my_id >= netstate.max_users) {
         ERRORLOG("Invalid my_id %i in network exchange (disconnected?)", netstate.my_id);
         return Lb_FAIL;
     }
@@ -321,7 +321,7 @@ TbError exchange_frame_block(enum NetMessageType msg_type, void *send_buf, void 
 
     const struct ScreenPacket *screen_packets = (const struct ScreenPacket *)server_buf;
     TbBool has_received_frame[MAX_NET_USERS] = {false};
-    TbBool is_host = my_player_number == get_host_player_id();
+    TbBool is_host = network_is_host();
     TbClockMSec wait_start_time = LbTimerClock();
     TbBool stop_waiting = false;
     while (LbTimerClock() - wait_start_time < TIMEOUT_LOBBY_EXCHANGE) {
@@ -329,7 +329,7 @@ TbError exchange_frame_block(enum NetMessageType msg_type, void *send_buf, void 
             break;
         }
         if (frontend_exchange && frame_size == sizeof(struct ScreenPacket)) {
-            for (NetUserId peer_id = 0; peer_id < netstate.max_players; peer_id += 1) {
+            for (NetUserId peer_id = 0; peer_id < netstate.max_users; peer_id += 1) {
                 const struct ScreenPacket *packet = &screen_packets[peer_id];
                 if ((packet->networkstatus_flags & NetStat_PlayerConnected) == 0) {
                     continue;
@@ -345,7 +345,7 @@ TbError exchange_frame_block(enum NetMessageType msg_type, void *send_buf, void 
             if (pass > 0) {
                 netstate.sp->update(OnNewUser);
             }
-            for (NetUserId peer_id = 0; peer_id < netstate.max_players && !stop_waiting; peer_id += 1) {
+            for (NetUserId peer_id = 0; peer_id < netstate.max_users && !stop_waiting; peer_id += 1) {
                 if (!can_send_to_peer(peer_id)) {
                     continue;
                 }
@@ -398,7 +398,7 @@ void wait_for_all_players(void)
 
     const TbClockMSec resend_interval = 50;
     TbBool has_received_frame[MAX_NET_USERS] = {false};
-    TbBool is_host = (my_player_number == get_host_player_id());
+    TbBool is_host = network_is_host();
     enum NetMessageType send_message_type;
     enum NetMessageType expected_message_type;
     if (is_host) {
@@ -430,7 +430,7 @@ void wait_for_all_players(void)
             last_send_time = now;
         }
         netstate.sp->update(OnNewUser);
-        for (NetUserId peer_id = 0; peer_id < netstate.max_players && result != Lb_OK; peer_id += 1) {
+        for (NetUserId peer_id = 0; peer_id < netstate.max_users && result != Lb_OK; peer_id += 1) {
             if (!can_send_to_peer(peer_id)) {
                 continue;
             }

--- a/src/net_exchange_common.h
+++ b/src/net_exchange_common.h
@@ -32,7 +32,7 @@ enum NetworkPeerSendMode {
 };
 
 TbBool read_network_message_text(char **read_pos, const char **text, size_t max_len);
-void send_network_chat_message(int player_id, const char *message);
+void send_network_chat_message(NetUserId sender, const char *message);
 struct PlayerInfo *prepare_network_chat_message(int player_id, const char *message);
 TbBool can_send_to_peer(NetUserId peer_id);
 void send_to_active_peers(int send_count, enum NetworkPeerSendMode send_mode, const char *buffer, size_t msg_size, NetUserId first_skip_id, NetUserId second_skip_id);

--- a/src/net_exchange_gameplay.c
+++ b/src/net_exchange_gameplay.c
@@ -46,7 +46,7 @@ int32_t multiplayer_speed_adjustment_ns;
 
 /******************************************************************************/
 
-// PACKET_HISTORY_SIZE affects how far apart two player's turns can be (if they divert too far then there's no easy recovering). It should be set as high as possible while still being safe to send, so less than 1300 bytes at once.
+// PACKET_HISTORY_SIZE affects how far apart two users' turns can be (if they divert too far then there's no easy recovering). It should be set as high as possible while still being safe to send, so less than 1300 bytes at once.
 // TURN_SYNC_MAX_ADJUSTMENT_NS being set too high causes stutters.
 #define PACKET_HISTORY_SIZE 40
 #define REPAIR_HISTORY_RESEND_INTERVAL 200
@@ -66,7 +66,7 @@ struct RedundantPacketBundle {
 };
 
 struct PacketHistoryHeader {
-    PlayerNumber player;
+    unsigned char /*NetUserId*/ user;
     unsigned int compressed_length;
     unsigned int original_length;
 };
@@ -77,7 +77,7 @@ static TbClockMSec server_turn_received_at = 0;
 static int64_t server_turn_position_ns = 0;
 static TbClockMSec last_repair_history_send[MAX_NET_USERS];
 static TbClockMSec last_turn_sync_send = 0;
-static PlayerNumber next_repair_history_player = 0;
+static NetUserId next_repair_history_user = 0;
 
 static int64_t get_current_turn_position_ns(void)
 {
@@ -146,7 +146,7 @@ TbError process_network_unpause_message(void)
     unpausing_in_progress = 1;
     keeper_screen_redraw();
     RendererPresentFrame();
-    if (my_player_number == get_host_player_id()) {
+    if (network_is_host()) {
         LbNetwork_BroadcastUnpause();
     }
     process_pause_packet(0, 0);
@@ -154,14 +154,16 @@ TbError process_network_unpause_message(void)
     return Lb_OK;
 }
 
-void process_gameplay_chat_message(int player_id, const char *message)
+void process_gameplay_chat_message(NetUserId user, const char *message)
 {
-    struct PlayerInfo *player = prepare_network_chat_message(player_id, message);
+    PlayerNumber plyr_idx = get_net_user_player_number(user);
+    struct PlayerInfo *player = prepare_network_chat_message(plyr_idx, message);
     if (message[0] != '\0') {
-        lua_on_chatmsg(player_id, player->mp_message_text);
-        if (player->mp_message_text[0] != cmd_char || !cmd_exec(player_id, player->mp_message_text + 1) || network_is_active()) {
-            message_add(MsgType_Player, player_id, player->mp_message_text);
-            play_non_3d_sample(snd_chat_message[player_id == my_player_number]);
+        SYNCLOG("Gameplay chat from user %d (player %d): %s", (int)user, (int)plyr_idx, message);
+        lua_on_chatmsg(plyr_idx, player->mp_message_text);
+        if (player->mp_message_text[0] != cmd_char || !cmd_exec(plyr_idx, player->mp_message_text + 1) || network_is_active()) {
+            message_add(MsgType_Player, plyr_idx, player->mp_message_text);
+            play_non_3d_sample(snd_chat_message[user == get_local_user()]);
         }
     }
     memset(player->mp_message_text, 0, PLAYER_MP_MESSAGE_LEN);
@@ -190,34 +192,34 @@ TbError process_network_turn_sync_message(NetUserId source, const char *buffer, 
     return Lb_OK;
 }
 
-void store_packet_history(PlayerNumber player, const struct Packet *packet)
+void store_packet_history(NetUserId user, const struct Packet *packet)
 {
-    if (player < 0 || player >= MAX_NET_USERS || is_packet_empty(packet)) {
+    if (user < 0 || user >= MAX_NET_USERS || is_packet_empty(packet)) {
         return;
     }
-    struct Packet *entry = &packet_history[player].entries[packet->turn % PACKET_HISTORY_SIZE];
+    struct Packet *entry = &packet_history[user].entries[packet->turn % PACKET_HISTORY_SIZE];
     if (!is_packet_empty(entry) && (GameTurnDelta)(entry->turn - packet->turn) > 0) {
         return;
     }
     *entry = *packet;
 }
 
-const struct Packet *get_history_packet(PlayerNumber player, GameTurn turn)
+const struct Packet *get_history_packet(NetUserId user, GameTurn turn)
 {
-    if (player < 0 || player >= MAX_NET_USERS) {
+    if (user < 0 || user >= MAX_NET_USERS) {
         return NULL;
     }
-    const struct Packet *packet = &packet_history[player].entries[turn % PACKET_HISTORY_SIZE];
+    const struct Packet *packet = &packet_history[user].entries[turn % PACKET_HISTORY_SIZE];
     if (is_packet_empty(packet) || packet->turn != turn) {
         return NULL;
     }
     return packet;
 }
 
-const struct Packet *get_latest_history_packet(PlayerNumber player)
+const struct Packet *get_latest_history_packet(NetUserId user)
 {
     const struct Packet *latest = NULL;
-    const struct PacketHistory *history = &packet_history[player];
+    const struct PacketHistory *history = &packet_history[user];
     for (int32_t i = 0; i < PACKET_HISTORY_SIZE; i += 1) {
         const struct Packet *packet = &history->entries[i];
         if (!is_packet_empty(packet) && (latest == NULL || (GameTurnDelta)(packet->turn - latest->turn) > 0)) {
@@ -236,12 +238,12 @@ TbBool read_repair_packet_history(NetUserId source, const char *buffer, size_t b
     }
     struct PacketHistoryHeader header;
     memcpy(&header, buffer, sizeof(header));
-    if (header.player < 0 || header.player >= netstate.max_players) {
-        WARNLOG("Gameplay repair history from peer %i had invalid player %d", source, (int)header.player);
+    if (header.user >= netstate.max_users) {
+        WARNLOG("Gameplay repair history from peer %i had invalid user %d", source, (int)header.user);
         return false;
     }
-    if (source != SERVER_ID && source != header.player) {
-        WARNLOG("Peer %i tried to send gameplay repair history for peer %i", source, (int)header.player);
+    if (source != SERVER_ID && source != header.user) {
+        WARNLOG("Peer %i tried to send gameplay repair history for peer %i", source, (int)header.user);
         return false;
     }
     if (buffer_size != sizeof(struct PacketHistoryHeader) + header.compressed_length) {
@@ -268,16 +270,16 @@ TbBool read_repair_packet_history(NetUserId source, const char *buffer, size_t b
         return false;
     }
     if (header.original_length < sizeof(unsigned char) + packet_bundle->valid_count * sizeof(struct Packet)) {
-        WARNLOG("Gameplay repair history from peer %i was truncated for player %d", source, (int)header.player);
+        WARNLOG("Gameplay repair history from peer %i was truncated for user %d", source, (int)header.user);
         return false;
     }
     for (unsigned char i = 0; i < packet_bundle->valid_count; i += 1) {
         const struct Packet *packet = &packet_bundle->packets[i];
         if (is_packet_empty(packet)) {
-            MULTIPLAYER_LOG("read_repair_packet_history: Skipping empty packet for player %d turn %lu", header.player, (unsigned long)packet->turn);
+            MULTIPLAYER_LOG("read_repair_packet_history: Skipping empty packet for user %d turn %lu", header.user, (unsigned long)packet->turn);
             continue;
         }
-        store_packet_history(header.player, packet);
+        store_packet_history(header.user, packet);
     }
     return true;
 }
@@ -290,26 +292,26 @@ void initialize_packet_history(void)
     multiplayer_speed_adjustment_ns = 0;
     memset(last_repair_history_send, 0, sizeof(last_repair_history_send));
     last_turn_sync_send = 0;
-    next_repair_history_player = 0;
+    next_repair_history_user = 0;
     input_lag_reset();
 }
 
-static TbBool player_has_required_turn_packets(PlayerNumber player)
+static TbBool user_has_required_turn_packets(NetUserId user)
 {
     GameTurn expected_turn = get_gameturn() - game.input_lag_turns;
-    if (get_history_packet(player, expected_turn) == NULL) {
+    if (get_history_packet(user, expected_turn) == NULL) {
         return false;
     }
     if (!input_lag_needs_lookahead()) {
         return true;
     }
-    return get_history_packet(player, expected_turn + 1) != NULL;
+    return get_history_packet(user, expected_turn + 1) != NULL;
 }
 
-static TbBool have_all_turn_packets(PlayerNumber local_packet_player)
+static TbBool have_all_turn_packets(NetUserId local_user)
 {
-    for (PlayerNumber player = 0; player < MAX_NET_USERS; player += 1) {
-        if (player != local_packet_player && network_player_active(player) && !player_has_required_turn_packets(player)) {
+    for (NetUserId user = 0; user < MAX_NET_USERS; user += 1) {
+        if (user != local_user && network_user_active(user) && !user_has_required_turn_packets(user)) {
             return false;
         }
     }
@@ -326,18 +328,18 @@ static TbBool host_lost(GameTurn turn, const char *state)
     return true;
 }
 
-static void send_player_repair_history(PlayerNumber player)
+static void send_user_repair_history(NetUserId user)
 {
-    if (player < 0 || player >= MAX_NET_USERS || !network_player_active(player)) {
+    if (user < 0 || user >= MAX_NET_USERS || !network_user_active(user)) {
         return;
     }
     struct RedundantPacketBundle packet_bundle;
     packet_bundle.valid_count = 0;
-    const struct Packet *latest = get_latest_history_packet(player);
+    const struct Packet *latest = get_latest_history_packet(user);
     if (latest == NULL) {
         return;
     }
-    const struct PacketHistory *history = &packet_history[player];
+    const struct PacketHistory *history = &packet_history[user];
     GameTurn latest_turn = latest->turn;
     for (GameTurnDelta offset = 0; offset < PACKET_HISTORY_SIZE; offset += 1) {
         if ((GameTurn)offset > latest_turn) {
@@ -358,56 +360,56 @@ static void send_player_repair_history(PlayerNumber player)
     uLongf compressed_size = sizeof(netstate.msg_buffer) - (write_pos - netstate.msg_buffer);
     int compress_result = compress((Bytef *)write_pos, &compressed_size, (const Bytef *)&packet_bundle, packet_history_size);
     if (compress_result != Z_OK) {
-        ERRORLOG("Gameplay repair history compression failed for player %d: zlib error %d", (int)player, compress_result);
+        ERRORLOG("Gameplay repair history compression failed for user %d: zlib error %d", (int)user, compress_result);
         return;
     }
     struct PacketHistoryHeader header;
-    header.player = player;
+    header.user = user;
     header.compressed_length = (unsigned int)compressed_size;
     header.original_length = (unsigned int)packet_history_size;
     memcpy(header_pos, &header, sizeof(header));
     size_t message_size = (write_pos - netstate.msg_buffer) + compressed_size;
     if (netstate.my_id != SERVER_ID) {
         if (can_send_to_peer(SERVER_ID)) {
-            MULTIPLAYER_LOG("Sending unreliable compressed gameplay repair history for player=%d to host (%lu -> %lu bytes)",
-                (int)player, (unsigned long)packet_history_size, (unsigned long)compressed_size);
+            MULTIPLAYER_LOG("Sending unreliable compressed gameplay repair history for user=%d to host (%lu -> %lu bytes)",
+                (int)user, (unsigned long)packet_history_size, (unsigned long)compressed_size);
             netstate.sp->sendmsg_single_unsequenced(SERVER_ID, netstate.msg_buffer, message_size);
         }
         return;
     }
     NetUserId skip_peer_id = INVALID_USER_ID;
-    if ((NetUserId)player != SERVER_ID) {
-        skip_peer_id = (NetUserId)player;
+    if (user != SERVER_ID) {
+        skip_peer_id = user;
     }
-    MULTIPLAYER_LOG("Sending unreliable compressed gameplay repair history for player=%d to clients (skip=%d) (%lu -> %lu bytes)",
-        (int)player, (int)skip_peer_id, (unsigned long)packet_history_size, (unsigned long)compressed_size);
+    MULTIPLAYER_LOG("Sending unreliable compressed gameplay repair history for user=%d to clients (skip=%d) (%lu -> %lu bytes)",
+        (int)user, (int)skip_peer_id, (unsigned long)packet_history_size, (unsigned long)compressed_size);
     send_to_active_peers(1, NetSend_Unsequenced, netstate.msg_buffer, message_size, skip_peer_id, INVALID_USER_ID);
 }
 
 static void send_repair_history_if_due(void)
 {
     TbClockMSec current_time = LbTimerClock();
-    PlayerNumber player = (PlayerNumber)netstate.my_id;
-    if (player == SERVER_ID) {
+    NetUserId user = netstate.my_id;
+    if (user == SERVER_ID) {
         PlayerNumber offset;
-        for (offset = 0; offset < netstate.max_players; offset += 1) {
-            player = (next_repair_history_player + offset) % netstate.max_players;
-            if (network_player_active(player) && (last_repair_history_send[player] == 0 || current_time - last_repair_history_send[player] >= REPAIR_HISTORY_RESEND_INTERVAL)) {
+        for (offset = 0; offset < netstate.max_users; offset += 1) {
+            user = (next_repair_history_user + offset) % netstate.max_users;
+            if (network_user_active(user) && (last_repair_history_send[user] == 0 || current_time - last_repair_history_send[user] >= REPAIR_HISTORY_RESEND_INTERVAL)) {
                 break;
             }
         }
-        if (offset == netstate.max_players) {
+        if (offset == netstate.max_users) {
             return;
         }
-        next_repair_history_player = (player + 1) % netstate.max_players;
-    } else if (last_repair_history_send[player] != 0 && current_time - last_repair_history_send[player] < REPAIR_HISTORY_RESEND_INTERVAL) {
+        next_repair_history_user = (user + 1) % netstate.max_users;
+    } else if (last_repair_history_send[user] != 0 && current_time - last_repair_history_send[user] < REPAIR_HISTORY_RESEND_INTERVAL) {
         return;
     }
-    last_repair_history_send[player] = current_time;
-    send_player_repair_history(player);
+    last_repair_history_send[user] = current_time;
+    send_user_repair_history(user);
 }
 
-static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, PlayerNumber local_packet_player)
+static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, NetUserId local_user)
 {
     GameTurn expected_turn = get_gameturn() - game.input_lag_turns;
     TbClockMSec wait_start_time = LbTimerClock();
@@ -421,19 +423,19 @@ static TbError wait_for_missing_packets(void *server_buf, size_t frame_size, Pla
         if (host_lost(expected_turn, "waiting for")) {
             return Lb_OK;
         }
-        turn_complete = have_all_turn_packets(local_packet_player);
-        for (NetUserId peer_id = 0; peer_id < netstate.max_players && !turn_complete; peer_id += 1) {
+        turn_complete = have_all_turn_packets(local_user);
+        for (NetUserId peer_id = 0; peer_id < netstate.max_users && !turn_complete; peer_id += 1) {
             if (!can_send_to_peer(peer_id)) {
                 continue;
             }
-            if (netstate.my_id == SERVER_ID && player_has_required_turn_packets(peer_id)) {
+            if (netstate.my_id == SERVER_ID && user_has_required_turn_packets(peer_id)) {
                 continue;
             }
             process_peer_msgs(peer_id, server_buf, frame_size);
             if (host_lost(expected_turn, "collecting")) {
                 return Lb_OK;
             }
-            turn_complete = have_all_turn_packets(local_packet_player);
+            turn_complete = have_all_turn_packets(local_user);
         }
         if (turn_complete) {
             break;
@@ -469,7 +471,7 @@ void network_update(void *server_buf, size_t frame_size)
         return;
     }
     netstate.sp->update(OnNewUser);
-    for (NetUserId peer_id = 0; peer_id < netstate.max_players; peer_id += 1) {
+    for (NetUserId peer_id = 0; peer_id < netstate.max_users; peer_id += 1) {
         if (can_send_to_peer(peer_id)) {
             process_peer_msgs(peer_id, server_buf, frame_size);
         }
@@ -488,9 +490,9 @@ TbError LbNetwork_ExchangeGameplay(void *send_buf, void *server_buf, size_t fram
     if (game.skip_initial_input_turns <= 0) {
         struct PlayerInfo *my_player = get_my_player();
         if (player_exists(my_player)) {
-            PlayerNumber local_packet_player = my_player->packet_num;
-            if (!have_all_turn_packets(local_packet_player)) {
-                return wait_for_missing_packets(server_buf, frame_size, local_packet_player);
+            NetUserId local_user = netstate.my_id;
+            if (!have_all_turn_packets(local_user)) {
+                return wait_for_missing_packets(server_buf, frame_size, local_user);
             }
         }
     }

--- a/src/net_exchange_gameplay.h
+++ b/src/net_exchange_gameplay.h
@@ -32,16 +32,16 @@ extern int32_t multiplayer_speed_adjustment_ns;
 struct Packet;
 
 void initialize_packet_history(void);
-void store_packet_history(PlayerNumber player, const struct Packet *packet);
-const struct Packet *get_history_packet(PlayerNumber player, GameTurn turn);
-const struct Packet *get_latest_history_packet(PlayerNumber player);
+void store_packet_history(NetUserId user, const struct Packet *packet);
+const struct Packet *get_history_packet(NetUserId user, GameTurn turn);
+const struct Packet *get_latest_history_packet(NetUserId user);
 TbBool read_repair_packet_history(NetUserId source, const char *buffer, size_t buffer_size);
 void network_update(void *server_buf, size_t frame_size);
 TbError LbNetwork_ExchangeGameplay(void *send_buf, void *server_buf, size_t frame_size);
 void LbNetwork_BroadcastUnpause(void);
 TbError process_network_unpause_message(void);
 TbError process_network_turn_sync_message(NetUserId source, const char *buffer, size_t buffer_size);
-void process_gameplay_chat_message(int player_id, const char *message);
+void process_gameplay_chat_message(NetUserId user, const char *message);
 
 #ifdef __cplusplus
 }

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -463,6 +463,7 @@ static void stop_network_game_state(void)
 {
     memset(net_user_info, 0, sizeof(net_user_info));
     clear_flag(game.system_flags, GSF_NetworkActive);
+    get_my_player()->user_id = SOLO_HUMAN_ID;
     clear_flag(game.system_flags, GSF_NetGameNoSync);
     clear_flag(game.system_flags, GSF_NetSeedNoSync);
     fe_network_active = 0;

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -53,7 +53,7 @@
 extern "C" {
 #endif
 /******************************************************************************/
-struct TbNetworkPlayerInfo net_player_info[MAX_NET_USERS];
+struct TbNetworkUserInfo net_user_info[MAX_NET_USERS];
 extern int32_t multiplayer_speed_adjustment_ns;
 /******************************************************************************/
 
@@ -76,13 +76,13 @@ short setup_network_service(enum FrontendNetService service)
 {
   struct ServiceInitData *init_data = NULL;
   SYNCMSG("Initializing 4-players type %d network", service);
-  memset(net_player_info, 0, sizeof(net_player_info));
+  memset(net_user_info, 0, sizeof(net_user_info));
   network_lobby_ping = 0;
   if (service != FrontendNetSvc_Online && service != FrontendNetSvc_LAN) {
     process_network_error(-800);
     return 0;
   }
-  if ( LbNetwork_Init(NS_ENET_UDP, MAX_NET_USERS, &net_player_info[0], init_data) )
+  if ( LbNetwork_Init(NS_ENET_UDP, MAX_NET_USERS, &net_user_info[0], init_data) )
   {
     process_network_error(-800);
     return 0;
@@ -99,27 +99,46 @@ short setup_network_service(enum FrontendNetService service)
   return 1;
 }
 
-unsigned long get_host_player_id(void) {
-    return 0;
-}
-
 int setup_old_network_service(void)
 {
     return setup_network_service(net_service_index_selected);
 }
 
+TbBool network_is_host(void)
+{
+    return netstate.my_id == SERVER_ID;
+}
+
+// map NetUserId -> PlayerNumber, or -1 for a user without a player.
+// Currently, this mapping is 1-1.
+// Potential future work: "archon mode" (multiple users share a player)
+static PlayerNumber net_user_player_number[MAX_NET_USERS];
+
+PlayerNumber get_net_user_player_number(NetUserId user)
+{
+    if (!network_is_active()) {
+        return (user == SOLO_HUMAN_ID) ? my_player_number : -1;
+    }
+    if ((user < 0) || (user >= MAX_NET_USERS)) {
+        return -1;
+    }
+    return net_user_player_number[user];
+}
 
 static void setup_players_from_startup_packets(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
-    int k = 0;
-    for (int i = 0; i < MAX_NET_USERS; i++) {
+    for (NetUserId i = 0; i < MAX_NET_USERS; i++) {
         const struct StartupSyncPacket *sync = &startup_sync_packets[i];
-        if (!net_player_info[i].network_user_active) {
+        if (!net_user_info[i].network_user_active) {
+            continue;
+        }
+        int k = get_net_user_player_number(i);
+        if (k < 0) {
             continue;
         }
         struct PlayerInfo *player = get_player(k);
         player->id_number = k;
-        player->packet_num = i;
+        player->user_id = i;
         player->allocflags |= PlaF_Allocated;
         switch (sync->video_rotate_mode) {
             case 0: player->view_mode_restore = PVM_IsoWibbleView; break;
@@ -139,17 +158,16 @@ static void setup_players_from_startup_packets(const struct StartupSyncPacket st
             game.creatures_tend_imprison = imprison;
             game.creatures_tend_flee = flee;
         }
-        snprintf(player->player_name, sizeof(struct TbNetworkPlayerName), "%s", net_player[i].name);
-        k++;
+        snprintf(player->player_name, sizeof(struct TbNetworkPlayerName), "%s", network_user_name(i));
     }
 }
 
 static TbBool verify_map_checksums(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
-    const TbBigChecksum *host = startup_sync_packets[get_host_player_id()].map_checksums;
+    const TbBigChecksum *host = startup_sync_packets[SERVER_ID].map_checksums;
     for (int i = 0; i < MAX_NET_USERS; i++) {
         const TbBigChecksum *client = startup_sync_packets[i].map_checksums;
-        if (!net_player_info[i].network_user_active) {
+        if (!net_user_info[i].network_user_active) {
             continue;
         }
         int diff_count = 0;
@@ -173,11 +191,11 @@ static TbBool verify_map_checksums(const struct StartupSyncPacket startup_sync_p
 
 static TbBool verify_startup_sprite_zip_checksums(const struct StartupSyncPacket startup_sync_packets[MAX_NET_USERS])
 {
-    int host_player_id = get_host_player_id();
-    const struct StartupSyncPacket *host_sync = &startup_sync_packets[host_player_id];
+    NetUserId host_user_id = SERVER_ID;
+    const struct StartupSyncPacket *host_sync = &startup_sync_packets[host_user_id];
     TbBool verified = true;
-    for (int i = 0; i < MAX_NET_USERS; i++) {
-        if (!net_player_info[i].network_user_active || i == host_player_id) {
+    for (NetUserId i = 0; i < MAX_NET_USERS; i++) {
+        if (!net_user_info[i].network_user_active || i == host_user_id) {
             continue;
         }
         const struct StartupSyncPacket *client_sync = &startup_sync_packets[i];
@@ -185,8 +203,8 @@ static TbBool verify_startup_sprite_zip_checksums(const struct StartupSyncPacket
             if (client_sync->required_sprite_zip_checksums[zip_idx] == host_sync->required_sprite_zip_checksums[zip_idx]) {
                 continue;
             }
-            WARNLOG("Custom sprite zip differs between %s and %s: %s", network_player_name(host_player_id), network_player_name(i), required_sprite_zips[zip_idx]);
-            message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s differs for %.12s", required_sprite_zips[zip_idx], network_player_name(i));
+            WARNLOG("Custom sprite zip differs between %s and %s: %s", network_user_name(host_user_id), network_user_name(i), required_sprite_zips[zip_idx]);
+            message_add_fmt(MsgType_Blank, 0, "/fxdata/%.30s differs for %.12s", required_sprite_zips[zip_idx], network_user_name(i));
             verified = false;
         }
     }
@@ -201,7 +219,7 @@ static uint8_t calculate_initial_input_lag(void)
 {
     int32_t player_count = 0;
     for (int32_t i = 0; i < MAX_NET_USERS; i++) {
-        if (net_player_info[i].network_user_active) {
+        if (net_user_info[i].network_user_active) {
             player_count++;
         }
     }
@@ -251,7 +269,7 @@ static TbBool net_startup_sync_exchange_and_apply(void)
     }
 
     for (int i = 0; i < MAX_NET_USERS; i++) {
-        if (net_player_info[i].network_user_active && !s_startup_sync_packets[i].startup_sync_packet_valid) {
+        if (net_user_info[i].network_user_active && !s_startup_sync_packets[i].startup_sync_packet_valid) {
             ERRORLOG("Startup sync exchange missed one or more peers");
             return false;
         }
@@ -265,7 +283,7 @@ static TbBool net_startup_sync_exchange_and_apply(void)
         create_frontend_error_box(5000, get_string(GUIStr_NetVerifyFxdataSame));
         return false;
     }
-    const struct StartupSyncPacket *host_sync = &s_startup_sync_packets[get_host_player_id()];
+    const struct StartupSyncPacket *host_sync = &s_startup_sync_packets[SERVER_ID];
     game.input_lag_turns = host_sync->initial_input_lag_turns;
     input_lag_reset();
     game.skip_initial_input_turns = calculate_skip_input();
@@ -281,12 +299,12 @@ static void setup_network_player_numbers(void)
     TbBool is_set = false;
     int k = 0;
     SYNCDBG(6, "Starting");
-    for (int i = 0; i < MAX_NET_USERS; i++)
+    for (NetUserId i = 0; i < MAX_NET_USERS; i++)
     {
-        struct PlayerInfo* player = get_player(i);
-        if (net_player_info[i].network_user_active)
+        net_user_player_number[i] = -1;
+        if (net_user_info[i].network_user_active)
         {
-            player->packet_num = i;
+            net_user_player_number[i] = k;
             if ((!is_set) && (my_player_number == i))
             {
                 is_set = true;
@@ -310,7 +328,7 @@ void setup_count_players(void)
     game.active_players_count = 0;
     for (int i = 0; i < MAX_NET_USERS; i++)
     {
-      if (net_player_info[i].network_user_active)
+      if (net_user_info[i].network_user_active)
         game.active_players_count++;
     }
   }
@@ -366,23 +384,23 @@ void are_disconnect_victories_allowed(void)
     }
 }
 
-/** Check whether a network player is active.
+/** Check whether a network user is active.
  *
- * @param plyr_idx
+ * @param user
  * @return
  */
-TbBool network_player_active(int plyr_idx)
+TbBool network_user_active(NetUserId user)
 {
-    if ((plyr_idx < 0) || (plyr_idx >= MAX_NET_USERS))
+    if ((user < 0) || (user >= MAX_NET_USERS))
         return false;
-    return (net_player_info[plyr_idx].network_user_active != 0);
+    return (net_user_info[user].network_user_active != 0);
 }
 
-const char *network_player_name(int plyr_idx)
+const char *network_user_name(NetUserId user)
 {
-    if ((plyr_idx < 0) || (plyr_idx >= MAX_NET_USERS))
+    if ((user < 0) || (user >= MAX_NET_USERS))
         return NULL;
-    return net_player_info[plyr_idx].name;
+    return net_user_info[user].name;
 }
 
 static void resolve_network_quit_outcome(struct PlayerInfo *player)
@@ -403,7 +421,7 @@ static TbBool network_has_remote_enemies_remaining(void)
     for (int i = 0; i < PLAYERS_COUNT; i++) {
         struct PlayerInfo *player = get_player(i);
         TbBool is_active_enemy = player_exists(player) && !is_my_player(player) && player->is_active == 1 && !player_cannot_win(player->id_number) && players_are_enemies(myplyr->id_number, player->id_number);
-        TbBool is_connected_network_player = (player->allocflags & PlaF_CompCtrl) == 0 && network_player_active(player->packet_num);
+        TbBool is_connected_network_player = (player->allocflags & PlaF_CompCtrl) == 0 && network_user_active(player->user_id);
         TbBool is_initial_computer_player = (player->allocflags & PlaF_CompCtrl) != 0 && i >= game.active_players_count;
         if (is_active_enemy && (is_connected_network_player || is_initial_computer_player)) {
             return true;
@@ -425,7 +443,7 @@ TbBool network_human_contenders_remain(void)
 
 static TbBool network_has_remote_users_remaining(void)
 {
-    for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_players; user_id += 1) {
+    for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_users; user_id += 1) {
         if (user_id != netstate.my_id && netstate.users[user_id].progress != USER_UNUSED) {
             return true;
         }
@@ -443,7 +461,7 @@ static void replace_network_player_with_ai(struct PlayerInfo *player)
 
 static void stop_network_game_state(void)
 {
-    memset(net_player_info, 0, sizeof(net_player_info));
+    memset(net_user_info, 0, sizeof(net_user_info));
     clear_flag(game.system_flags, GSF_NetworkActive);
     clear_flag(game.system_flags, GSF_NetGameNoSync);
     clear_flag(game.system_flags, GSF_NetSeedNoSync);
@@ -477,7 +495,7 @@ static TbBool host_already_won_level(void)
         if ((GameTurn)offset > newest_turn) {
             break;
         }
-        const struct Packet *host_packet = get_history_packet(get_host_player_id(), newest_turn - offset);
+        const struct Packet *host_packet = get_history_packet(SERVER_ID, newest_turn - offset);
         if (host_packet != NULL && host_packet->action == PckA_FinishGame && host_packet->actn_par1 == VicS_WonLevel) {
             return true;
         }
@@ -489,7 +507,7 @@ void process_player_leave_game_packet(struct PlayerInfo *player)
 {
     if (player != get_my_player()) {
         if (network_is_active()) {
-            OnDroppedUser(player->packet_num, NETDROP_MANUAL);
+            OnDroppedUser(player->user_id, NETDROP_MANUAL);
             process_disconnected_network_players();
             return;
         }
@@ -519,7 +537,7 @@ void process_disconnected_network_players(void)
     }
     for (int player_index = 0; player_index < MAX_NET_USERS; player_index++) {
         struct PlayerInfo *player = get_player(player_index);
-        if (!player_exists(player) || is_my_player(player) || (!host_disconnected && network_player_active(player->packet_num))) {
+        if (!player_exists(player) || is_my_player(player) || (!host_disconnected && network_user_active(player->user_id))) {
             continue;
         }
         disconnected = true;
@@ -532,7 +550,7 @@ void process_disconnected_network_players(void)
         if ((player->allocflags & PlaF_CompCtrl) == 0) {
             network_lobby_ping = GetPing(my_player_number);
             input_lag_reset_request(calculate_initial_input_lag());
-            if (!host_disconnected && player->id_number != get_host_player_id() && player->player_name[0] != '\0') {
+            if (!host_disconnected && player->id_number != get_net_user_player_number(SERVER_ID) && player->player_name[0] != '\0') {
                 message_add_fmt(MsgType_Blank, 0, get_string(GUIStr_NetPlayerDisconnected), player->player_name);
                 JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);
             }

--- a/src/net_game.h
+++ b/src/net_game.h
@@ -36,7 +36,7 @@ struct TbNetworkSessionNameEntry;
 struct PlayerInfo;
 
 /******************************************************************************/
-extern struct TbNetworkPlayerInfo net_player_info[MAX_NET_USERS];
+extern struct TbNetworkUserInfo net_user_info[MAX_NET_USERS];
 
 #pragma pack()
 /******************************************************************************/
@@ -48,13 +48,14 @@ void are_disconnect_victories_allowed(void);
 
 long network_session_join(void);
 
-TbBool network_player_active(int plyr_idx);
-const char *network_player_name(int plyr_idx);
+TbBool network_user_active(NetUserId);
+const char *network_user_name(NetUserId);
 TbBool network_human_contenders_remain(void);
 void process_player_leave_game_packet(struct PlayerInfo *player);
 void process_disconnected_network_players(void);
 void sync_initial_network_seed(void);
-unsigned long get_host_player_id(void);
+TbBool network_is_host(void);
+PlayerNumber get_net_user_player_number(NetUserId user);
 /******************************************************************************/
 #ifdef __cplusplus
 }

--- a/src/net_input_lag.c
+++ b/src/net_input_lag.c
@@ -147,10 +147,10 @@ void input_lag_update(struct Packet *packet)
     }
     input_lag_decrease_last_update = current_time;
     packet->input_lag_turns = local_input_lag_request;
-    if (my_player_number != get_host_player_id() || !netstate.sp) { return; }
-    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+    if (!network_is_host() || !netstate.sp) { return; }
+    for (NetUserId id = 0; id < netstate.max_users; id += 1) {
         if (id == netstate.my_id || netstate.users[id].progress != USER_LOGGEDIN) { continue; }
-        const struct Packet *peer_packet = get_latest_history_packet((PlayerNumber)id);
+        const struct Packet *peer_packet = get_latest_history_packet(id);
         if (peer_packet != NULL && (uint8_t)peer_packet->input_lag_turns <= MAXIMUM_INPUT_LAG_TURNS && peer_packet->input_lag_turns > packet->input_lag_turns) {
             packet->input_lag_turns = peer_packet->input_lag_turns;
         }

--- a/src/net_lobby.c
+++ b/src/net_lobby.c
@@ -112,7 +112,7 @@ TbError process_login_message(NetUserId source, char *read_pos)
     memcpy(reply_pos, &netstate.users[SERVER_ID].version, sizeof(netstate.users[SERVER_ID].version));
     reply_pos += sizeof(netstate.users[SERVER_ID].version);
     send_message_buffer(source, reply_pos);
-    for (NetUserId user_id = 0; user_id < netstate.max_players; user_id += 1) {
+    for (NetUserId user_id = 0; user_id < netstate.max_users; user_id += 1) {
         if (netstate.users[user_id].progress == USER_UNUSED) {
             continue;
         }
@@ -133,7 +133,7 @@ TbError process_user_update_message(NetUserId source, char *read_pos, const char
     }
     NetUserId user_id = (NetUserId)read_pos[0];
     read_pos += 1;
-    if (user_id < 0 || user_id >= netstate.max_players) {
+    if (user_id < 0 || user_id >= netstate.max_users) {
         ERRORLOG("Critical error: Out of range user ID %i received from server, could be used for buffer overflow attack", user_id);
         abort();
     }
@@ -283,7 +283,7 @@ TbError LbNetwork_Join(struct TbNetworkSessionNameEntry *nsname, char *plyr_name
 TbError LbNetwork_EnableNewPlayers(TbBool allow)
 {
     if (!netstate.locked && !allow) {
-        for (NetUserId i = 0; i < netstate.max_players; i += 1) {
+        for (NetUserId i = 0; i < netstate.max_users; i += 1) {
             if (netstate.users[i].progress == USER_CONNECTED) {
                 netstate.sp->drop_user(i);
             }
@@ -314,7 +314,7 @@ TbError LbNetwork_Stop(void)
 TbError LbNetwork_EnumeratePlayers(struct TbNetworkSessionNameEntry *, TbNetworkCallbackFunc callback, void *buf)
 {
     struct TbNetworkCallbackData data;
-    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+    for (NetUserId id = 0; id < netstate.max_users; id += 1) {
         if (!IsUserActive(id)) {
             continue;
         }

--- a/src/net_main.c
+++ b/src/net_main.c
@@ -19,7 +19,7 @@
 #include "keeperfx.hpp"
 #include "post_inc.h"
 
-static struct TbNetworkPlayerInfo *local_player_info;
+static struct TbNetworkUserInfo *local_user_info;
 
 struct NetState netstate;
 
@@ -31,7 +31,7 @@ TbBool IsUserActive(NetUserId id)
 int32_t GetRemoteUserCount(void)
 {
     int32_t count = 0;
-    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+    for (NetUserId id = 0; id < netstate.max_users; id += 1) {
         if (id != netstate.my_id && IsUserActive(id)) {
             count += 1;
         }
@@ -42,15 +42,15 @@ int32_t GetRemoteUserCount(void)
 void UpdateLocalPlayerInfo(NetUserId id)
 {
     TbBool active = netstate.users[id].progress != USER_UNUSED;
-    if (local_player_info[id].network_user_active && !active) {
-        local_player_info[id].connection_id++;
+    if (local_user_info[id].network_user_active && !active) {
+        local_user_info[id].connection_id++;
     }
-    local_player_info[id].network_user_active = active;
-    if (!local_player_info[id].network_user_active) {
-        memset(local_player_info[id].name, 0, sizeof(local_player_info[id].name));
+    local_user_info[id].network_user_active = active;
+    if (!local_user_info[id].network_user_active) {
+        memset(local_user_info[id].name, 0, sizeof(local_user_info[id].name));
         return;
     }
-    strcpy(local_player_info[id].name, netstate.users[id].name);
+    strcpy(local_user_info[id].name, netstate.users[id].name);
 }
 
 char *begin_net_message(enum NetMessageType msg_type)
@@ -75,7 +75,7 @@ void send_remote_buffer(const char *end_ptr)
         }
         return;
     }
-    for (NetUserId id = 0; id < netstate.max_players; id += 1) {
+    for (NetUserId id = 0; id < netstate.max_users; id += 1) {
         if (id == netstate.my_id || !IsUserActive(id)) {
             continue;
         }
@@ -97,12 +97,12 @@ void SendUserUpdate(NetUserId dest, NetUserId updated_user)
     send_message_buffer(dest, write_pos);
 }
 
-TbError LbNetwork_Init(uint32_t srvcindex, uint32_t maxplayrs, struct TbNetworkPlayerInfo *locplayr, struct ServiceInitData *)
+TbError LbNetwork_Init(uint32_t srvcindex, uint32_t maxplayrs, struct TbNetworkUserInfo *locplayr, struct ServiceInitData *)
 {
-    local_player_info = locplayr;
+    local_user_info = locplayr;
     memset(&netstate, 0, sizeof(netstate));
-    netstate.max_players = maxplayrs;
-    for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_players; user_id += 1) {
+    netstate.max_users = maxplayrs;
+    for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_users; user_id += 1) {
         netstate.users[user_id].id = user_id;
     }
     if (srvcindex == NS_ENET_UDP) {
@@ -122,7 +122,7 @@ TbBool OnNewUser(NetUserId *assigned_id)
     if (netstate.locked) {
         return false;
     }
-    for (NetUserId id = 0; id < (NetUserId)netstate.max_players; id += 1) {
+    for (NetUserId id = 0; id < (NetUserId)netstate.max_users; id += 1) {
         if (netstate.users[id].progress == USER_UNUSED) {
             *assigned_id = id;
             netstate.users[id].progress = USER_CONNECTED;
@@ -137,7 +137,7 @@ TbBool OnNewUser(NetUserId *assigned_id)
 void OnDroppedUser(NetUserId id, enum NetDropReason reason)
 {
     assert(id >= 0);
-    assert(id < (int)netstate.max_players);
+    assert(id < (int)netstate.max_users);
     if (netstate.my_id == id) {
         NETMSG("Warning: Trying to drop local user. There's a bug in code somewhere, probably server trying to send message to itself.");
         return;
@@ -153,7 +153,7 @@ void OnDroppedUser(NetUserId id, enum NetDropReason reason)
     memset(&netstate.users[id], 0, sizeof(netstate.users[id]));
     netstate.users[id].id = id;
     if (netstate.my_id == SERVER_ID && id != SERVER_ID) {
-        for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_players; user_id += 1) {
+        for (NetUserId user_id = 0; user_id < (NetUserId)netstate.max_users; user_id += 1) {
             if (user_id == netstate.my_id) {
                 continue;
             }

--- a/src/net_main.h
+++ b/src/net_main.h
@@ -40,6 +40,7 @@ extern "C" {
 #define MAX_NET_USERS 4
 #define MAX_NET_PEERS (MAX_NET_USERS - 1)
 #define SERVER_ID 0
+#define SOLO_HUMAN_ID 0 /* human player's user id in non-multiplayer, when relevant */
 #define NET_MSG_BUFFER_SIZE 5000
 #define INVALID_USER_ID 23456
 
@@ -118,13 +119,13 @@ struct NetState {
     char password[32];
     NetUserId my_id;
     int seq_nbr;
-    unsigned max_players;
+    unsigned max_users;
     char msg_buffer[NET_MSG_BUFFER_SIZE];
     char msg_buffer_null;
     TbBool locked;
 };
 
-struct TbNetworkPlayerInfo {
+struct TbNetworkUserInfo {
     char name[32];
     int32_t network_user_active;
     uint32_t connection_id;
@@ -153,7 +154,7 @@ static inline TbBool net_versions_match(const struct GameVersionPacket *version_
         (version_a->build == version_b->build);
 }
 
-TbError LbNetwork_Init(uint32_t srvcindex, uint32_t maxplayrs, struct TbNetworkPlayerInfo *locplayr, struct ServiceInitData *init_data);
+TbError LbNetwork_Init(uint32_t srvcindex, uint32_t maxplayrs, struct TbNetworkUserInfo *locplayr, struct ServiceInitData *init_data);
 TbBool OnNewUser(NetUserId *assigned_id);
 void OnDroppedUser(NetUserId id, enum NetDropReason reason);
 TbBool IsUserActive(NetUserId id);

--- a/src/net_matchmaking.c
+++ b/src/net_matchmaking.c
@@ -521,11 +521,11 @@ void matchmaking_finish_lobby(enum MatchmakingLobbyResult result, int map_number
             int write_position = snprintf(finish_message, sizeof(finish_message), "{\"action\":\"game_started\",\"id\":\"%s\",\"mapNumber\":%d,\"mapName\":\"%s\",\"players\":[", hosted_lobby_id, map_number, escaped_map_name);
             const char *separator = "";
             for (int i = 0; i < MAX_NET_USERS; i++) {
-                if (!network_player_active(i)) {
+                if (!network_user_active(i)) {
                     continue;
                 }
                 char escaped_name[NETSP_PLAYER_NAME_MAX_LEN * 2 + 1];
-                json_escape(escaped_name, sizeof(escaped_name), network_player_name(i));
+                json_escape(escaped_name, sizeof(escaped_name), network_user_name(i));
                 write_position += snprintf(finish_message + write_position, sizeof(finish_message) - write_position, "%s\"%s\"", separator, escaped_name);
                 separator = ",";
             }

--- a/src/net_resync.cpp
+++ b/src/net_resync.cpp
@@ -304,7 +304,7 @@ TbBool LbNetwork_Resync(void * data_buffer, size_t buffer_length)
     MULTIPLAYER_LOG("Starting resync, my_id=%d, buffer_length=%u", netstate.my_id, (uint32_t)buffer_length);
 
     TbBool result;
-    if (my_player_number == get_host_player_id()) {
+    if (network_is_host()) {
         MULTIPLAYER_LOG("Resync: I am the server");
         result = send_resync_data(data_buffer, buffer_length);
     } else {
@@ -433,7 +433,7 @@ void resync_game(void)
     reset_eye_lenses();
     store_localised_game_structure();
     TbBool result;
-    if (my_player_number == get_host_player_id()) {
+    if (network_is_host()) {
         result = send_resync_game();
     } else {
         result = receive_resync_game();

--- a/src/packets.c
+++ b/src/packets.c
@@ -116,7 +116,7 @@ extern "C" {
 }
 #endif
 /******************************************************************************/
-extern TbBool process_players_global_cheats_packet_action(PlayerNumber plyr_idx, struct Packet* pckt);
+extern TbBool process_player_global_cheats_packet_action(PlayerNumber plyr_idx, struct Packet* pckt);
 extern TbBool process_players_dungeon_control_cheats_packet_action(PlayerNumber plyr_idx, struct Packet* pckt);
 /******************************************************************************/
 TbBool unpausing_in_progress = 0;
@@ -153,19 +153,19 @@ TbBool is_packet_empty(const struct Packet *pckt) {
     return true;
 }
 
-void update_double_click_detection(long plyr_idx)
+void update_double_click_detection(NetUserId user)
 {
-    struct Packet* pckt = get_packet(plyr_idx);
+    struct Packet* pckt = get_packet(user);
     if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
     {
-        if (packet_left_button_click_space_count[plyr_idx] < 5)
-            packet_left_button_double_clicked[plyr_idx] = 1;
-        packet_left_button_click_space_count[plyr_idx] = 0;
+        if (packet_left_button_click_space_count[user] < 5)
+            packet_left_button_double_clicked[user] = 1;
+        packet_left_button_click_space_count[user] = 0;
   }
   if ((pckt->control_flags & (PCtr_LBtnClick|PCtr_LBtnHeld)) == 0)
   {
-    if (packet_left_button_click_space_count[plyr_idx] < INT32_MAX)
-      packet_left_button_click_space_count[plyr_idx]++;
+    if (packet_left_button_click_space_count[user] < INT32_MAX)
+      packet_left_button_click_space_count[user]++;
   }
 }
 
@@ -195,12 +195,13 @@ struct Room *keeper_build_room(long stl_x,long stl_y,long plyr_idx,long rkind)
     return room;
 }
 
-TbBool process_dungeon_control_packet_spell_overcharge(long plyr_idx)
+TbBool process_dungeon_control_packet_spell_overcharge(NetUserId user)
 {
-    struct PlayerInfo* player = get_player(plyr_idx);
+    struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    const PlayerNumber plyr_idx = player->id_number;
     struct Dungeon* dungeon = get_players_dungeon(player);
     SYNCDBG(6,"Starting for player %d state %s",(int)plyr_idx,player_state_code_name(player->work_state));
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(user);
 
     while (game.conf.rules[plyr_idx].magic.allow_instant_charge_up && (pckt->additional_packet_values & PCAdV_SpeedupPressed))
     {
@@ -545,8 +546,8 @@ void update_box_lag_compensation(struct PlayerInfo* player) {
     box_lag_compensation_x = 0;
     box_lag_compensation_y = 0;
     if (is_my_player(player)) {
-        struct Packet* auth_pckt = get_packet_direct(player->packet_num);
-        const struct Packet *visual_pckt = get_history_packet(player->packet_num, get_gameturn());
+        struct Packet* auth_pckt = get_packet(player->user_id);
+        const struct Packet *visual_pckt = get_history_packet(player->user_id, get_gameturn());
         if (visual_pckt != NULL) {
             box_lag_compensation_x = coord_slab(auth_pckt->pos_x) - coord_slab(visual_pckt->pos_x);
             box_lag_compensation_y = coord_slab(auth_pckt->pos_y) - coord_slab(visual_pckt->pos_y);
@@ -556,10 +557,11 @@ void update_box_lag_compensation(struct PlayerInfo* player) {
     }
 }
 
-void process_players_dungeon_control_packet_control(long plyr_idx)
+void process_user_dungeon_control_packet_control(NetUserId user)
 {
+    const PlayerNumber plyr_idx = get_net_user_player_number(user);
     struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(user);
     SYNCDBG(6,"Processing player %d action %d",(int)plyr_idx,(int)pckt->action);
     struct Camera* cam = get_player_active_camera(player);
     if (cam == NULL) {
@@ -588,7 +590,7 @@ void process_players_dungeon_control_packet_control(long plyr_idx)
     if (is_my_player(player)) {
         update_box_lag_compensation(player);
     }
-    process_dungeon_control_packet_clicks(plyr_idx);
+    process_dungeon_control_packet_clicks(user);
     update_mouse_light(player);
 }
 
@@ -629,12 +631,13 @@ void process_camera_action(struct Camera cams[], const struct Packet *pckt)
     }
 }
 
-TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
+TbBool process_user_global_packet_action(NetUserId user)
 {
   //TODO PACKET add commands from beta
+  PlayerNumber plyr_idx = get_net_user_player_number(user);
   struct PlayerInfo* player = get_player(plyr_idx);
-  struct Packet* pckt = get_packet_direct(player->packet_num);
-  SYNCDBG(6,"Processing player %d action %d",(int)plyr_idx,(int)pckt->action);
+  struct Packet* pckt = get_packet(user);
+  SYNCDBG(6,"Processing user %d action %d",(int)user,(int)pckt->action);
   struct Dungeon *dungeon;
   struct Thing *thing;
   int i;
@@ -690,7 +693,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
           quit_game = 1;
           return 0;
         }
-        TbBool host_packet = player->packet_num == get_host_player_id();
+        TbBool host_packet = player->user_id == SERVER_ID;
         if (!my_player) {
           if (host_packet && (player->victory_state != VicS_LostLevel)) {
             get_my_player()->additional_flags &= ~PlaAF_UnlockedLordTorture;
@@ -720,7 +723,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       return 0;
       }
   case PckA_PlyrMsgEnd:
-      process_gameplay_chat_message(player->id_number, player->mp_pending_message);
+      process_gameplay_chat_message(player->user_id, player->mp_pending_message);
       player->mp_pending_message[0] = '\0';
       return 0;
   case PckA_PlyrMsgClear:
@@ -803,7 +806,7 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
       if (network_is_active()
           || (lbDisplay.PhysicalScreenWidth > 320))
       {
-        if (is_my_player_number(plyr_idx))
+        if (get_local_user() == user)
           toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
         set_player_mode(player, PVT_DungeonTop);
       } else
@@ -1058,53 +1061,54 @@ TbBool process_players_global_packet_action(PlayerNumber plyr_idx)
         return false;
     }
     default:
-      return process_players_global_cheats_packet_action(plyr_idx, pckt);
+      return process_player_global_cheats_packet_action(plyr_idx, pckt);
   }
 }
 
-void process_players_map_packet_control(long plyr_idx)
+void process_user_map_packet_control(NetUserId user)
 {
+    const PlayerNumber plyr_idx = get_net_user_player_number(user);
     SYNCDBG(6,"Starting");
     struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(user);
     // Get map coordinates
-    process_map_packet_clicks(plyr_idx);
+    process_map_packet_clicks(user);
     player->cameras[CamIV_Parchment].mappos.x.val = pckt->pos_x;
     player->cameras[CamIV_Parchment].mappos.y.val = pckt->pos_y;
     update_mouse_light(player);
     SYNCDBG(8,"Finished");
 }
 
-void process_map_packet_clicks(long plyr_idx)
+void process_map_packet_clicks(NetUserId user)
 {
     SYNCDBG(7,"Starting");
-    packet_left_button_double_clicked[plyr_idx] = 0;
-    struct Packet* pckt = get_packet(plyr_idx);
+    packet_left_button_double_clicked[user] = 0;
+    struct Packet* pckt = get_packet(user);
     if ((pckt->control_flags & PCtr_Gui) == 0)
     {
-        update_double_click_detection(plyr_idx);
+        update_double_click_detection(user);
     }
     SYNCDBG(8,"Finished");
 }
 
 /**
  * Process packet with input commands for given player.
- * @param plyr_idx Player to process packet for.
+ * @param user User to process packet for.
  */
-void process_players_packet(long plyr_idx)
+void process_user_packet(NetUserId user)
 {
-    struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    struct Packet* pckt = get_packet(user);
     if (is_packet_empty(pckt))
     {
-        MULTIPLAYER_LOG("process_players_packet: Skipping empty packet for player %ld", plyr_idx);
+        MULTIPLAYER_LOG("process_user_packet: Skipping empty packet for user %d", user);
         return;
     }
-    SYNCDBG(6, "Processing player %ld packet of type %d.", plyr_idx, (int)pckt->action);
+    SYNCDBG(6, "Processing user %d packet of type %d.", user, (int)pckt->action);
     player->input_crtr_control = ((pckt->additional_packet_values & PCAdV_CrtrContrlPressed) != 0);
     player->input_crtr_query = ((pckt->additional_packet_values & PCAdV_CrtrQueryPressed) != 0);
 
-  if (!process_players_global_packet_action(plyr_idx))
+  if (!process_user_global_packet_action(user))
   {
       // Different changes to the game are possible for different views.
       // For each there can be a control change (which is view change or mouse event not translated to action),
@@ -1112,20 +1116,20 @@ void process_players_packet(long plyr_idx)
       switch (player->view_type)
       {
           case PVT_DungeonTop:
-            process_players_dungeon_control_packet_control(plyr_idx);
-            process_players_dungeon_control_packet_action(plyr_idx);
+            process_user_dungeon_control_packet_control(user);
+            process_user_dungeon_control_packet_action(user);
             break;
           case PVT_CreatureContrl:
-            process_players_creature_control_packet_control(plyr_idx);
-            process_players_creature_control_packet_action(plyr_idx);
+            process_user_creature_control_packet_control(user);
+            process_user_creature_control_packet_action(user);
             break;
           case PVT_CreaturePasngr:
-            //process_players_creature_passenger_packet_control(plyr_idx); -- there are no control changes in passenger mode
-            process_players_creature_passenger_packet_action(plyr_idx);
+            //process_user_creature_passenger_packet_control(user); -- there are no control changes in passenger mode
+            process_user_creature_passenger_packet_action(user);
             break;
           case PVT_MapScreen:
-            process_players_map_packet_control(plyr_idx);
-            //process_players_map_packet_action(plyr_idx); -- there are no actions to perform from map screen
+            process_user_map_packet_control(user);
+            //process_user_map_packet_action(user); -- there are no actions to perform from map screen
             break;
           default:
             break;
@@ -1134,10 +1138,11 @@ void process_players_packet(long plyr_idx)
   SYNCDBG(8,"Finished");
 }
 
-void process_players_creature_passenger_packet_action(long plyr_idx)
+void process_user_creature_passenger_packet_action(NetUserId user)
 {
+    const PlayerNumber plyr_idx = get_net_user_player_number(user);
     struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(user);
     SYNCDBG(6,"Processing player %d action %d",(int)plyr_idx,(int)pckt->action);
     if (pckt->action == PckA_PasngrCtrlExit)
     {
@@ -1148,10 +1153,11 @@ void process_players_creature_passenger_packet_action(long plyr_idx)
     SYNCDBG(8,"Finished");
 }
 
-TbBool process_players_dungeon_control_packet_action(long plyr_idx)
+TbBool process_user_dungeon_control_packet_action(NetUserId user)
 {
+    const PlayerNumber plyr_idx = get_net_user_player_number(user);
     struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(user);
     SYNCDBG(6,"Processing player %d action %d",(int)plyr_idx,(int)pckt->action);
     switch (pckt->action)
     {
@@ -1226,14 +1232,15 @@ TbBool can_process_creature_input(struct Thing *thing)
     return true;
 }
 
-void process_players_creature_control_packet_control(long idx)
+void process_user_creature_control_packet_control(NetUserId user)
 {
+    const PlayerNumber plyr_idx = get_net_user_player_number(user);
     SYNCDBG(6,"Starting");
     struct InstanceInfo *inst_inf;
     long i;
-    struct PlayerInfo* player = get_player(idx);
+    struct PlayerInfo* player = get_player(plyr_idx);
     struct Thing* cctng = thing_get(player->controlled_thing_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(user);
     struct CreatureControl* ccctrl = creature_control_get_from_thing(cctng);
     ThingIndex target_idx;
     if (can_process_creature_input(cctng))
@@ -1436,8 +1443,9 @@ void process_players_creature_control_packet_control(long idx)
     }
 }
 
-void process_players_creature_control_packet_action(long plyr_idx)
+void process_user_creature_control_packet_action(NetUserId user)
 {
+  const PlayerNumber plyr_idx = get_net_user_player_number(user);
   struct CreatureControl *cctrl;
   struct InstanceInfo *inst_inf;
   struct PlayerInfo *player;
@@ -1445,7 +1453,7 @@ void process_players_creature_control_packet_action(long plyr_idx)
   struct Packet *pckt;
   long i;
   player = get_player(plyr_idx);
-  pckt = get_packet_direct(player->packet_num);
+  pckt = get_packet(user);
   SYNCDBG(6,"Processing player %d action %d",(int)plyr_idx,(int)pckt->action);
   switch (pckt->action)
   {
@@ -1573,11 +1581,11 @@ static void load_old_packets(void)
             MULTIPLAYER_LOG("load_input_lag_packets: cleared packet[%s] (no stored packet)", player_name);
         }
     }
-    input_lag_observe_host_packet(&game.packets[get_host_player_id()]);
+    input_lag_observe_host_packet(&game.packets[SERVER_ID]);
 }
 
 void set_local_packet_turn(void) {
-    struct Packet* pckt = get_packet(my_player_number);
+    struct Packet* pckt = get_local_packet();
     pckt->turn = get_gameturn();
     MULTIPLAYER_LOG("set_local_packet_turn: turn=%lu checksum=%08lx", (unsigned long)get_gameturn(), (unsigned long)pckt->checksum);
 }
@@ -1588,22 +1596,21 @@ void set_local_packet_turn(void) {
  */
 void exchange_packets(void)
 {
-    struct PlayerInfo* player = get_my_player();
     SYNCDBG(5, "Starting");
 
     MULTIPLAYER_LOG("process_packets: === BEGIN turn=%lu ===", (unsigned long)get_gameturn());
-    input_lag_update(get_packet_direct(player->packet_num));
+    const NetUserId local_user = get_local_user();
+    input_lag_update(get_local_packet());
     set_local_packet_turn();
     update_turn_checksums();
     update_local_dig_tag_prediction();
-    store_packet_history(player->packet_num, get_packet_direct(player->packet_num));
+    store_packet_history(local_user, get_local_packet());
     if (game.game_kind != GKind_LocalGame)
     {
         if (!game.packet_load_enable || game.packet_load_initialized)
         {
-            struct Packet* my_packet = get_packet_direct(player->packet_num);
-            const char* player_name;
-            if (player->packet_num == 0) {player_name = "Host";} else {player_name = "Client";}
+            struct Packet* my_packet = get_local_packet();
+            const char* player_name = (local_user == SERVER_ID) ? "Host" : "Client";
             MULTIPLAYER_LOG("process_packets: SENDING packet[%s] turn=%lu checksum=%08lx", player_name, (unsigned long)my_packet->turn, (unsigned long)my_packet->checksum);
             if (LbNetwork_ExchangeGameplay(my_packet, game.packets, sizeof(struct Packet)) != Lb_OK) {
                 ERRORLOG("LbNetwork_ExchangeGameplay failed");
@@ -1648,11 +1655,15 @@ void process_packets(void)
     write_debug_packets();
     #endif
     // Process the packets
-    for (int i=0; i<PACKETS_COUNT; i++)
+    for (NetUserId user = 0; user < PACKETS_COUNT; user++)
     {
-        struct PlayerInfo* packet_player = get_player(i);
+        const PlayerNumber plyr_idx = get_net_user_player_number(user);
+        if (plyr_idx < 0) {
+            continue;
+        }
+        struct PlayerInfo* packet_player = get_player(plyr_idx);
         if (player_exists(packet_player) && ((packet_player->allocflags & PlaF_CompCtrl) == 0)) {
-            process_players_packet(i);
+            process_user_packet(user);
         }
     }
     update_local_dig_prediction_cursor_preview();

--- a/src/packets.h
+++ b/src/packets.h
@@ -22,6 +22,7 @@
 #include "bflib_basics.h"
 #include "bflib_keybrd.h"
 #include "globals.h"
+#include "net_main.h"
 #include "player_data.h"
 #include <stdint.h>
 
@@ -321,8 +322,9 @@ struct PacketEx
 #pragma pack()
 /******************************************************************************/
 /******************************************************************************/
-struct Packet *get_packet_direct(long pckt_idx);
-struct Packet *get_packet(long plyr_idx);
+struct Packet *get_local_packet(void);
+NetUserId get_local_user(void);
+struct Packet *get_packet(NetUserId user);
 void set_packet_action(struct Packet *pckt, unsigned char pcktype, long par1, long par2, unsigned short par3, unsigned short par4);
 TbBool is_packet_empty(const struct Packet *pckt);
 void set_players_packet_action(struct PlayerInfo *player, unsigned char pcktype, unsigned long par1, unsigned long par2, unsigned short par3, unsigned short par4);
@@ -334,12 +336,12 @@ void unset_players_packet_control(struct PlayerInfo *player, unsigned long flag)
 void set_players_packet_position(struct Packet *pckt, long x, long y, unsigned char context);
 void set_packet_pause_toggle(void);
 struct Thing *get_thing_under_hand(struct PlayerInfo *player, MapCoord x, MapCoord y);
-TbBool process_dungeon_control_packet_clicks(long idx);
-TbBool process_players_dungeon_control_packet_action(long idx);
-void process_players_creature_control_packet_control(long idx);
-void process_players_creature_passenger_packet_action(long idx);
-void process_players_creature_control_packet_action(long idx);
-void process_map_packet_clicks(long idx);
+TbBool process_dungeon_control_packet_clicks(NetUserId user);
+TbBool process_user_dungeon_control_packet_action(NetUserId user);
+void process_user_creature_control_packet_control(NetUserId user);
+void process_user_creature_passenger_packet_action(NetUserId user);
+void process_user_creature_control_packet_action(NetUserId user);
+void process_map_packet_clicks(NetUserId user);
 void process_pause_packet(long a1, long a2);
 void process_camera_controls(struct Camera* cam, const struct Packet* pckt, struct PlayerInfo* player, TbBool is_local_camera);
 void process_camera_action(struct Camera cams[], const struct Packet* pckt);

--- a/src/packets_cheats.c
+++ b/src/packets_cheats.c
@@ -766,7 +766,7 @@ TbBool packets_process_cheats(
     return true;
 }
 
-TbBool process_players_global_cheats_packet_action(PlayerNumber plyr_idx, struct Packet* pckt)
+TbBool process_player_global_cheats_packet_action(PlayerNumber plyr_idx, struct Packet* pckt)
 {
   struct PlayerInfo* player;
   switch (pckt->action)

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -16,6 +16,7 @@
  *     (at your option) any later version.
  */
 /******************************************************************************/
+#include "net_game.h"
 #include "pre_inc.h"
 #include "config_players.h"
 #include "config_powerhands.h"
@@ -50,9 +51,9 @@
 #include "keeperfx.hpp"
 #include "post_inc.h"
 
-extern TbBool process_dungeon_control_packet_spell_overcharge(long plyr_idx);
+extern TbBool process_dungeon_control_packet_spell_overcharge(NetUserId user);
 
-extern void update_double_click_detection(long plyr_idx);
+extern void update_double_click_detection(NetUserId user);
 
 // Returns false if mouse is on map edges or on GUI
 TbBool is_mouse_on_map(struct Packet* pckt)
@@ -68,7 +69,7 @@ TbBool is_mouse_on_map(struct Packet* pckt)
 
 void remember_cursor_subtile(struct PlayerInfo *player)
 {
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(player->user_id);
     MapSubtlCoord cursor_subtile_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord cursor_subtile_y = coord_subtile(pckt->pos_y);
     player->previous_cursor_subtile_x = player->cursor_subtile_x;
@@ -114,10 +115,11 @@ struct Thing *get_thing_under_hand(struct PlayerInfo *player, MapCoord x, MapCoo
     return INVALID_THING;
 }
 
-TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
+TbBool process_dungeon_control_packet_dungeon_build_room(NetUserId user)
 {
-    struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    PlayerNumber plyr_idx = player->id_number;
+    struct Packet* pckt = get_packet(user);
     MapCoord x = (pckt->pos_x);
     MapCoord y = (pckt->pos_y);
     MapSubtlCoord stl_x = coord_subtile(x);
@@ -196,10 +198,11 @@ TbBool process_dungeon_control_packet_dungeon_build_room(long plyr_idx)
     return true;
 }
 
-TbBool process_dungeon_power_hand_state(long plyr_idx)
+TbBool process_dungeon_power_hand_state(NetUserId user)
 {
-    struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    PlayerNumber plyr_idx = player->id_number;
+    struct Packet* pckt = get_packet(user);
     MapCoord x = pckt->pos_x;
     MapCoord y = pckt->pos_y;
     MapSubtlCoord stl_x = coord_subtile(x);
@@ -269,12 +272,13 @@ TbBool process_dungeon_power_hand_state(long plyr_idx)
     return true;
 }
 
-TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
+TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
 {
     struct Thing *thing;
-    struct PlayerInfo* player = get_player(plyr_idx);
+    struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    PlayerNumber plyr_idx = player->id_number;
     struct Dungeon* dungeon = get_players_dungeon(player);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(user);
     MapCoord x = pckt->pos_x;
     MapCoord y = pckt->pos_y;
     MapSubtlCoord stl_x = coord_subtile(x);
@@ -288,7 +292,7 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
     player->render_roomspace.highlight_mode = settings.highlight_mode; // reset one-click highlight mode
     player->render_roomspace.drag_mode = player->one_click_lock_cursor;
     player->pickup_all_gold = (pckt->additional_packet_values & PCAdV_RotatePressed);
-    process_dungeon_power_hand_state(plyr_idx);
+    process_dungeon_power_hand_state(user);
     if ((pckt->control_flags & PCtr_MapCoordsValid) != 0)
     {
         if ( (player->primary_cursor_state == CSt_PickAxe) || ( (player->primary_cursor_state == CSt_PowerHand) && ((player->additional_flags & PlaAF_ChosenSubTileIsHigh) != 0) ) )
@@ -549,10 +553,11 @@ TbBool process_dungeon_control_packet_dungeon_control(long plyr_idx)
     return true;
 }
 
-TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
+TbBool process_dungeon_control_packet_sell_operation(NetUserId user)
 {
-    struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    PlayerNumber plyr_idx = player->id_number;
+    struct Packet* pckt = get_packet(user);
     if ((pckt->control_flags & PCtr_MapCoordsValid) == 0)
     {
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->full_slab_cursor != 0))
@@ -653,10 +658,11 @@ TbBool process_dungeon_control_packet_sell_operation(long plyr_idx)
     return true;
 }
 
-TbBool process_dungeon_control_packet_dungeon_place_trap(long plyr_idx)
+TbBool process_dungeon_control_packet_dungeon_place_trap(NetUserId user)
 {
-    struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    PlayerNumber plyr_idx = player->id_number;
+    struct Packet* pckt = get_packet(user);
     MapCoord x = (pckt->pos_x);
     MapCoord y = (pckt->pos_y);
     MapSubtlCoord stl_x = coord_subtile(x);
@@ -697,20 +703,21 @@ TbBool process_dungeon_control_packet_dungeon_place_trap(long plyr_idx)
     return true;
 }
 
-TbBool process_dungeon_control_packet_clicks(long plyr_idx)
+TbBool process_dungeon_control_packet_clicks(NetUserId user)
 {
     struct Thing *thing;
     PowerKind pwkind;
-    struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet_direct(player->packet_num);
-    SYNCDBG(6,"Starting for player %d state %s",(int)plyr_idx,player_state_code_name(player->work_state));
+    struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    const PlayerNumber plyr_idx = player->id_number;
+    struct Packet* pckt = get_packet(user);
+    SYNCDBG(6,"Starting for user %d state %s",user,player_state_code_name(player->work_state));
     TbBool thing_target_action = (pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing);
     player->full_slab_cursor = 1;
     player->primary_cursor_state = (pckt->additional_packet_values & PCAdV_ContextMask) >> 1;
-    packet_left_button_double_clicked[plyr_idx] = 0;
+    packet_left_button_double_clicked[user] = 0;
     player->mouse_on_map = is_mouse_on_map(pckt);
     remember_cursor_subtile(player);
-    process_dungeon_control_packet_spell_overcharge(plyr_idx);
+    process_dungeon_control_packet_spell_overcharge(user);
     if (flag_is_set(pckt->control_flags,PCtr_Gui))
         return false;
     TbBool ret = true;
@@ -726,7 +733,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
         map_volume_box.visible = 0;
     }
 
-    update_double_click_detection(plyr_idx);
+    update_double_click_detection(user);
     player->thing_under_hand = 0;
     MapCoord x = (pckt->pos_x);
     MapCoord y = (pckt->pos_y);
@@ -745,10 +752,10 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
     switch (player->work_state)
     {
         case PSt_CtrlDungeon:
-            process_dungeon_control_packet_dungeon_control(plyr_idx);
+            process_dungeon_control_packet_dungeon_control(user);
             break;
         case PSt_BuildRoom:
-            process_dungeon_control_packet_dungeon_build_room(plyr_idx);
+            process_dungeon_control_packet_dungeon_build_room(user);
             break;
         case PSt_CallToArms:
         case PSt_SightOfEvil:
@@ -855,7 +862,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             }
             break;
         case PSt_PlaceTrap:
-            process_dungeon_control_packet_dungeon_place_trap(plyr_idx);
+            process_dungeon_control_packet_dungeon_place_trap(user);
             break;
         case PSt_PlaceDoor:
         {
@@ -894,7 +901,7 @@ TbBool process_dungeon_control_packet_clicks(long plyr_idx)
             }
             break;
         case PSt_Sell:
-            process_dungeon_control_packet_sell_operation(plyr_idx);
+            process_dungeon_control_packet_sell_operation(user);
             break;
         default:
             if (!packets_process_cheats(plyr_idx, x, y, pckt,

--- a/src/packets_misc.c
+++ b/src/packets_misc.c
@@ -16,6 +16,7 @@
  *     (at your option) any later version.
  */
 /******************************************************************************/
+#include "net_game.h"
 #include "pre_inc.h"
 #include "kfx/renderer/RendererManager.h"
 #include "packets.h"
@@ -43,17 +44,37 @@ unsigned long last_pause_toggle_time = 0;
 extern TbBool IMPRISON_BUTTON_DEFAULT;
 extern TbBool FLEE_BUTTON_DEFAULT;
 extern TbBool get_skip_heart_zoom_feature(void);
-extern unsigned long get_host_player_id(void);
 extern TbBool keeper_screen_redraw(void);
 /******************************************************************************/
 #ifdef __cplusplus
 }
 #endif
 
+NetUserId get_local_user(void)
+{
+    if (!network_is_active())
+    {
+        return SOLO_HUMAN_ID;
+    }
+
+    if (netstate.my_id >= 0 && netstate.my_id < MAX_NET_USERS)
+    {
+        return netstate.my_id;
+    }
+
+    assert(false);
+    return 0;
+}
+
+struct Packet *get_local_packet(void)
+{
+    return get_packet(get_local_user());
+}
+
 void set_players_packet_action(struct PlayerInfo *player, unsigned char pcktype,
         unsigned long par1, unsigned long par2, unsigned short par3, unsigned short par4)
 {
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(player->user_id);
     pckt->actn_par1 = par1;
     pckt->actn_par2 = par2;
     pckt->actn_par3 = par3;
@@ -63,7 +84,7 @@ void set_players_packet_action(struct PlayerInfo *player, unsigned char pcktype,
 
 unsigned char get_players_packet_action(struct PlayerInfo *player)
 {
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(player->user_id);
     return pckt->action;
 }
 
@@ -74,7 +95,7 @@ void set_packet_control(struct Packet *pckt, unsigned long flag)
 
 void set_players_packet_control(struct PlayerInfo *player, unsigned long flag)
 {
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(player->user_id);
     pckt->control_flags |= flag;
 }
 
@@ -85,7 +106,7 @@ void unset_packet_control(struct Packet *pckt, unsigned long flag)
 
 void unset_players_packet_control(struct PlayerInfo *player, unsigned long flag)
 {
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(player->user_id);
     pckt->control_flags &= ~flag;
 }
 
@@ -99,29 +120,15 @@ void set_players_packet_position(struct Packet *pckt, long x, long y, unsigned c
 }
 
 /**
- * Gives a pointer for the player's packet.
- * @param plyr_idx The player index for which we want the packet.
+ * Gives a pointer to the packet of a given network user.
+ * @param user Network user id. Note that it may differ from the player index.
  * @return Returns Packet pointer. On error, returns a dummy structure.
  */
-struct Packet *get_packet(long plyr_idx)
+struct Packet *get_packet(NetUserId user)
 {
-    struct PlayerInfo* player = get_player(plyr_idx);
-    if (player_invalid(player))
+    if ((user < 0) || (user >= PACKETS_COUNT))
         return INVALID_PACKET;
-    if (player->packet_num >= PACKETS_COUNT)
-        return INVALID_PACKET;
-    return &game.packets[player->packet_num];
-}
-/**
- * Gives a pointer to packet of given index.
- * @param pckt_idx Packet index in the array. Note that it may differ from player index.
- * @return Returns Packet pointer. On error, returns a dummy structure.
- */
-struct Packet *get_packet_direct(long pckt_idx)
-{
-    if ((pckt_idx < 0) || (pckt_idx >= PACKETS_COUNT))
-        return INVALID_PACKET;
-    return &game.packets[pckt_idx];
+    return &game.packets[user];
 }
 
 void clear_packets(void)
@@ -388,7 +395,7 @@ void set_packet_pause_toggle()
     struct PlayerInfo* player = get_my_player();
     if (player_invalid(player))
         return;
-    if (player->packet_num >= PACKETS_COUNT)
+    if (player->user_id >= PACKETS_COUNT)
         return;
     if (game.game_kind != GKind_LocalGame) {
         unsigned long current_time = LbTimerClock();
@@ -408,7 +415,7 @@ void set_packet_pause_toggle()
         keeper_screen_redraw();
         RendererPresentFrame();
         LbNetwork_BroadcastUnpause();
-        if (my_player_number == get_host_player_id()) {
+        if (network_is_host()) {
             process_pause_packet(0, 0);
         }
         unpausing_in_progress = 0;

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -24,6 +24,7 @@
 #include "engine_camera.h"
 #include "bflib_video.h"
 #include "roomspace.h"
+#include "net_main.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -156,8 +157,7 @@ struct PlayerInfo {
     unsigned char input_crtr_query;
     unsigned char display_flags;
     unsigned char *lens_palette;
-    /** Index of packet slot associated with this player. */
-    unsigned char packet_num;
+    unsigned char /*NetUserId*/ user_id;
     int32_t hand_animationId;
     unsigned int hand_busy_until_turn;
     char player_name[20];

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -1105,6 +1105,7 @@ void init_players_local_game(void)
     SYNCDBG(4,"Starting");
     struct PlayerInfo* player = get_my_player();
     player->id_number = my_player_number;
+    player->user_id = SOLO_HUMAN_ID;
     player->allocflags |= PlaF_Allocated;
 
     if( player->id_number == PLAYER_GOOD)

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -676,7 +676,7 @@ void get_dungeon_sell_user_roomspace(struct RoomSpace *roomspace, PlayerNumber p
     current_roomspace.plyr_idx = plyr_idx;
     MapSlabCoord drag_start_x = slb_x;
     MapSlabCoord drag_start_y = slb_y;
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(player->user_id);
     player->one_click_lock_cursor = false;
     player->one_click_mode_exclusive = false;
     if (player->ignore_next_PCtr_LBtnRelease)
@@ -763,7 +763,7 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
     best_roomspace.rkind = rkind;
     MapSlabCoord drag_start_x = slb_x;
     MapSlabCoord drag_start_y = slb_y;
-    struct Packet* pckt = get_packet_direct(player->packet_num);
+    struct Packet* pckt = get_packet(player->user_id);
     struct RoomSpace temp_best_room;
     player->one_click_lock_cursor = false;
     if (player->ignore_next_PCtr_LBtnRelease)
@@ -1358,7 +1358,7 @@ void update_roomspaces()
 void process_build_roomspace_inputs(PlayerNumber plyr_idx)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
-    struct Packet* pckt = get_packet(plyr_idx);
+    struct Packet* pckt = get_packet(player->user_id);
     if (room_role_matches(player->chosen_room_kind,RoRoF_PassLava|RoRoF_PassWater|RoRoF_PassAbyss))
     {
         TbBool drag_check = ( ( (is_game_key_pressed(Gkey_BestRoomSpace, false, true)) || (is_game_key_pressed(Gkey_SquareRoomSpace, false, true)) ) && (left_button_held));
@@ -1441,8 +1441,8 @@ void process_build_roomspace_inputs(PlayerNumber plyr_idx)
 
 void process_sell_roomspace_inputs(PlayerNumber plyr_idx)
 {
-    struct Packet* pckt = get_packet(plyr_idx);
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct Packet* pckt = get_packet(player->user_id);
     if (is_game_key_pressed(Gkey_SellTrapOnSubtile, false, true))
     {
         set_packet_action(pckt, PckA_SetRoomspaceSubtile, 0, 0, 0, 0);
@@ -1528,7 +1528,7 @@ void process_highlight_roomspace_inputs(PlayerNumber plyr_idx)
             player = get_player(plyr_idx);
             if (player->roomspace_mode != single_subtile_mode)
             {
-                struct Packet* pckt = get_packet(my_player_number);
+                struct Packet* pckt = get_local_packet();
                 set_packet_action(pckt, PckA_SetRoomspaceSubtile, 0, 0, 0, 0);
                 reset_roomspace = true;
             }

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -143,7 +143,7 @@ static TbBool update_predicted_build_or_sell_roomspace_preview(struct RoomSpace 
     if ((player->work_state != PSt_BuildRoom) && (player->work_state != PSt_Sell)) {
         return false;
     }
-    struct Packet *direct_packet = get_packet_direct(player->packet_num);
+    struct Packet *direct_packet = get_packet(player->user_id);
     struct PlayerInfo saved_player = *player;
     struct Packet saved_packet = *direct_packet;
     *direct_packet = *pckt;
@@ -163,7 +163,7 @@ static TbBool update_predicted_build_or_sell_roomspace_preview(struct RoomSpace 
 
 void update_local_dig_tag_prediction(void)
 {
-    struct Packet *pckt = get_packet(my_player_number);
+    struct Packet *pckt = get_local_packet();
     if (!local_dig_prediction_is_enabled()) {
         local_dig_render_roomspace_active = false;
         memset(&local_dig_tag_prediction, 0, sizeof(local_dig_tag_prediction));
@@ -252,8 +252,8 @@ unsigned char get_local_dig_prediction_render_flags(MapSubtlCoord stl_x, MapSubt
 void update_local_dig_prediction_cursor_preview(void)
 {
     struct PlayerInfo *player = get_my_player();
-    const struct Packet *pckt = get_history_packet(player->packet_num, get_gameturn());
-    const struct Packet *direct_packet = get_packet_direct(player->packet_num);
+    const struct Packet *pckt = get_history_packet(get_local_user(), get_gameturn());
+    const struct Packet *direct_packet = get_local_packet();
     if ((local_dig_roomspace_prediction.action != PckA_None) && ((GameTurnDelta)(direct_packet->turn - local_dig_roomspace_prediction.turn) >= 0)) {
         memset(&local_dig_roomspace_prediction, 0, sizeof(local_dig_roomspace_prediction));
     }


### PR DESCRIPTION
**User**: a human/device connected to the game.
**Player**: a faction such as PLAYER0 (the red keeper), PLAYER1( the blue keeper), PLAYER2, ... the heroes, neutrals, etc.

Sometimes the code is a bit imprecise on the distinction. Users on the network are occasionally referred to as "players". In order to eventually implement "archon mode" (allowing multiple users to control the same player co-operatively), I've gone through the codebase to try to solidify this distinction.

In particular, where possible, I've switched away from ever inferring the _user_ from the _player_, as future work on archon mode may mean that players can have multiple users. Instead, using a user id is generally preferred to using a player idx anywhere the distinction between two users of the same player might someday be important. To this end, I've added `PlayerNumber get_net_user_player_number(NetUserId user)`. I'd like to eventually deprecate and remove the `user_id` field in `PlayerInfo` entirely.

**TL;DR**: prefer the direction `User --> Player`, avoid `Player --> User`.

Sorry for the largeish diff, but it's mostly a couple consistent find/replace rules, and it should allow for smaller bite-sized work toward archon mode in the future. Hopefully.