### PR TITLE
Window Icon (on linux)

### DIFF
--- a/build/cmake/modules/BuildTargets.cmake
+++ b/build/cmake/modules/BuildTargets.cmake
@@ -14,6 +14,20 @@ elseif(UNIX AND NOT APPLE)
     list(FILTER KEEPERFX_SOURCES_CXX EXCLUDE REGEX "/PlatformWindows\\.cpp$")
 endif()
 
+# Window icon
+if(NOT WIN32)
+    set(KFX_ICON_PNG "${CMAKE_SOURCE_DIR}/res/keeperfx_icon256-24bpp.png")
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${KFX_ICON_PNG}")
+    file(READ "${KFX_ICON_PNG}" _icon_hex HEX)
+    string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1," _icon_bytes "${_icon_hex}")
+    set(KFX_ICON_C "${CMAKE_BINARY_DIR}/generated/window_icon.c")
+    file(WRITE "${KFX_ICON_C}.in"
+        "const unsigned char kfx_window_icon_png[] = {${_icon_bytes}};\n"
+        "const unsigned int kfx_window_icon_png_size = sizeof(kfx_window_icon_png);\n")
+    configure_file("${KFX_ICON_C}.in" "${KFX_ICON_C}" COPYONLY)
+    list(APPEND KEEPERFX_SOURCES_C "${KFX_ICON_C}")
+endif()
+
 add_executable(keeperfx       ${KEEPERFX_SOURCES_C} ${KEEPERFX_SOURCES_CXX})
 add_executable(keeperfx_hvlog ${KEEPERFX_SOURCES_C} ${KEEPERFX_SOURCES_CXX})
 target_compile_definitions(keeperfx       PUBLIC BFDEBUG_LEVEL=0)

--- a/src/kfx/platform/WindowSystemSDL.cpp
+++ b/src/kfx/platform/WindowSystemSDL.cpp
@@ -11,7 +11,30 @@
 #include "bflib_basics.h"
 #include "bflib_video.h"
 #include <SDL3/SDL.h>
+#include <SDL3_image/SDL_image.h>
 #include "post_inc.h"
+
+#ifndef _WIN32
+extern "C" const unsigned char kfx_window_icon_png[];
+extern "C" const unsigned int kfx_window_icon_png_size;
+#endif
+
+static void ApplyWindowIcon(SDL_Window *window)
+{
+#ifndef _WIN32
+    SDL_Surface *icon = IMG_Load_IO(SDL_IOFromConstMem(kfx_window_icon_png, kfx_window_icon_png_size), true);
+    if (icon == nullptr) {
+        WARNLOG("Failed to load window icon: %s", SDL_GetError());
+        return;
+    }
+    if (!SDL_SetWindowIcon(window, icon)) {
+        WARNLOG("Failed to window icon: %s", SDL_GetError());
+    }
+    SDL_DestroySurface(icon);
+#else
+    // MS Windows executable gets icon from .rc resource
+#endif
+}
 
 /******************************************************************************/
 
@@ -267,6 +290,7 @@ bool WindowSystemSDL::CreateWindow(const char* title, int x, int y, int w, int h
     lbWindow = SDL_CreateWindow(title, w, h, sdl3_flags);
     if (!lbWindow)
         return false;
+    ApplyWindowIcon(lbWindow);
 
     // A window created with SDL_WINDOW_FULLSCREEN starts as desktop fullscreen,
     // which is exactly what a desktop-fullscreen mode wants; an exclusive mode is
@@ -298,6 +322,7 @@ bool WindowSystemSDL::RecreateForSoftwareRenderer()
         ERRORLOG("WindowSystemSDL::RecreateForSoftwareRenderer failed: %s", SDL_GetError());
         return false;
     }
+    ApplyWindowIcon(lbWindow);
     SDL_SetWindowPosition(lbWindow, x, y);
     SDL_ShowWindow(lbWindow);
     return true;


### PR DESCRIPTION
Adds the keeperfx window icon to the game window on Linux.

This should fix the problem for non-windows OSes too, like Mac, but I haven't tested those.