### PR TITLE
Faster startup when launching single level externally

### DIFF
--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -114,9 +114,6 @@ ROTATE_AROUND_MOUSE=OFF
 ; If you're a streamer or create video content, consider keeping the splash screens enabled so that viewers are aware of KeeperFX.
 STARTUP=LEGAL FX INTRO
 
-; Skip the introductory zoom-in on the player's Dungeon Heart. Possible values: TRUE, FALSE, LAUNCHED_EXTERNALLY.
-SKIP_HEART_ZOOM=LAUNCHED_EXTERNALLY
-
 ; Creature flower size and thought bubble size.
 CREATURE_STATUS_SIZE=16
 

--- a/config/keeperfx.cfg
+++ b/config/keeperfx.cfg
@@ -114,8 +114,8 @@ ROTATE_AROUND_MOUSE=OFF
 ; If you're a streamer or create video content, consider keeping the splash screens enabled so that viewers are aware of KeeperFX.
 STARTUP=LEGAL FX INTRO
 
-; Skip the introductory zoom-in on the player's Dungeon Heart whenever you start a map.
-SKIP_HEART_ZOOM=FALSE
+; Skip the introductory zoom-in on the player's Dungeon Heart. Possible values: TRUE, FALSE, LAUNCHED_EXTERNALLY.
+SKIP_HEART_ZOOM=LAUNCHED_EXTERNALLY
 
 ; Creature flower size and thought bubble size.
 CREATURE_STATUS_SIZE=16

--- a/src/config_keeperfx.c
+++ b/src/config_keeperfx.c
@@ -733,17 +733,24 @@ static void load_file_configuration(const char *fname, const char *sname, const 
           }
           break;
         case 23: //SKIP_HEART_ZOOM
-          i = recognize_conf_parameter(buf,&pos,len,logicval_type);
-          if (i <= 0)
-          {
+          get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf));
+          i = get_id(logicval_type, word_buf);
+          if (strcasecmp(word_buf, "LAUNCHED_EXTERNALLY") == 0) {
+            i = 2;
+            if (flag_is_set(start_params.operation_flags, GOF_SingleLevel)) {
+              i = 1;
+            }
+          }
+          if (i <= 0) {
               CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
                 COMMAND_TEXT(cmd_num),config_textname);
             break;
           }
-          if (i == 1)
-              features_enabled |= Ft_SkipHeartZoom;
-          else
-              features_enabled &= ~Ft_SkipHeartZoom;
+          if (i == 1) {
+            features_enabled |= Ft_SkipHeartZoom;
+          } else {
+            features_enabled &= ~Ft_SkipHeartZoom;
+          }
           break;
         case 24: //CURSOR_EDGE_CAMERA_PANNING
           i = recognize_conf_parameter(buf,&pos,len,logicval_type);
@@ -1179,7 +1186,6 @@ void process_cmdline_overrides(void)
 {
   if (flag_is_set(start_params.operation_flags, GOF_SingleLevel)) {
     clear_flag(start_params.startup_flags, SFlg_Legal | SFlg_FX | SFlg_Intro);
-    features_enabled |= Ft_SkipHeartZoom;
   }
   // Use CD for music rather than OGG files
   if (start_params.overrides[Clo_CDMusic]) {

--- a/src/config_keeperfx.c
+++ b/src/config_keeperfx.c
@@ -1177,9 +1177,12 @@ short load_configuration(void)
  */
 void process_cmdline_overrides(void)
 {
+  if (flag_is_set(start_params.operation_flags, GOF_SingleLevel)) {
+    clear_flag(start_params.startup_flags, SFlg_Legal | SFlg_FX | SFlg_Intro);
+    features_enabled |= Ft_SkipHeartZoom;
+  }
   // Use CD for music rather than OGG files
-  if (start_params.overrides[Clo_CDMusic])
-  {
+  if (start_params.overrides[Clo_CDMusic]) {
     features_enabled &= ~Ft_NoCdMusic;
   }
 }

--- a/src/config_keeperfx.c
+++ b/src/config_keeperfx.c
@@ -142,7 +142,7 @@ const struct NamedCommand conf_commands[] = {
   {"PAUSE_MUSIC_WHEN_GAME_PAUSED"  , 20},
   {"MUTE_AUDIO_ON_FOCUS_LOST"      , 21},
   {"STARTUP"                       , 22},
-  {"unused"                        , 23},
+  {"SKIP_HEART_ZOOM"               , 23},
   {"CURSOR_EDGE_CAMERA_PANNING"    , 24},
   {"DELTA_TIME"                    , 25},
   {"CREATURE_STATUS_SIZE"          , 26},
@@ -732,7 +732,8 @@ static void load_file_configuration(const char *fname, const char *sname, const 
               }
           }
           break;
-        case 23: //unused
+        case 23: //SKIP_HEART_ZOOM
+          CONFLOG("The \"%s\" setting is unused. Use the -skipheartzoom command line option instead.", COMMAND_TEXT(cmd_num));
           break;
         case 24: //CURSOR_EDGE_CAMERA_PANNING
           i = recognize_conf_parameter(buf,&pos,len,logicval_type);

--- a/src/config_keeperfx.c
+++ b/src/config_keeperfx.c
@@ -142,7 +142,7 @@ const struct NamedCommand conf_commands[] = {
   {"PAUSE_MUSIC_WHEN_GAME_PAUSED"  , 20},
   {"MUTE_AUDIO_ON_FOCUS_LOST"      , 21},
   {"STARTUP"                       , 22},
-  {"SKIP_HEART_ZOOM"               , 23},
+  {"unused"                        , 23},
   {"CURSOR_EDGE_CAMERA_PANNING"    , 24},
   {"DELTA_TIME"                    , 25},
   {"CREATURE_STATUS_SIZE"          , 26},
@@ -732,25 +732,7 @@ static void load_file_configuration(const char *fname, const char *sname, const 
               }
           }
           break;
-        case 23: //SKIP_HEART_ZOOM
-          get_conf_parameter_single(buf, &pos, len, word_buf, sizeof(word_buf));
-          i = get_id(logicval_type, word_buf);
-          if (strcasecmp(word_buf, "LAUNCHED_EXTERNALLY") == 0) {
-            i = 2;
-            if (flag_is_set(start_params.operation_flags, GOF_SingleLevel)) {
-              i = 1;
-            }
-          }
-          if (i <= 0) {
-              CONFWRNLOG("Couldn't recognize \"%s\" command parameter in %s file.",
-                COMMAND_TEXT(cmd_num),config_textname);
-            break;
-          }
-          if (i == 1) {
-            features_enabled |= Ft_SkipHeartZoom;
-          } else {
-            features_enabled &= ~Ft_SkipHeartZoom;
-          }
+        case 23: //unused
           break;
         case 24: //CURSOR_EDGE_CAMERA_PANNING
           i = recognize_conf_parameter(buf,&pos,len,logicval_type);

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -143,6 +143,7 @@ struct StartupParameters {
     char config_file[CMDLN_MAXLEN+1];
     GameTurn pause_at_gameturn;
     unsigned char startup_flags;
+    TbBool skip_heart_zoom;
 #ifdef FUNCTESTING
     unsigned char functest_flags;
     char functest_name[FTEST_MAX_NAME_LENGTH];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -353,7 +353,7 @@ short setup_game(void)
   features_enabled |= Ft_RelativeMouseMode; // use SDL relative ("raw") mouse mode; set RELATIVE_MOUSE_MODE=OFF for the grab-and-warp scheme
   features_enabled &= ~Ft_PauseMusicOnGamePause; // don't pause the music, if the user pauses the game
   features_enabled &= ~Ft_MuteAudioOnLoseFocus; // don't mute the audio, if the game window loses focus
-  if (flag_is_set(start_params.operation_flags, GOF_SingleLevel)) {
+  if (start_params.skip_heart_zoom) {
     features_enabled |= Ft_SkipHeartZoom;
   } else {
     features_enabled &= ~Ft_SkipHeartZoom;
@@ -1796,6 +1796,10 @@ static short process_command_line(unsigned short argc, char *argv[])
       if (strcasecmp(parstr, "nointro") == 0)
       {
         start_params.no_intro = true;
+      } else
+      if (strcasecmp(parstr, "skipheartzoom") == 0)
+      {
+        start_params.skip_heart_zoom = true;
       } else
       if (strcasecmp(parstr, "nocd") == 0) // kept for legacy reasons
       {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -353,7 +353,11 @@ short setup_game(void)
   features_enabled |= Ft_RelativeMouseMode; // use SDL relative ("raw") mouse mode; set RELATIVE_MOUSE_MODE=OFF for the grab-and-warp scheme
   features_enabled &= ~Ft_PauseMusicOnGamePause; // don't pause the music, if the user pauses the game
   features_enabled &= ~Ft_MuteAudioOnLoseFocus; // don't mute the audio, if the game window loses focus
-  features_enabled &= ~Ft_SkipHeartZoom; // don't skip the dungeon heart zoom in
+  if (flag_is_set(start_params.operation_flags, GOF_SingleLevel)) {
+    features_enabled |= Ft_SkipHeartZoom;
+  } else {
+    features_enabled &= ~Ft_SkipHeartZoom;
+  }
   features_enabled &= ~Ft_DisableCursorCameraPanning; // don't disable cursor camera panning
   features_enabled |= Ft_DeltaTime; // enable delta time
   features_enabled |= Ft_NoCdMusic; // use music files (OGG) rather than CD music


### PR DESCRIPTION
I don't know why I didn't think of this years ago when we added `SKIP_HEART_ZOOM` and `STARTUP`, it's obvious it should be disabled when launching from unearth AND enabled when playing normally. Instead of needing to pick one or the other.

No one who is launching from unearth would want to see these things when repeatedly testing their level.

Most players aren't going to bother going out of their way to edit keeperfx.cfg to save themselves a couple of seconds. And remember this is functionally the same as "extra compilation time".