### PR TITLE
ensure that HIDE_VARIABLE also clears down script_variables array

### DIFF
--- a/src/lua_api.c
+++ b/src/lua_api.c
@@ -924,7 +924,9 @@ static int lua_DISPLAY_VARIABLE_WITH_LABEL(lua_State *L)
 }
 
 static int lua_Hide_variable(lua_State *L)
-{
+{    
+    memset(game.script_variables, 0, sizeof(game.script_variables));
+    game.active_script_var_count = 0;
     game.flags_gui &= ~GGUI_Variable;
     return 0;
 }

--- a/src/lvl_script_commands.c
+++ b/src/lvl_script_commands.c
@@ -3751,7 +3751,9 @@ static void hide_timer_process(struct ScriptContext *context)
 
 static void hide_variable_process(struct ScriptContext *context)
 {
-   game.flags_gui &= ~GGUI_Variable;
+    memset(game.script_variables, 0, sizeof(game.script_variables));
+    game.active_script_var_count = 0;
+    game.flags_gui &= ~GGUI_Variable;
 }
 
 static void create_effect_check(const struct ScriptLine *scline)


### PR DESCRIPTION
clear script_variables when calling HIDE_VARIABLE is called so that they aren't redisplayed when the next DISPLAY_VARIABLE is called