### PR TITLE
Measure loading screen time

### DIFF
--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -956,6 +956,7 @@ static TbBool wait_at_frontend(void)
     }
     reenter_video_mode();
 
+    level_load_time_phase(LevelLoadTime_EngineStartup);
     display_loading_screen();
 
     short flgmem;
@@ -982,11 +983,13 @@ static TbBool wait_at_frontend(void)
           clear_flag(game.system_flags, GSF_NetworkActive);
           RendererClearScreen(0);
           RendererPresentFrame();
+          level_load_time_phase(LevelLoadTime_Data);
           if (!load_game(game.save_game_slot))
           {
               ERRORLOG("Loading game %d failed; quitting.",(int)game.save_game_slot);
               quit_game = 1;
           }
+          level_load_time_phase(LevelLoadTime_GameSetup);
           game.save_game_slot = flgmem;
           break;
     case FeSt_PACKET_DEMO:

--- a/src/kfx/platform/PlatformWindows.cpp
+++ b/src/kfx/platform/PlatformWindows.cpp
@@ -422,6 +422,8 @@ LONG __stdcall Vex_handler(_EXCEPTION_POINTERS *ExceptionInfo)
         return EXCEPTION_CONTINUE_EXECUTION; // Thrown by OutputDebugStringA, intended for debugger
     } else if (exception_code == 0xe24c4a02) {
         return EXCEPTION_EXECUTE_HANDLER; // Thrown by luaJIT for some reason
+    } else if (exception_code == 0x406d1388) {
+        return EXCEPTION_CONTINUE_SEARCH;
     }
     LbJustLog("Exception 0x%08lx thrown: %s\n", exception_code, exception_name(exception_code));
     return EXCEPTION_CONTINUE_SEARCH;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,6 +77,7 @@
 #include "player_utils.h"
 #include "config_players.h"
 #include "player_computer.h"
+#include "timer.h"
 #include "game_heap.h"
 #include "game_saves.h"
 #include "engine_render.h"
@@ -493,6 +494,8 @@ short setup_game(void)
 
   if (result == 1)
   {
+      if (flag_is_set(start_params.operation_flags, GOF_SingleLevel) && !(game_flags2 & (GF2_Connect | GF2_Server)))
+          level_load_time_phase(LevelLoadTime_EngineStartup);
       display_loading_screen();
   }
   LbDataFreeAll(legal_load_files);

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -59,6 +59,7 @@
 #include "sounds.h"
 #include "api.h"
 #include "net_resync.h"
+#include "timer.h"
 
 #ifdef FUNCTESTING
   #include "ftests/ftest.h"
@@ -181,8 +182,11 @@ static TbBool init_level(void)
     // sounds are added to the already-restored bank (not wiped afterwards).
     sound_restore_to_campaign_snapshot();
     // Load configs which may have per-campaign part, and can even be modified within a level
+    level_load_time_phase(LevelLoadTime_Sprites);
     init_custom_sprites(get_selected_level_number());
+    level_load_time_phase(LevelLoadTime_Configs);
     load_stats_files();
+    level_load_time_phase(LevelLoadTime_GameSetup);
     check_and_auto_fix_stats();
 
     // We should do this after 'load stats'
@@ -205,17 +209,21 @@ static TbBool init_level(void)
     
     // Load the actual level files
     int level = get_selected_level_number();
+    level_load_time_phase(LevelLoadTime_Data);
     TbBool script_preloaded = preload_script(level);
     if (!load_map_file(level)) {
         create_frontend_error_box(15000, "Map content is missing or incompatible.");
         JUSTMSG("Unable to load level %d from %s", level, campaign.name);
         return false;
     }
+    level_load_time_phase(LevelLoadTime_GameSetup);
     if (!script_preloaded && !luascript_loaded) {
         show_onscreen_msg(200,"%s: No Script %d", get_string(GUIStr_Error), level);
         JUSTMSG("Unable to load script level %d from %s", level, campaign.name);
     }
+    level_load_time_phase(LevelLoadTime_Navigation);
     init_navigation();
+    level_load_time_phase(LevelLoadTime_GameSetup);
     snprintf(game.campaign_fname, sizeof(game.campaign_fname), "%s", campaign.fname);
     light_set_lights_on(1);
     {
@@ -441,6 +449,7 @@ void faststartup_network_game(CoroutineLoop *context)
 
 CoroutineLoopState set_not_has_quit(CoroutineLoop *context)
 {
+    level_load_time_phase(LevelLoadTime_Total);
     get_my_player()->display_flags &= ~PlaF6_PlyrHasQuit;
     return CLS_CONTINUE;
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 
 #include "bflib_datetm.h"
+#include "globals.h"
 
 #include "post_inc.h"
 
@@ -32,7 +33,36 @@ struct TimerTime Timer;
 TbBool TimerGame = false;
 TbBool TimerNoReset = false;
 TbBool TimerFreeze = false;
+static TbClockMSec level_load_times[LevelLoadTime_Count];
+static TbClockMSec level_load_total_start;
+static TbClockMSec level_load_phase_start;
+static enum LevelLoadTimeKind level_load_phase;
+static TbBool level_load_time_active;
 /******************************************************************************/
+
+void level_load_time_phase(enum LevelLoadTimeKind kind)
+{
+    TbClockMSec now = LbTimerClock();
+    if (kind == LevelLoadTime_EngineStartup && !level_load_time_active) {
+        memset(level_load_times, 0, sizeof(level_load_times));
+        level_load_total_start = now;
+        level_load_phase_start = now;
+        level_load_phase = LevelLoadTime_EngineStartup;
+        level_load_time_active = true;
+        return;
+    }
+    if (!level_load_time_active)
+        return;
+    level_load_times[level_load_phase] += now - level_load_phase_start;
+    if (kind == LevelLoadTime_Total) {
+        level_load_times[LevelLoadTime_Total] = now - level_load_total_start;
+        JUSTLOG("Level load timing: Engine startup: %d ms, Custom sprites: %d ms, Config files: %d ms, Level data: %d ms, Navigation: %d ms, Game setup: %d ms, Total: %d ms", level_load_times[LevelLoadTime_EngineStartup], level_load_times[LevelLoadTime_Sprites], level_load_times[LevelLoadTime_Configs], level_load_times[LevelLoadTime_Data], level_load_times[LevelLoadTime_Navigation], level_load_times[LevelLoadTime_GameSetup], level_load_times[LevelLoadTime_Total]);
+        level_load_time_active = false;
+        return;
+    }
+    level_load_phase = kind;
+    level_load_phase_start = now;
+}
 
 void update_time(void)
 {

--- a/src/timer.h
+++ b/src/timer.h
@@ -27,6 +27,17 @@ extern "C" {
 
 void update_time(void);
 extern TbClockMSec timerstarttime;
+enum LevelLoadTimeKind {
+    LevelLoadTime_Total,
+    LevelLoadTime_Sprites,
+    LevelLoadTime_Configs,
+    LevelLoadTime_Data,
+    LevelLoadTime_Navigation,
+    LevelLoadTime_GameSetup,
+    LevelLoadTime_EngineStartup,
+    LevelLoadTime_Count,
+};
+void level_load_time_phase(enum LevelLoadTimeKind kind);
 struct TimerTime {
         unsigned char Hours;
         unsigned char Minutes;


### PR DESCRIPTION
Useful as a point of comparison for future improvements and regressions.

It looks like this in the log:

`[0] level_load_time_phase: Level load timing: Engine startup: 227 ms, Custom sprites: 455 ms, Config files: 126 ms, Level data: 60 ms, Navigation: 5 ms, Game setup: 13 ms, Total: 886 ms`

And a heavy example:

`[0] level_load_time_phase: Level load timing: Engine startup: 993 ms, Custom sprites: 2718 ms, Config files: 169 ms, Level data: 75 ms, Navigation: 35 ms, Game setup: 82 ms, Total: 4072 ms`

I've also fixed this harmless error: `Exception 0x406d1388 thrown: Unknown`