### PR TITLE
Pull local-only data out of PlayerInfo

### DIFF
--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -199,7 +199,6 @@ static void draw_creature_view_icons(struct Thing* creatng)
 void setup_engine_window(long x, long y, long width, long height)
 {
     SYNCDBG(6,"Starting for size (%ld,%ld) at (%ld,%ld)",width,height,x,y);
-    struct PlayerInfo* player = get_my_player();
     if ((game.operation_flags & GOF_ShowGui) != 0)
     {
       if (x > MyScreenWidth)
@@ -225,38 +224,36 @@ void setup_engine_window(long x, long y, long width, long height)
       height = MyScreenHeight-y;
     if (height < 0)
       height = 0;
-    player->engine_window_x = x;
-    player->engine_window_y = y;
-    player->engine_window_width = width;
-    player->engine_window_height = height;
+    local_info.engine_window_x = x;
+    local_info.engine_window_y = y;
+    local_info.engine_window_width = width;
+    local_info.engine_window_height = height;
 }
 
 void store_engine_window(TbGraphicsWindow *ewnd,int divider)
 {
-    struct PlayerInfo* player = get_my_player();
     if (divider <= 1)
     {
-        ewnd->x = player->engine_window_x;
-        ewnd->y = player->engine_window_y;
-        ewnd->width = player->engine_window_width;
-        ewnd->height = player->engine_window_height;
+        ewnd->x = local_info.engine_window_x;
+        ewnd->y = local_info.engine_window_y;
+        ewnd->width = local_info.engine_window_width;
+        ewnd->height = local_info.engine_window_height;
     } else
     {
-        ewnd->x = player->engine_window_x/divider;
-        ewnd->y = player->engine_window_y/divider;
-        ewnd->width = player->engine_window_width/divider;
-        ewnd->height = player->engine_window_height/divider;
+        ewnd->x = local_info.engine_window_x/divider;
+        ewnd->y = local_info.engine_window_y/divider;
+        ewnd->width = local_info.engine_window_width/divider;
+        ewnd->height = local_info.engine_window_height/divider;
     }
     ewnd->ptr = NULL;
 }
 
 void load_engine_window(TbGraphicsWindow *ewnd)
 {
-    struct PlayerInfo* player = get_my_player();
-    player->engine_window_x = ewnd->x;
-    player->engine_window_y = ewnd->y;
-    player->engine_window_width = ewnd->width;
-    player->engine_window_height = ewnd->height;
+    local_info.engine_window_x = ewnd->x;
+    local_info.engine_window_y = ewnd->y;
+    local_info.engine_window_width = ewnd->width;
+    local_info.engine_window_height = ewnd->height;
 }
 
 void map_fade(unsigned char *outbuf, unsigned char *srcbuf1, unsigned char *srcbuf2, unsigned char *fade_tbl, unsigned char *ghost_tbl, long a6, long const xmax, long const ymax, long a9)
@@ -571,7 +568,7 @@ void redraw_creature_view(void)
     }
     draw_gui();
     if ((game.operation_flags & GOF_ShowGui) != 0) {
-        draw_overlay_compass(player->minimap_pos_x, player->minimap_pos_y);
+        draw_overlay_compass(local_info.minimap_pos_x, local_info.minimap_pos_y);
     }
     message_draw();
     gui_draw_all_boxes();
@@ -634,7 +631,7 @@ void redraw_isometric_view(void)
     }
     draw_gui();
     if ((game.operation_flags & GOF_ShowGui) != 0) {
-        draw_overlay_compass(player->minimap_pos_x, player->minimap_pos_y);
+        draw_overlay_compass(local_info.minimap_pos_x, local_info.minimap_pos_y);
     }
     message_draw();
     gui_draw_all_boxes();
@@ -656,7 +653,7 @@ void redraw_frontview(void)
     }
     draw_gui();
     if (flag_is_set(game.operation_flags,GOF_ShowGui)) {
-        draw_overlay_compass(player->minimap_pos_x, player->minimap_pos_y);
+        draw_overlay_compass(local_info.minimap_pos_x, local_info.minimap_pos_y);
     }
     message_draw();
     draw_power_hand();
@@ -747,7 +744,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
         return;
     }
     // Mouse over panel map
-    if (((game.operation_flags & GOF_ShowGui) != 0) && mouse_is_over_panel_map(player->minimap_pos_x, player->minimap_pos_y))
+    if (((game.operation_flags & GOF_ShowGui) != 0) && mouse_is_over_panel_map(local_info.minimap_pos_x, local_info.minimap_pos_y))
     {
         if (game.small_map_state == 2) {
             set_pointer_graphic(MousePG_Invisible);
@@ -980,11 +977,11 @@ void redraw_display(void)
         break;
     case PVM_ParchFadeIn:
         parchment_loaded = 0;
-        player->palette_fade_step_map = map_fade_in(player->palette_fade_step_map);
+        local_info.palette_fade_step_map = map_fade_in(local_info.palette_fade_step_map);
         break;
     case PVM_ParchFadeOut:
         parchment_loaded = 0;
-        player->palette_fade_step_map = map_fade_out(player->palette_fade_step_map);
+        local_info.palette_fade_step_map = map_fade_out(local_info.palette_fade_step_map);
         break;
     default:
         ERRORLOG("Unsupported drawing state, %d",(int)player->view_mode);
@@ -1073,7 +1070,7 @@ void redraw_display(void)
               player->view_mode == PVM_IsoStraightView ||
               player->view_mode == PVM_CreatureView
           ) {
-              pos_x = player->engine_window_x + (MyScreenWidth - w - player->engine_window_x) / 2;
+              pos_x = local_info.engine_window_x + (MyScreenWidth - w - local_info.engine_window_x) / 2;
           } else {
               pos_x = (MyScreenWidth-w)/2;
           }
@@ -1140,12 +1137,11 @@ void redraw_display(void)
 TbBool keeper_screen_redraw(void)
 {
     SYNCDBG(5,"Starting");
-    struct PlayerInfo* player = get_my_player();
     RendererClearScreen(144);
     if (RendererLockFramebuffer() == Lb_SUCCESS)
     {
-        setup_engine_window(player->engine_window_x, player->engine_window_y,
-            player->engine_window_width, player->engine_window_height);
+        setup_engine_window(local_info.engine_window_x, local_info.engine_window_y,
+            local_info.engine_window_width, local_info.engine_window_height);
         redraw_display();
         RendererUnlockFramebuffer();
         return true;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -663,16 +663,14 @@ static long compute_cells_away(void) // For overhead view, not for 1st person vi
     int32_t ymax;
     int32_t xcell;
     int32_t ycell;
-    struct PlayerInfo *player;
     long ncells_a;
-    player = get_my_player();
-    half_width = (player->engine_window_width >> 1);
-    half_height = (player->engine_window_height >> 1);
-    xcell = ((half_width<<1) + (half_width>>4))/pixel_size - player->engine_window_x/pixel_size;
-    ycell = ((8 * high_offset[1]) >> 8) - (half_width>>4)/pixel_size - player->engine_window_y/pixel_size;
+    half_width = (local_info.engine_window_width >> 1);
+    half_height = (local_info.engine_window_height >> 1);
+    xcell = ((half_width<<1) + (half_width>>4))/pixel_size - local_info.engine_window_x/pixel_size;
+    ycell = ((8 * high_offset[1]) >> 8) - (half_width>>4)/pixel_size - local_info.engine_window_y/pixel_size;
     get_floor_pointed_at(xcell, ycell, &xmax, &ymax);
-    xcell = (half_width)/pixel_size - player->engine_window_x/pixel_size;
-    ycell = (half_height)/pixel_size - player->engine_window_y/pixel_size;
+    xcell = (half_width)/pixel_size - local_info.engine_window_x/pixel_size;
+    ycell = (half_height)/pixel_size - local_info.engine_window_y/pixel_size;
     get_floor_pointed_at(xcell, ycell, &xmin, &ymin);
     xcell = abs(ymax - ymin);
     ycell = abs(xmax - xmin);
@@ -1749,14 +1747,13 @@ static void create_box_coords(struct EngineCoord *coord, long x, long z, long y)
 
 static void do_perspective_rotation(long x, long y, long z)
 {
-    struct PlayerInfo *player = get_my_player();
     struct EngineCoord epos;
     long zoom;
     long engine_w;
     long engine_h;
     zoom = camera_zoom / pixel_size;
-    engine_w = player->engine_window_width/pixel_size;
-    engine_h = player->engine_window_height/pixel_size;
+    engine_w = local_info.engine_window_width/pixel_size;
+    engine_h = local_info.engine_window_height/pixel_size;
     epos.x = -x;
     epos.y = 0;
     epos.z = y;
@@ -2469,8 +2466,8 @@ static void fiddle_gamut(long pos_x, long pos_y)
     case PVM_IsoWibbleView:
     case PVM_IsoStraightView:
         // Retrieve coordinates on limiting map points
-        ewwidth = player->engine_window_width / pixel_size;
-        ewheight = player->engine_window_height / pixel_size - ((8 * high_offset[1]) >> 8);
+        ewwidth = local_info.engine_window_width / pixel_size;
+        ewheight = local_info.engine_window_height / pixel_size - ((8 * high_offset[1]) >> 8);
         ewzoom = (768 * (camera_zoom/pixel_size)) >> 17;
         fiddle_gamut_find_limits(floor_x, floor_y, ewwidth, ewheight, ewzoom);
         // Place the area at proper base coords
@@ -5784,9 +5781,8 @@ static void draw_stripey_line(long x1,long y1,long x2,long y2,unsigned char line
     unsigned char color_index = get_gameturn() & 0xf;
 
     // get engine window width and height
-    struct PlayerInfo *player = get_my_player();
-    long relative_window_width = ((player->engine_window_width * 256) / (pixel_size * 256)) - 1;
-    long relative_window_height = ((player->engine_window_height * 256) / (pixel_size * 256)) - 1;
+    long relative_window_width = ((local_info.engine_window_width * 256) / (pixel_size * 256)) - 1;
+    long relative_window_height = ((local_info.engine_window_height * 256) / (pixel_size * 256)) - 1;
 
     // Bresenham’s Line Drawing Algorithm - handles all octants
     // A and B are relative, and are set to be either X (shallow curves) or Y (steep curves).
@@ -5992,15 +5988,13 @@ static void draw_stripey_line(long x1,long y1,long x2,long y2,unsigned char line
 
 static void draw_clipped_line(long x1, long y1, long x2, long y2, TbPixel color)
 {
-    struct PlayerInfo *player;
     if ((x1 >= 0) || (x2 >= 0))
     {
       if ((y1 >= 0) || (y2 >= 0))
       {
-        player = get_my_player();
-        if ((x1 < player->engine_window_width) || (x2 < player->engine_window_width))
+        if ((x1 < local_info.engine_window_width) || (x2 < local_info.engine_window_width))
         {
-          if ((y1 < player->engine_window_height) || (y2 < player->engine_window_height))
+          if ((y1 < local_info.engine_window_height) || (y2 < local_info.engine_window_height))
           {
             draw_stripey_line(x1, y1, x2, y2, color);
           }
@@ -7317,8 +7311,8 @@ static TbBool project_point_helper(struct PlayerInfo *player, int zoom, MapCoord
 {
     int vertical_shift;
     int64_t new_zoom;
-    short window_width = player->engine_window_width;
-    short window_height = player->engine_window_height;
+    short window_width = local_info.engine_window_width;
+    short window_height = local_info.engine_window_height;
 
     *x_out = (zoom * horizontal_delta >> 16) + (*(uint16_t *)&window_width / 2);
     vertical_shift = zoom * vertical_delta >> 8;
@@ -7608,7 +7602,7 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
     myplyr = get_my_player();
     cube_itm = (qdrant + 2) & 3;
     delta_y = (zoom << 7) / 256;
-    bckt_idx = myplyr->engine_window_height - (pos_y >> 8) + FRONTVIEW_BUCKET_MARGIN;
+    bckt_idx = local_info.engine_window_height - (pos_y >> 8) + FRONTVIEW_BUCKET_MARGIN;
     // Check if there's enough place to draw
     if (!is_free_space_in_poly_pool(8))
       return;
@@ -9287,8 +9281,8 @@ void draw_frontview_engine(struct Camera *cam)
     cam->zoom = camera_zoom;//TODO [zoom] remove when all cam->zoom will be changed to camera_zoom
     cam_x = cam->mappos.x.val;
     cam_y = cam->mappos.y.val;
-    pointer_x = (GetMouseX() - player->engine_window_x) / pixel_size;
-    pointer_y = (GetMouseY() - player->engine_window_y) / pixel_size;
+    pointer_x = (GetMouseX() - local_info.engine_window_x) / pixel_size;
+    pointer_y = (GetMouseY() - local_info.engine_window_y) / pixel_size;
     LbScreenStoreGraphicsWindow(&grwnd);
     store_engine_window(&ewnd,pixel_size);
     LbScreenSetGraphicsWindow(ewnd.x, ewnd.y, ewnd.width, ewnd.height);

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -977,10 +977,10 @@ static TbBool get_level_lost_inputs(void)
               }
               long mmzoom;
               if (16/mm_units_per_px < 3)
-                  mmzoom = (player->minimap_zoom) / (3-16/mm_units_per_px);
+                  mmzoom = (local_info.minimap_zoom) / (3-16/mm_units_per_px);
               else
-                  mmzoom = (player->minimap_zoom);
-              inp_done = get_small_map_inputs(player->minimap_pos_x*mm_units_per_px/16, player->minimap_pos_y*mm_units_per_px/16, mmzoom);
+                  mmzoom = (local_info.minimap_zoom);
+              inp_done = get_small_map_inputs(local_info.minimap_pos_x*mm_units_per_px/16, local_info.minimap_pos_y*mm_units_per_px/16, mmzoom);
               if ( !inp_done )
                 get_bookmark_inputs();
               get_dungeon_control_nonaction_inputs();
@@ -1357,11 +1357,11 @@ static TbBool get_dungeon_control_action_inputs(void)
     long mmzoom;
     if (16 / mm_units_per_px < 3)
     {
-        mmzoom = (player->minimap_zoom) / scale_value_for_resolution_with_upp(2, mm_units_per_px);
+        mmzoom = (local_info.minimap_zoom) / scale_value_for_resolution_with_upp(2, mm_units_per_px);
     }
     else
-        mmzoom = (player->minimap_zoom);
-    if (get_small_map_inputs(player->minimap_pos_x * mm_units_per_px / 16, player->minimap_pos_y * mm_units_per_px / 16, mmzoom))
+        mmzoom = (local_info.minimap_zoom);
+    if (get_small_map_inputs(local_info.minimap_pos_x * mm_units_per_px / 16, local_info.minimap_pos_y * mm_units_per_px / 16, mmzoom))
         return 1;
 
     if (player->work_state == PSt_CtrlDungeon)
@@ -2408,8 +2408,8 @@ static TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *
   struct PlayerInfo* player = get_my_player();
   TbBool hand_is_empty = power_hand_is_empty(player);
   if ((pointer_x < 0) || (pointer_y < 0)
-   || (pointer_x >= player->engine_window_width/pixel_size)
-   || (pointer_y >= player->engine_window_height/pixel_size))
+   || (pointer_x >= local_info.engine_window_width/pixel_size)
+   || (pointer_y >= local_info.engine_window_height/pixel_size))
       return false;
   if (top_pointed_at_x <= game.map_subtiles_x)
     x = top_pointed_at_x;
@@ -2972,7 +2972,7 @@ static short get_inputs(void)
         {
           if (!network_is_active())
             game.operation_flags &= ~GOF_Paused;
-          player->status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible) [duplicate? unneeded?]
+          local_info.status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible) [duplicate? unneeded?]
           set_players_packet_action(player, PckA_SetViewType, PVT_MapScreen, 0,0,0);
         }
         return false;
@@ -3045,7 +3045,6 @@ short get_gui_inputs(short gameplay_on)
   }
   update_busy_doing_gui_on_menu();
   int fmmenu_idx = first_monopoly_menu();
-  struct PlayerInfo* player = get_my_player();
   int gmbtn_idx = -1;
   ActiveButtonID nx_over_slider_button = -1;
   struct GuiButton *gbtn;
@@ -3063,7 +3062,7 @@ short get_gui_inputs(short gameplay_on)
       if ((gbtn->btype_value & LbBFeF_NoMouseOver) != 0)
           continue;
       // TODO GUI Introduce circular buttons instead of specific condition for pannel map
-      if ((menu_id_to_number(GMnu_MAIN) >= 0) && mouse_is_over_panel_map(player->minimap_pos_x,player->minimap_pos_y))
+      if ((menu_id_to_number(GMnu_MAIN) >= 0) && mouse_is_over_panel_map(local_info.minimap_pos_x,local_info.minimap_pos_y))
           continue;
       if ( (check_if_mouse_is_over_button(gbtn) && !game_is_busy_doing_gui_string_input())
         || ((gbtn->gbtype == LbBtnT_Hotspot) && (gbtn->button_state_left_pressed != 0)) )

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2021,8 +2021,6 @@ int create_button(struct GuiMenu *gmnu, struct GuiButtonInit *gbinit, int units_
 
 long compute_menu_position_x(long desired_pos,int menu_width, int units_per_px)
 {
-  struct PlayerInfo *player;
-  player = get_my_player();
   long scaled_width;
   scaled_width = (menu_width * units_per_px + 8) / 16;
   long pos;
@@ -2032,7 +2030,7 @@ long compute_menu_position_x(long desired_pos,int menu_width, int units_per_px)
       pos = GetMouseX() - (scaled_width >> 1);
       break;
   case POS_GAMECTR: // Player-based positioning
-      pos = (player->engine_window_x) + (player->engine_window_width >> 1) - (scaled_width >> 1);
+      pos = (local_info.engine_window_x) + (local_info.engine_window_width >> 1) - (scaled_width >> 1);
       break;
   case POS_MOUSPRV: // Place menu centered over previous mouse position
       pos = old_menu_mouse_x - (scaled_width >> 1);
@@ -2058,8 +2056,8 @@ long compute_menu_position_x(long desired_pos,int menu_width, int units_per_px)
   {
     if (pos+scaled_width > MyScreenWidth)
       pos = MyScreenWidth-scaled_width;
-    if (pos < player->engine_window_x)
-      pos = player->engine_window_x;
+    if (pos < local_info.engine_window_x)
+      pos = local_info.engine_window_x;
   } else
   {
     if (pos+scaled_width > MyScreenWidth)
@@ -2072,7 +2070,6 @@ long compute_menu_position_x(long desired_pos,int menu_width, int units_per_px)
 
 long compute_menu_position_y(long desired_pos,int menu_height, int units_per_px)
 {
-    struct PlayerInfo *player = get_my_player();
     long scaled_height;
     scaled_height = (menu_height * units_per_px + 8) / 16;
     long pos;
@@ -2082,7 +2079,7 @@ long compute_menu_position_y(long desired_pos,int menu_height, int units_per_px)
         pos = GetMouseY() - (scaled_height >> 1);
         break;
     case POS_GAMECTR: // Player-based positioning
-        pos = (player->engine_window_height >> 1) - ((scaled_height+20*units_per_px/16) >> 1);
+        pos = (local_info.engine_window_height >> 1) - ((scaled_height+20*units_per_px/16) >> 1);
         break;
     case POS_MOUSPRV: // Place menu centered over previous mouse position
         pos = old_menu_mouse_y - (scaled_height >> 1);

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -190,20 +190,18 @@ short get_pixels_scaled_and_zoomed(long basic_zoom)
 
 void gui_zoom_in(struct GuiButton *gbtn)
 {
-    struct PlayerInfo* player = get_my_player();
-    if (player->minimap_zoom > 128) {
-        player->minimap_zoom >>= 1;
-        settings.minimap_zoom = player->minimap_zoom;
+    if (local_info.minimap_zoom > 128) {
+        local_info.minimap_zoom >>= 1;
+        settings.minimap_zoom = local_info.minimap_zoom;
         save_settings();
     }
 }
 
 void gui_zoom_out(struct GuiButton *gbtn)
 {
-    struct PlayerInfo* player = get_my_player();
-    if (player->minimap_zoom < 2048) {
-        player->minimap_zoom <<= 1;
-        settings.minimap_zoom = player->minimap_zoom;
+    if (local_info.minimap_zoom < 2048) {
+        local_info.minimap_zoom <<= 1;
+        settings.minimap_zoom = local_info.minimap_zoom;
         save_settings();
     }
 }
@@ -2659,11 +2657,11 @@ void draw_whole_status_panel(void)
     // Draws gold amount; note that button_sprite[] is used instead of full font
     draw_gold_total(player->id_number, gmnu->pos_x + gmnu->width/2, gmnu->pos_y + gmnu->height*67/200, fs_units_per_px, dungeon->total_money_owned);
     if (16/mm_units_per_px < 3)
-        mmzoom = (player->minimap_zoom) / scale_value_for_resolution_with_upp(2,mm_units_per_px);
+        mmzoom = (local_info.minimap_zoom) / scale_value_for_resolution_with_upp(2,mm_units_per_px);
     else
-        mmzoom = player->minimap_zoom;
-    panel_map_draw_slabs(player->minimap_pos_x, player->minimap_pos_y, mm_units_per_px, mmzoom);
-    long basic_zoom = player->minimap_zoom;
+        mmzoom = local_info.minimap_zoom;
+    panel_map_draw_slabs(local_info.minimap_pos_x, local_info.minimap_pos_y, mm_units_per_px, mmzoom);
+    long basic_zoom = local_info.minimap_zoom;
     panel_map_draw_overlay_things(mm_units_per_px, mmzoom, basic_zoom);
     unsigned char placefill_threshold = (LbScreenHeight() >= 400) ? 80 : 40;
     if (LbScreenHeight() - gmnu->height >= placefill_threshold)

--- a/src/frontmenu_saves.c
+++ b/src/frontmenu_saves.c
@@ -138,7 +138,7 @@ void gui_save_game(struct GuiButton *gbtn)
           create_error_box(GUIStr_ErrorSaving);
       }
   }
-  set_players_packet_action(player, PckA_UpdatePause, player->paused_state_restore, 0, 0, 0);
+  set_players_packet_action(player, PckA_UpdatePause, local_info.paused_state_restore, 0, 0, 0);
 }
 
 void update_loadsave_input_strings(struct CatalogueEntry *game_catalg)
@@ -264,7 +264,7 @@ void init_save_menu(struct GuiMenu *gmnu)
 {
   SYNCDBG(6,"Starting");
   struct PlayerInfo* player = get_my_player();
-  player->paused_state_restore = flag_is_set(game.operation_flags, GOF_Paused);
+  local_info.paused_state_restore = flag_is_set(game.operation_flags, GOF_Paused);
   set_players_packet_action(player, PckA_UpdatePause, 1, 1, 0, 0);
   load_game_save_catalogue();
   gui_vscroll_offset = 0;

--- a/src/ftests/ftest_util.c
+++ b/src/ftests/ftest_util.c
@@ -310,8 +310,8 @@ void ftest_util_center_cursor_over_dungeon_view()
     }
 
     struct TbPoint point;
-    point.x = player->engine_window_width/2;
-    point.y = player->engine_window_height/2;
+    point.x = local_info.engine_window_width/2;
+    point.y = local_info.engine_window_height/2;
     if ((game.operation_flags & GOF_ShowGui) != 0)
     {
         point.x += status_panel_width;

--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -26,6 +26,7 @@
 
 #include "config.h"
 #include "config_campaigns.h"
+#include "config_settings.h"
 #include "dungeon_stats.h"
 #include "config_creature.h"
 #include "config_crtrmodel.h"
@@ -483,13 +484,16 @@ TbBool load_game(long slot_num)
     struct PlayerInfo* player = get_my_player();
     clear_flag(player->additional_flags, PlaAF_LightningPaletteIsActive);
     clear_flag(player->additional_flags, PlaAF_FreezePaletteIsActive);
-    player->palette_fade_step_pain = 0;
-    player->palette_fade_step_possession = 0;
-    player->lens_palette = 0;
+    local_info.palette_fade_step_pain = 0;
+    local_info.palette_fade_step_possession = 0;
+    local_info.lens_palette = 0;
+    local_info.minimap_pos_x = 11;
+    local_info.minimap_pos_y = 11;
+    local_info.minimap_zoom = settings.minimap_zoom;
     // Reinitialize lens first (restores lens_palette pointer from config)
     reinitialise_eye_lens(game.applied_lens_type);
     // Apply the appropriate palette (lens palette if active, otherwise engine default)
-    PaletteSetPlayerPalette(player, player->lens_palette ? player->lens_palette : engine_palette);
+    PaletteSetPlayerPalette(player, local_info.lens_palette ? local_info.lens_palette : engine_palette);
     init_local_cameras(player);
     // Update the lights system state
     light_import_system_state(&game.lightst);

--- a/src/gui_parchment.c
+++ b/src/gui_parchment.c
@@ -1085,27 +1085,27 @@ void draw_zoom_box(void)
 
     long draw_tiles = 13;
     long subtile_unscaled = 8;
-    if (player->minimap_zoom == 128)
+    if (local_info.minimap_zoom == 128)
     {
         draw_tiles = 6;
         subtile_unscaled = 18;
     } else
-    if (player->minimap_zoom == 256)
+    if (local_info.minimap_zoom == 256)
     {
         draw_tiles = 9;
         subtile_unscaled = 12;
     } else
-    if (player->minimap_zoom == 512)
+    if (local_info.minimap_zoom == 512)
     {
         draw_tiles = 12;
         subtile_unscaled = 9;
     } else
-    if (player->minimap_zoom == 1024)
+    if (local_info.minimap_zoom == 1024)
     {
         draw_tiles = 18;
         subtile_unscaled = 6;
     } else
-    if (player->minimap_zoom == 2048)
+    if (local_info.minimap_zoom == 2048)
     {
         draw_tiles = 36;
         subtile_unscaled = 3;

--- a/src/kfx/lense/PaletteEffect.cpp
+++ b/src/kfx/lense/PaletteEffect.cpp
@@ -47,7 +47,7 @@ TbBool PaletteEffect::Setup(long lens_idx)
     struct PlayerInfo* player = get_my_player();
     
     // Set lens_palette first, then call PaletteSetPlayerPalette to apply it
-    player->lens_palette = cfg->palette;
+    local_info.lens_palette = cfg->palette;
     PaletteSetPlayerPalette(player, cfg->palette);
     
     m_current_lens = lens_idx;
@@ -59,7 +59,7 @@ void PaletteEffect::Cleanup()
 {
     if (m_current_lens >= 0) {
         struct PlayerInfo* player = get_my_player();
-        player->lens_palette = NULL;
+        local_info.lens_palette = NULL;
         PaletteSetPlayerPalette(player, engine_palette);
         m_current_lens = -1;
         SYNCDBG(9, "Palette effect cleaned up");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -570,12 +570,11 @@ static bool players_cursor_is_at_top_of_view()
 
 TbBool engine_point_to_map(struct Camera *camera, long screen_x, long screen_y, int32_t *map_x, int32_t *map_y)
 {
-    struct PlayerInfo *player = get_my_player();
     *map_x = 0;
     *map_y = 0;
     if ( (pointer_x >= 0) && (pointer_y >= 0)
-      && (pointer_x < (player->engine_window_width/pixel_size))
-      && (pointer_y < (player->engine_window_height/pixel_size)) )
+      && (pointer_x < (local_info.engine_window_width/pixel_size))
+      && (pointer_y < (local_info.engine_window_height/pixel_size)) )
     {
         if ( players_cursor_is_at_top_of_view() )
         {
@@ -905,8 +904,8 @@ void reinit_level_after_load(void)
     SYNCDBG(6,"Starting");
     // Reinit structures from within the game
     player = get_my_player();
-    player->lens_palette = 0;
-    player->main_palette = engine_palette;
+    local_info.lens_palette = 0;
+    local_info.main_palette = engine_palette;
     init_navigation();
     reinit_packets_after_load();
     game.easter_eggs_enabled = start_params.easter_egg;
@@ -1144,10 +1143,8 @@ void reset_creature_max_levels(void)
 
 void change_engine_window_relative_size(long w_delta, long h_delta)
 {
-    struct PlayerInfo *myplyr;
-    myplyr=get_my_player();
-    setup_engine_window(myplyr->engine_window_x, myplyr->engine_window_y,
-        myplyr->engine_window_width+w_delta, myplyr->engine_window_height+h_delta);
+    setup_engine_window(local_info.engine_window_x, local_info.engine_window_y,
+        local_info.engine_window_width+w_delta, local_info.engine_window_height+h_delta);
 }
 
 void PaletteSetPlayerPalette(struct PlayerInfo *player, unsigned char *pal)
@@ -1161,16 +1158,15 @@ void PaletteSetPlayerPalette(struct PlayerInfo *player, unsigned char *pal)
     {
       player->additional_flags &= ~PlaAF_FreezePaletteIsActive; // flag Freeze palette is not active
     }
-    if ( (player->lens_palette == 0) || ((pal != player->main_palette) && (pal == player->lens_palette)) )
+    if (!is_my_player(player))
+        return;
+    if ( (local_info.lens_palette == 0) || ((pal != local_info.main_palette) && (pal == local_info.lens_palette)) )
     {
-        player->main_palette = pal;
-        player->palette_fade_step_pain = 0;
-        player->palette_fade_step_possession = 0;
-        if (is_my_player(player))
-        {
-            LbScreenWaitVbi();
-            RendererPaletteSet(pal);
-        }
+        local_info.main_palette = pal;
+        local_info.palette_fade_step_pain = 0;
+        local_info.palette_fade_step_possession = 0;
+        LbScreenWaitVbi();
+        RendererPaletteSet(pal);
     }
 }
 
@@ -1209,13 +1205,12 @@ void centre_engine_window(void)
 {
     long window_center_x;
     long window_center_y;
-    struct PlayerInfo *player=get_my_player();
     if ((game.operation_flags & GOF_ShowGui) != 0)
-      window_center_x = (MyScreenWidth-player->engine_window_width-status_panel_width) / 2 + status_panel_width;
+      window_center_x = (MyScreenWidth-local_info.engine_window_width-status_panel_width) / 2 + status_panel_width;
     else
-      window_center_x = (MyScreenWidth-player->engine_window_width) / 2;
-    window_center_y = (MyScreenHeight-player->engine_window_height) / 2;
-    setup_engine_window(window_center_x, window_center_y, player->engine_window_width, player->engine_window_height);
+      window_center_x = (MyScreenWidth-local_info.engine_window_width) / 2;
+    window_center_y = (MyScreenHeight-local_info.engine_window_height) / 2;
+    setup_engine_window(window_center_x, window_center_y, local_info.engine_window_width, local_info.engine_window_height);
 }
 
 void turn_off_query(PlayerNumber plyr_idx)
@@ -1613,8 +1608,8 @@ void engine(struct PlayerInfo *player, struct Camera *cam)
     mx = cam->mappos.x.val;
     my = cam->mappos.y.val;
     mz = cam->mappos.z.val;
-    pointer_x = (GetMouseX() - player->engine_window_x) / pixel_size;
-    pointer_y = (GetMouseY() - player->engine_window_y) / pixel_size;
+    pointer_x = (GetMouseX() - local_info.engine_window_x) / pixel_size;
+    pointer_y = (GetMouseY() - local_info.engine_window_y) / pixel_size;
     lens = cam->horizontal_fov * scale_value_by_horizontal_resolution(4) / pixel_size;
     if (lens_mode == 0)
         update_blocks_pointed();

--- a/src/net_resync.cpp
+++ b/src/net_resync.cpp
@@ -428,8 +428,7 @@ TbBool receive_resync_game(void)
 void resync_game(void)
 {
     SYNCDBG(2,"Starting");
-    struct PlayerInfo* player = get_my_player();
-    draw_out_of_sync_box(0, 32*units_per_pixel/16, player->engine_window_x);
+    draw_out_of_sync_box(0, 32*units_per_pixel/16, local_info.engine_window_x);
     reset_eye_lenses();
     store_localised_game_structure();
     TbBool result;

--- a/src/packets.c
+++ b/src/packets.c
@@ -747,10 +747,9 @@ TbBool process_user_global_packet_action(NetUserId user)
       process_pause_packet(pckt->actn_par1, 0);
       return 1;
   case PckA_SetCluedo:
-      player->video_cluedo_mode = pckt->actn_par1;
       if (is_my_player(player))
       {
-        settings.video_cluedo_mode = player->video_cluedo_mode;
+        settings.video_cluedo_mode = pckt->actn_par1;
         save_settings();
       }
       return 0;
@@ -769,10 +768,10 @@ TbBool process_user_global_packet_action(NetUserId user)
       }
       return 0;
   case PckA_SetMinimapConf:
-      player->minimap_zoom = pckt->actn_par1;
       if (is_my_player(player))
       {
-        settings.minimap_zoom = player->minimap_zoom;
+        local_info.minimap_zoom = pckt->actn_par1;
+        settings.minimap_zoom = local_info.minimap_zoom;
         save_settings();
       }
       return 0;

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -44,6 +44,7 @@ TbPixel possession_hit_colours[] =   {133, 89, 167, 141,  31,  31, 110,  54,  46
 unsigned short const player_cubes[] = {0x00C0, 0x00C1, 0x00C2, 0x00C3, 0x00C7, 0x00C6 };
 
 struct PlayerInfo bad_player;
+struct LocalInfo local_info;
 
 /** The current player's number. */
 unsigned char my_player_number;
@@ -266,6 +267,7 @@ void clear_players(void)
     }
     memset(&bad_player, 0, sizeof(struct PlayerInfo));
     bad_player.id_number = PLAYERS_COUNT;
+    memset(&local_info, 0, sizeof(local_info));
     game.active_players_count = 0;
     //game.game_kind = GKind_LocalGame;
 }
@@ -476,19 +478,23 @@ void set_player_mode(struct PlayerInfo *player, unsigned short nview)
         set_engine_view(player, PVM_IsoWibbleView);
       }
       if (is_my_player(player))
+      {
         toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
-      if ((game.operation_flags & GOF_ShowGui) != 0)
-        setup_engine_window(status_panel_width, 0, MyScreenWidth, MyScreenHeight);
-      else
-        setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
+        if ((game.operation_flags & GOF_ShowGui) != 0)
+          setup_engine_window(status_panel_width, 0, MyScreenWidth, MyScreenHeight);
+        else
+          setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
+      }
       break;
   }
   case PVT_CreatureContrl:
   case PVT_CreaturePasngr:
       set_engine_view(player, PVM_CreatureView);
       if (is_my_player(player))
+      {
         game.view_mode_flags &= ~GNFldD_CreatureViewMode;
-      setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
+        setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
+      }
       break;
   case PVT_MapScreen:
       if (is_my_player(player)) {

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -147,16 +147,11 @@ struct CheatSelection
 
 struct PlayerInfo {
     unsigned char allocflags;
-    TbBool tooltips_restore; /**< Used to store/restore the value of settings.tooltips_on when transitioning to/from the map. */
-    TbBool status_menu_restore; /**< Used to store/restore the current status menu visibility when the map is shown/hidden. */
-    TbBool paused_state_restore; /**< Used to restore pause state after saving */
-    TbBool swipe_sprite_drawLR; /**< Used to decide whether to draw the swipe sprite left to right (TRUE), or [default] right to left (FALSE). */
     unsigned char boxsize; //field_2 seems to be used in DK, so now renamed and used in KeeperFX
     unsigned char additional_flags; // Uses PlayerAdditionalFlags
     unsigned char input_crtr_control;
     unsigned char input_crtr_query;
     unsigned char display_flags;
-    unsigned char *lens_palette;
     unsigned char /*NetUserId*/ user_id;
     int32_t hand_animationId;
     unsigned int hand_busy_until_turn;
@@ -181,13 +176,6 @@ struct PlayerInfo {
     short cta_flag_idx;
     short influenced_thing_idx;
     GameTurn influenced_thing_creation;
-    short engine_window_width;
-    short engine_window_height;
-    short engine_window_x;
-    short engine_window_y;
-    short minimap_pos_x;
-    short minimap_pos_y;
-    unsigned short minimap_zoom;
     unsigned char view_type;
     PlayerState work_state;
     unsigned char primary_cursor_state;
@@ -211,13 +199,8 @@ struct PlayerInfo {
     /** If view mode is temporarily covered by another, the original mode which is to be restored later will be saved here.*/
     char view_mode_restore;
     int32_t dungeon_camera_zoom;
-    int32_t palette_fade_step_map;
-    int32_t palette_fade_step_pain;
-    int32_t palette_fade_step_possession;
-    unsigned char *main_palette;
     /** Overcharge level while casting keeper powers. */
     int32_t cast_expand_level;
-    char video_cluedo_mode;
     MapCoordDelta zoom_to_movement_x;
     MapCoordDelta zoom_to_movement_y;
     GameTurn power_of_cooldown_turn;
@@ -261,7 +244,7 @@ struct PlayerInfo {
     int isometric_tilt;
     unsigned short generate_speed;
     int first_person_unfreeze_delay;
-    };
+};
 
 /******************************************************************************/
 
@@ -270,6 +253,27 @@ extern short local_thing_under_hand;
 
 #pragma pack()
 /******************************************************************************/
+
+struct LocalInfo {
+    TbBool tooltips_restore; /**< Used to store/restore the value of settings.tooltips_on when transitioning to/from the map. */
+    TbBool status_menu_restore; /**< Used to store/restore the current status menu visibility when the map is shown/hidden. */
+    TbBool paused_state_restore; /**< Used to restore pause state after saving */
+    TbBool swipe_sprite_drawLR; /**< Used to decide whether to draw the swipe sprite left to right (TRUE), or [default] right to left (FALSE). */
+    unsigned char *lens_palette;
+    unsigned char *main_palette;
+    int32_t palette_fade_step_map;
+    int32_t palette_fade_step_pain;
+    int32_t palette_fade_step_possession;
+    short engine_window_width;
+    short engine_window_height;
+    short engine_window_x;
+    short engine_window_y;
+    short minimap_pos_x;
+    short minimap_pos_y;
+    unsigned short minimap_zoom;
+};
+
+extern struct LocalInfo local_info;
 extern unsigned short player_colors_map[];
 extern TbPixel player_path_colours[];
 extern TbPixel player_room_colours[];

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -317,7 +317,7 @@ long pinstfs_passenger_control_creature(struct PlayerInfo *player, int32_t *n)
   player->allocflags |= PlaF_MouseInputDisabled;
   if (is_my_player(player))
   {
-    player->palette_fade_step_possession = 1;
+    local_info.palette_fade_step_possession = 1;
     turn_off_all_window_menus();
     turn_off_menu(GMnu_CREATURE_QUERY1);
     turn_off_menu(GMnu_CREATURE_QUERY2);
@@ -491,7 +491,7 @@ long pinstfs_direct_leave_creature(struct PlayerInfo *player, int32_t *n)
   if (is_my_player(player))
   {
       PaletteSetPlayerPalette(player, engine_palette);
-      player->palette_fade_step_possession = 11;
+      local_info.palette_fade_step_possession = 11;
       turn_off_all_window_menus();
       turn_off_query_menus();
       turn_on_main_panel_menu();
@@ -533,7 +533,7 @@ long pinstfs_passenger_leave_creature(struct PlayerInfo *player, int32_t *n)
   if (is_my_player(player))
   {
     PaletteSetPlayerPalette(player, engine_palette);
-    player->palette_fade_step_possession = 11;
+    local_info.palette_fade_step_possession = 11;
     turn_off_all_window_menus();
     turn_off_query_menus();
     turn_off_all_panel_menus();
@@ -747,14 +747,14 @@ long pinstfe_control_creature_fade(struct PlayerInfo *player, int32_t *n)
 long pinstfs_fade_to_map(struct PlayerInfo *player, int32_t *n)
 {
     struct Camera* cam = get_player_active_camera(player);
-    player->palette_fade_step_map = 0;
     player->allocflags |= PlaF_MouseInputDisabled;
     player->view_mode_restore = cam->view_mode;
     if (is_my_player(player))
     {
-        player->tooltips_restore = settings.tooltips_on; // store tooltips setting before starting the fade
+        local_info.palette_fade_step_map = 0;
+        local_info.tooltips_restore = settings.tooltips_on; // store tooltips setting before starting the fade
         settings.tooltips_on = false; // don't show tooltips during the fade
-        player->status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible)
+        local_info.status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible)
   }
   set_engine_view(player, PVM_ParchFadeIn);
   return 0;
@@ -770,7 +770,7 @@ long pinstfe_fade_to_map(struct PlayerInfo *player, int32_t *n)
 {
   set_player_mode(player, PVT_MapScreen);
   if (is_my_player(player))
-    settings.tooltips_on = player->tooltips_restore; // restore tooltips setting after the fade is completed
+    settings.tooltips_on = local_info.tooltips_restore; // restore tooltips setting after the fade is completed
   player->allocflags &= ~PlaF_MouseInputDisabled;
   return 0;
 }
@@ -780,11 +780,11 @@ long pinstfs_fade_from_map(struct PlayerInfo *player, int32_t *n)
   player->allocflags |= PlaF_MouseInputDisabled;
   if (is_my_player(player))
   {
-    player->tooltips_restore = settings.tooltips_on; // store tooltips setting before starting the fade
+    local_info.tooltips_restore = settings.tooltips_on; // store tooltips setting before starting the fade
     settings.tooltips_on = false; // don't show tooltips during the fade
     game.operation_flags &= ~GOF_ShowPanel;
+    local_info.palette_fade_step_map = 32;
   }
-  player->palette_fade_step_map = 32;
   set_player_mode(player, PVT_DungeonTop);
   set_engine_view(player, PVM_ParchFadeOut);
   return 0;
@@ -800,8 +800,8 @@ long pinstfe_fade_from_map(struct PlayerInfo *player, int32_t *n)
     struct PlayerInfo* myplyr = get_player(my_player_number);
     set_engine_view(player, player->view_mode_restore);
     if (player->id_number == myplyr->id_number) {
-        settings.tooltips_on = player->tooltips_restore; // restore tooltips setting after the fade is completed
-        toggle_status_menu(player->status_menu_restore); // restore the status menu visiblity now that the map is no longer visible
+        settings.tooltips_on = local_info.tooltips_restore; // restore tooltips setting after the fade is completed
+        toggle_status_menu(local_info.status_menu_restore); // restore the status menu visiblity now that the map is no longer visible
     }
     player->allocflags &= ~PlaF_MouseInputDisabled;
     return 0;

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -777,14 +777,16 @@ void init_player_as_single_keeper(struct PlayerInfo *player)
 void init_player(struct PlayerInfo *player, short no_explore)
 {
     SYNCDBG(5,"Starting");
-    player->minimap_pos_x = 11;
-    player->minimap_pos_y = 11;
-    player->minimap_zoom = settings.minimap_zoom;
-    setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
+    if (is_my_player(player))
+    {
+        local_info.minimap_pos_x = 11;
+        local_info.minimap_pos_y = 11;
+        local_info.minimap_zoom = settings.minimap_zoom;
+        setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
+        local_info.main_palette = engine_palette;
+    }
     player->continue_work_state = PSt_CtrlDungeon;
     player->work_state = PSt_CtrlDungeon;
-    player->main_palette = engine_palette;
-    player->minimap_zoom = settings.minimap_zoom;
     player->isometric_view_zoom_level = settings.isometric_view_zoom_level;
     player->frontview_zoom_level = settings.frontview_zoom_level;
     player->isometric_tilt = settings.isometric_tilt;
@@ -819,7 +821,8 @@ void init_player(struct PlayerInfo *player, short no_explore)
         break;
     case GKind_MultiGame:
         //workaround until settings are synced through multiplayer
-        player->minimap_zoom = 256;
+        if (is_my_player(player))
+            local_info.minimap_zoom = 256;
         if (game.packet_save_head.isometric_view_zoom_level == 0)
         {
             player->isometric_view_zoom_level = CAMERA_ZOOM_MAX;

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -560,7 +560,7 @@ void draw_power_hand(void)
     }
     // Now draw
     if (((game.operation_flags & GOF_ShowGui) != 0) && (game.small_map_state != 2)
-      && mouse_is_over_panel_map(player->minimap_pos_x, player->minimap_pos_y))
+      && mouse_is_over_panel_map(local_info.minimap_pos_x, local_info.minimap_pos_y))
     {
         MapSubtlCoord stl_x;
         MapSubtlCoord stl_y;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -366,14 +366,13 @@ TbBool load_swipe_graphic_for_creature(const struct Thing *thing)
 /**
  * Randomise the draw direction of the swipe sprite in the first-person possession view.
  *
- * Sets PlayerInfo->swipe_sprite_drawLR to either TRUE or FALSE.
+ * Sets local_info.swipe_sprite_drawLR to either TRUE or FALSE.
  *
  * Draw direction is either: left-to-right (TRUE) or right-to-left (FALSE)
  */
 void randomise_swipe_graphic_direction()
 {
-    struct PlayerInfo* myplyr = get_my_player();
-    myplyr->swipe_sprite_drawLR = UNSYNC_RANDOM(2); // equal chance to be left-to-right or right-to-left
+    local_info.swipe_sprite_drawLR = UNSYNC_RANDOM(2); // equal chance to be left-to-right or right-to-left
 }
 
 void draw_swipe_graphic(void)
@@ -408,13 +407,13 @@ void draw_swipe_graphic(void)
             int scrpos_y = (MyScreenHeight * 16 / units_per_px - (startspr->SHeight + endspr->SHeight)) / 2;
             const struct TbSprite *spr;
             int scrpos_x;
-            if (myplyr->swipe_sprite_drawLR)
+            if (local_info.swipe_sprite_drawLR)
             {
                 int delta_y = sprlist[1].SHeight;
                 for (i=0; i < SWIPE_SPRITES_X*SWIPE_SPRITES_Y; i+=SWIPE_SPRITES_X)
                 {
                     spr = &startspr[i];
-                    scrpos_x = ((MyScreenWidth + (2 * myplyr->engine_window_x)) * 16 / units_per_px - allwidth)/ 2;
+                    scrpos_x = ((MyScreenWidth + (2 * local_info.engine_window_x)) * 16 / units_per_px - allwidth)/ 2;
                     for (n=0; n < SWIPE_SPRITES_X; n++)
                     {
                         LbSpriteDrawResized(scrpos_x * units_per_px / 16, scrpos_y * units_per_px / 16, units_per_px, spr);
@@ -3312,7 +3311,7 @@ void prepare_to_controlled_creature_death(struct Thing *thing)
         turn_on_main_panel_menu();
         set_flag_value(game.operation_flags, GOF_ShowPanel, (game.operation_flags & GOF_ShowGui) != 0);
         PaletteSetPlayerPalette(player, engine_palette);
-        player->palette_fade_step_possession = 11;
+        local_info.palette_fade_step_possession = 11;
     }
     light_turn_light_on(player->cursor_light_idx);
 }
@@ -4355,10 +4354,10 @@ void draw_creature_view(struct Thing *thing)
   // Draw swipe into buffer BEFORE lens effects (so overlay renders on top of swipe)
   draw_swipe_graphic();
   // Get the actual viewport dimensions (accounts for sidebar)
-  long view_width = player->engine_window_width / pixel_size;
-  long view_height = player->engine_window_height / pixel_size;
-  long view_x = player->engine_window_x / pixel_size;
-  long view_y = player->engine_window_y / pixel_size;
+  long view_width = local_info.engine_window_width / pixel_size;
+  long view_height = local_info.engine_window_height / pixel_size;
+  long view_x = local_info.engine_window_x / pixel_size;
+  long view_y = local_info.engine_window_y / pixel_size;
   // Restore original graphics settings
   lbDisplay.WScreen = wscr_cp;
   LbScreenLoadGraphicsWindow(&grwnd);

--- a/src/vidfade.c
+++ b/src/vidfade.c
@@ -281,20 +281,22 @@ void ProperForcedFadePalette(unsigned char *pal, long fade_steps, enum TbPalette
 
 long PaletteFadePlayer(struct PlayerInfo *player)
 {
+    if (!is_my_player(player))
+        return 0;
     long i;
     unsigned char palette[PALETTE_SIZE];
     // Find the fade step
-    if ((player->palette_fade_step_pain != 0) && (player->palette_fade_step_possession != 0))
+    if ((local_info.palette_fade_step_pain != 0) && (local_info.palette_fade_step_possession != 0))
     {
-        i = 12 * (player->palette_fade_step_pain - 1) + 10 * (player->palette_fade_step_possession - 1);
+        i = 12 * (local_info.palette_fade_step_pain - 1) + 10 * (local_info.palette_fade_step_possession - 1);
   } else
-  if (player->palette_fade_step_possession != 0)
+  if (local_info.palette_fade_step_possession != 0)
   {
-    i = 2 * (5 * (player->palette_fade_step_possession-1));
+    i = 2 * (5 * (local_info.palette_fade_step_possession-1));
   } else
-  if (player->palette_fade_step_pain != 0)
+  if (local_info.palette_fade_step_pain != 0)
   {
-    i = 4 * (3 * (player->palette_fade_step_pain-1));
+    i = 4 * (3 * (local_info.palette_fade_step_pain-1));
   } else
   { // both are == 0 - no fade
     return 0;
@@ -305,7 +307,7 @@ long PaletteFadePlayer(struct PlayerInfo *player)
   // Create the new palette
   for (i=0; i < PALETTE_COLORS; i++)
   {
-      unsigned char* src = &player->main_palette[3 * i];
+      unsigned char* src = &local_info.main_palette[3 * i];
       unsigned char* dst = &palette[3 * i];
       unsigned long pix = ((step * (((long)src[0]) - 63)) / 120) + 63;
       if (pix > 63)
@@ -321,19 +323,19 @@ long PaletteFadePlayer(struct PlayerInfo *player)
       dst[2] = pix;
   }
   // Update the fade step
-  if (player->palette_fade_step_pain > 0)
-    player->palette_fade_step_pain--;
-  if ((player->palette_fade_step_possession == 0) || (player->instance_num == PI_UnusedSlot18) || (player->instance_num == PI_UnusedSlot17))
+  if (local_info.palette_fade_step_pain > 0)
+    local_info.palette_fade_step_pain--;
+  if ((local_info.palette_fade_step_possession == 0) || (player->instance_num == PI_UnusedSlot18) || (player->instance_num == PI_UnusedSlot17))
   {
   } else
   if ((player->instance_num == PI_DirctCtrl) || (player->instance_num == PI_PsngrCtrl))
   {
-    if (player->palette_fade_step_possession <= 12)
-      player->palette_fade_step_possession++;
+    if (local_info.palette_fade_step_possession <= 12)
+      local_info.palette_fade_step_possession++;
   } else
   {
-    if (player->palette_fade_step_possession > 0)
-      player->palette_fade_step_possession--;
+    if (local_info.palette_fade_step_possession > 0)
+      local_info.palette_fade_step_possession--;
   }
   // Set the palette to screen
   LbScreenWaitVbi();
@@ -343,13 +345,15 @@ long PaletteFadePlayer(struct PlayerInfo *player)
 
 void PaletteApplyPainToPlayer(struct PlayerInfo *player, long intense)
 {
-    long i = player->palette_fade_step_pain + intense;
+    if (!is_my_player(player))
+        return;
+    long i = local_info.palette_fade_step_pain + intense;
     if (i < 1)
         i = 1;
     else
     if (i > 10)
         i = 10;
-    player->palette_fade_step_pain = i;
+    local_info.palette_fade_step_pain = i;
 }
 
 


### PR DESCRIPTION
As part of the "Archon mode" effort, I'm trying to clean up `PlayerInfo` a bit, to only contain data which really is *per-player*, as opposed to e.g. per-user (where multiple users can control a single player).

These fields don't seem to me to belong in `PlayerInfo`; they don't matter for any player which isn't the local human, so I'm moving them into a new `LocalInfo` struct.