### PR TITLE
Fix pathfinding lag behind lava

### DIFF
--- a/src/ariadne.c
+++ b/src/ariadne.c
@@ -323,6 +323,41 @@ static long navigation_rule_normal(NavColour treeA, NavColour treeB)
     return nav_thing_can_travel_over_lava;
 }
 
+static TbBool navigation_triangle_reachable(int32_t first_triangle, int32_t second_triangle)
+{
+    if (!regions_connected(first_triangle, second_triangle)) {
+        return false;
+    }
+    if (first_triangle == second_triangle) {
+        return true;
+    }
+    tags_init();
+    store_current_tag(first_triangle);
+    tree_val[0] = first_triangle;
+    for (uint32_t head = 0, tail = 1; head < tail; head++) {
+        int32_t triangle = tree_val[head];
+        for (int32_t edge = 0; edge < 3; edge++) {
+            int32_t next = Triangles[triangle].tags[edge];
+            if (next < 0 || is_current_tag(next)) {
+                continue;
+            }
+            NavColour next_alt = get_triangle_tree_alt(next);
+            if ((next_alt & NAVMAP_FLOORHEIGHT_MASK) == NAVMAP_FLOORHEIGHT_MAX) {
+                continue;
+            }
+            if (!navigation_rule_normal(get_triangle_tree_alt(triangle), next_alt)) {
+                continue;
+            }
+            if (next == second_triangle) {
+                return true;
+            }
+            store_current_tag(next);
+            tree_val[tail++] = next;
+        }
+    }
+    return false;
+}
+
 void set_nav_rule_default(void)
 {
     nav_rulesA2B = navigation_rule_normal;
@@ -3235,7 +3270,7 @@ void path_init8_wide_f(struct Path *path, long start_x, long start_y, long end_x
         return;
     }
     NAVIDBG(19,"%s: prepared triangles %ld -> %ld", func_name,tree_triA,tree_triB);
-    if (!navigation_regions_connected(tree_triA, tree_triB, owner_player_navigating))
+    if (!navigation_triangle_reachable(tree_triA, tree_triB))
     {
         NAVIDBG(9,"%s: Regions not connected, cannot trace a path.", func_name);
         return;

--- a/src/ariadne_regions.c
+++ b/src/ariadne_regions.c
@@ -22,9 +22,7 @@
 
 #include "globals.h"
 #include "bflib_basics.h"
-#include "ariadne_navitree.h"
 #include "ariadne_tringls.h"
-#include "player_data.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
@@ -51,43 +49,6 @@ static long RegionQueue[REGION_QUEUE_LEN];
 /******************************************************************************/
 struct RegionT bad_region;
 /******************************************************************************/
-TbBool navigation_regions_connected(int32_t first_triangle, int32_t second_triangle, PlayerNumber owner)
-{
-    if (!regions_connected(first_triangle, second_triangle)) {
-        return false;
-    }
-    if (owner < 0 || owner >= PLAYERS_COUNT) {
-        return true;
-    }
-    NavColour blocked_mask = NAVMAP_FLOORHEIGHT_MASK | 1 << (NAVMAP_OWNERSELECT_BIT + owner);
-    if ((get_triangle_tree_alt(first_triangle) & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX || (get_triangle_tree_alt(second_triangle) & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
-        return true;
-    }
-    if (first_triangle == second_triangle) {
-        return true;
-    }
-    tags_init();
-    store_current_tag(first_triangle);
-    tree_val[0] = first_triangle;
-    for (uint32_t head = 0, tail = 1; head < tail; head++) {
-        for (int32_t edge = 0; edge < 3; edge++) {
-            int32_t next = Triangles[tree_val[head]].tags[edge];
-            if (next < 0 || is_current_tag(next)) {
-                continue;
-            }
-            if ((get_triangle_tree_alt(next) & blocked_mask) >= NAVMAP_FLOORHEIGHT_MAX) {
-                continue;
-            }
-            if (next == second_triangle) {
-                return true;
-            }
-            store_current_tag(next);
-            tree_val[tail++] = next;
-        }
-    }
-    return false;
-}
-
 /**
  * Allocates region ID.
  * @return The region ID, or 0 on failure.

--- a/src/ariadne_regions.h
+++ b/src/ariadne_regions.h
@@ -32,7 +32,6 @@ extern "C" {
 
 /******************************************************************************/
 TbBool regions_connected(long first_tree_region, long second_tree_region);
-TbBool navigation_regions_connected(int32_t first_triangle, int32_t second_triangle, PlayerNumber owner);
 void region_store_init(void);
 long region_get(void);
 void region_put(long nreg);


### PR DESCRIPTION
Improvement of #5164 in order to fix #5161

Renamed the function to `navigation_triangle_reachable` and moved it so it can use `navigation_rule_normal` to check for other blockages.

Does not fix the 2-cube high (guard posts next to water) navigation issues in this specific map: https://github.com/dkfans/keeperfx/issues/5161#issuecomment-5466902926
I tried, but it's very difficult to fix.