### PR TITLE
separate some fields from `PlayerInfo` to `UserState`.

### DIFF
--- a/src/console_cmd.c
+++ b/src/console_cmd.c
@@ -132,6 +132,16 @@ void do_param1_completion_for_name_command(PlayerNumber plyr_idx, char *args_str
 extern void render_set_sprite_debug(int level);
 extern TbBool process_user_global_packet_action(NetUserId user);
 
+// player's user, or if that's invalid then the local user
+static NetUserId console_cmd_user(PlayerNumber plyr_idx)
+{
+    NetUserId user = get_player(plyr_idx)->user_id;
+    if (user < 0) {
+        user = get_local_user();
+    }
+    return user;
+}
+
 static struct GuiBoxOption cmd_comp_procs_data[COMPUTER_PROCESSES_COUNT + 3] = {
   {"!", 1, NULL, NULL, 0, 0, 0, 0, 0, 0, 0, 0 }
 };
@@ -826,7 +836,7 @@ TbBool cmd_reveal(PlayerNumber plyr_idx, char * args)
     }
     if (r > 0) {
         int radius_offset = r / 2;
-        struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+        struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
         MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
         MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
         clear_dig_for_map_rect(player->id_number,
@@ -857,7 +867,7 @@ TbBool cmd_conceal(PlayerNumber plyr_idx, char * args)
     }
     if (r > 0) {
         int radius_offset = r / 2;
-        struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+        struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
         MapSubtlCoord stl_x = coord_subtile((pckt->pos_x));
         MapSubtlCoord stl_y = coord_subtile((pckt->pos_y));
         conceal_map_area(player->id_number, stl_x - radius_offset, stl_x + r - radius_offset, stl_y - radius_offset, stl_y + r - radius_offset, false);
@@ -1046,7 +1056,7 @@ TbBool cmd_create_gold(PlayerNumber plyr_idx, char * args)
             targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "parameter 1 requires a number");
         return false;
     }
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     struct Thing * thing = create_gold_pot_at(pckt->pos_x, pckt->pos_y, plyr_idx);
     if (thing_is_invalid(thing)) {
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "coordinate thing is invalid");
@@ -1087,13 +1097,13 @@ TbBool cmd_look(PlayerNumber plyr_idx, char * args)
     long room_id = get_id(room_desc, pr1str);
     if (room_id != -1) {
         go_to_my_next_room_of_type(room_id);
-        process_user_global_packet_action(get_player(plyr_idx)->user_id); // Dirty hack
+        process_user_global_packet_action(console_cmd_user(plyr_idx)); // Dirty hack
         return true;
     }
     long crmodel = get_id(creature_desc, pr1str);
     if(crmodel != -1) {
         go_to_next_creature_of_model_and_gui_job(crmodel, CrGUIJob_Any, TPF_OrderedPick);
-        process_user_global_packet_action(get_player(plyr_idx)->user_id); // Dirty hack
+        process_user_global_packet_action(console_cmd_user(plyr_idx)); // Dirty hack
         return true;
     }
     TbMapLocation loc = {0};
@@ -1101,15 +1111,14 @@ TbBool cmd_look(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "failed to get map location");
         return false;
     }
-    struct PlayerInfo * player = get_player(plyr_idx);
     MapSubtlCoord stl_x, stl_y;
     find_map_location_coords(loc, &stl_x, &stl_y, plyr_idx, __func__);
     if (stl_x == 0 && stl_y == 0) {
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "subtile coord is invalid");
         return false;
     }
-    set_players_packet_action(player, PckA_ZoomToPosition, subtile_coord_center(stl_x), subtile_coord_center(stl_y), 0, 0);
-    process_user_global_packet_action(get_player(plyr_idx)->user_id); // Dirty hack
+    set_packet_action(get_packet(console_cmd_user(plyr_idx)), PckA_ZoomToPosition, subtile_coord_center(stl_x), subtile_coord_center(stl_y), 0, 0);
+    process_user_global_packet_action(console_cmd_user(plyr_idx)); // Dirty hack
     return true;
 }
 
@@ -1124,7 +1133,7 @@ TbBool cmd_create_object(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require parameter 1 as object model");
         return false;
     }
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     struct Coord3d pos = {0};
     pos.x.stl.num = coord_subtile(pckt->pos_x);
     pos.y.stl.num = coord_subtile(pckt->pos_y);
@@ -1206,7 +1215,7 @@ TbBool cmd_create_creature(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "creature model [%d] exceeds (%d, %d)", crmodel, 0, game.conf.crtr_conf.model_count);
         return false;
     }
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
     if (subtile_coords_invalid(stl_x, stl_y)) {
@@ -1298,7 +1307,7 @@ TbBool cmd_create_thing(PlayerNumber plyr_idx, char * args)
             targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "model is invalid");
         return false;
     }
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     struct Coord3d pos = {0};
     pos.x.stl.num = coord_subtile(pckt->pos_x);
     pos.y.stl.num = coord_subtile(pckt->pos_y);
@@ -1546,7 +1555,7 @@ TbBool cmd_place_slab(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require parameter 1 as slbkind");
         return false;
     }
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
     MapSlabCoord slb_x = subtile_slab(stl_x);
@@ -1898,7 +1907,7 @@ TbBool cmd_mapwho_info(PlayerNumber plyr_idx, char * args)
     char * pr1str = strsep_param_with_space(&args);
     struct Coord3d pos = {0};
     if (pr1str == NULL) {
-        struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+        struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
         pos.x.val = pckt->pos_x;
         pos.y.val = pckt->pos_y;
     } else {
@@ -2006,7 +2015,7 @@ TbBool cmd_cursor_pos(PlayerNumber plyr_idx, char * args)
         targeted_message_add(MsgType_Player, plyr_idx, plyr_idx, GUI_MESSAGES_DELAY, "require 'cheat mode'");
         return false;
     }
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     struct Coord3d pos = {0};
     pos.x.val = pckt->pos_x;
     pos.y.val = pckt->pos_y;
@@ -2024,7 +2033,7 @@ TbBool cmd_get_thing(PlayerNumber plyr_idx, char * args)
         return false;
     }
     char * pr1str = strsep_param_with_space(&args);
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     MapSubtlCoord stl_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord stl_y = coord_subtile(pckt->pos_y);
     struct Thing * thing = (pr1str != NULL) ? thing_get(atoi(pr1str)) : get_nearest_thing_at_position(stl_x, stl_y);
@@ -2101,7 +2110,7 @@ TbBool cmd_move_thing(PlayerNumber plyr_idx, char * args)
             pos.z.val = get_floor_height_at(&pos);
         }
     } else {
-        struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+        struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
         pos.x.val = pckt->pos_x;
         pos.y.val = pckt->pos_y;
         pos.z.val = get_floor_height_at(&pos);
@@ -2134,7 +2143,7 @@ TbBool cmd_get_room(PlayerNumber plyr_idx, char * args)
         return false;
     }
     char * pr1str = strsep_param_with_space(&args);
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     MapSubtlCoord stl_x = coord_subtile((pckt->pos_x));
     MapSubtlCoord stl_y = coord_subtile((pckt->pos_y));
     struct Room * room = (pr1str != NULL) ? room_get(atoi(pr1str)) : subtile_room_get(stl_x, stl_y);
@@ -2175,7 +2184,7 @@ TbBool cmd_slab_health(PlayerNumber plyr_idx, char * args)
         return false;
     }
     char * pr1str = strsep_param_with_space(&args);
-    struct Packet * pckt = get_packet(get_player(plyr_idx)->user_id);
+    struct Packet * pckt = get_packet(console_cmd_user(plyr_idx));
     MapSubtlCoord stl_x = coord_subtile((pckt->pos_x));
     MapSubtlCoord stl_y = coord_subtile((pckt->pos_y));
     struct SlabMap * slb = get_slabmap_for_subtile(stl_x, stl_y);

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -732,7 +732,8 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
     struct Thing *thing;
     struct Dungeon* dungeon = get_dungeon(player->id_number);
     struct PlayerStateConfigStats* plrst_cfg_stat = get_player_state_stats(player->work_state);
-    if (dungeon_invalid(dungeon))
+    struct UserState* uinfo = get_user_state(get_local_user());
+    if (dungeon_invalid(dungeon) || (uinfo == NULL))
     {
         set_pointer_graphic(MousePG_Invisible);
         return;
@@ -808,7 +809,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
             thing = thing_get(thing_under_hand);
             TRACE_THING(thing);
             TbBool can_cast = false;
-            if ((player->input_crtr_control) && (thing_exists(thing)) && (dungeon->things_in_hand[0] != thing_under_hand))
+            if ((uinfo->input_crtr_control) && (thing_exists(thing)) && (dungeon->things_in_hand[0] != thing_under_hand))
             {
                 PowerKind pwkind = PwrK_POSSESS;
                 if (can_cast_spell(player->id_number, pwkind, thing->mappos.x.stl.num, thing->mappos.y.stl.num, thing, CastChk_Default))
@@ -839,7 +840,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
 
                 player->display_flags |= PlaF6_DisplayNeedsUpdate;
             } else
-            if (((player->input_crtr_query) && !thing_is_invalid(thing)) && (dungeon->things_in_hand[0] != thing_under_hand)
+            if (((uinfo->input_crtr_query) && !thing_is_invalid(thing)) && (dungeon->things_in_hand[0] != thing_under_hand)
                 && can_thing_be_queried(thing, player->id_number))
             {
                 set_pointer_graphic(MousePG_Query);

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -224,36 +224,36 @@ void setup_engine_window(long x, long y, long width, long height)
       height = MyScreenHeight-y;
     if (height < 0)
       height = 0;
-    local_info.engine_window_x = x;
-    local_info.engine_window_y = y;
-    local_info.engine_window_width = width;
-    local_info.engine_window_height = height;
+    local_state.engine_window_x = x;
+    local_state.engine_window_y = y;
+    local_state.engine_window_width = width;
+    local_state.engine_window_height = height;
 }
 
 void store_engine_window(TbGraphicsWindow *ewnd,int divider)
 {
     if (divider <= 1)
     {
-        ewnd->x = local_info.engine_window_x;
-        ewnd->y = local_info.engine_window_y;
-        ewnd->width = local_info.engine_window_width;
-        ewnd->height = local_info.engine_window_height;
+        ewnd->x = local_state.engine_window_x;
+        ewnd->y = local_state.engine_window_y;
+        ewnd->width = local_state.engine_window_width;
+        ewnd->height = local_state.engine_window_height;
     } else
     {
-        ewnd->x = local_info.engine_window_x/divider;
-        ewnd->y = local_info.engine_window_y/divider;
-        ewnd->width = local_info.engine_window_width/divider;
-        ewnd->height = local_info.engine_window_height/divider;
+        ewnd->x = local_state.engine_window_x/divider;
+        ewnd->y = local_state.engine_window_y/divider;
+        ewnd->width = local_state.engine_window_width/divider;
+        ewnd->height = local_state.engine_window_height/divider;
     }
     ewnd->ptr = NULL;
 }
 
 void load_engine_window(TbGraphicsWindow *ewnd)
 {
-    local_info.engine_window_x = ewnd->x;
-    local_info.engine_window_y = ewnd->y;
-    local_info.engine_window_width = ewnd->width;
-    local_info.engine_window_height = ewnd->height;
+    local_state.engine_window_x = ewnd->x;
+    local_state.engine_window_y = ewnd->y;
+    local_state.engine_window_width = ewnd->width;
+    local_state.engine_window_height = ewnd->height;
 }
 
 void map_fade(unsigned char *outbuf, unsigned char *srcbuf1, unsigned char *srcbuf2, unsigned char *fade_tbl, unsigned char *ghost_tbl, long a6, long const xmax, long const ymax, long a9)
@@ -568,7 +568,7 @@ void redraw_creature_view(void)
     }
     draw_gui();
     if ((game.operation_flags & GOF_ShowGui) != 0) {
-        draw_overlay_compass(local_info.minimap_pos_x, local_info.minimap_pos_y);
+        draw_overlay_compass(local_state.minimap_pos_x, local_state.minimap_pos_y);
     }
     message_draw();
     gui_draw_all_boxes();
@@ -631,7 +631,7 @@ void redraw_isometric_view(void)
     }
     draw_gui();
     if ((game.operation_flags & GOF_ShowGui) != 0) {
-        draw_overlay_compass(local_info.minimap_pos_x, local_info.minimap_pos_y);
+        draw_overlay_compass(local_state.minimap_pos_x, local_state.minimap_pos_y);
     }
     message_draw();
     gui_draw_all_boxes();
@@ -653,7 +653,7 @@ void redraw_frontview(void)
     }
     draw_gui();
     if (flag_is_set(game.operation_flags,GOF_ShowGui)) {
-        draw_overlay_compass(local_info.minimap_pos_x, local_info.minimap_pos_y);
+        draw_overlay_compass(local_state.minimap_pos_x, local_state.minimap_pos_y);
     }
     message_draw();
     draw_power_hand();
@@ -745,7 +745,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
         return;
     }
     // Mouse over panel map
-    if (((game.operation_flags & GOF_ShowGui) != 0) && mouse_is_over_panel_map(local_info.minimap_pos_x, local_info.minimap_pos_y))
+    if (((game.operation_flags & GOF_ShowGui) != 0) && mouse_is_over_panel_map(local_state.minimap_pos_x, local_state.minimap_pos_y))
     {
         if (game.small_map_state == 2) {
             set_pointer_graphic(MousePG_Invisible);
@@ -978,11 +978,11 @@ void redraw_display(void)
         break;
     case PVM_ParchFadeIn:
         parchment_loaded = 0;
-        local_info.palette_fade_step_map = map_fade_in(local_info.palette_fade_step_map);
+        local_state.palette_fade_step_map = map_fade_in(local_state.palette_fade_step_map);
         break;
     case PVM_ParchFadeOut:
         parchment_loaded = 0;
-        local_info.palette_fade_step_map = map_fade_out(local_info.palette_fade_step_map);
+        local_state.palette_fade_step_map = map_fade_out(local_state.palette_fade_step_map);
         break;
     default:
         ERRORLOG("Unsupported drawing state, %d",(int)player->view_mode);
@@ -1071,7 +1071,7 @@ void redraw_display(void)
               player->view_mode == PVM_IsoStraightView ||
               player->view_mode == PVM_CreatureView
           ) {
-              pos_x = local_info.engine_window_x + (MyScreenWidth - w - local_info.engine_window_x) / 2;
+              pos_x = local_state.engine_window_x + (MyScreenWidth - w - local_state.engine_window_x) / 2;
           } else {
               pos_x = (MyScreenWidth-w)/2;
           }
@@ -1141,8 +1141,8 @@ TbBool keeper_screen_redraw(void)
     RendererClearScreen(144);
     if (RendererLockFramebuffer() == Lb_SUCCESS)
     {
-        setup_engine_window(local_info.engine_window_x, local_info.engine_window_y,
-            local_info.engine_window_width, local_info.engine_window_height);
+        setup_engine_window(local_state.engine_window_x, local_state.engine_window_y,
+            local_state.engine_window_width, local_state.engine_window_height);
         redraw_display();
         RendererUnlockFramebuffer();
         return true;

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -732,8 +732,8 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
     struct Thing *thing;
     struct Dungeon* dungeon = get_dungeon(player->id_number);
     struct PlayerStateConfigStats* plrst_cfg_stat = get_player_state_stats(player->work_state);
-    struct UserState* uinfo = get_user_state(get_local_user());
-    if (dungeon_invalid(dungeon) || (uinfo == NULL))
+    struct UserState* ustate = get_user_state(player->user_id);
+    if (dungeon_invalid(dungeon))
     {
         set_pointer_graphic(MousePG_Invisible);
         return;
@@ -809,7 +809,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
             thing = thing_get(thing_under_hand);
             TRACE_THING(thing);
             TbBool can_cast = false;
-            if ((uinfo->input_crtr_control) && (thing_exists(thing)) && (dungeon->things_in_hand[0] != thing_under_hand))
+            if ((ustate->input_crtr_control) && (thing_exists(thing)) && (dungeon->things_in_hand[0] != thing_under_hand))
             {
                 PowerKind pwkind = PwrK_POSSESS;
                 if (can_cast_spell(player->id_number, pwkind, thing->mappos.x.stl.num, thing->mappos.y.stl.num, thing, CastChk_Default))
@@ -840,7 +840,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
 
                 player->display_flags |= PlaF6_DisplayNeedsUpdate;
             } else
-            if (((uinfo->input_crtr_query) && !thing_is_invalid(thing)) && (dungeon->things_in_hand[0] != thing_under_hand)
+            if (((ustate->input_crtr_query) && !thing_is_invalid(thing)) && (dungeon->things_in_hand[0] != thing_under_hand)
                 && can_thing_be_queried(thing, player->id_number))
             {
                 set_pointer_graphic(MousePG_Query);

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -664,13 +664,13 @@ static long compute_cells_away(void) // For overhead view, not for 1st person vi
     int32_t xcell;
     int32_t ycell;
     long ncells_a;
-    half_width = (local_info.engine_window_width >> 1);
-    half_height = (local_info.engine_window_height >> 1);
-    xcell = ((half_width<<1) + (half_width>>4))/pixel_size - local_info.engine_window_x/pixel_size;
-    ycell = ((8 * high_offset[1]) >> 8) - (half_width>>4)/pixel_size - local_info.engine_window_y/pixel_size;
+    half_width = (local_state.engine_window_width >> 1);
+    half_height = (local_state.engine_window_height >> 1);
+    xcell = ((half_width<<1) + (half_width>>4))/pixel_size - local_state.engine_window_x/pixel_size;
+    ycell = ((8 * high_offset[1]) >> 8) - (half_width>>4)/pixel_size - local_state.engine_window_y/pixel_size;
     get_floor_pointed_at(xcell, ycell, &xmax, &ymax);
-    xcell = (half_width)/pixel_size - local_info.engine_window_x/pixel_size;
-    ycell = (half_height)/pixel_size - local_info.engine_window_y/pixel_size;
+    xcell = (half_width)/pixel_size - local_state.engine_window_x/pixel_size;
+    ycell = (half_height)/pixel_size - local_state.engine_window_y/pixel_size;
     get_floor_pointed_at(xcell, ycell, &xmin, &ymin);
     xcell = abs(ymax - ymin);
     ycell = abs(xmax - xmin);
@@ -1752,8 +1752,8 @@ static void do_perspective_rotation(long x, long y, long z)
     long engine_w;
     long engine_h;
     zoom = camera_zoom / pixel_size;
-    engine_w = local_info.engine_window_width/pixel_size;
-    engine_h = local_info.engine_window_height/pixel_size;
+    engine_w = local_state.engine_window_width/pixel_size;
+    engine_h = local_state.engine_window_height/pixel_size;
     epos.x = -x;
     epos.y = 0;
     epos.z = y;
@@ -2466,8 +2466,8 @@ static void fiddle_gamut(long pos_x, long pos_y)
     case PVM_IsoWibbleView:
     case PVM_IsoStraightView:
         // Retrieve coordinates on limiting map points
-        ewwidth = local_info.engine_window_width / pixel_size;
-        ewheight = local_info.engine_window_height / pixel_size - ((8 * high_offset[1]) >> 8);
+        ewwidth = local_state.engine_window_width / pixel_size;
+        ewheight = local_state.engine_window_height / pixel_size - ((8 * high_offset[1]) >> 8);
         ewzoom = (768 * (camera_zoom/pixel_size)) >> 17;
         fiddle_gamut_find_limits(floor_x, floor_y, ewwidth, ewheight, ewzoom);
         // Place the area at proper base coords
@@ -5781,8 +5781,8 @@ static void draw_stripey_line(long x1,long y1,long x2,long y2,unsigned char line
     unsigned char color_index = get_gameturn() & 0xf;
 
     // get engine window width and height
-    long relative_window_width = ((local_info.engine_window_width * 256) / (pixel_size * 256)) - 1;
-    long relative_window_height = ((local_info.engine_window_height * 256) / (pixel_size * 256)) - 1;
+    long relative_window_width = ((local_state.engine_window_width * 256) / (pixel_size * 256)) - 1;
+    long relative_window_height = ((local_state.engine_window_height * 256) / (pixel_size * 256)) - 1;
 
     // Bresenham’s Line Drawing Algorithm - handles all octants
     // A and B are relative, and are set to be either X (shallow curves) or Y (steep curves).
@@ -5992,9 +5992,9 @@ static void draw_clipped_line(long x1, long y1, long x2, long y2, TbPixel color)
     {
       if ((y1 >= 0) || (y2 >= 0))
       {
-        if ((x1 < local_info.engine_window_width) || (x2 < local_info.engine_window_width))
+        if ((x1 < local_state.engine_window_width) || (x2 < local_state.engine_window_width))
         {
-          if ((y1 < local_info.engine_window_height) || (y2 < local_info.engine_window_height))
+          if ((y1 < local_state.engine_window_height) || (y2 < local_state.engine_window_height))
           {
             draw_stripey_line(x1, y1, x2, y2, color);
           }
@@ -7311,8 +7311,8 @@ static TbBool project_point_helper(struct PlayerInfo *player, int zoom, MapCoord
 {
     int vertical_shift;
     int64_t new_zoom;
-    short window_width = local_info.engine_window_width;
-    short window_height = local_info.engine_window_height;
+    short window_width = local_state.engine_window_width;
+    short window_height = local_state.engine_window_height;
 
     *x_out = (zoom * horizontal_delta >> 16) + (*(uint16_t *)&window_width / 2);
     vertical_shift = zoom * vertical_delta >> 8;
@@ -7602,7 +7602,7 @@ static void draw_element(struct Map *map, long lightness, long stl_x, long stl_y
     myplyr = get_my_player();
     cube_itm = (qdrant + 2) & 3;
     delta_y = (zoom << 7) / 256;
-    bckt_idx = local_info.engine_window_height - (pos_y >> 8) + FRONTVIEW_BUCKET_MARGIN;
+    bckt_idx = local_state.engine_window_height - (pos_y >> 8) + FRONTVIEW_BUCKET_MARGIN;
     // Check if there's enough place to draw
     if (!is_free_space_in_poly_pool(8))
       return;
@@ -9281,8 +9281,8 @@ void draw_frontview_engine(struct Camera *cam)
     cam->zoom = camera_zoom;//TODO [zoom] remove when all cam->zoom will be changed to camera_zoom
     cam_x = cam->mappos.x.val;
     cam_y = cam->mappos.y.val;
-    pointer_x = (GetMouseX() - local_info.engine_window_x) / pixel_size;
-    pointer_y = (GetMouseY() - local_info.engine_window_y) / pixel_size;
+    pointer_x = (GetMouseX() - local_state.engine_window_x) / pixel_size;
+    pointer_y = (GetMouseY() - local_state.engine_window_y) / pixel_size;
     LbScreenStoreGraphicsWindow(&grwnd);
     store_engine_window(&ewnd,pixel_size);
     LbScreenSetGraphicsWindow(ewnd.x, ewnd.y, ewnd.width, ewnd.height);

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -977,10 +977,10 @@ static TbBool get_level_lost_inputs(void)
               }
               long mmzoom;
               if (16/mm_units_per_px < 3)
-                  mmzoom = (local_info.minimap_zoom) / (3-16/mm_units_per_px);
+                  mmzoom = (local_state.minimap_zoom) / (3-16/mm_units_per_px);
               else
-                  mmzoom = (local_info.minimap_zoom);
-              inp_done = get_small_map_inputs(local_info.minimap_pos_x*mm_units_per_px/16, local_info.minimap_pos_y*mm_units_per_px/16, mmzoom);
+                  mmzoom = (local_state.minimap_zoom);
+              inp_done = get_small_map_inputs(local_state.minimap_pos_x*mm_units_per_px/16, local_state.minimap_pos_y*mm_units_per_px/16, mmzoom);
               if ( !inp_done )
                 get_bookmark_inputs();
               get_dungeon_control_nonaction_inputs();
@@ -1357,11 +1357,11 @@ static TbBool get_dungeon_control_action_inputs(void)
     long mmzoom;
     if (16 / mm_units_per_px < 3)
     {
-        mmzoom = (local_info.minimap_zoom) / scale_value_for_resolution_with_upp(2, mm_units_per_px);
+        mmzoom = (local_state.minimap_zoom) / scale_value_for_resolution_with_upp(2, mm_units_per_px);
     }
     else
-        mmzoom = (local_info.minimap_zoom);
-    if (get_small_map_inputs(local_info.minimap_pos_x * mm_units_per_px / 16, local_info.minimap_pos_y * mm_units_per_px / 16, mmzoom))
+        mmzoom = (local_state.minimap_zoom);
+    if (get_small_map_inputs(local_state.minimap_pos_x * mm_units_per_px / 16, local_state.minimap_pos_y * mm_units_per_px / 16, mmzoom))
         return 1;
 
     if (player->work_state == PSt_CtrlDungeon)
@@ -2408,8 +2408,8 @@ static TbBool get_player_coords_and_context(struct Coord3d *pos, unsigned char *
   struct PlayerInfo* player = get_my_player();
   TbBool hand_is_empty = power_hand_is_empty(player);
   if ((pointer_x < 0) || (pointer_y < 0)
-   || (pointer_x >= local_info.engine_window_width/pixel_size)
-   || (pointer_y >= local_info.engine_window_height/pixel_size))
+   || (pointer_x >= local_state.engine_window_width/pixel_size)
+   || (pointer_y >= local_state.engine_window_height/pixel_size))
       return false;
   if (top_pointed_at_x <= game.map_subtiles_x)
     x = top_pointed_at_x;
@@ -2972,7 +2972,7 @@ static short get_inputs(void)
         {
           if (!network_is_active())
             game.operation_flags &= ~GOF_Paused;
-          local_info.status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible) [duplicate? unneeded?]
+          local_state.status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible) [duplicate? unneeded?]
           set_players_packet_action(player, PckA_SetViewType, PVT_MapScreen, 0,0,0);
         }
         return false;
@@ -3062,7 +3062,7 @@ short get_gui_inputs(short gameplay_on)
       if ((gbtn->btype_value & LbBFeF_NoMouseOver) != 0)
           continue;
       // TODO GUI Introduce circular buttons instead of specific condition for pannel map
-      if ((menu_id_to_number(GMnu_MAIN) >= 0) && mouse_is_over_panel_map(local_info.minimap_pos_x,local_info.minimap_pos_y))
+      if ((menu_id_to_number(GMnu_MAIN) >= 0) && mouse_is_over_panel_map(local_state.minimap_pos_x,local_state.minimap_pos_y))
           continue;
       if ( (check_if_mouse_is_over_button(gbtn) && !game_is_busy_doing_gui_string_input())
         || ((gbtn->gbtype == LbBtnT_Hotspot) && (gbtn->button_state_left_pressed != 0)) )

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2030,7 +2030,7 @@ long compute_menu_position_x(long desired_pos,int menu_width, int units_per_px)
       pos = GetMouseX() - (scaled_width >> 1);
       break;
   case POS_GAMECTR: // Player-based positioning
-      pos = (local_info.engine_window_x) + (local_info.engine_window_width >> 1) - (scaled_width >> 1);
+      pos = (local_state.engine_window_x) + (local_state.engine_window_width >> 1) - (scaled_width >> 1);
       break;
   case POS_MOUSPRV: // Place menu centered over previous mouse position
       pos = old_menu_mouse_x - (scaled_width >> 1);
@@ -2056,8 +2056,8 @@ long compute_menu_position_x(long desired_pos,int menu_width, int units_per_px)
   {
     if (pos+scaled_width > MyScreenWidth)
       pos = MyScreenWidth-scaled_width;
-    if (pos < local_info.engine_window_x)
-      pos = local_info.engine_window_x;
+    if (pos < local_state.engine_window_x)
+      pos = local_state.engine_window_x;
   } else
   {
     if (pos+scaled_width > MyScreenWidth)
@@ -2079,7 +2079,7 @@ long compute_menu_position_y(long desired_pos,int menu_height, int units_per_px)
         pos = GetMouseY() - (scaled_height >> 1);
         break;
     case POS_GAMECTR: // Player-based positioning
-        pos = (local_info.engine_window_height >> 1) - ((scaled_height+20*units_per_px/16) >> 1);
+        pos = (local_state.engine_window_height >> 1) - ((scaled_height+20*units_per_px/16) >> 1);
         break;
     case POS_MOUSPRV: // Place menu centered over previous mouse position
         pos = old_menu_mouse_y - (scaled_height >> 1);

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -190,18 +190,18 @@ short get_pixels_scaled_and_zoomed(long basic_zoom)
 
 void gui_zoom_in(struct GuiButton *gbtn)
 {
-    if (local_info.minimap_zoom > 128) {
-        local_info.minimap_zoom >>= 1;
-        settings.minimap_zoom = local_info.minimap_zoom;
+    if (local_state.minimap_zoom > 128) {
+        local_state.minimap_zoom >>= 1;
+        settings.minimap_zoom = local_state.minimap_zoom;
         save_settings();
     }
 }
 
 void gui_zoom_out(struct GuiButton *gbtn)
 {
-    if (local_info.minimap_zoom < 2048) {
-        local_info.minimap_zoom <<= 1;
-        settings.minimap_zoom = local_info.minimap_zoom;
+    if (local_state.minimap_zoom < 2048) {
+        local_state.minimap_zoom <<= 1;
+        settings.minimap_zoom = local_state.minimap_zoom;
         save_settings();
     }
 }
@@ -2657,11 +2657,11 @@ void draw_whole_status_panel(void)
     // Draws gold amount; note that button_sprite[] is used instead of full font
     draw_gold_total(player->id_number, gmnu->pos_x + gmnu->width/2, gmnu->pos_y + gmnu->height*67/200, fs_units_per_px, dungeon->total_money_owned);
     if (16/mm_units_per_px < 3)
-        mmzoom = (local_info.minimap_zoom) / scale_value_for_resolution_with_upp(2,mm_units_per_px);
+        mmzoom = (local_state.minimap_zoom) / scale_value_for_resolution_with_upp(2,mm_units_per_px);
     else
-        mmzoom = local_info.minimap_zoom;
-    panel_map_draw_slabs(local_info.minimap_pos_x, local_info.minimap_pos_y, mm_units_per_px, mmzoom);
-    long basic_zoom = local_info.minimap_zoom;
+        mmzoom = local_state.minimap_zoom;
+    panel_map_draw_slabs(local_state.minimap_pos_x, local_state.minimap_pos_y, mm_units_per_px, mmzoom);
+    long basic_zoom = local_state.minimap_zoom;
     panel_map_draw_overlay_things(mm_units_per_px, mmzoom, basic_zoom);
     unsigned char placefill_threshold = (LbScreenHeight() >= 400) ? 80 : 40;
     if (LbScreenHeight() - gmnu->height >= placefill_threshold)

--- a/src/frontmenu_saves.c
+++ b/src/frontmenu_saves.c
@@ -138,7 +138,7 @@ void gui_save_game(struct GuiButton *gbtn)
           create_error_box(GUIStr_ErrorSaving);
       }
   }
-  set_players_packet_action(player, PckA_UpdatePause, local_info.paused_state_restore, 0, 0, 0);
+  set_players_packet_action(player, PckA_UpdatePause, local_state.paused_state_restore, 0, 0, 0);
 }
 
 void update_loadsave_input_strings(struct CatalogueEntry *game_catalg)
@@ -264,7 +264,7 @@ void init_save_menu(struct GuiMenu *gmnu)
 {
   SYNCDBG(6,"Starting");
   struct PlayerInfo* player = get_my_player();
-  local_info.paused_state_restore = flag_is_set(game.operation_flags, GOF_Paused);
+  local_state.paused_state_restore = flag_is_set(game.operation_flags, GOF_Paused);
   set_players_packet_action(player, PckA_UpdatePause, 1, 1, 0, 0);
   load_game_save_catalogue();
   gui_vscroll_offset = 0;

--- a/src/ftests/ftest_util.c
+++ b/src/ftests/ftest_util.c
@@ -310,8 +310,8 @@ void ftest_util_center_cursor_over_dungeon_view()
     }
 
     struct TbPoint point;
-    point.x = local_info.engine_window_width/2;
-    point.y = local_info.engine_window_height/2;
+    point.x = local_state.engine_window_width/2;
+    point.y = local_state.engine_window_height/2;
     if ((game.operation_flags & GOF_ShowGui) != 0)
     {
         point.x += status_panel_width;

--- a/src/game_legacy.h
+++ b/src/game_legacy.h
@@ -232,6 +232,7 @@ struct Game {
     char active_lens_type;
     unsigned char applied_lens_type;
     struct PlayerInfo players[PLAYERS_COUNT];
+    struct UserState user_states[MAX_NET_USERS];
     struct Column columns_data[COLUMNS_COUNT];
     unsigned short slabset_num;
     struct SlabSet slabset[SLABSET_COUNT];

--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -484,16 +484,16 @@ TbBool load_game(long slot_num)
     struct PlayerInfo* player = get_my_player();
     clear_flag(player->additional_flags, PlaAF_LightningPaletteIsActive);
     clear_flag(player->additional_flags, PlaAF_FreezePaletteIsActive);
-    local_info.palette_fade_step_pain = 0;
-    local_info.palette_fade_step_possession = 0;
-    local_info.lens_palette = 0;
-    local_info.minimap_pos_x = 11;
-    local_info.minimap_pos_y = 11;
-    local_info.minimap_zoom = settings.minimap_zoom;
+    local_state.palette_fade_step_pain = 0;
+    local_state.palette_fade_step_possession = 0;
+    local_state.lens_palette = 0;
+    local_state.minimap_pos_x = 11;
+    local_state.minimap_pos_y = 11;
+    local_state.minimap_zoom = settings.minimap_zoom;
     // Reinitialize lens first (restores lens_palette pointer from config)
     reinitialise_eye_lens(game.applied_lens_type);
     // Apply the appropriate palette (lens palette if active, otherwise engine default)
-    PaletteSetPlayerPalette(player, local_info.lens_palette ? local_info.lens_palette : engine_palette);
+    PaletteSetPlayerPalette(player, local_state.lens_palette ? local_state.lens_palette : engine_palette);
     init_local_cameras(player);
     // Update the lights system state
     light_import_system_state(&game.lightst);

--- a/src/gui_parchment.c
+++ b/src/gui_parchment.c
@@ -1085,27 +1085,27 @@ void draw_zoom_box(void)
 
     long draw_tiles = 13;
     long subtile_unscaled = 8;
-    if (local_info.minimap_zoom == 128)
+    if (local_state.minimap_zoom == 128)
     {
         draw_tiles = 6;
         subtile_unscaled = 18;
     } else
-    if (local_info.minimap_zoom == 256)
+    if (local_state.minimap_zoom == 256)
     {
         draw_tiles = 9;
         subtile_unscaled = 12;
     } else
-    if (local_info.minimap_zoom == 512)
+    if (local_state.minimap_zoom == 512)
     {
         draw_tiles = 12;
         subtile_unscaled = 9;
     } else
-    if (local_info.minimap_zoom == 1024)
+    if (local_state.minimap_zoom == 1024)
     {
         draw_tiles = 18;
         subtile_unscaled = 6;
     } else
-    if (local_info.minimap_zoom == 2048)
+    if (local_state.minimap_zoom == 2048)
     {
         draw_tiles = 36;
         subtile_unscaled = 3;

--- a/src/keeperfx.hpp
+++ b/src/keeperfx.hpp
@@ -228,7 +228,7 @@ short zoom_to_next_annoyed_creature(void);
 TbBool LbIsFrozenOrPaused(void); // from bflib_inputctrl.cpp
 
 void update_local_mouse_light(void);
-void update_mouse_light(struct PlayerInfo *player);
+void update_mouse_light(NetUserId user);
 void delete_all_structures(void);
 void clear_map(void);
 void clear_game(void);

--- a/src/kfx/lense/PaletteEffect.cpp
+++ b/src/kfx/lense/PaletteEffect.cpp
@@ -47,7 +47,7 @@ TbBool PaletteEffect::Setup(long lens_idx)
     struct PlayerInfo* player = get_my_player();
     
     // Set lens_palette first, then call PaletteSetPlayerPalette to apply it
-    local_info.lens_palette = cfg->palette;
+    local_state.lens_palette = cfg->palette;
     PaletteSetPlayerPalette(player, cfg->palette);
     
     m_current_lens = lens_idx;
@@ -59,7 +59,7 @@ void PaletteEffect::Cleanup()
 {
     if (m_current_lens >= 0) {
         struct PlayerInfo* player = get_my_player();
-        local_info.lens_palette = NULL;
+        local_state.lens_palette = NULL;
         PaletteSetPlayerPalette(player, engine_palette);
         m_current_lens = -1;
         SYNCDBG(9, "Palette effect cleaned up");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1417,11 +1417,12 @@ short complete_level(struct PlayerInfo *player)
     return true;
 }
 
-static void set_mouse_light(struct PlayerInfo *player, TbBool valid, struct Coord3d pos)
+static void set_mouse_light(NetUserId user, TbBool valid, struct Coord3d pos)
 {
-    const int idx = player->cursor_light_idx;
-    if (idx == 0)
+    struct UserState *ustate = get_user_state(user);
+    if ((ustate == NULL) || (ustate->cursor_light_idx == 0))
         return;
+    const int idx = ustate->cursor_light_idx;
 
     if (valid)
     {
@@ -1429,7 +1430,7 @@ static void set_mouse_light(struct PlayerInfo *player, TbBool valid, struct Coor
         light_turn_light_on(idx);
         light_set_light_position(idx, &pos);
 
-        if (is_my_player(player))
+        if (user == get_local_user())
             game.mouse_light_pos = pos;
     }
     else
@@ -1457,27 +1458,29 @@ void update_local_mouse_light(void)
     struct Coord3d pos;
     const TbBool valid = screen_to_map(cam, GetMouseX(), GetMouseY(), &pos);
 
-    set_mouse_light(player, valid, pos);
+    NetUserId user = get_local_user();
+    set_mouse_light(user, valid, pos);
 
-    if (player->cursor_light_idx != 0)
-        light_reset_interpolation(player->cursor_light_idx);
+    struct UserState *ustate = get_user_state(user);
+    if ((ustate != NULL) && (ustate->cursor_light_idx != 0))
+        light_reset_interpolation(ustate->cursor_light_idx);
 }
 
-void update_mouse_light(struct PlayerInfo *player)
+void update_mouse_light(NetUserId user)
 {
     SYNCDBG(6,"Starting");
     const struct Packet *pckt = nullptr;
 
-    if (is_my_player(player))
-        pckt = get_history_packet(player->user_id, get_gameturn());
+    if (user == get_local_user())
+        pckt = get_history_packet(user, get_gameturn());
     if (pckt == nullptr)
-        pckt = get_packet(player->user_id);
+        pckt = get_packet(user);
 
     const TbBool valid = (pckt->control_flags & PCtr_MapCoordsValid) != 0;
     struct Coord3d pos;
     pos.x.val = pckt->pos_x;
     pos.y.val = pckt->pos_y;
-    set_mouse_light(player, valid, pos);
+    set_mouse_light(user, valid, pos);
 }
 
 void update_block_pointed(int i,long x, long x_frac, long y, long y_frac)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1036,6 +1036,7 @@ void clear_players_for_save(void)
       memcpy(&cammem,&player->cameras[CamIV_FirstPerson],sizeof(struct Camera));
       memset(player, 0, sizeof(struct PlayerInfo));
       player->id_number = saved_player_id;
+      player->user_id = -1;
       player->is_active = saved_is_active;
       set_flag_value(player->allocflags, PlaF_Allocated, ((saved_allocation_flags & PlaF_Allocated) != 0));
       set_flag_value(player->allocflags, PlaF_CompCtrl, ((saved_allocation_flags & PlaF_CompCtrl) != 0));
@@ -1419,10 +1420,9 @@ short complete_level(struct PlayerInfo *player)
 
 static void set_mouse_light(NetUserId user, TbBool valid, struct Coord3d pos)
 {
-    struct UserState *ustate = get_user_state(user);
-    if ((ustate == NULL) || (ustate->cursor_light_idx == 0))
+    const int idx = get_user_state(user)->cursor_light_idx;
+    if (idx == 0)
         return;
-    const int idx = ustate->cursor_light_idx;
 
     if (valid)
     {
@@ -1461,9 +1461,9 @@ void update_local_mouse_light(void)
     NetUserId user = get_local_user();
     set_mouse_light(user, valid, pos);
 
-    struct UserState *ustate = get_user_state(user);
-    if ((ustate != NULL) && (ustate->cursor_light_idx != 0))
-        light_reset_interpolation(ustate->cursor_light_idx);
+    const int idx = get_user_state(user)->cursor_light_idx;
+    if (idx != 0)
+        light_reset_interpolation(idx);
 }
 
 void update_mouse_light(NetUserId user)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -576,8 +576,8 @@ TbBool engine_point_to_map(struct Camera *camera, long screen_x, long screen_y, 
     *map_x = 0;
     *map_y = 0;
     if ( (pointer_x >= 0) && (pointer_y >= 0)
-      && (pointer_x < (local_info.engine_window_width/pixel_size))
-      && (pointer_y < (local_info.engine_window_height/pixel_size)) )
+      && (pointer_x < (local_state.engine_window_width/pixel_size))
+      && (pointer_y < (local_state.engine_window_height/pixel_size)) )
     {
         if ( players_cursor_is_at_top_of_view() )
         {
@@ -907,8 +907,8 @@ void reinit_level_after_load(void)
     SYNCDBG(6,"Starting");
     // Reinit structures from within the game
     player = get_my_player();
-    local_info.lens_palette = 0;
-    local_info.main_palette = engine_palette;
+    local_state.lens_palette = 0;
+    local_state.main_palette = engine_palette;
     init_navigation();
     reinit_packets_after_load();
     game.easter_eggs_enabled = start_params.easter_egg;
@@ -1147,8 +1147,8 @@ void reset_creature_max_levels(void)
 
 void change_engine_window_relative_size(long w_delta, long h_delta)
 {
-    setup_engine_window(local_info.engine_window_x, local_info.engine_window_y,
-        local_info.engine_window_width+w_delta, local_info.engine_window_height+h_delta);
+    setup_engine_window(local_state.engine_window_x, local_state.engine_window_y,
+        local_state.engine_window_width+w_delta, local_state.engine_window_height+h_delta);
 }
 
 void PaletteSetPlayerPalette(struct PlayerInfo *player, unsigned char *pal)
@@ -1164,11 +1164,11 @@ void PaletteSetPlayerPalette(struct PlayerInfo *player, unsigned char *pal)
     }
     if (!is_my_player(player))
         return;
-    if ( (local_info.lens_palette == 0) || ((pal != local_info.main_palette) && (pal == local_info.lens_palette)) )
+    if ( (local_state.lens_palette == 0) || ((pal != local_state.main_palette) && (pal == local_state.lens_palette)) )
     {
-        local_info.main_palette = pal;
-        local_info.palette_fade_step_pain = 0;
-        local_info.palette_fade_step_possession = 0;
+        local_state.main_palette = pal;
+        local_state.palette_fade_step_pain = 0;
+        local_state.palette_fade_step_possession = 0;
         LbScreenWaitVbi();
         RendererPaletteSet(pal);
     }
@@ -1210,11 +1210,11 @@ void centre_engine_window(void)
     long window_center_x;
     long window_center_y;
     if ((game.operation_flags & GOF_ShowGui) != 0)
-      window_center_x = (MyScreenWidth-local_info.engine_window_width-status_panel_width) / 2 + status_panel_width;
+      window_center_x = (MyScreenWidth-local_state.engine_window_width-status_panel_width) / 2 + status_panel_width;
     else
-      window_center_x = (MyScreenWidth-local_info.engine_window_width) / 2;
-    window_center_y = (MyScreenHeight-local_info.engine_window_height) / 2;
-    setup_engine_window(window_center_x, window_center_y, local_info.engine_window_width, local_info.engine_window_height);
+      window_center_x = (MyScreenWidth-local_state.engine_window_width) / 2;
+    window_center_y = (MyScreenHeight-local_state.engine_window_height) / 2;
+    setup_engine_window(window_center_x, window_center_y, local_state.engine_window_width, local_state.engine_window_height);
 }
 
 void turn_off_query(PlayerNumber plyr_idx)
@@ -1614,8 +1614,8 @@ void engine(struct PlayerInfo *player, struct Camera *cam)
     mx = cam->mappos.x.val;
     my = cam->mappos.y.val;
     mz = cam->mappos.z.val;
-    pointer_x = (GetMouseX() - local_info.engine_window_x) / pixel_size;
-    pointer_y = (GetMouseY() - local_info.engine_window_y) / pixel_size;
+    pointer_x = (GetMouseX() - local_state.engine_window_x) / pixel_size;
+    pointer_y = (GetMouseY() - local_state.engine_window_y) / pixel_size;
     lens = cam->horizontal_fov * scale_value_by_horizontal_resolution(4) / pixel_size;
     if (lens_mode == 0)
         update_blocks_pointed();

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -342,7 +342,7 @@ TbBool startup_saved_packet_game(void)
     setup_zombie_players();//TODO GUI What about packet file from network game? No zombies there..
     init_players();
     get_my_player()->user_id = SOLO_HUMAN_ID;
-    init_user(SOLO_HUMAN_ID);
+    init_user_state(get_my_player()->user_id);
     if (game.active_players_count == 1)
         game.game_kind = GKind_LocalGame;
     if (game.turns_stored < game.turns_fastforward)

--- a/src/main_game.c
+++ b/src/main_game.c
@@ -341,6 +341,8 @@ TbBool startup_saved_packet_game(void)
         return false;
     setup_zombie_players();//TODO GUI What about packet file from network game? No zombies there..
     init_players();
+    get_my_player()->user_id = SOLO_HUMAN_ID;
+    init_user(SOLO_HUMAN_ID);
     if (game.active_players_count == 1)
         game.game_kind = GKind_LocalGame;
     if (game.turns_stored < game.turns_fastforward)

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -33,6 +33,7 @@
 #include "player_data.h"
 #include "front_landview.h"
 #include "player_utils.h"
+#include "light_data.h"
 #include "packets.h"
 #include "frontend.h"
 #include "front_network.h"
@@ -148,7 +149,7 @@ static void setup_players_from_startup_packets(const struct StartupSyncPacket st
         }
         player->is_active = 1;
         init_player(player, 0);
-        init_user(i);
+        init_user_state(player->user_id);
         player->isometric_view_zoom_level = sync->isometric_view_zoom_level;
         player->frontview_zoom_level = sync->frontview_zoom_level;
         TbBool imprison = (sync->initial_tendencies & CrTend_Imprison) != 0;
@@ -464,7 +465,30 @@ static void stop_network_game_state(void)
 {
     memset(net_user_info, 0, sizeof(net_user_info));
     clear_flag(game.system_flags, GSF_NetworkActive);
-    get_my_player()->user_id = SOLO_HUMAN_ID;
+    struct PlayerInfo *myplyr = get_my_player();
+    NetUserId old_user = myplyr->user_id;
+    for (NetUserId user = 0; user < MAX_NET_USERS; user++) {
+        if (user == old_user) {
+            continue;
+        }
+        struct UserState *ustate = get_user_state(user);
+        if (ustate->cursor_light_idx != 0) {
+            light_delete_light(ustate->cursor_light_idx);
+        }
+        memset(ustate, 0, sizeof(*ustate));
+    }
+    struct UserState *old_state = get_user_state(old_user);
+    if ((old_user != SOLO_HUMAN_ID) && !user_state_invalid(old_state)) {
+        *get_user_state(SOLO_HUMAN_ID) = *old_state;
+        memset(old_state, 0, sizeof(*old_state));
+    }
+    for (PlayerNumber plyr_idx = 0; plyr_idx < PLAYERS_COUNT; plyr_idx++) {
+        struct PlayerInfo *player = get_player(plyr_idx);
+        if (player != myplyr) {
+            player->user_id = -1;
+        }
+    }
+    myplyr->user_id = SOLO_HUMAN_ID;
     clear_flag(game.system_flags, GSF_NetGameNoSync);
     clear_flag(game.system_flags, GSF_NetSeedNoSync);
     fe_network_active = 0;

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -148,6 +148,7 @@ static void setup_players_from_startup_packets(const struct StartupSyncPacket st
         }
         player->is_active = 1;
         init_player(player, 0);
+        init_user(i);
         player->isometric_view_zoom_level = sync->isometric_view_zoom_level;
         player->frontview_zoom_level = sync->frontview_zoom_level;
         TbBool imprison = (sync->initial_tendencies & CrTend_Imprison) != 0;

--- a/src/net_resync.cpp
+++ b/src/net_resync.cpp
@@ -428,7 +428,7 @@ TbBool receive_resync_game(void)
 void resync_game(void)
 {
     SYNCDBG(2,"Starting");
-    draw_out_of_sync_box(0, 32*units_per_pixel/16, local_info.engine_window_x);
+    draw_out_of_sync_box(0, 32*units_per_pixel/16, local_state.engine_window_x);
     reset_eye_lenses();
     store_localised_game_structure();
     TbBool result;

--- a/src/packets.c
+++ b/src/packets.c
@@ -1104,9 +1104,9 @@ void process_user_packet(NetUserId user)
         return;
     }
     SYNCDBG(6, "Processing user %d packet of type %d.", user, (int)pckt->action);
-    struct UserState* uinfo = get_user_state(user);
-    uinfo->input_crtr_control = ((pckt->additional_packet_values & PCAdV_CrtrContrlPressed) != 0);
-    uinfo->input_crtr_query = ((pckt->additional_packet_values & PCAdV_CrtrQueryPressed) != 0);
+    struct UserState* ustate = get_user_state(user);
+    ustate->input_crtr_control = ((pckt->additional_packet_values & PCAdV_CrtrContrlPressed) != 0);
+    ustate->input_crtr_query = ((pckt->additional_packet_values & PCAdV_CrtrQueryPressed) != 0);
 
   if (!process_user_global_packet_action(user))
   {

--- a/src/packets.c
+++ b/src/packets.c
@@ -591,7 +591,7 @@ void process_user_dungeon_control_packet_control(NetUserId user)
         update_box_lag_compensation(player);
     }
     process_dungeon_control_packet_clicks(user);
-    update_mouse_light(player);
+    update_mouse_light(user);
 }
 
 static void set_all_cameras_position(struct Camera cams[], int32_t pos_x, int32_t pos_y)
@@ -1074,7 +1074,7 @@ void process_user_map_packet_control(NetUserId user)
     process_map_packet_clicks(user);
     player->cameras[CamIV_Parchment].mappos.x.val = pckt->pos_x;
     player->cameras[CamIV_Parchment].mappos.y.val = pckt->pos_y;
-    update_mouse_light(player);
+    update_mouse_light(user);
     SYNCDBG(8,"Finished");
 }
 
@@ -1104,8 +1104,9 @@ void process_user_packet(NetUserId user)
         return;
     }
     SYNCDBG(6, "Processing user %d packet of type %d.", user, (int)pckt->action);
-    player->input_crtr_control = ((pckt->additional_packet_values & PCAdV_CrtrContrlPressed) != 0);
-    player->input_crtr_query = ((pckt->additional_packet_values & PCAdV_CrtrQueryPressed) != 0);
+    struct UserState* uinfo = get_user_state(user);
+    uinfo->input_crtr_control = ((pckt->additional_packet_values & PCAdV_CrtrContrlPressed) != 0);
+    uinfo->input_crtr_query = ((pckt->additional_packet_values & PCAdV_CrtrQueryPressed) != 0);
 
   if (!process_user_global_packet_action(user))
   {

--- a/src/packets.c
+++ b/src/packets.c
@@ -770,8 +770,8 @@ TbBool process_user_global_packet_action(NetUserId user)
   case PckA_SetMinimapConf:
       if (is_my_player(player))
       {
-        local_info.minimap_zoom = pckt->actn_par1;
-        settings.minimap_zoom = local_info.minimap_zoom;
+        local_state.minimap_zoom = pckt->actn_par1;
+        settings.minimap_zoom = local_state.minimap_zoom;
         save_settings();
       }
       return 0;

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -414,7 +414,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
         } else
         if (player->cursor_button_down != 0)
         {
-            TbBool direct_control_target = !thing_target_action && (player->thing_under_hand != 0) && (player->input_crtr_control != 0);
+            TbBool direct_control_target = !thing_target_action && (player->thing_under_hand != 0) && (get_user_state(user)->input_crtr_control != 0);
             if (direct_control_target && (dungeon->things_in_hand[0] != player->thing_under_hand)) {
                 thing = get_creature_near_for_controlling(player->id_number, x, y);
                 if (!thing_is_invalid(thing))
@@ -430,7 +430,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
                     set_player_state(player, player->continue_work_state, 0);
                 }
                 unset_packet_control(pckt, PCtr_LBtnRelease);
-            } else if (!thing_target_action && player->input_crtr_query != 0) {
+            } else if (!thing_target_action && get_user_state(user)->input_crtr_query != 0) {
                 thing = get_creature_near(x, y);
                 if (!can_thing_be_queried(thing, plyr_idx))
                 {

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -118,6 +118,13 @@ TbBool is_my_player_number(PlayerNumber plyr_num)
     return (plyr_num == myplyr->id_number);
 }
 
+struct UserState *get_user_state(NetUserId user)
+{
+    if ((user < 0) || (user >= MAX_NET_USERS))
+        return NULL;
+    return &game.user_states[user];
+}
+
 TbBool player_is_roaming(PlayerNumber plyr_num)
 {
     struct PlayerInfo* player = get_player(plyr_num);
@@ -252,6 +259,7 @@ void clear_players(void)
         struct PlayerInfo* player = &game.players[i];
         memset(player, 0, sizeof(struct PlayerInfo));
         player->id_number = PLAYERS_COUNT;
+        player->user_id = -1;
         switch (i)
         {
         case PLAYER_GOOD:
@@ -267,6 +275,8 @@ void clear_players(void)
     }
     memset(&bad_player, 0, sizeof(struct PlayerInfo));
     bad_player.id_number = PLAYERS_COUNT;
+    bad_player.user_id = -1;
+    memset(game.user_states, 0, sizeof(game.user_states));
     memset(&local_info, 0, sizeof(local_info));
     game.active_players_count = 0;
     //game.game_kind = GKind_LocalGame;

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -45,6 +45,7 @@ unsigned short const player_cubes[] = {0x00C0, 0x00C1, 0x00C2, 0x00C3, 0x00C7, 0
 
 struct PlayerInfo bad_player;
 struct LocalInfo local_info;
+struct UserState bad_user_state;
 
 /** The current player's number. */
 unsigned char my_player_number;
@@ -118,11 +119,19 @@ TbBool is_my_player_number(PlayerNumber plyr_num)
     return (plyr_num == myplyr->id_number);
 }
 
+// returns user's UserState, or INVALID_USER_STATE.
 struct UserState *get_user_state(NetUserId user)
 {
     if ((user < 0) || (user >= MAX_NET_USERS))
-        return NULL;
+        return INVALID_USER_STATE;
     return &game.user_states[user];
+}
+
+TbBool user_state_invalid(const struct UserState *ustate)
+{
+    if (ustate == INVALID_USER_STATE)
+        return true;
+    return (ustate == NULL);
 }
 
 TbBool player_is_roaming(PlayerNumber plyr_num)
@@ -278,6 +287,7 @@ void clear_players(void)
     bad_player.user_id = -1;
     memset(game.user_states, 0, sizeof(game.user_states));
     memset(&local_info, 0, sizeof(local_info));
+    memset(&bad_user_state, 0, sizeof(bad_user_state));
     game.active_players_count = 0;
     //game.game_kind = GKind_LocalGame;
 }

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -44,7 +44,7 @@ TbPixel possession_hit_colours[] =   {133, 89, 167, 141,  31,  31, 110,  54,  46
 unsigned short const player_cubes[] = {0x00C0, 0x00C1, 0x00C2, 0x00C3, 0x00C7, 0x00C6 };
 
 struct PlayerInfo bad_player;
-struct LocalInfo local_info;
+struct LocalState local_state;
 struct UserState bad_user_state;
 
 /** The current player's number. */
@@ -286,7 +286,7 @@ void clear_players(void)
     bad_player.id_number = PLAYERS_COUNT;
     bad_player.user_id = -1;
     memset(game.user_states, 0, sizeof(game.user_states));
-    memset(&local_info, 0, sizeof(local_info));
+    memset(&local_state, 0, sizeof(local_state));
     memset(&bad_user_state, 0, sizeof(bad_user_state));
     game.active_players_count = 0;
     //game.game_kind = GKind_LocalGame;

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -146,6 +146,14 @@ struct CheatSelection
     unsigned char chosen_experience_level;
 };
 
+/*
+ * Per-player game data.
+ *
+ * Players can be human-controlled, AI controlled, etc. (See player_instances.h)
+ * 
+ * Note: for legacy reasons, this struct currently contains some fields that
+ * should eventually be ported to UserState or LocalState.
+*/
 struct PlayerInfo {
     unsigned char allocflags;
     unsigned char boxsize; //field_2 seems to be used in DK, so now renamed and used in KeeperFX
@@ -244,6 +252,12 @@ struct PlayerInfo {
     int first_person_unfreeze_delay;
 };
 
+/* Game state that exists per human user. Computer-controlled
+ * players are not users.
+ *
+ * Local games only have a single user. Networked games have one
+ * user per client, including the host.
+ */
 struct UserState {
     unsigned char input_crtr_control;
     unsigned char input_crtr_query;
@@ -258,7 +272,12 @@ extern short local_thing_under_hand;
 #pragma pack()
 /******************************************************************************/
 
-struct LocalInfo {
+/* Miscellaneous state relating to this device and
+ * the local human player.
+ *
+ * Not sync'd over the network.
+ */
+extern struct LocalState {
     TbBool tooltips_restore; /**< Used to store/restore the value of settings.tooltips_on when transitioning to/from the map. */
     TbBool status_menu_restore; /**< Used to store/restore the current status menu visibility when the map is shown/hidden. */
     TbBool paused_state_restore; /**< Used to restore pause state after saving */
@@ -275,9 +294,8 @@ struct LocalInfo {
     short minimap_pos_x;
     short minimap_pos_y;
     unsigned short minimap_zoom;
-};
+} local_state;
 
-extern struct LocalInfo local_info;
 extern unsigned short player_colors_map[];
 extern TbPixel player_path_colours[];
 extern TbPixel player_room_colours[];

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -149,10 +149,8 @@ struct PlayerInfo {
     unsigned char allocflags;
     unsigned char boxsize; //field_2 seems to be used in DK, so now renamed and used in KeeperFX
     unsigned char additional_flags; // Uses PlayerAdditionalFlags
-    unsigned char input_crtr_control;
-    unsigned char input_crtr_query;
     unsigned char display_flags;
-    unsigned char /*NetUserId*/ user_id;
+    NetUserId user_id; // -1 if no user
     int32_t hand_animationId;
     unsigned int hand_busy_until_turn;
     char player_name[20];
@@ -181,7 +179,6 @@ struct PlayerInfo {
     unsigned char primary_cursor_state;
     unsigned char secondary_cursor_state;
     PlayerState continue_work_state;
-    short cursor_light_idx;
     char mp_message_text[PLAYER_MP_MESSAGE_LEN];
     char mp_pending_message[PLAYER_MP_MESSAGE_LEN];
     char mp_message_text_last[PLAYER_MP_MESSAGE_LEN];
@@ -246,6 +243,12 @@ struct PlayerInfo {
     int first_person_unfreeze_delay;
 };
 
+struct UserState {
+    unsigned char input_crtr_control;
+    unsigned char input_crtr_query;
+    short cursor_light_idx;
+};
+
 /******************************************************************************/
 
 extern unsigned char my_player_number;
@@ -289,6 +292,7 @@ struct PlayerInfo *get_player_f(PlayerNumber plyr_idx,const char *func_name);
 TbBool player_invalid(const struct PlayerInfo *player);
 TbBool player_exists(const struct PlayerInfo *player);
 TbBool is_my_player(const struct PlayerInfo *player);
+struct UserState *get_user_state(NetUserId user);
 TbBool is_my_player_number(PlayerNumber plyr_num);
 TbBool player_allied_with(const struct PlayerInfo *player, PlayerNumber ally_idx);
 TbBool players_are_enemies(PlayerNumber plyr1_idx, PlayerNumber plyr2_idx);

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -34,6 +34,7 @@ extern "C" {
 #define COLOURS_COUNT       9
 
 #define INVALID_PLAYER (&bad_player)
+#define INVALID_USER_STATE (&bad_user_state)
 
 #define PLAYER_MP_MESSAGE_LEN  64
 
@@ -285,6 +286,7 @@ extern TbPixel player_highlight_colours[];
 extern TbPixel possession_hit_colours[];
 extern unsigned short const player_cubes[];
 extern struct PlayerInfo bad_player;
+extern struct UserState bad_user_state;
 /******************************************************************************/
 struct PlayerInfo *get_player_f(PlayerNumber plyr_idx,const char *func_name);
 #define get_player(plyr_idx) get_player_f(plyr_idx,__func__)
@@ -293,6 +295,7 @@ TbBool player_invalid(const struct PlayerInfo *player);
 TbBool player_exists(const struct PlayerInfo *player);
 TbBool is_my_player(const struct PlayerInfo *player);
 struct UserState *get_user_state(NetUserId user);
+TbBool user_state_invalid(const struct UserState *ustate);
 TbBool is_my_player_number(PlayerNumber plyr_num);
 TbBool player_allied_with(const struct PlayerInfo *player, PlayerNumber ally_idx);
 TbBool players_are_enemies(PlayerNumber plyr1_idx, PlayerNumber plyr2_idx);

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -503,7 +503,7 @@ long pinstfs_direct_leave_creature(struct PlayerInfo *player, int32_t *n)
   player->allocflags |= PlaF_KeyboardInputDisabled;
   player->influenced_thing_idx = 0;
   player->influenced_thing_creation = 0;
-  light_turn_light_on(player->cursor_light_idx);
+  turn_user_cursor_light(player->user_id, true);
   return 0;
 }
 
@@ -544,7 +544,7 @@ long pinstfs_passenger_leave_creature(struct PlayerInfo *player, int32_t *n)
   player->allocflags |= PlaF_KeyboardInputDisabled;
   player->influenced_thing_idx = 0;
   player->influenced_thing_creation = 0;
-  light_turn_light_on(player->cursor_light_idx);
+  turn_user_cursor_light(player->user_id, true);
   return 0;
 }
 
@@ -582,7 +582,7 @@ long pinstfs_zoom_to_heart(struct PlayerInfo *player, int32_t *n)
     if (is_my_player_number(player->id_number)) {
         LbPaletteDataFillWhite(zoom_to_heart_palette);
     }
-    light_turn_light_off(player->cursor_light_idx);
+    turn_user_cursor_light(player->user_id, false);
     struct Thing* thing = get_player_soul_container(player->id_number);
     ThingModel spectator_breed = get_players_spectator_model(player->id_number);
     struct Coord3d mappos;
@@ -713,7 +713,7 @@ long pinstfe_zoom_out_of_heart(struct PlayerInfo *player, int32_t *n)
     cam->rotation_angle_x = DEGREES_45;
     set_local_camera_destination(player);
   }
-  light_turn_light_on(player->cursor_light_idx);
+  turn_user_cursor_light(player->user_id, true);
   player->allocflags &= ~PlaF_KeyboardInputDisabled;
   player->allocflags &= ~PlaF_MouseInputDisabled;
   game.view_mode_flags &= ~GNFldD_CreaturePasngr;
@@ -739,7 +739,7 @@ long pinstfe_control_creature_fade(struct PlayerInfo *player, int32_t *n)
       PaletteSetPlayerPalette(player, engine_palette);
   }
   player->allocflags &= ~PlaF_KeyboardInputDisabled;
-  light_turn_light_off(player->cursor_light_idx);
+  turn_user_cursor_light(player->user_id, false);
   player->allocflags &= ~PlaF_MouseInputDisabled;
   return 0;
 }

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -317,7 +317,7 @@ long pinstfs_passenger_control_creature(struct PlayerInfo *player, int32_t *n)
   player->allocflags |= PlaF_MouseInputDisabled;
   if (is_my_player(player))
   {
-    local_info.palette_fade_step_possession = 1;
+    local_state.palette_fade_step_possession = 1;
     turn_off_all_window_menus();
     turn_off_menu(GMnu_CREATURE_QUERY1);
     turn_off_menu(GMnu_CREATURE_QUERY2);
@@ -491,7 +491,7 @@ long pinstfs_direct_leave_creature(struct PlayerInfo *player, int32_t *n)
   if (is_my_player(player))
   {
       PaletteSetPlayerPalette(player, engine_palette);
-      local_info.palette_fade_step_possession = 11;
+      local_state.palette_fade_step_possession = 11;
       turn_off_all_window_menus();
       turn_off_query_menus();
       turn_on_main_panel_menu();
@@ -533,7 +533,7 @@ long pinstfs_passenger_leave_creature(struct PlayerInfo *player, int32_t *n)
   if (is_my_player(player))
   {
     PaletteSetPlayerPalette(player, engine_palette);
-    local_info.palette_fade_step_possession = 11;
+    local_state.palette_fade_step_possession = 11;
     turn_off_all_window_menus();
     turn_off_query_menus();
     turn_off_all_panel_menus();
@@ -751,10 +751,10 @@ long pinstfs_fade_to_map(struct PlayerInfo *player, int32_t *n)
     player->view_mode_restore = cam->view_mode;
     if (is_my_player(player))
     {
-        local_info.palette_fade_step_map = 0;
-        local_info.tooltips_restore = settings.tooltips_on; // store tooltips setting before starting the fade
+        local_state.palette_fade_step_map = 0;
+        local_state.tooltips_restore = settings.tooltips_on; // store tooltips setting before starting the fade
         settings.tooltips_on = false; // don't show tooltips during the fade
-        local_info.status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible)
+        local_state.status_menu_restore = toggle_status_menu(0); // store current status menu visibility, and hide the status menu (when the map is visible)
   }
   set_engine_view(player, PVM_ParchFadeIn);
   return 0;
@@ -770,7 +770,7 @@ long pinstfe_fade_to_map(struct PlayerInfo *player, int32_t *n)
 {
   set_player_mode(player, PVT_MapScreen);
   if (is_my_player(player))
-    settings.tooltips_on = local_info.tooltips_restore; // restore tooltips setting after the fade is completed
+    settings.tooltips_on = local_state.tooltips_restore; // restore tooltips setting after the fade is completed
   player->allocflags &= ~PlaF_MouseInputDisabled;
   return 0;
 }
@@ -780,10 +780,10 @@ long pinstfs_fade_from_map(struct PlayerInfo *player, int32_t *n)
   player->allocflags |= PlaF_MouseInputDisabled;
   if (is_my_player(player))
   {
-    local_info.tooltips_restore = settings.tooltips_on; // store tooltips setting before starting the fade
+    local_state.tooltips_restore = settings.tooltips_on; // store tooltips setting before starting the fade
     settings.tooltips_on = false; // don't show tooltips during the fade
     game.operation_flags &= ~GOF_ShowPanel;
-    local_info.palette_fade_step_map = 32;
+    local_state.palette_fade_step_map = 32;
   }
   set_player_mode(player, PVT_DungeonTop);
   set_engine_view(player, PVM_ParchFadeOut);
@@ -800,8 +800,8 @@ long pinstfe_fade_from_map(struct PlayerInfo *player, int32_t *n)
     struct PlayerInfo* myplyr = get_player(my_player_number);
     set_engine_view(player, player->view_mode_restore);
     if (player->id_number == myplyr->id_number) {
-        settings.tooltips_on = local_info.tooltips_restore; // restore tooltips setting after the fade is completed
-        toggle_status_menu(local_info.status_menu_restore); // restore the status menu visiblity now that the map is no longer visible
+        settings.tooltips_on = local_state.tooltips_restore; // restore tooltips setting after the fade is completed
+        toggle_status_menu(local_state.status_menu_restore); // restore the status menu visiblity now that the map is no longer visible
     }
     player->allocflags &= ~PlaF_MouseInputDisabled;
     return 0;

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -759,21 +759,21 @@ void init_keeper_map_exploration_by_creatures(struct PlayerInfo *player)
 
 void turn_user_cursor_light(NetUserId user, TbBool turn_on)
 {
-    struct UserState* ustate = get_user_state(user);
-    if ((ustate == NULL) || (ustate->cursor_light_idx == 0))
+    const int idx = get_user_state(user)->cursor_light_idx;
+    if (idx == 0)
         return;
     if (turn_on)
-        light_turn_light_on(ustate->cursor_light_idx);
+        light_turn_light_on(idx);
     else
-        light_turn_light_off(ustate->cursor_light_idx);
+        light_turn_light_off(idx);
 }
 
-void init_user(NetUserId user)
+void init_user_state(NetUserId user)
 {
     struct UserState* ustate = get_user_state(user);
-    if (ustate == NULL)
+    if (user_state_invalid(ustate))
     {
-        ERRORLOG("Cannot init user %d", (int)user);
+        ERRORLOG("Cannot init state of user %d", (int)user);
         return;
     }
     memset(ustate, 0, sizeof(*ustate));
@@ -1140,7 +1140,7 @@ void init_players_local_game(void)
         default: player->view_mode_restore = PVM_IsoWibbleView; break;
     }
     init_player(player, 0);
-    init_user(SOLO_HUMAN_ID);
+    init_user_state(player->user_id);
     set_creature_tendencies(player, CrTend_Imprison, IMPRISON_BUTTON_DEFAULT);
     set_creature_tendencies(player, CrTend_Flee, FLEE_BUTTON_DEFAULT);
     game.creatures_tend_imprison = IMPRISON_BUTTON_DEFAULT;

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -757,8 +757,26 @@ void init_keeper_map_exploration_by_creatures(struct PlayerInfo *player)
     do_to_players_all_creatures_of_model(player->id_number, CREATURE_ANY, check_map_explored_at_current_pos);
 }
 
-void init_player_as_single_keeper(struct PlayerInfo *player)
+void turn_user_cursor_light(NetUserId user, TbBool turn_on)
 {
+    struct UserState* ustate = get_user_state(user);
+    if ((ustate == NULL) || (ustate->cursor_light_idx == 0))
+        return;
+    if (turn_on)
+        light_turn_light_on(ustate->cursor_light_idx);
+    else
+        light_turn_light_off(ustate->cursor_light_idx);
+}
+
+void init_user(NetUserId user)
+{
+    struct UserState* ustate = get_user_state(user);
+    if (ustate == NULL)
+    {
+        ERRORLOG("Cannot init user %d", (int)user);
+        return;
+    }
+    memset(ustate, 0, sizeof(*ustate));
     struct InitLight ilght;
     memset(&ilght, 0, sizeof(struct InitLight));
     ilght.radius = 2560;
@@ -766,11 +784,11 @@ void init_player_as_single_keeper(struct PlayerInfo *player)
     ilght.flags = 5;
     ilght.is_dynamic = 1;
     unsigned short idx = light_create_light(&ilght);
-    player->cursor_light_idx = idx;
+    ustate->cursor_light_idx = idx;
     if (idx != 0) {
         light_set_light_never_cache(idx);
     } else {
-        WARNLOG("Cannot allocate light to player %d.",(int)player->id_number);
+        WARNLOG("Cannot allocate cursor light to user %d.",(int)user);
     }
 }
 
@@ -811,7 +829,6 @@ void init_player(struct PlayerInfo *player, short no_explore)
     switch (game.game_kind)
     {
     case GKind_LocalGame:
-        init_player_as_single_keeper(player);
         init_player_start(player, false);
         reset_player_mode(player, PVT_DungeonTop);
         if ( !no_explore ) {
@@ -836,7 +853,6 @@ void init_player(struct PlayerInfo *player, short no_explore)
           ERRORLOG("Non Keeper in Keeper game");
           break;
         }
-        init_player_as_single_keeper(player);
         init_player_start(player, false);
         reset_player_mode(player, PVT_DungeonTop);
         init_keeper_map_exploration_by_terrain(player);
@@ -1124,6 +1140,7 @@ void init_players_local_game(void)
         default: player->view_mode_restore = PVM_IsoWibbleView; break;
     }
     init_player(player, 0);
+    init_user(SOLO_HUMAN_ID);
     set_creature_tendencies(player, CrTend_Imprison, IMPRISON_BUTTON_DEFAULT);
     set_creature_tendencies(player, CrTend_Flee, FLEE_BUTTON_DEFAULT);
     game.creatures_tend_imprison = IMPRISON_BUTTON_DEFAULT;

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -797,11 +797,11 @@ void init_player(struct PlayerInfo *player, short no_explore)
     SYNCDBG(5,"Starting");
     if (is_my_player(player))
     {
-        local_info.minimap_pos_x = 11;
-        local_info.minimap_pos_y = 11;
-        local_info.minimap_zoom = settings.minimap_zoom;
+        local_state.minimap_pos_x = 11;
+        local_state.minimap_pos_y = 11;
+        local_state.minimap_zoom = settings.minimap_zoom;
         setup_engine_window(0, 0, MyScreenWidth, MyScreenHeight);
-        local_info.main_palette = engine_palette;
+        local_state.main_palette = engine_palette;
     }
     player->continue_work_state = PSt_CtrlDungeon;
     player->work_state = PSt_CtrlDungeon;
@@ -839,7 +839,7 @@ void init_player(struct PlayerInfo *player, short no_explore)
     case GKind_MultiGame:
         //workaround until settings are synced through multiplayer
         if (is_my_player(player))
-            local_info.minimap_zoom = 256;
+            local_state.minimap_zoom = 256;
         if (game.packet_save_head.isometric_view_zoom_level == 0)
         {
             player->isometric_view_zoom_level = CAMERA_ZOOM_MAX;

--- a/src/player_utils.h
+++ b/src/player_utils.h
@@ -57,7 +57,7 @@ TbBool player_sell_door_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, M
 
 void init_players(void);
 void init_player(struct PlayerInfo *player, short no_explore);
-void init_user(NetUserId user);
+void init_user_state(NetUserId user);
 void turn_user_cursor_light(NetUserId user, TbBool turn_on);
 void post_init_players(void);
 void post_init_player(struct PlayerInfo* player);

--- a/src/player_utils.h
+++ b/src/player_utils.h
@@ -21,6 +21,7 @@
 
 #include "bflib_basics.h"
 #include "globals.h"
+#include "net_main.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,6 +57,8 @@ TbBool player_sell_door_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, M
 
 void init_players(void);
 void init_player(struct PlayerInfo *player, short no_explore);
+void init_user(NetUserId user);
+void turn_user_cursor_light(NetUserId user, TbBool turn_on);
 void post_init_players(void);
 void post_init_player(struct PlayerInfo* player);
 void init_players_local_game(void);

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -560,7 +560,7 @@ void draw_power_hand(void)
     }
     // Now draw
     if (((game.operation_flags & GOF_ShowGui) != 0) && (game.small_map_state != 2)
-      && mouse_is_over_panel_map(local_info.minimap_pos_x, local_info.minimap_pos_y))
+      && mouse_is_over_panel_map(local_state.minimap_pos_x, local_state.minimap_pos_y))
     {
         MapSubtlCoord stl_x;
         MapSubtlCoord stl_y;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -74,6 +74,7 @@
 #include "map_blocks.h"
 #include "map_utils.h"
 #include "player_instances.h"
+#include "player_utils.h"
 #include "config_players.h"
 #include "power_hand.h"
 #include "power_process.h"
@@ -3313,7 +3314,7 @@ void prepare_to_controlled_creature_death(struct Thing *thing)
         PaletteSetPlayerPalette(player, engine_palette);
         local_info.palette_fade_step_possession = 11;
     }
-    light_turn_light_on(player->cursor_light_idx);
+    turn_user_cursor_light(player->user_id, true);
 }
 
 void delete_armour_effects_attached_to_creature(struct Thing *thing)

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -367,13 +367,13 @@ TbBool load_swipe_graphic_for_creature(const struct Thing *thing)
 /**
  * Randomise the draw direction of the swipe sprite in the first-person possession view.
  *
- * Sets local_info.swipe_sprite_drawLR to either TRUE or FALSE.
+ * Sets local_state.swipe_sprite_drawLR to either TRUE or FALSE.
  *
  * Draw direction is either: left-to-right (TRUE) or right-to-left (FALSE)
  */
 void randomise_swipe_graphic_direction()
 {
-    local_info.swipe_sprite_drawLR = UNSYNC_RANDOM(2); // equal chance to be left-to-right or right-to-left
+    local_state.swipe_sprite_drawLR = UNSYNC_RANDOM(2); // equal chance to be left-to-right or right-to-left
 }
 
 void draw_swipe_graphic(void)
@@ -408,13 +408,13 @@ void draw_swipe_graphic(void)
             int scrpos_y = (MyScreenHeight * 16 / units_per_px - (startspr->SHeight + endspr->SHeight)) / 2;
             const struct TbSprite *spr;
             int scrpos_x;
-            if (local_info.swipe_sprite_drawLR)
+            if (local_state.swipe_sprite_drawLR)
             {
                 int delta_y = sprlist[1].SHeight;
                 for (i=0; i < SWIPE_SPRITES_X*SWIPE_SPRITES_Y; i+=SWIPE_SPRITES_X)
                 {
                     spr = &startspr[i];
-                    scrpos_x = ((MyScreenWidth + (2 * local_info.engine_window_x)) * 16 / units_per_px - allwidth)/ 2;
+                    scrpos_x = ((MyScreenWidth + (2 * local_state.engine_window_x)) * 16 / units_per_px - allwidth)/ 2;
                     for (n=0; n < SWIPE_SPRITES_X; n++)
                     {
                         LbSpriteDrawResized(scrpos_x * units_per_px / 16, scrpos_y * units_per_px / 16, units_per_px, spr);
@@ -3312,7 +3312,7 @@ void prepare_to_controlled_creature_death(struct Thing *thing)
         turn_on_main_panel_menu();
         set_flag_value(game.operation_flags, GOF_ShowPanel, (game.operation_flags & GOF_ShowGui) != 0);
         PaletteSetPlayerPalette(player, engine_palette);
-        local_info.palette_fade_step_possession = 11;
+        local_state.palette_fade_step_possession = 11;
     }
     turn_user_cursor_light(player->user_id, true);
 }
@@ -4355,10 +4355,10 @@ void draw_creature_view(struct Thing *thing)
   // Draw swipe into buffer BEFORE lens effects (so overlay renders on top of swipe)
   draw_swipe_graphic();
   // Get the actual viewport dimensions (accounts for sidebar)
-  long view_width = local_info.engine_window_width / pixel_size;
-  long view_height = local_info.engine_window_height / pixel_size;
-  long view_x = local_info.engine_window_x / pixel_size;
-  long view_y = local_info.engine_window_y / pixel_size;
+  long view_width = local_state.engine_window_width / pixel_size;
+  long view_height = local_state.engine_window_height / pixel_size;
+  long view_x = local_state.engine_window_x / pixel_size;
+  long view_y = local_state.engine_window_y / pixel_size;
   // Restore original graphics settings
   lbDisplay.WScreen = wscr_cp;
   LbScreenLoadGraphicsWindow(&grwnd);

--- a/src/vidfade.c
+++ b/src/vidfade.c
@@ -286,17 +286,17 @@ long PaletteFadePlayer(struct PlayerInfo *player)
     long i;
     unsigned char palette[PALETTE_SIZE];
     // Find the fade step
-    if ((local_info.palette_fade_step_pain != 0) && (local_info.palette_fade_step_possession != 0))
+    if ((local_state.palette_fade_step_pain != 0) && (local_state.palette_fade_step_possession != 0))
     {
-        i = 12 * (local_info.palette_fade_step_pain - 1) + 10 * (local_info.palette_fade_step_possession - 1);
+        i = 12 * (local_state.palette_fade_step_pain - 1) + 10 * (local_state.palette_fade_step_possession - 1);
   } else
-  if (local_info.palette_fade_step_possession != 0)
+  if (local_state.palette_fade_step_possession != 0)
   {
-    i = 2 * (5 * (local_info.palette_fade_step_possession-1));
+    i = 2 * (5 * (local_state.palette_fade_step_possession-1));
   } else
-  if (local_info.palette_fade_step_pain != 0)
+  if (local_state.palette_fade_step_pain != 0)
   {
-    i = 4 * (3 * (local_info.palette_fade_step_pain-1));
+    i = 4 * (3 * (local_state.palette_fade_step_pain-1));
   } else
   { // both are == 0 - no fade
     return 0;
@@ -307,7 +307,7 @@ long PaletteFadePlayer(struct PlayerInfo *player)
   // Create the new palette
   for (i=0; i < PALETTE_COLORS; i++)
   {
-      unsigned char* src = &local_info.main_palette[3 * i];
+      unsigned char* src = &local_state.main_palette[3 * i];
       unsigned char* dst = &palette[3 * i];
       unsigned long pix = ((step * (((long)src[0]) - 63)) / 120) + 63;
       if (pix > 63)
@@ -323,19 +323,19 @@ long PaletteFadePlayer(struct PlayerInfo *player)
       dst[2] = pix;
   }
   // Update the fade step
-  if (local_info.palette_fade_step_pain > 0)
-    local_info.palette_fade_step_pain--;
-  if ((local_info.palette_fade_step_possession == 0) || (player->instance_num == PI_UnusedSlot18) || (player->instance_num == PI_UnusedSlot17))
+  if (local_state.palette_fade_step_pain > 0)
+    local_state.palette_fade_step_pain--;
+  if ((local_state.palette_fade_step_possession == 0) || (player->instance_num == PI_UnusedSlot18) || (player->instance_num == PI_UnusedSlot17))
   {
   } else
   if ((player->instance_num == PI_DirctCtrl) || (player->instance_num == PI_PsngrCtrl))
   {
-    if (local_info.palette_fade_step_possession <= 12)
-      local_info.palette_fade_step_possession++;
+    if (local_state.palette_fade_step_possession <= 12)
+      local_state.palette_fade_step_possession++;
   } else
   {
-    if (local_info.palette_fade_step_possession > 0)
-      local_info.palette_fade_step_possession--;
+    if (local_state.palette_fade_step_possession > 0)
+      local_state.palette_fade_step_possession--;
   }
   // Set the palette to screen
   LbScreenWaitVbi();
@@ -347,13 +347,13 @@ void PaletteApplyPainToPlayer(struct PlayerInfo *player, long intense)
 {
     if (!is_my_player(player))
         return;
-    long i = local_info.palette_fade_step_pain + intense;
+    long i = local_state.palette_fade_step_pain + intense;
     if (i < 1)
         i = 1;
     else
     if (i > 10)
         i = 10;
-    local_info.palette_fade_step_pain = i;
+    local_state.palette_fade_step_pain = i;
 }
 
 


### PR DESCRIPTION
As part of the "Archon mode" effort, I'm trying to sort out what fields in `PlayerInfo` really belong in `PlayerInfo` (one per keeper etc.) vs what should be per-user (i.e. per actual human playing).

To that end, I've made a `UserState` struct, which is also part of the game state, but is per-user instead of per-player. For now I've just moved a handful of fields over that I thought would be easy to do start with, but there are dozens more to port over afterward if this PR is approved. The biggest one in this PR is the user's hand light, which should be per-user instead of per-player.

_Note bene_:
- Only human users get a cursor light. (Computer-controlled players used to have a spurious light which to my understanding was not even visible, but that is now removed.)
- Console commands for a userless player (i.e. computer-controlled) fall back to the local user's cursor. This only matters for the API as chat-based console commands always have a user, but the API doesn't work in netplay. It's a bit crufty though, I'd welcome suggestions.
- Save data broken due to game data struct layout change. (Should I write a migration or is this just SOP?)
- I'm calling it `UserState` because "user info" is already taken by networking code. (`UserState` is part of the game state, and even on local mode there exists one so it doesn't feel like it belongs in the network's "user info" to me.)

See also this PR to pull local-only info out of `PlayerInfo`: https://github.com/dkfans/keeperfx/pull/5216