### PR TITLE
Fix first person rendering of columns with every cube filled

### DIFF
--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -325,8 +325,14 @@ struct BucketKindRoomFlag { // BasicQ type 17,19
 
 
 
+/* Corner slot holding the ceiling vertex. Slots 0..COLUMN_STACK_HEIGHT belong to the
+   cubes of a column and the abyss walls own the slots above them, so the ceiling needs
+   a slot of its own past both. Sharing slot COLUMN_STACK_HEIGHT with the cubes made a
+   column with every cube filled draw its top face and topmost side at ceiling height. */
+#define ENGINE_COL_CEILING_CORNER (COLUMN_STACK_HEIGHT + ABYSS_WALL_RENDER_HEIGHT + 3)
+
 struct EngineCol {
-    struct EngineCoord cors[COLUMN_STACK_HEIGHT + ABYSS_WALL_RENDER_HEIGHT + 3];
+    struct EngineCoord cors[ENGINE_COL_CEILING_CORNER + 1];
 };
 
 struct SideOri {
@@ -1174,7 +1180,7 @@ static void fill_in_points_perspective(struct Camera *cam, long bstl_x, long bst
         {
             wibl = get_wibble_from_table(cam, wib_x + 2 * (hmax + 2 * wib_y - hmin) + 32, stl_x, stl_y);
         }
-        ecord = &ecol->cors[8];
+        ecord = &ecol->cors[ENGINE_COL_CEILING_CORNER];
         {
             ecord->x = apos + wibl->offset_x;
             ecord->y = hpos + wibl->offset_y;
@@ -4393,7 +4399,7 @@ static void do_a_plane_of_engine_columns_perspective(long stl_x, long stl_y, lon
         // Draw the universal ceiling on top of the columns
         TbBool edge_abyss = abyss && ((center_x == 1) || (center_x == game.map_subtiles_x - 1) || (stl_y == 1) || (stl_y == game.map_subtiles_y - 1));
         if (!edge_abyss) {
-            ecpos = 8;
+            ecpos = ENGINE_COL_CEILING_CORNER;
             textr_idx = floor_to_ceiling_map[colmn->floor_texture * !abyss];
             textr_idx = engine_remap_texture_blocks(center_x, stl_y, textr_idx);
             do_a_trig_gourad_tr(&fec[0].cors[ecpos], &fec[1].cors[ecpos], &bec[1].cors[ecpos], textr_idx, -1);


### PR DESCRIPTION
I've been doing some experiments with maps in KeeperFX and found a bug.

I created a modified version of the Eversmile map featuring a large pyramid to showcase all possible height levels.

Eversmile with a big room with a piramid (all is well rendered):
<img width="1920" height="1080" alt="Eversmile with piramid" src="https://github.com/user-attachments/assets/d4ebb09c-8173-4e69-9083-e74899e2500f" />

Now with possession mode (bug, the topmost level of the pyramid has a wall extending all the way up to the ceiling):
<img width="1920" height="1080" alt="Eversmile with piramid in possession mode" src="https://github.com/user-attachments/assets/9d91a15f-08e9-4e15-90d4-e580010aaeca" />

Walking in possession mode on the topmost level of the pyramid shows no floor:
<img width="1920" height="1080" alt="Eversmile with piramid 04" src="https://github.com/user-attachments/assets/c80d87f5-9d87-46d9-a689-3152fdcf2e74" />

Fixed:
<img width="1920" height="1080" alt="Eversmile with piramid 05 fixed" src="https://github.com/user-attachments/assets/5b2480ec-021b-44a1-a38b-0d486ba557d8" />

<img width="1920" height="1080" alt="Eversmile with piramid 06 fixed" src="https://github.com/user-attachments/assets/7a3b7960-4d2a-4589-8ea9-68bc8e984b35" />

The ceiling vertex and the top corner of a fully-filled column (all
COLUMN_STACK_HEIGHT cubes) shared the same slot in `struct EngineCol`. The
ceiling gets written after the column, so it overwrites that corner, and the
column's top face and topmost side stretch up to ceiling height instead of
its own.

Never showed up before because every fully-filled column in the stock maps is
blocking, and a blocking column's own height is also its ceiling, so the two
values always matched by coincidence. Shows up on a walkable one, whose
ceiling comes from the surrounding walls instead.

Isometric and cluedo view are unaffected, they don't draw a ceiling.

Gives the ceiling its own slot past the cube and abyss-wall ones.