### PR TITLE
Fix distance error log spam from effects falling into abyss

### DIFF
--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -889,12 +889,12 @@ TbBool thing_is_exempt_from_z_axis_clipping(const struct Thing *thing)
     return false;
 }
 
-unsigned short push_thingz_against_wall_at(const struct Thing *thing, const struct Coord3d *pos)
+MapCoord push_thingz_against_wall_at(const struct Thing *thing, const struct Coord3d *pos)
 {
   unsigned short clipbox_size = thing->clipbox_size_z;
   long height = get_ceiling_height_above_thing_at(thing, pos);
-  short z_thing = (short)thing->mappos.z.val;
-  short z_pos = (short)pos->z.val;
+  MapCoord z_thing = thing->mappos.z.val;
+  MapCoord z_pos = pos->z.val;
   if ( (height - 1) <= (z_pos + clipbox_size) )
   {
     return (height - clipbox_size) - 1;
@@ -905,7 +905,7 @@ unsigned short push_thingz_against_wall_at(const struct Thing *thing, const stru
   }
   if ( z_pos < z_thing )
   {
-    return (z_pos & 0xFF00) + COORD_PER_STL;
+    return (z_pos & 0xFFFFFF00) + COORD_PER_STL;
   }
   return ((((z_pos + clipbox_size) & 0xFFFFFF00) - clipbox_size) + 255);
 }

--- a/src/thing_physics.h
+++ b/src/thing_physics.h
@@ -67,7 +67,7 @@ long get_ceiling_height_above_thing_at(const struct Thing *thing, const struct C
 void get_floor_and_ceiling_height_under_thing_at(const struct Thing *thing,
     const struct Coord3d *pos, MapCoord *floor_height_cor, MapCoord *ceiling_height_cor);
 TbBool thing_is_exempt_from_z_axis_clipping(const struct Thing *thing);
-unsigned short push_thingz_against_wall_at(const struct Thing *thing, const struct Coord3d *pos);
+MapCoord push_thingz_against_wall_at(const struct Thing *thing, const struct Coord3d *pos);
 TbBool position_over_floor_level(const struct Thing* thing, const struct Coord3d* pos);
 TbBool map_is_solid_at_height(MapSubtlCoord stl_x, MapSubtlCoord stl_y, MapCoord height_beg, MapCoord height_end);
 TbBool move_object_to_nearest_free_position(struct Thing *thing);


### PR DESCRIPTION
fixes this:
```
Error: [210] interpolate_thing: The EFFECTELEMENT_ENTRANCE_MIST effect element index 8311 owned by player 2 moved an unrealistic distance((117,205,65531) to (117,205,252)), refusing interpolation.
Error: [210] interpolate_thing: The EFFECTELEMENT_ENTRANCE_MIST effect element index 8311 owned by player 2 moved an unrealistic distance((117,205,65531) to (117,205,252)), refusing interpolation.
Error: [210] interpolate_thing: The EFFECTELEMENT_ENTRANCE_MIST effect element index 8311 owned by player 2 moved an unrealistic distance((117,205,65531) to (117,205,252)), refusing interpolation.
```