### PR TITLE
Fixed in-game wibble placement

### DIFF
--- a/libexterns.mk
+++ b/libexterns.mk
@@ -45,10 +45,9 @@ libsdl: $(SDL_MAIN_LIBRARY)
 # If we have tar gzip prebuild, download and extract it
 $(SDL_MAIN_LIBRARY): sdl/$(SDL_PACKAGE)
 	-$(ECHO) 'Extracting package: $<'
-	# Grep is used to remove bogus error messages, return state of tar is also ignored
-	-cd "$(<D)"; \
+	cd "$(<D)"; \
 	tar --strip-components=2 -zxmUf "$(<F)" SDL3-3.4.12/i686-w64-mingw32/bin SDL3-3.4.12/i686-w64-mingw32/include SDL3-3.4.12/i686-w64-mingw32/lib SDL3-3.4.12/i686-w64-mingw32/share 2>&1 | \
-	grep -v '^.*: Archive value .* is out of .* range.*$$'
+	sed '/^.*: Archive value .* is out of .* range.*$$/d'
 	$(CP) sdl/bin/SDL3.dll sdl/for_final_package/
 	-$(ECHO) 'Finished extracting: $<'
 	-$(ECHO) ' '

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -729,7 +729,7 @@ void copy_block_with_cube_groups(short itm_idx, MapSubtlCoord stl_x, MapSubtlCoo
     }
 }
 
-void set_alt_bit_based_on_slab(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+void set_subtile_wibble(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
     unsigned char wibble = get_slab_kind_stats(slbkind)->wibble;
     if (slab_kind_is_liquid(slbkind))
@@ -781,7 +781,7 @@ void place_slab_columns(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl
             if ( column_index_check < 0 )
               ERRORLOG("BBlocks instead of columns");
             update_map_collide(slbkind, stl_x+dx, stl_y+dy);
-            set_alt_bit_based_on_slab(slbkind, stl_x+dx, stl_y+dy);
+            set_subtile_wibble(slbkind, stl_x+dx, stl_y+dy);
             colid++;
         }
     }
@@ -1433,7 +1433,7 @@ static void shuffle_unattached_things_on_slab(MapSlabCoord slb_x, MapSlabCoord s
     }
 }
 
-void set_alt_bit_on_slabs_around(MapSlabCoord slb_x, MapSlabCoord slb_y)
+void update_wibble_on_surrounding_slabs(MapSlabCoord slb_x, MapSlabCoord slb_y)
 {
     for (int i = 0; i < AROUND_EIGHT_LENGTH; i++)
     {
@@ -1456,7 +1456,7 @@ void set_alt_bit_on_slabs_around(MapSlabCoord slb_x, MapSlabCoord slb_y)
                 MapSubtlCoord sstl_y;
                 sstl_x = slab_subtile(sslb_x, ssub_x);
                 sstl_y = slab_subtile(sslb_y, ssub_y);
-                set_alt_bit_based_on_slab(slb->kind, sstl_x, sstl_y);
+                set_subtile_wibble(slb->kind, sstl_x, sstl_y);
             }
         }
     }
@@ -1585,7 +1585,7 @@ void place_animating_slab_type_on_map(SlabKind slbkind, char ani_frame, MapSubtl
     delete_attached_things_on_slab(slb_x, slb_y);
     dump_slab_on_map(slbkind, SLABSETS_PER_SLAB * slbkind + ani_frame, stl_x, stl_y, owner);
     shuffle_unattached_things_on_slab(slb_x, slb_y);
-    set_alt_bit_on_slabs_around(slb_x, slb_y);
+    update_wibble_on_surrounding_slabs(slb_x, slb_y);
     if (slbkind == SlbT_GEMS)
     {
         remove_unwanted_things_from_wall_slab(slb_x, slb_y);

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -731,22 +731,14 @@ void copy_block_with_cube_groups(short itm_idx, MapSubtlCoord stl_x, MapSubtlCoo
 
 void set_alt_bit_based_on_slab(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
-    struct SlabConfigStats *slabst;
-    slabst = get_slab_kind_stats(slbkind);
-
-    unsigned long wibble;
-
-    wibble = slabst->wibble;
+    unsigned char wibble = get_slab_kind_stats(slbkind)->wibble;
     if (slab_kind_is_liquid(slbkind))
     {
-        MapSlabCoord slb_x;
-        MapSlabCoord slb_y;
-        slb_x = subtile_slab(stl_x);
-        slb_y = subtile_slab(stl_y);
-        MapSlabCoord start_slb_x;
-        MapSlabCoord start_slb_y;
-        start_slb_x = slb_x;
-        start_slb_y = slb_y;
+        MapSlabCoord slb_x = subtile_slab(stl_x);
+        MapSlabCoord slb_y = subtile_slab(stl_y);
+        MapSlabCoord start_slb_x = slb_x;
+        MapSlabCoord start_slb_y = slb_y;
+
         if ((stl_x % STL_PER_SLB) == 0) {
             start_slb_x--;
         }
@@ -755,18 +747,13 @@ void set_alt_bit_based_on_slab(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCo
         }
         for (MapSlabCoord y = start_slb_y; y <= slb_y; y++) {
             for (MapSlabCoord x = start_slb_x; x <= slb_x; x++) {
-                if ((x == slb_x) && (y == slb_y)) {
-                    continue;
-                }
-                if (!slab_kind_is_liquid(get_slabmap_block(x, y)->kind)) {
+                if (((x != slb_x) || (y != slb_y)) && !slab_kind_is_liquid(get_slabmap_block(x, y)->kind)) {
                     wibble = 1;
                 }
             }
         }
     }
-    struct Map *mapblk;
-    mapblk = get_map_block_at(stl_x, stl_y);
-    set_mapblk_wibble_value(mapblk, wibble);
+    set_mapblk_wibble_value(get_map_block_at(stl_x, stl_y), wibble);
 }
 
 void place_slab_columns(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y, const ColumnIndex *col_idx)

--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -734,47 +734,34 @@ void set_alt_bit_based_on_slab(SlabKind slbkind, MapSubtlCoord stl_x, MapSubtlCo
     struct SlabConfigStats *slabst;
     slabst = get_slab_kind_stats(slbkind);
 
-    unsigned short sibling_flags;
-    unsigned short edge_flags;
     unsigned long wibble;
 
-    sibling_flags = 0;
-    edge_flags = 0;
     wibble = slabst->wibble;
     if (slab_kind_is_liquid(slbkind))
     {
-        if ((stl_x % 3) == 0)
-            edge_flags = 0x01;
-        if ((stl_y % 3) == 0)
-            edge_flags |= 0x02;
         MapSlabCoord slb_x;
         MapSlabCoord slb_y;
         slb_x = subtile_slab(stl_x);
         slb_y = subtile_slab(stl_y);
-        struct SlabMap *slb;
-        slb = get_slabmap_block(slb_x-1, slb_y);
-        if (slab_kind_is_liquid(slb->kind))
-            sibling_flags |= 0x01;
-        slb = get_slabmap_block(slb_x, slb_y-1);
-        if (slab_kind_is_liquid(slb->kind))
-            sibling_flags |= 0x02;
-        slb = get_slabmap_block(slb_x-1, slb_y-1);
-        if (slab_kind_is_liquid(slb->kind))
-            sibling_flags |= 0x04;
-
-        if (edge_flags == 3)
-        {
-          if (sibling_flags == (0x01|0x02|0x04))
-              wibble = 2;
-        } else
-        if (edge_flags == 1)
-        {
-          if (sibling_flags & 0x01)
-              wibble = 2;
-        } else
-        if ((edge_flags != 2) || (sibling_flags & 0x02))
-        {
-            wibble = 2;
+        MapSlabCoord start_slb_x;
+        MapSlabCoord start_slb_y;
+        start_slb_x = slb_x;
+        start_slb_y = slb_y;
+        if ((stl_x % STL_PER_SLB) == 0) {
+            start_slb_x--;
+        }
+        if ((stl_y % STL_PER_SLB) == 0) {
+            start_slb_y--;
+        }
+        for (MapSlabCoord y = start_slb_y; y <= slb_y; y++) {
+            for (MapSlabCoord x = start_slb_x; x <= slb_x; x++) {
+                if ((x == slb_x) && (y == slb_y)) {
+                    continue;
+                }
+                if (!slab_kind_is_liquid(get_slabmap_block(x, y)->kind)) {
+                    wibble = 1;
+                }
+            }
         }
     }
     struct Map *mapblk;

--- a/src/map_blocks.h
+++ b/src/map_blocks.h
@@ -43,7 +43,7 @@ TbBool subtile_is_diggable_at_diagonal_angle(struct Thing *thing, unsigned short
 
 #define place_slab_type_on_map(nslab, stl_x, stl_y, owner, keep_blocks_around) place_slab_type_on_map_f(nslab, stl_x, stl_y, owner, keep_blocks_around, __func__)
 void place_slab_type_on_map_f(SlabKind nslab, MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber owner, unsigned char a5,const char *func_name);
-void set_alt_bit_on_slabs_around(MapSlabCoord slb_x, MapSlabCoord slb_y);
+void update_wibble_on_surrounding_slabs(MapSlabCoord slb_x, MapSlabCoord slb_y);
 void mine_out_block(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx);
 TbBool dig_has_revealed_area(MapSubtlCoord rev_stl_x, MapSubtlCoord rev_stl_y, PlayerNumber plyr_idx);
 void dig_out_block(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx);

--- a/src/room_util.c
+++ b/src/room_util.c
@@ -313,7 +313,7 @@ TbBool replace_slab_from_script(MapSlabCoord slb_x, MapSlabCoord slb_y, unsigned
             else
             {
                 place_slab_type_on_map(slabkind, slab_subtile(slb_x, 0), slab_subtile(slb_y, 0), plyr_idx, 0);
-                set_alt_bit_on_slabs_around(slb_x, slb_y);
+                update_wibble_on_surrounding_slabs(slb_x, slb_y);
             }
             return true;
         }


### PR DESCRIPTION
Follow up to #5184
After updating terrain.cfg it exposed a problem in the math for dynamically placed (in-game) wibble. Such as lava traps, which were creating a wavy animation on the side of a nearby wall.

also fixed an SDL compilation warning