### PR TITLE
Fix flying creatures remaining airborne when KO'd

### DIFF
--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -3210,6 +3210,7 @@ void make_creature_unconscious(struct Thing *creatng)
         update_dead_creatures_list_for_owner(creatng);
     }
     creatng->active_state = CrSt_CreatureUnconscious;
+    clear_flag(creatng->movement_flags, TMvF_Flying);
     cctrl->creature_control_flags |= CCFlg_PreventDamage;
     cctrl->creature_control_flags |= CCFlg_NoCompControl;
     cctrl->conscious_back_turns = game.conf.rules[creatng->owner].creature.game_turns_unconscious;
@@ -4803,6 +4804,7 @@ short state_cleanup_unconscious(struct Thing *creatng)
 {
     TRACE_THING(creatng);
     make_creature_conscious_without_changing_state(creatng);
+    restore_creature_flight_flag(creatng);
     return 1;
 }
 

--- a/src/creature_states.c
+++ b/src/creature_states.c
@@ -3224,6 +3224,7 @@ void make_creature_conscious_without_changing_state(struct Thing *creatng)
     cctrl->creature_control_flags &= ~CCFlg_PreventDamage;
     cctrl->creature_control_flags &= ~CCFlg_NoCompControl;
     cctrl->conscious_back_turns = 0;
+    restore_creature_flight_flag(creatng);
     if ((creatng->state_flags & TF1_IsDragged1) != 0)
     {
         struct Thing* sectng = thing_get(cctrl->dragtng_idx);
@@ -4804,7 +4805,6 @@ short state_cleanup_unconscious(struct Thing *creatng)
 {
     TRACE_THING(creatng);
     make_creature_conscious_without_changing_state(creatng);
-    restore_creature_flight_flag(creatng);
     return 1;
 }
 

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6059,7 +6059,7 @@ short update_creature_movements(struct Thing *thing)
 
 void check_for_creature_escape_from_lava(struct Thing *thing)
 {
-    if (((thing->alloc_flags & TAlF_IsControlled) == 0) && ((thing->movement_flags & TMvF_IsOnLava) != 0))
+    if (((thing->alloc_flags & TAlF_IsControlled) == 0) && ((thing->movement_flags & TMvF_IsOnLava) != 0) && !creature_is_being_unconscious(thing))
     {
         struct CreatureModelConfig* crconf = creature_stats_get_from_thing(thing);
         if (crconf->hurt_by_lava > 0)

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1095,7 +1095,7 @@ TbBool set_thing_spell_flags_f(struct Thing *thing, SpellKind spell_idx, GameTur
         {
             set_flag(cctrl->spell_flags, CSAfF_Freeze);
             set_flag(cctrl->stateblock_flags, CCSpl_Freeze);
-            if ((thing->movement_flags & TMvF_Flying) != 0)
+            if ((thing->movement_flags & TMvF_Flying) != 0 || (creature_is_being_unconscious(thing) && (crconf->flying || creature_under_spell_effect(thing, CSAfF_Flying))))
             {
                 set_flag(thing->movement_flags, TMvF_Grounded);
                 clear_flag(thing->movement_flags, TMvF_Flying);
@@ -1330,7 +1330,9 @@ TbBool clear_thing_spell_flags_f(struct Thing *thing, unsigned long spell_flags,
         clear_flag(cctrl->stateblock_flags, CCSpl_Freeze);
         if (flag_is_set(thing->movement_flags, TMvF_Grounded))
         {
-            set_flag(thing->movement_flags, TMvF_Flying);
+            if (!creature_is_being_unconscious(thing)) {
+                restore_creature_flight_flag(thing);
+            }
             clear_flag(thing->movement_flags, TMvF_Grounded);
         }
         cleared = true;


### PR DESCRIPTION
Fixes this:
<img width="699" height="791" alt="image" src="https://github.com/user-attachments/assets/f6a15aad-2599-4071-b3a4-92b88192b667" />

This also fixes interactions with the freeze spell, so they only regain flight when both freeze and unconsciousness have ended.