### PR TITLE
Multiplayer: more local camera + parchment map fixes

### DIFF
--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -1065,10 +1065,7 @@ void redraw_display(void)
           long w = (LbTextStringWidth(text) * units_per_pixel / 16 + 2 * (LbTextCharWidth(' ') * units_per_pixel / 16));
           long pos_x;
           struct Camera *camera = get_local_active_camera(player);
-          unsigned char view_mode = camera->view_mode;
-          TbBool world_view = view_mode == PVM_IsoWibbleView || view_mode == PVM_FrontView;
-          world_view |= view_mode == PVM_IsoStraightView || view_mode == PVM_CreatureView;
-          if (world_view) {
+          if (camera->view_mode == PVM_IsoWibbleView || camera->view_mode == PVM_FrontView || camera->view_mode == PVM_IsoStraightView || camera->view_mode == PVM_CreatureView) {
               pos_x = local_state.engine_window_x + (MyScreenWidth - w - local_state.engine_window_x) / 2;
           } else {
               pos_x = (MyScreenWidth-w)/2;

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -511,8 +511,7 @@ void set_engine_view(struct PlayerInfo *player, long val)
 void draw_overlay_compass(long base_x, long base_y)
 {
     struct PlayerInfo* player = get_my_player();
-    struct Camera* camera = get_player_active_camera(player);
-    struct Camera* cam = get_local_camera(camera);
+    struct Camera* cam = get_local_active_camera(player);
     unsigned short flg_mem = RendererGetDrawFlags();
     LbTextSetFont(winfont);
     RendererAddDrawFlags(Lb_SPRITE_TRANSPAR4);
@@ -616,7 +615,7 @@ void redraw_isometric_view(void)
         return;
     TbGraphicsWindow ewnd;
     memset(&ewnd, 0, sizeof(TbGraphicsWindow));
-    struct Camera* render_cam = get_local_camera(&player->cameras[CamIV_Isometric]);
+    struct Camera* render_cam = get_local_active_camera(player);
     update_explored_flags_for_power_sight(player);
     engine(player,render_cam);
     if (smooth_on)
@@ -644,7 +643,7 @@ void redraw_frontview(void)
 {
     SYNCDBG(6,"Starting");
     struct PlayerInfo* player = get_my_player();
-    struct Camera* render_cam = get_local_camera(&player->cameras[CamIV_FrontView]);
+    struct Camera* render_cam = get_local_active_camera(player);
     update_explored_flags_for_power_sight(player);
     draw_frontview_engine(render_cam);
      remove_explored_flags_for_power_sight(player);
@@ -916,7 +915,7 @@ void process_pointer_graphic(void)
 {
     struct PlayerInfo* player = get_my_player();
     SYNCDBG(6,"Starting for view %d, player state %s, instance %d",(int)player->view_type,player_state_code_name(player->work_state),(int)player->instance_num);
-    switch (player->view_type)
+    switch (get_local_view_type(player))
     {
     case PVT_DungeonTop:
         // This case is complicated
@@ -956,7 +955,7 @@ void redraw_display(void)
     else
       process_pointer_graphic();
     interpolate_local_cameras();
-    switch (player->view_mode)
+    switch (get_local_active_camera(player)->view_mode)
     {
     case PVM_EmptyView:
         break;
@@ -1065,12 +1064,8 @@ void redraw_display(void)
           const char * text = get_string(GUIStr_PausedMsg);
           long w = (LbTextStringWidth(text) * units_per_pixel / 16 + 2 * (LbTextCharWidth(' ') * units_per_pixel / 16));
           long pos_x;
-          if (
-              player->view_mode == PVM_IsoWibbleView ||
-              player->view_mode == PVM_FrontView ||
-              player->view_mode == PVM_IsoStraightView ||
-              player->view_mode == PVM_CreatureView
-          ) {
+          struct Camera *camera = get_local_active_camera(player);
+          if (camera->view_mode == PVM_IsoWibbleView || camera->view_mode == PVM_FrontView || camera->view_mode == PVM_IsoStraightView || camera->view_mode == PVM_CreatureView) {
               pos_x = local_state.engine_window_x + (MyScreenWidth - w - local_state.engine_window_x) / 2;
           } else {
               pos_x = (MyScreenWidth-w)/2;

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -1065,7 +1065,10 @@ void redraw_display(void)
           long w = (LbTextStringWidth(text) * units_per_pixel / 16 + 2 * (LbTextCharWidth(' ') * units_per_pixel / 16));
           long pos_x;
           struct Camera *camera = get_local_active_camera(player);
-          if (camera->view_mode == PVM_IsoWibbleView || camera->view_mode == PVM_FrontView || camera->view_mode == PVM_IsoStraightView || camera->view_mode == PVM_CreatureView) {
+          unsigned char view_mode = camera->view_mode;
+          TbBool world_view = view_mode == PVM_IsoWibbleView || view_mode == PVM_FrontView;
+          world_view |= view_mode == PVM_IsoStraightView || view_mode == PVM_CreatureView;
+          if (world_view) {
               pos_x = local_state.engine_window_x + (MyScreenWidth - w - local_state.engine_window_x) / 2;
           } else {
               pos_x = (MyScreenWidth-w)/2;

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -5315,14 +5315,7 @@ static void draw_engine_number(struct BucketKindFloatingGoldText *num)
     w = scale_ui_value(spr->SWidth) * scale_by_zoom;
     h = scale_ui_value(spr->SHeight) * scale_by_zoom;
     struct Camera *active_cam = get_local_active_camera(player);
-    if (active_cam != NULL) {
-        unsigned char view_mode = active_cam->view_mode;
-        TbBool overhead_view = view_mode == PVM_IsoWibbleView || view_mode == PVM_FrontView;
-        overhead_view |= view_mode == PVM_IsoStraightView;
-        if (!overhead_view) {
-            RendererSetDrawFlags(flg_mem);
-            return;
-        }
+    if (active_cam != NULL && (active_cam->view_mode == PVM_IsoWibbleView || active_cam->view_mode == PVM_FrontView || active_cam->view_mode == PVM_IsoStraightView)) {
         // Count digits to be displayed
         ndigits=0;
         for (remaining_digits = num->lvl; remaining_digits > 0; remaining_digits /= 10)

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -2452,12 +2452,13 @@ static void fiddle_gamut_set_minmaxes(int32_t *floor_x, int32_t *floor_y, long m
 static void fiddle_gamut(long pos_x, long pos_y)
 {
     struct PlayerInfo *player = get_my_player();
+    struct Camera *camera = get_local_active_camera(player);
     long ewwidth;
     long ewheight;
     long ewzoom;
     int32_t floor_x[4];
     int32_t floor_y[4];
-    switch (player->view_mode)
+    switch (camera->view_mode)
     {
     case PVM_CreatureView:
         fiddle_half_gamut(pos_x, pos_y, 1, cells_away);
@@ -5102,7 +5103,7 @@ static void process_keeper_flame_on_sprite(struct BucketKindJontySprite* jspr, l
         scale = (flame.sprite_size * base_sprite_size / thing->sprite_size);
     }
 
-    if (player->view_type == PVT_DungeonTop)
+    if (get_local_view_type(player) == PVT_DungeonTop)
     {
         add_x = (base_sprite_size * flame.td_add_x) >> 5;
         add_y = (base_sprite_size * flame.td_add_y) >> 5;
@@ -5313,13 +5314,8 @@ static void draw_engine_number(struct BucketKindFloatingGoldText *num)
     spr = get_button_sprite(GBS_fontchars_number_dig0);
     w = scale_ui_value(spr->SWidth) * scale_by_zoom;
     h = scale_ui_value(spr->SHeight) * scale_by_zoom;
-    struct Camera *active_cam = get_player_active_camera(player);
-    if (
-        active_cam != NULL &&
-        (active_cam->view_mode == PVM_IsoWibbleView ||
-         active_cam->view_mode == PVM_FrontView ||
-         active_cam->view_mode == PVM_IsoStraightView)
-    ) {
+    struct Camera *active_cam = get_local_active_camera(player);
+    if (active_cam != NULL && (active_cam->view_mode == PVM_IsoWibbleView || active_cam->view_mode == PVM_FrontView || active_cam->view_mode == PVM_IsoStraightView)) {
         // Count digits to be displayed
         ndigits=0;
         for (remaining_digits = num->lvl; remaining_digits > 0; remaining_digits /= 10)
@@ -5349,7 +5345,7 @@ static void draw_engine_room_flagpole(struct BucketKindRoomFlag *rflg)
         return;
     }
     struct PlayerInfo *player = get_my_player();
-    const struct Camera *cam = get_local_camera(get_player_active_camera(player));
+    const struct Camera *cam = get_local_active_camera(player);
 
     if (
         cam->view_mode == PVM_IsoWibbleView ||
@@ -5508,7 +5504,7 @@ void fill_status_sprite_indexes(struct Thing *thing, struct CreatureControl *cct
 void draw_status_sprites(long scrpos_x, long scrpos_y, struct Thing *thing)
 {
     struct PlayerInfo *player = get_my_player();
-    const struct Camera *cam = get_local_camera(get_player_active_camera(player));
+    const struct Camera *cam = get_local_active_camera(player);
     if (cam == NULL)
     {
         return;
@@ -5748,7 +5744,7 @@ static void draw_engine_room_flag_top(struct BucketKindRoomFlag *rflg)
         return;
     }
     struct PlayerInfo *player = get_my_player();
-    const struct Camera *cam = get_local_camera(get_player_active_camera(player));
+    const struct Camera *cam = get_local_active_camera(player);
 
     if (
         cam->view_mode == PVM_IsoWibbleView ||
@@ -6969,7 +6965,7 @@ static void display_drawlist(void) // Draws isometric and 1st person view. Not f
                 break;
             case QK_JontyISOSprite: // Spinning key
                 player = get_my_player();
-                cam = get_local_camera(get_player_active_camera(player));
+                cam = get_local_active_camera(player);
                 if (cam != NULL)
                 {
                     if (cam->view_mode == PVM_IsoWibbleView || cam->view_mode == PVM_IsoStraightView) {
@@ -8073,7 +8069,7 @@ void process_keeper_sprite(short x, short y, unsigned short kspr_base, short ksp
             lltemp = dim_oh * (48 - (long)cctrl->sacrifice.animation_counter);
             cutoff = ((((lltemp >> 24) & 0x1F) + (long)lltemp) >> 5) / 2;
         }
-        if (player->view_mode == PVM_CreatureView)
+        if (get_local_active_camera(player)->view_mode == PVM_CreatureView)
         {
             water_source_cutoff = cutoff;
             water_y_offset = (2 * scale * cutoff) >> 5;
@@ -8180,7 +8176,7 @@ static void draw_mapwho_ariadne_path(struct Thing *thing)
 {
     // Don't draw debug pathfinding lines in Possession to avoid crash
     struct PlayerInfo *player = get_my_player();
-    if (player->view_mode == PVM_CreatureView)
+    if (get_local_active_camera(player)->view_mode == PVM_CreatureView)
         return;
 
     struct Ariadne *arid;
@@ -8253,7 +8249,7 @@ static void draw_jonty_mapwho(struct BucketKindJontySprite *jspr)
     if (!thing_is_invalid(thing))
     {
         if ((local_thing_under_hand == thing->index) && ((get_gameturn() % (4 * gui_blink_rate)) >= 2 * gui_blink_rate)) {
-          struct Camera *active_cam = get_player_active_camera(player);
+          struct Camera *active_cam = get_local_active_camera(player);
           if ((active_cam != NULL) && (active_cam->view_mode == PVM_IsoWibbleView || active_cam->view_mode == PVM_IsoStraightView))
           {
               RendererAddDrawFlags(Lb_SPRITE_REMAP);

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -5315,7 +5315,14 @@ static void draw_engine_number(struct BucketKindFloatingGoldText *num)
     w = scale_ui_value(spr->SWidth) * scale_by_zoom;
     h = scale_ui_value(spr->SHeight) * scale_by_zoom;
     struct Camera *active_cam = get_local_active_camera(player);
-    if (active_cam != NULL && (active_cam->view_mode == PVM_IsoWibbleView || active_cam->view_mode == PVM_FrontView || active_cam->view_mode == PVM_IsoStraightView)) {
+    if (active_cam != NULL) {
+        unsigned char view_mode = active_cam->view_mode;
+        TbBool overhead_view = view_mode == PVM_IsoWibbleView || view_mode == PVM_FrontView;
+        overhead_view |= view_mode == PVM_IsoStraightView;
+        if (!overhead_view) {
+            RendererSetDrawFlags(flg_mem);
+            return;
+        }
         // Count digits to be displayed
         ndigits=0;
         for (remaining_digits = num->lvl; remaining_digits > 0; remaining_digits /= 10)

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -725,8 +725,9 @@ static short get_global_inputs(void)
     get_players_message_inputs();
     return true;
   }
-  if (((view_type == PVT_DungeonTop) || (view_type == PVT_CreatureContrl)) && (network_is_active() || ((game.flags_gui & GGUI_SoloChatEnabled) != 0)))
-  {
+  TbBool chat_view = view_type == PVT_DungeonTop || view_type == PVT_CreatureContrl;
+  TbBool chat_enabled = network_is_active() || (game.flags_gui & GGUI_SoloChatEnabled) != 0;
+  if (chat_view && chat_enabled) {
       if (is_key_pressed(KC_RETURN,KMod_NONE))
       {
           if (menu_is_active(GMnu_QUIT))
@@ -914,7 +915,10 @@ static TbBool get_level_lost_inputs(void)
     {
       if (is_key_pressed(KC_TAB,KMod_DONTCARE))
       {
-          if (camera->view_mode == PVM_IsoWibbleView || camera->view_mode == PVM_FrontView || camera->view_mode == PVM_IsoStraightView) {
+          unsigned char view_mode = camera->view_mode;
+          TbBool overhead_view = view_mode == PVM_IsoWibbleView || view_mode == PVM_FrontView;
+          overhead_view |= view_mode == PVM_IsoStraightView;
+          if (overhead_view) {
             clear_key_pressed(KC_TAB);
             toggle_gui();
           }

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -725,9 +725,7 @@ static short get_global_inputs(void)
     get_players_message_inputs();
     return true;
   }
-  TbBool chat_view = view_type == PVT_DungeonTop || view_type == PVT_CreatureContrl;
-  TbBool chat_enabled = network_is_active() || (game.flags_gui & GGUI_SoloChatEnabled) != 0;
-  if (chat_view && chat_enabled) {
+  if ((view_type == PVT_DungeonTop || view_type == PVT_CreatureContrl) && (network_is_active() || (game.flags_gui & GGUI_SoloChatEnabled) != 0)) {
       if (is_key_pressed(KC_RETURN,KMod_NONE))
       {
           if (menu_is_active(GMnu_QUIT))
@@ -915,10 +913,7 @@ static TbBool get_level_lost_inputs(void)
     {
       if (is_key_pressed(KC_TAB,KMod_DONTCARE))
       {
-          unsigned char view_mode = camera->view_mode;
-          TbBool overhead_view = view_mode == PVM_IsoWibbleView || view_mode == PVM_FrontView;
-          overhead_view |= view_mode == PVM_IsoStraightView;
-          if (overhead_view) {
+          if (camera->view_mode == PVM_IsoWibbleView || camera->view_mode == PVM_FrontView || camera->view_mode == PVM_IsoStraightView) {
             clear_key_pressed(KC_TAB);
             toggle_gui();
           }

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -3014,6 +3014,9 @@ void input(void)
         pckt->additional_packet_values &= ~PCAdV_RotatePressed;
 
     get_inputs();
+    if ((game.mode_flags & MFlg_IsDemoMode) == 0 && !game.packet_load_enable) {
+        update_local_view_prediction(pckt);
+    }
 
     SYNCDBG(7,"Finished");
 }

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -638,7 +638,7 @@ static short get_bookmark_inputs(void)
         if (is_key_pressed(kcode, KMod_CONTROL))
         {
             clear_key_pressed(kcode);
-            struct Camera* camera = get_player_active_camera(player);
+            struct Camera* camera = get_local_active_camera(player);
             if (camera != NULL)
             {
                 bmark->x = camera->mappos.x.stl.num;
@@ -719,14 +719,13 @@ static short get_global_inputs(void)
   if (game_is_busy_doing_gui_string_input())
     return false;
   struct PlayerInfo* player = get_my_player();
+  unsigned char view_type = get_local_view_type(player);
   if ((player->allocflags & PlaF_NewMPMessage) != 0)
   {
     get_players_message_inputs();
     return true;
   }
-  if (((player->view_type == PVT_DungeonTop) || (player->view_type == PVT_CreatureContrl))
-  && (network_is_active() ||
-     ((game.flags_gui & GGUI_SoloChatEnabled) != 0)))
+  if (((view_type == PVT_DungeonTop) || (view_type == PVT_CreatureContrl)) && (network_is_active() || ((game.flags_gui & GGUI_SoloChatEnabled) != 0)))
   {
       if (is_key_pressed(KC_RETURN,KMod_NONE))
       {
@@ -855,6 +854,8 @@ static TbBool get_level_lost_inputs(void)
 {
     SYNCDBG(6,"Starting");
     struct PlayerInfo* player = get_my_player();
+    unsigned char view_type = get_local_view_type(player);
+    struct Camera* camera = get_local_active_camera(player);
     if ((player->allocflags & PlaF_NewMPMessage) != 0)
     {
       get_players_message_inputs();
@@ -882,15 +883,14 @@ static TbBool get_level_lost_inputs(void)
     {
         set_players_packet_action(player, PckA_FinishGame, player->victory_state, 0, 0, 0);
     }
-    if (player->view_type == PVT_MapScreen)
+    if (view_type == PVT_MapScreen)
     {
-        struct Camera* camera = get_player_active_camera(player);
         long mouse_x = GetMouseX();
         long mouse_y = GetMouseY();
         // Position on the parchment map on which we're doing action
         int32_t map_x;
         int32_t map_y;
-        TbBool map_valid = point_to_overhead_map(get_local_camera(camera), mouse_x / pixel_size, mouse_y / pixel_size, &map_x, &map_y);
+        TbBool map_valid = point_to_overhead_map(camera, mouse_x / pixel_size, mouse_y / pixel_size, &map_x, &map_y);
         if (is_game_key_pressed(Gkey_SwitchToMap, true, false))
         {
             zoom_from_parchment_map();
@@ -910,15 +910,11 @@ static TbBool get_level_lost_inputs(void)
             }
         }
     } else
-    if (player->view_type == PVT_DungeonTop)
+    if (view_type == PVT_DungeonTop)
     {
       if (is_key_pressed(KC_TAB,KMod_DONTCARE))
       {
-          if (
-            player->view_mode == PVM_IsoWibbleView ||
-            player->view_mode == PVM_FrontView ||
-            player->view_mode == PVM_IsoStraightView
-          ) {
+          if (camera->view_mode == PVM_IsoWibbleView || camera->view_mode == PVM_FrontView || camera->view_mode == PVM_IsoStraightView) {
             clear_key_pressed(KC_TAB);
             toggle_gui();
           }
@@ -944,7 +940,7 @@ static TbBool get_level_lost_inputs(void)
     get_options_menu_inputs();
 
     TbBool inp_done=false;
-    switch (player->view_type)
+    switch (view_type)
     {
       case PVT_DungeonTop:
         inp_done = menu_is_active(GMnu_SPELL_LOST);
@@ -1179,6 +1175,7 @@ static short get_status_panel_keyboard_action_inputs(void)
 static TbBool get_dungeon_control_pausable_action_inputs(void)
 {
     struct PlayerInfo* player = get_my_player();
+    struct Camera* camera = get_local_active_camera(player);
     if (get_players_packet_action(player) != PckA_None)
       return true;
 
@@ -1225,7 +1222,7 @@ static TbBool get_dungeon_control_pausable_action_inputs(void)
             }
         }
     }
-    if (player->view_mode == PVM_IsoWibbleView || player->view_mode == PVM_IsoStraightView)
+    if (camera->view_mode == PVM_IsoWibbleView || camera->view_mode == PVM_IsoStraightView)
     {
         if (is_key_pressed(KC_TAB, !KMod_CONTROL))
         {
@@ -1270,7 +1267,7 @@ static TbBool get_dungeon_control_pausable_action_inputs(void)
             return true;
         }
     }
-    if (player->view_mode == PVM_FrontView)
+    if (camera->view_mode == PVM_FrontView)
     {
         if (is_game_key_pressed(Gkey_ToggleGui, true, false))
         {
@@ -1990,7 +1987,7 @@ static void set_packet_action_for_thing_under_hand(struct Packet* pckt)
 {
     NetUserId user = get_local_user();
     struct PlayerInfo* player = get_my_player();
-    if ((player->view_type != PVT_DungeonTop) || ((pckt->control_flags & PCtr_Gui) != 0) || (local_thing_under_hand <= 0) || (pckt->action != PckA_None) || (get_gameturn() - hand_pick_pending_turn <= game.input_lag_turns)) {
+    if ((get_local_view_type(player) != PVT_DungeonTop) || ((pckt->control_flags & PCtr_Gui) != 0) || (local_thing_under_hand <= 0) || (pckt->action != PckA_None) || (get_gameturn() - hand_pick_pending_turn <= game.input_lag_turns)) {
         return;
     }
     int32_t cursor_state = (pckt->additional_packet_values & PCAdV_ContextMask) >> 1;
@@ -2080,13 +2077,13 @@ static void get_packet_control_mouse_clicks(void)
 static short get_map_action_inputs(void)
 {
     struct PlayerInfo* player = get_my_player();
-    struct Camera* camera = get_player_active_camera(player);
+    struct Camera* camera = get_local_active_camera(player);
     long mouse_x = GetMouseX();
     long mouse_y = GetMouseY();
     // Get map coordinates from mouse position on parchment screen
     int32_t map_x;
     int32_t map_y;
-    TbBool map_valid = point_to_overhead_map(get_local_camera(camera), mouse_x / pixel_size, mouse_y / pixel_size, &map_x, &map_y);
+    TbBool map_valid = point_to_overhead_map(camera, mouse_x / pixel_size, mouse_y / pixel_size, &map_x, &map_y);
     if  (map_valid)
     {
         MapSubtlCoord stl_x = coord_subtile(map_x);
@@ -2324,7 +2321,6 @@ static void get_overhead_view_nonaction_inputs(void)
         if (mx >= MyScreenWidth-4)
           set_packet_control(pckt, PCtr_MoveRight);
     }
-    set_local_camera_destination(player);
 }
 
 static void get_front_view_nonaction_inputs(void)
@@ -2486,6 +2482,7 @@ static void get_dungeon_control_nonaction_inputs(void)
   my_mouse_x = GetMouseX();
   my_mouse_y = GetMouseY();
   struct PlayerInfo* player = get_my_player();
+  struct Camera* camera = get_local_active_camera(player);
   struct Packet* pckt = get_local_packet();
   if (get_gameturn() - hand_pick_pending_turn > game.input_lag_turns) {
     local_thing_under_hand = 0;
@@ -2500,7 +2497,7 @@ static void get_dungeon_control_nonaction_inputs(void)
     }
   } else
   {
-    if (screen_to_map(get_local_camera(get_player_active_camera(player)), my_mouse_x, my_mouse_y, &pos))
+    if (screen_to_map(camera, my_mouse_x, my_mouse_y, &pos))
     {
         set_players_packet_position(pckt, pos.x.val, pos.y.val, 0);
         pckt->additional_packet_values &= ~PCAdV_ContextMask; // reset cursor states to 0 (CSt_DefaultArrow)
@@ -2549,7 +2546,7 @@ static void get_dungeon_control_nonaction_inputs(void)
       set_packet_control(pckt, PCtr_ViewRotatePos);
   if ((player->allocflags & PlaF_NewMPMessage) == 0)
   {
-      switch (player->view_mode)
+      switch (camera->view_mode)
       {
       case PVM_IsoWibbleView:
       case PVM_IsoStraightView:
@@ -2573,7 +2570,8 @@ static void get_map_nonaction_inputs(void)
     pos.y.val = 0;
     pos.z.val = 0;
     struct PlayerInfo* player = get_my_player();
-    TbBool coords_valid = screen_to_map(get_local_camera(get_player_active_camera(player)), GetMouseX(), GetMouseY(), &pos);
+    struct Camera* camera = get_local_active_camera(player);
+    TbBool coords_valid = screen_to_map(camera, GetMouseX(), GetMouseY(), &pos);
     set_players_packet_position(get_local_packet(), pos.x.val, pos.y.val, 0);
     struct Packet* pckt = get_local_packet();
     if (coords_valid) {
@@ -2581,7 +2579,7 @@ static void get_map_nonaction_inputs(void)
     } else {
         unset_packet_control(pckt, PCtr_MapCoordsValid);
     }
-    if (((game.operation_flags & GOF_Paused) == 0) && (player->view_mode == PVM_ParchmentView))
+    if (((game.operation_flags & GOF_Paused) == 0) && (camera->view_mode == PVM_ParchmentView))
     {
         get_overhead_view_nonaction_inputs();
     }
@@ -2741,7 +2739,7 @@ static void get_player_gui_clicks(void)
   if ( ((game.operation_flags & GOF_Paused) != 0) && ((game.operation_flags & GOF_WorldInfluence) == 0))
     return;
   struct PlayerInfo *player = get_my_player();
-  switch (player->view_type)
+  switch (get_local_view_type(player))
   {
   case PVT_CreaturePasngr:
       if (right_button_released)
@@ -2933,8 +2931,9 @@ static short get_inputs(void)
     if (game_is_busy_doing_gui_string_input())
       return false;
     get_screen_capture_inputs();
-    SYNCDBG(7,"Getting inputs for view %d",(int)player->view_type);
-    switch (player->view_type)
+    unsigned char view_type = get_local_view_type(player);
+    SYNCDBG(7,"Getting inputs for view %d",(int)view_type);
+    switch (view_type)
     {
     case PVT_DungeonTop:
         get_dungeon_control_pausable_action_inputs();
@@ -3481,7 +3480,7 @@ static void process_cheat_mode_selection_inputs(void)
                 if (is_key_pressed(KC_LALT, KMod_DONTCARE))
                 {
                     struct Coord3d pos;
-                    if (screen_to_map(get_local_camera(get_player_active_camera(player)), GetMouseX(), GetMouseY(), &pos))
+                    if (screen_to_map(get_local_active_camera(player), GetMouseX(), GetMouseY(), &pos))
                     {
                         MapSlabCoord slb_x = subtile_slab(pos.x.stl.num);
                         MapSlabCoord slb_y = subtile_slab(pos.y.stl.num);

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -358,11 +358,14 @@ void gui_area_enemy_battlers(struct GuiButton *gbtn)
 
 short zoom_to_fight(PlayerNumber plyr_idx)
 {
-    struct PlayerInfo* player = get_my_player();
     if (active_battle_exists(plyr_idx))
     {
         struct Dungeon* dungeon = get_players_num_dungeon(my_player_number);
-        set_players_packet_action(player, PckA_ZoomToBattle, dungeon->visible_battles[0], 0, 0, 0);
+        struct CreatureBattle* battle = creature_battle_get(dungeon->visible_battles[0]);
+        struct Thing* thing = thing_get(battle->first_creatr);
+        if (thing_exists(thing)) {
+            move_local_camera_to_position(thing->mappos.x.val, thing->mappos.y.val);
+        }
         step_battles_forward(plyr_idx);
         return true;
     }

--- a/src/frontmenu_ingame_map.c
+++ b/src/frontmenu_ingame_map.c
@@ -260,10 +260,9 @@ int draw_overlay_call_to_arms(struct PlayerInfo *player, long units_per_px, long
     int i;
     int n;
     SYNCDBG(18,"Starting");
-    struct Camera *active_cam = get_player_active_camera(player);
-    if (active_cam == NULL)
+    struct Camera *cam = get_local_active_camera(player);
+    if (cam == NULL)
         return 0;
-    struct Camera *cam = get_local_camera(active_cam);
     n = 0;
     const struct StructureList *slist = get_list_for_thing_class(TCls_Object);
     k = 0;
@@ -310,10 +309,9 @@ int draw_overlay_traps(struct PlayerInfo *player, long units_per_px, long scaled
     int i;
     int n;
     SYNCDBG(18,"Starting");
-    struct Camera *active_cam = get_player_active_camera(player);
-    if (active_cam == NULL)
+    struct Camera *cam = get_local_active_camera(player);
+    if (cam == NULL)
         return 0;
-    struct Camera *cam = get_local_camera(active_cam);
     n = 0;
     k = 0;
     const struct StructureList *slist = get_list_for_thing_class(TCls_Trap);
@@ -389,10 +387,9 @@ int draw_overlay_spells_and_boxes(struct PlayerInfo *player, long units_per_px, 
     int i;
     int n;
     SYNCDBG(18,"Starting");
-    struct Camera *active_cam = get_player_active_camera(player);
-    if (active_cam == NULL)
+    struct Camera *cam = get_local_active_camera(player);
+    if (cam == NULL)
         return 0;
-    struct Camera *cam = get_local_camera(active_cam);
     n = 0;
     const struct StructureList *slist = get_list_for_thing_class(TCls_Object);
     k = 0;
@@ -473,7 +470,7 @@ void panel_map_draw_creature_dot(long mapos_x, long mapos_y, RealScreenCoord bas
 int draw_overlay_possessed_thing(struct PlayerInfo* player, long mapos_x, long mapos_y, RealScreenCoord basepos, TbPixel col, long basic_zoom, TbBool isLowRes)
 {
     const struct Camera* cam;
-    cam = get_local_camera(get_player_active_camera(player));
+    cam = get_local_active_camera(player);
     if (cam == NULL)
         return 0;
     if (cam->view_mode != PVM_CreatureView)
@@ -513,10 +510,9 @@ int draw_overlay_creatures(struct PlayerInfo *player, long units_per_px, long zo
     int i;
     int n;
     SYNCDBG(18,"Starting");
-    struct Camera *active_cam = get_player_active_camera(player);
-    if (active_cam == NULL)
+    struct Camera *cam = get_local_active_camera(player);
+    if (cam == NULL)
         return 0;
-    struct Camera *cam = get_local_camera(active_cam);
     n = 0;
     k = 0;
     const struct StructureList *slist = get_list_for_thing_class(TCls_Creature);
@@ -632,10 +628,9 @@ int draw_overlay_creatures(struct PlayerInfo *player, long units_per_px, long zo
  */
 int draw_line_to_heart(struct PlayerInfo *player, long units_per_px, long zoom)
 {
-    struct Camera *active_cam = get_player_active_camera(player);
-    if (active_cam == NULL)
+    struct Camera *cam = get_local_active_camera(player);
+    if (cam == NULL)
         return 0;
-    struct Camera *cam = get_local_camera(active_cam);
     struct Thing *thing = get_player_soul_container(player->id_number);
 
     if (!thing_exists(thing)) {
@@ -809,8 +804,8 @@ void panel_map_update(long x, long y, long w, long h)
 
 static void do_map_rotate_stuff(float relpos_x, float relpos_y, float *coord_x, float *coord_y, long zoom)
 {
-    const struct PlayerInfo *player = get_my_player();
-    const struct Camera *cam = get_local_camera(get_player_active_camera(player));
+    struct PlayerInfo *player = get_my_player();
+    const struct Camera *cam = get_local_active_camera(player);
     const int angle = cam->rotation_angle_x & ANGLE_MASK_4;
     const int shift_x = -LbSinL(angle);
     const int shift_y = LbCosL(angle);
@@ -1252,7 +1247,7 @@ void panel_map_draw_slabs(long x, long y, long units_per_px, long zoom)
     auto_gen_tables(units_per_px);
     update_panel_colors();
     struct PlayerInfo *player = get_my_player();
-    struct Camera *cam = get_local_camera(get_player_active_camera(player));
+    struct Camera *cam = get_local_active_camera(player);
 
     if ((cam == NULL) || (MapDiagonalLength < 1))
         return;

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -67,6 +67,7 @@
 #include "frontend.h"
 #include "front_input.h"
 #include "game_legacy.h"
+#include "local_camera.h"
 #include "keeperfx.hpp"
 #include "vidfade.h"
 #include "kjm_input.h"
@@ -725,8 +726,10 @@ void gui_choose_spell(struct GuiButton *gbtn)
 
 void go_to_next_spell_of_type(PowerKind pwkind)
 {
-    struct Packet* pckt = get_local_packet();
-    set_packet_action(pckt, PckA_ZoomToSpell, pwkind, 0, 0, 0);
+    struct Coord3d pos;
+    if (find_power_cast_place(my_player_number, pwkind, &pos)) {
+        move_local_camera_to_position(pos.x.val, pos.y.val);
+    }
 }
 
 void gui_go_to_next_spell(struct GuiButton *gbtn)
@@ -934,8 +937,8 @@ void go_to_next_trap_of_type(ThingModel tngmodel, PlayerNumber plyr_idx)
     }
     i = seltrap[tngmodel];
     if (i > 0) {
-        struct Packet* pckt = get_local_packet();
-        set_packet_action(pckt, PckA_ZoomToTrap, i, 0, 0, 0);
+        thing = thing_get(i);
+        move_local_camera_to_position(thing->mappos.x.val, thing->mappos.y.val);
     }
 }
 
@@ -989,8 +992,8 @@ void go_to_next_door_of_type(ThingModel tngmodel, PlayerNumber plyr_idx)
     }
     i = seldoor[tngmodel];
     if (i > 0) {
-        struct Packet* pckt = get_local_packet();
-        set_packet_action(pckt, PckA_ZoomToDoor, i, 0, 0, 0);
+        thing = thing_get(i);
+        move_local_camera_to_position(thing->mappos.x.val, thing->mappos.y.val);
     }
 }
 
@@ -1647,9 +1650,9 @@ RoomIndex find_next_room_of_type(PlayerNumber plyr_idx, RoomKind rkind)
 void go_to_my_next_room_of_type_and_select(RoomKind rkind)
 {
     RoomIndex room_idx = find_my_next_room_of_type(rkind);
-    struct PlayerInfo* player = get_my_player();
     if (room_idx > 0) {
-        set_players_packet_action(player, PckA_ZoomToRoom, room_idx, 0, 0, 0);
+        struct Room* room = room_get(room_idx);
+        move_local_camera_to_position(subtile_coord_center(room->central_stl_x), subtile_coord_center(room->central_stl_y));
     }
 }
 
@@ -1657,10 +1660,9 @@ void go_to_my_next_room_of_type(RoomKind rkind)
 {
     //_DK_go_to_my_next_room_of_type(rkind); return;
     RoomIndex room_idx = find_my_next_room_of_type(rkind);
-    struct PlayerInfo* player = get_my_player();
     if (room_idx > 0) {
         struct Room* room = room_get(room_idx);
-        set_players_packet_action(player, PckA_ZoomToPosition, subtile_coord_center(room->central_stl_x), subtile_coord_center(room->central_stl_y), 0, 0);
+        move_local_camera_to_position(subtile_coord_center(room->central_stl_x), subtile_coord_center(room->central_stl_y));
     }
 }
 

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1647,15 +1647,6 @@ RoomIndex find_next_room_of_type(PlayerNumber plyr_idx, RoomKind rkind)
     return next_room[rkind];
 }
 
-void go_to_my_next_room_of_type_and_select(RoomKind rkind)
-{
-    RoomIndex room_idx = find_my_next_room_of_type(rkind);
-    if (room_idx > 0) {
-        struct Room* room = room_get(room_idx);
-        move_local_camera_to_position(subtile_coord_center(room->central_stl_x), subtile_coord_center(room->central_stl_y));
-    }
-}
-
 void go_to_my_next_room_of_type(RoomKind rkind)
 {
     //_DK_go_to_my_next_room_of_type(rkind); return;
@@ -1669,7 +1660,7 @@ void go_to_my_next_room_of_type(RoomKind rkind)
 void gui_go_to_next_room(struct GuiButton *gbtn)
 {
     unsigned long rkind = gbtn->content.lval;
-    go_to_my_next_room_of_type_and_select(rkind);
+    go_to_my_next_room_of_type(rkind);
     game.chosen_room_kind = rkind;
     struct RoomConfigStats* roomst = get_room_kind_stats(rkind);
     game.chosen_room_spridx = roomst->bigsym_sprite_idx;

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -734,9 +734,8 @@ void go_to_next_spell_of_type(PowerKind pwkind)
 
 void gui_go_to_next_spell(struct GuiButton *gbtn)
 {
-    PowerKind pwkind = gbtn->content.lval;
-    go_to_next_spell_of_type(pwkind);
-    set_chosen_power(pwkind, gbtn->tooltip_stridx);
+    go_to_next_spell_of_type(gbtn->content.lval);
+    gui_choose_spell(gbtn);
 }
 
 void gui_area_spell_button(struct GuiButton *gbtn)

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -1659,12 +1659,8 @@ void go_to_my_next_room_of_type(RoomKind rkind)
 
 void gui_go_to_next_room(struct GuiButton *gbtn)
 {
-    unsigned long rkind = gbtn->content.lval;
-    go_to_my_next_room_of_type(rkind);
-    game.chosen_room_kind = rkind;
-    struct RoomConfigStats* roomst = get_room_kind_stats(rkind);
-    game.chosen_room_spridx = roomst->bigsym_sprite_idx;
-    game.chosen_room_tooltip = gbtn->tooltip_stridx;
+    go_to_my_next_room_of_type(gbtn->content.lval);
+    gui_choose_room(gbtn);
 }
 
 void gui_over_room_button(struct GuiButton *gbtn)

--- a/src/frontmenu_ingame_tabs.h
+++ b/src/frontmenu_ingame_tabs.h
@@ -103,7 +103,6 @@ void update_room_tab_to_config(void);
 void update_trap_tab_to_config(void);
 void update_powers_tab_to_config(void);
 
-void go_to_my_next_room_of_type_and_select(RoomKind rkind);
 void go_to_my_next_room_of_type(RoomKind rkind);
 RoomIndex find_my_next_room_of_type(RoomKind rkind);
 RoomIndex find_next_room_of_type(PlayerNumber plyr_idx, RoomKind rkind);

--- a/src/game_saves.c
+++ b/src/game_saves.c
@@ -484,6 +484,7 @@ TbBool load_game(long slot_num)
     struct PlayerInfo* player = get_my_player();
     clear_flag(player->additional_flags, PlaAF_LightningPaletteIsActive);
     clear_flag(player->additional_flags, PlaAF_FreezePaletteIsActive);
+    local_state.view_type = PVT_None;
     local_state.palette_fade_step_pain = 0;
     local_state.palette_fade_step_possession = 0;
     local_state.lens_palette = 0;

--- a/src/gui_parchment.c
+++ b/src/gui_parchment.c
@@ -1216,8 +1216,6 @@ void zoom_from_parchment_map(void)
     if (network_is_active()
         || (lbDisplay.PhysicalScreenWidth > 320))
     {
-        if ((game.operation_flags & GOF_ShowPanel) != 0)
-          toggle_status_menu(1);
         set_players_packet_action(player, PckA_LoadViewType, PVT_DungeonTop, 0,0,0);
     } else
     {

--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -459,18 +459,18 @@ TbBool input_gameplay_tooltips(TbBool gameplay_on)
     struct PlayerInfo* player = get_my_player();
     if ((gameplay_on) && (tool_tip_time == 0) && (!busy_doing_gui))
     {
-      struct Camera *camera = get_player_active_camera(player);
+      struct Camera *camera = get_local_active_camera(player);
       if (camera == NULL)
         {
             ERRORLOG("No active camera");
             return false;
         }
         struct Coord3d mappos;
-      if (screen_to_map(get_local_camera(camera), GetMouseX(), GetMouseY(), &mappos))
+      if (screen_to_map(camera, GetMouseX(), GetMouseY(), &mappos))
         {
             if (subtile_revealed(mappos.x.stl.num,mappos.y.stl.num, player->id_number))
             {
-                if (player->view_mode != PVM_CreatureView)
+                if (camera->view_mode != PVM_CreatureView)
                     shown = setup_scrolling_tooltips(&mappos);
             }
         }
@@ -623,7 +623,7 @@ void draw_tooltip_at(long ttpos_x,long ttpos_y,char *tttext)
   struct PlayerInfo* player = get_my_player();
   long pos_x = ttpos_x;
   long pos_y = ttpos_y;
-  if (player->view_type == PVT_MapScreen)
+  if (get_local_view_type(player) == PVT_MapScreen)
   {
       pos_y = GetMouseY() + scale_ui_value(24);
       if (pos_y > MyScreenHeight - scale_ui_value(104))

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -313,6 +313,9 @@ void sync_local_camera(struct PlayerInfo *player)
         return;
     }
     struct Camera *camera = get_player_active_camera(player);
+    if (camera == &player->cameras[CamIV_Parchment] || player->view_mode == PVM_ParchmentView) {
+        return;
+    }
     if (camera == &player->cameras[CamIV_FirstPerson]) {
         sync_first_person_camera(camera, player);
         return;
@@ -324,7 +327,7 @@ void sync_local_camera(struct PlayerInfo *player)
 
 void set_local_camera_destination(struct PlayerInfo *player)
 {
-    if (!is_my_player(player) || !local_camera_ready) {
+    if (!is_my_player(player) || !local_camera_ready || player->view_mode == PVM_ParchmentView) {
         return;
     }
     for (int cam_idx = CamIV_Isometric; cam_idx <= CamIV_FrontView; cam_idx++) {

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -40,27 +40,18 @@
 extern "C" {
 #endif
 /******************************************************************************/
-static struct Camera local_cameras[4];
-static struct Camera previous_local_cameras[4];
-static struct Camera destination_local_cameras[4];
-float previous_deviation_x;
-float previous_deviation_y;
-float destination_deviation_x;
-float destination_deviation_y;
+static struct Camera local_cameras[CamIV_EndList];
+static struct Camera previous_local_cameras[CamIV_EndList];
+static struct Camera destination_local_cameras[CamIV_EndList];
+static float previous_deviation_x;
+static float previous_deviation_y;
+static float destination_deviation_x;
+static float destination_deviation_y;
 static TbBool local_camera_ready;
 static MapCoord local_camera_move_target[2];
 static MapCoordDelta local_camera_move_delta[2];
 static TbBool local_camera_move_active;
 /******************************************************************************/
-
-static const struct Packet* get_packet_for_local_camera_update(void)
-{
-    struct PlayerInfo *player = get_my_player();
-    if (player_invalid(player)) {
-        return NULL;
-    }
-    return get_history_packet(get_local_user(), get_gameturn());
-}
 
 void send_camera_catchup_packets(void)
 {
@@ -146,7 +137,7 @@ void init_local_cameras(struct PlayerInfo *player)
     if (!is_my_player(player)) {
         return;
     }
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < CamIV_EndList; i++) {
         sync_camera_state(i, &player->cameras[i]);
     }
     local_camera_move_active = false;
@@ -158,8 +149,7 @@ void move_local_camera_to_position(MapCoord x, MapCoord y)
     if (!local_camera_ready) {
         return;
     }
-    struct Camera *active_camera = get_local_active_camera(get_my_player());
-    int cam_idx = active_camera - local_cameras;
+    int cam_idx = get_local_active_camera(get_my_player()) - local_cameras;
     struct Camera *cam = &destination_local_cameras[cam_idx];
     local_camera_move_target[0] = x;
     local_camera_move_target[1] = y;
@@ -196,16 +186,6 @@ static void update_local_first_person_camera(struct Thing *ctrltng, const struct
     }
 }
 
-static void update_camera_deviations(int active_cam_idx)
-{
-    struct Dungeon* dungeon = get_players_num_dungeon(my_player_number);
-    if (dungeon->camera_deviate_jump != 0) {
-        long angle = destination_local_cameras[active_cam_idx].rotation_angle_x;
-        destination_deviation_x += ( (dungeon->camera_deviate_jump * LbSinL(angle) >> 8) >> 8);
-        destination_deviation_y += (-(dungeon->camera_deviate_jump * LbCosL(angle) >> 8) >> 8);
-    }
-}
-
 void update_local_cameras(void)
 {
     if (!local_camera_ready) {
@@ -213,7 +193,7 @@ void update_local_cameras(void)
     }
     struct PlayerInfo *player = get_my_player();
     struct Thing *ctrltng = thing_get(player->controlled_thing_idx);
-    const struct Packet *pckt = get_packet_for_local_camera_update();
+    const struct Packet *pckt = get_history_packet(get_local_user(), get_gameturn());
     previous_deviation_x = destination_deviation_x;
     previous_deviation_y = destination_deviation_y;
     destination_deviation_x = 0;
@@ -222,13 +202,10 @@ void update_local_cameras(void)
     if (pckt != NULL) {
         process_camera_action(destination_local_cameras, pckt);
     }
-    for (int i = 0; i < 4; i++) {
-        previous_local_cameras[i] = destination_local_cameras[i];
-    }
+    memcpy(previous_local_cameras, destination_local_cameras, sizeof(previous_local_cameras));
 
-    struct Camera *cam = get_local_active_camera(player);
-    int active_cam_idx = cam - local_cameras;
-    if (cam->view_mode == PVM_CreatureView && thing_exists(ctrltng)) {
+    int active_cam_idx = get_local_active_camera(player) - local_cameras;
+    if (active_cam_idx == CamIV_FirstPerson && thing_exists(ctrltng)) {
         update_local_first_person_camera(ctrltng, pckt);
         return;
     }
@@ -236,19 +213,24 @@ void update_local_cameras(void)
         return;
     }
 
-    cam = &destination_local_cameras[active_cam_idx];
+    struct Camera *cam = &destination_local_cameras[active_cam_idx];
     if (active_cam_idx == CamIV_Parchment) {
         local_camera_move_active = false;
     }
     if (local_camera_move_active) {
         local_camera_move_active = !view_move_camera_to_position(cam, local_camera_move_target[0], local_camera_move_target[1], local_camera_move_delta[0], local_camera_move_delta[1]);
     } else {
-        process_camera_controls(cam, pckt, player, true);
+        process_camera_controls(cam, pckt, player);
         view_process_camera_inertia(cam);
     }
 
     if (active_cam_idx == CamIV_Isometric) {
-        update_camera_deviations(active_cam_idx);
+        struct Dungeon* dungeon = get_players_num_dungeon(my_player_number);
+        if (dungeon->camera_deviate_jump != 0) {
+            int32_t angle = cam->rotation_angle_x;
+            destination_deviation_x += ( (dungeon->camera_deviate_jump * LbSinL(angle) >> 8) >> 8);
+            destination_deviation_y += (-(dungeon->camera_deviate_jump * LbCosL(angle) >> 8) >> 8);
+        }
     }
 }
 
@@ -264,8 +246,8 @@ static void interpolate_camera_deviations(void)
     }
     const float interpolated_deviation_x = interpolate(previous_deviation_x, destination_deviation_x);
     const float interpolated_deviation_y = interpolate(previous_deviation_y, destination_deviation_y);
-    long total_deviation_x = (long)interpolated_deviation_x;
-    long total_deviation_y = (long)interpolated_deviation_y;
+    int32_t total_deviation_x = (int32_t)interpolated_deviation_x;
+    int32_t total_deviation_y = (int32_t)interpolated_deviation_y;
     struct Dungeon* dungeon = get_players_num_dungeon(my_player_number);
     if (dungeon->camera_deviate_quake != 0) {
         total_deviation_x += UNSYNC_RANDOM(80) - 40;
@@ -275,20 +257,10 @@ static void interpolate_camera_deviations(void)
         return;
     }
     struct Camera* cam = &local_cameras[CamIV_Isometric];
-    long x = cam->mappos.x.val + total_deviation_x;
-    long y = cam->mappos.y.val + total_deviation_y;
-    if (x < 0) {
-        x = 0;
-    } else if (x > (game.map_subtiles_x + 1) * COORD_PER_STL - 1) {
-        x = (game.map_subtiles_x + 1) * COORD_PER_STL - 1;
-    }
-    if (y < 0) {
-        y = 0;
-    } else if (y > (game.map_subtiles_y + 1) * COORD_PER_STL - 1) {
-        y = (game.map_subtiles_y + 1) * COORD_PER_STL - 1;
-    }
-    cam->mappos.x.val = x;
-    cam->mappos.y.val = y;
+    const MapCoord max_x = (game.map_subtiles_x + 1) * COORD_PER_STL - 1;
+    const MapCoord max_y = (game.map_subtiles_y + 1) * COORD_PER_STL - 1;
+    cam->mappos.x.val = clamp(cam->mappos.x.val + total_deviation_x, 0, max_x);
+    cam->mappos.y.val = clamp(cam->mappos.y.val + total_deviation_y, 0, max_y);
 }
 
 void interpolate_local_cameras(void)
@@ -296,7 +268,7 @@ void interpolate_local_cameras(void)
     if (!local_camera_ready) {
         return;
     }
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < CamIV_EndList; i++) {
         struct Camera* prev = &previous_local_cameras[i];
         struct Camera* desired = &destination_local_cameras[i];
         struct Camera* out = &local_cameras[i];
@@ -331,7 +303,7 @@ void sync_local_camera(struct PlayerInfo *player)
         sync_first_person_camera(camera, player);
         return;
     }
-    for (int cam_idx = CamIV_Isometric; cam_idx <= CamIV_FrontView; cam_idx++) {
+    for (int cam_idx = 0; cam_idx < CamIV_EndList; cam_idx++) {
         sync_camera_state(cam_idx, &player->cameras[cam_idx]);
     }
 }
@@ -341,9 +313,7 @@ void set_local_camera_destination(struct PlayerInfo *player)
     if (!is_my_player(player) || !local_camera_ready || get_local_view_type(player) == PVT_MapScreen) {
         return;
     }
-    for (int cam_idx = CamIV_Isometric; cam_idx <= CamIV_FrontView; cam_idx++) {
-        destination_local_cameras[cam_idx] = player->cameras[cam_idx];
-    }
+    memcpy(destination_local_cameras, player->cameras, sizeof(destination_local_cameras));
     struct Thing *ctrltng = thing_get(player->controlled_thing_idx);
     if (thing_exists(ctrltng)) {
         destination_local_cameras[CamIV_FirstPerson].rotation_angle_x = ctrltng->move_angle_xy;
@@ -353,21 +323,18 @@ void set_local_camera_destination(struct PlayerInfo *player)
 
 void update_local_view_prediction(const struct Packet *pckt)
 {
-    unsigned char view_type = PVT_None;
-    if (pckt->action == PckA_SaveViewType && pckt->actn_par1 == PVT_MapScreen) {
-        view_type = PVT_MapScreen;
-    }
-    if ((pckt->action == PckA_LoadViewType && pckt->actn_par1 == PVT_DungeonTop) || pckt->action == PckA_ZoomFromMap) {
-        view_type = PVT_DungeonTop;
-    }
-    if (view_type == PVT_None) {
-        return;
-    }
-    local_state.view_type = view_type;
-    if (view_type == PVT_MapScreen) {
+    switch (pckt->action) {
+    case PckA_SaveViewType:
+        local_state.view_type = PVT_MapScreen;
         toggle_status_menu(0);
-    } else {
+        break;
+    case PckA_LoadViewType:
+    case PckA_ZoomFromMap:
+        local_state.view_type = PVT_DungeonTop;
         toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
+        break;
+    default:
+        return;
     }
 }
 

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -50,7 +50,7 @@ static float destination_deviation_y;
 static TbBool local_camera_ready;
 static MapCoord local_camera_move_target[2];
 static MapCoordDelta local_camera_move_delta[2];
-static TbBool local_camera_move_active;
+static struct Camera *local_camera_move_cam;
 /******************************************************************************/
 
 void send_camera_catchup_packets(void)
@@ -140,7 +140,7 @@ void init_local_cameras(struct PlayerInfo *player)
     for (int i = 0; i < CamIV_EndList; i++) {
         sync_camera_state(i, &player->cameras[i]);
     }
-    local_camera_move_active = false;
+    local_camera_move_cam = NULL;
     local_camera_ready = true;
 }
 
@@ -151,10 +151,10 @@ void move_local_camera_to_position(MapCoord x, MapCoord y)
     }
     int cam_idx = get_local_active_camera(get_my_player()) - local_cameras;
     struct Camera *cam = &destination_local_cameras[cam_idx];
+    local_camera_move_cam = cam;
     local_camera_move_target[0] = x;
     local_camera_move_target[1] = y;
     view_set_camera_move_to_position(cam, x, y, &local_camera_move_delta[0], &local_camera_move_delta[1]);
-    local_camera_move_active = true;
 }
 
 static void update_local_first_person_camera(struct Thing *ctrltng, const struct Packet *pckt)
@@ -214,12 +214,12 @@ void update_local_cameras(void)
     }
 
     struct Camera *cam = &destination_local_cameras[active_cam_idx];
-    if (active_cam_idx == CamIV_Parchment) {
-        local_camera_move_active = false;
+    if (local_camera_move_cam != NULL) {
+        if (view_move_camera_to_position(local_camera_move_cam, local_camera_move_target[0], local_camera_move_target[1], local_camera_move_delta[0], local_camera_move_delta[1])) {
+            local_camera_move_cam = NULL;
+        }
     }
-    if (local_camera_move_active) {
-        local_camera_move_active = !view_move_camera_to_position(cam, local_camera_move_target[0], local_camera_move_target[1], local_camera_move_delta[0], local_camera_move_delta[1]);
-    } else {
+    if (local_camera_move_cam != cam) {
         process_camera_controls(cam, pckt, player);
         view_process_camera_inertia(cam);
     }
@@ -323,6 +323,9 @@ void set_local_camera_destination(struct PlayerInfo *player)
 
 void update_local_view_prediction(const struct Packet *pckt)
 {
+    if (pckt->action == PckA_ZoomFromMap) {
+        local_camera_move_cam = NULL;
+    }
     if (pckt->action == PckA_SaveViewType && pckt->actn_par1 == PVT_MapScreen) {
         local_state.view_type = PVT_MapScreen;
         toggle_status_menu(0);

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -31,6 +31,7 @@
 #include "map_data.h"
 #include "bflib_math.h"
 #include "frontmenu_ingame_map.h"
+#include "frontend.h"
 
 #include <math.h>
 #include "post_inc.h"
@@ -347,6 +348,26 @@ void set_local_camera_destination(struct PlayerInfo *player)
     if (thing_exists(ctrltng)) {
         destination_local_cameras[CamIV_FirstPerson].rotation_angle_x = ctrltng->move_angle_xy;
         destination_local_cameras[CamIV_FirstPerson].rotation_angle_y = ctrltng->move_angle_z;
+    }
+}
+
+void update_local_view_prediction(const struct Packet *pckt)
+{
+    unsigned char view_type = PVT_None;
+    if (pckt->action == PckA_SaveViewType && pckt->actn_par1 == PVT_MapScreen) {
+        view_type = PVT_MapScreen;
+    }
+    if ((pckt->action == PckA_LoadViewType && pckt->actn_par1 == PVT_DungeonTop) || pckt->action == PckA_ZoomFromMap) {
+        view_type = PVT_DungeonTop;
+    }
+    if (view_type == PVT_None) {
+        return;
+    }
+    local_state.view_type = view_type;
+    if (view_type == PVT_MapScreen) {
+        toggle_status_menu(0);
+    } else {
+        toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
     }
 }
 

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -323,18 +323,12 @@ void set_local_camera_destination(struct PlayerInfo *player)
 
 void update_local_view_prediction(const struct Packet *pckt)
 {
-    switch (pckt->action) {
-    case PckA_SaveViewType:
+    if (pckt->action == PckA_SaveViewType && pckt->actn_par1 == PVT_MapScreen) {
         local_state.view_type = PVT_MapScreen;
         toggle_status_menu(0);
-        break;
-    case PckA_LoadViewType:
-    case PckA_ZoomFromMap:
+    } else if ((pckt->action == PckA_LoadViewType && pckt->actn_par1 == PVT_DungeonTop) || pckt->action == PckA_ZoomFromMap) {
         local_state.view_type = PVT_DungeonTop;
         toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
-        break;
-    default:
-        return;
     }
 }
 

--- a/src/local_camera.c
+++ b/src/local_camera.c
@@ -39,14 +39,14 @@
 extern "C" {
 #endif
 /******************************************************************************/
-struct Camera local_cameras[4];
-struct Camera previous_local_cameras[4];
-struct Camera destination_local_cameras[4];
+static struct Camera local_cameras[4];
+static struct Camera previous_local_cameras[4];
+static struct Camera destination_local_cameras[4];
 float previous_deviation_x;
 float previous_deviation_y;
 float destination_deviation_x;
 float destination_deviation_y;
-TbBool local_camera_ready;
+static TbBool local_camera_ready;
 static MapCoord local_camera_move_target[2];
 static MapCoordDelta local_camera_move_delta[2];
 static TbBool local_camera_move_active;
@@ -70,10 +70,12 @@ void send_camera_catchup_packets(void)
         return;
     }
     struct PlayerInfo* player = get_my_player();
+    if (get_local_view_type(player) != player->view_type) {
+        return;
+    }
 
-    // Determine which camera to compare based on view mode
     int cam_idx;
-    switch (player->view_mode)
+    switch (get_local_active_camera(player)->view_mode)
     {
     case PVM_FrontView:
         cam_idx = CamIV_FrontView;
@@ -114,14 +116,14 @@ void send_camera_catchup_packets(void)
     }
 }
 
-void sync_camera_state(int cam_idx, struct Camera *cam)
+static void sync_camera_state(int cam_idx, struct Camera *cam)
 {
     local_cameras[cam_idx] = *cam;
     destination_local_cameras[cam_idx] = *cam;
     previous_local_cameras[cam_idx] = *cam;
 }
 
-void sync_first_person_camera(struct Camera *cam, struct PlayerInfo *player)
+static void sync_first_person_camera(struct Camera *cam, struct PlayerInfo *player)
 {
     if (player->controlled_thing_idx <= 0) {
         return;
@@ -155,10 +157,9 @@ void move_local_camera_to_position(MapCoord x, MapCoord y)
     if (!local_camera_ready) {
         return;
     }
-    struct Camera *cam = &destination_local_cameras[CamIV_Isometric];
-    if (get_my_player()->view_mode == PVM_FrontView) {
-        cam = &destination_local_cameras[CamIV_FrontView];
-    }
+    struct Camera *active_camera = get_local_active_camera(get_my_player());
+    int cam_idx = active_camera - local_cameras;
+    struct Camera *cam = &destination_local_cameras[cam_idx];
     local_camera_move_target[0] = x;
     local_camera_move_target[1] = y;
     view_set_camera_move_to_position(cam, x, y, &local_camera_move_delta[0], &local_camera_move_delta[1]);
@@ -194,7 +195,7 @@ static void update_local_first_person_camera(struct Thing *ctrltng, const struct
     }
 }
 
-void update_camera_deviations(int active_cam_idx)
+static void update_camera_deviations(int active_cam_idx)
 {
     struct Dungeon* dungeon = get_players_num_dungeon(my_player_number);
     if (dungeon->camera_deviate_jump != 0) {
@@ -206,25 +207,27 @@ void update_camera_deviations(int active_cam_idx)
 
 void update_local_cameras(void)
 {
-    for (int i = 0; i < 4; i++) {
-        previous_local_cameras[i] = destination_local_cameras[i];
-    }
-    previous_deviation_x = destination_deviation_x;
-    previous_deviation_y = destination_deviation_y;
-
     if (!local_camera_ready) {
         return;
     }
     struct PlayerInfo *player = get_my_player();
     struct Thing *ctrltng = thing_get(player->controlled_thing_idx);
     const struct Packet *pckt = get_packet_for_local_camera_update();
+    previous_deviation_x = destination_deviation_x;
+    previous_deviation_y = destination_deviation_y;
     destination_deviation_x = 0;
     destination_deviation_y = 0;
 
     if (pckt != NULL) {
         process_camera_action(destination_local_cameras, pckt);
     }
-    if (player->view_mode == PVM_CreatureView && thing_exists(ctrltng)) {
+    for (int i = 0; i < 4; i++) {
+        previous_local_cameras[i] = destination_local_cameras[i];
+    }
+
+    struct Camera *cam = get_local_active_camera(player);
+    int active_cam_idx = cam - local_cameras;
+    if (cam->view_mode == PVM_CreatureView && thing_exists(ctrltng)) {
         update_local_first_person_camera(ctrltng, pckt);
         return;
     }
@@ -232,9 +235,10 @@ void update_local_cameras(void)
         return;
     }
 
-    // Only process camera controls for the currently active camera view
-    int active_cam_idx = (player->view_mode == PVM_FrontView) ? CamIV_FrontView : CamIV_Isometric;
-    struct Camera *cam = &destination_local_cameras[active_cam_idx];
+    cam = &destination_local_cameras[active_cam_idx];
+    if (active_cam_idx == CamIV_Parchment) {
+        local_camera_move_active = false;
+    }
     if (local_camera_move_active) {
         local_camera_move_active = !view_move_camera_to_position(cam, local_camera_move_target[0], local_camera_move_target[1], local_camera_move_delta[0], local_camera_move_delta[1]);
     } else {
@@ -242,13 +246,19 @@ void update_local_cameras(void)
         view_process_camera_inertia(cam);
     }
 
-    update_camera_deviations(active_cam_idx);
+    if (active_cam_idx == CamIV_Isometric) {
+        update_camera_deviations(active_cam_idx);
+    }
 }
 
-void interpolate_camera_deviations(void)
+static void interpolate_camera_deviations(void)
 {
     struct PlayerInfo* my_player = get_my_player();
-    if (!player_exists(my_player) || my_player->view_mode == PVM_CreatureView || my_player->view_mode == PVM_FrontView) {
+    if (!player_exists(my_player)) {
+        return;
+    }
+    struct Camera *active_camera = get_local_active_camera(my_player);
+    if (active_camera->view_mode != PVM_IsoWibbleView && active_camera->view_mode != PVM_IsoStraightView) {
         return;
     }
     const float interpolated_deviation_x = interpolate(previous_deviation_x, destination_deviation_x);
@@ -327,7 +337,7 @@ void sync_local_camera(struct PlayerInfo *player)
 
 void set_local_camera_destination(struct PlayerInfo *player)
 {
-    if (!is_my_player(player) || !local_camera_ready || player->view_mode == PVM_ParchmentView) {
+    if (!is_my_player(player) || !local_camera_ready || get_local_view_type(player) == PVT_MapScreen) {
         return;
     }
     for (int cam_idx = CamIV_Isometric; cam_idx <= CamIV_FrontView; cam_idx++) {
@@ -340,18 +350,34 @@ void set_local_camera_destination(struct PlayerInfo *player)
     }
 }
 
-struct Camera* get_local_camera(struct Camera* cam)
+unsigned char get_local_view_type(const struct PlayerInfo *player)
 {
-    if (!local_camera_ready) {
-        return cam;
+    if (!is_my_player(player) || local_state.view_type == PVT_None) {
+        return player->view_type;
     }
-    struct PlayerInfo *player = get_my_player();
-    for (int cam_idx = CamIV_Isometric; cam_idx <= CamIV_FrontView; cam_idx++) {
-        if (cam == &player->cameras[cam_idx]) {
-            return &local_cameras[cam_idx];
+    if (local_state.view_type == PVT_MapScreen || player->view_type == PVT_MapScreen) {
+        return local_state.view_type;
+    }
+    return player->view_type;
+}
+
+struct Camera* get_local_active_camera(struct PlayerInfo *player)
+{
+    struct Camera *camera = get_player_active_camera(player);
+    if (camera == NULL || !is_my_player(player) || !local_camera_ready) {
+        return camera;
+    }
+    unsigned char view_type = get_local_view_type(player);
+    if (view_type == PVT_MapScreen) {
+        return &local_cameras[CamIV_Parchment];
+    }
+    if (view_type == PVT_DungeonTop && player->view_type == PVT_MapScreen) {
+        if (player->view_mode_restore == PVM_FrontView) {
+            return &local_cameras[CamIV_FrontView];
         }
+        return &local_cameras[CamIV_Isometric];
     }
-    return cam;
+    return &local_cameras[camera - player->cameras];
 }
 /******************************************************************************/
 #ifdef __cplusplus

--- a/src/local_camera.h
+++ b/src/local_camera.h
@@ -39,6 +39,7 @@ void interpolate_local_cameras(void);
 void sync_local_camera(struct PlayerInfo *player);
 void set_local_camera_destination(struct PlayerInfo *player);
 void move_local_camera_to_position(MapCoord x, MapCoord y);
+void update_local_view_prediction(const struct Packet *pckt);
 unsigned char get_local_view_type(const struct PlayerInfo *player);
 struct Camera* get_local_active_camera(struct PlayerInfo *player);
 void send_camera_catchup_packets(void);

--- a/src/local_camera.h
+++ b/src/local_camera.h
@@ -33,18 +33,14 @@ struct Packet;
 struct PlayerInfo;
 
 /******************************************************************************/
-extern struct Camera local_cameras[4];
-extern struct Camera previous_local_cameras[4];
-extern struct Camera destination_local_cameras[4];
-extern TbBool local_camera_ready;
-/******************************************************************************/
 void init_local_cameras(struct PlayerInfo *player);
 void update_local_cameras(void);
 void interpolate_local_cameras(void);
 void sync_local_camera(struct PlayerInfo *player);
 void set_local_camera_destination(struct PlayerInfo *player);
 void move_local_camera_to_position(MapCoord x, MapCoord y);
-struct Camera* get_local_camera(struct Camera* cam);
+unsigned char get_local_view_type(const struct PlayerInfo *player);
+struct Camera* get_local_active_camera(struct PlayerInfo *player);
 void send_camera_catchup_packets(void);
 
 /******************************************************************************/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1454,7 +1454,7 @@ void update_local_mouse_light(void)
     if (game_is_busy_doing_gui_string_input())
         return;
 
-    struct Camera *cam = get_local_camera(get_player_active_camera(player));
+    struct Camera *cam = get_local_active_camera(player);
     struct Coord3d pos;
     const TbBool valid = screen_to_map(cam, GetMouseX(), GetMouseY(), &pos);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -875,7 +875,7 @@ short zoom_to_next_annoyed_creature(void)
     {
       return false;
     }
-    set_players_packet_action(player, PckA_ZoomToPosition, thing->mappos.x.val, thing->mappos.y.val, 0, 0);
+    move_local_camera_to_position(thing->mappos.x.val, thing->mappos.y.val);
     return true;
 }
 

--- a/src/packets.c
+++ b/src/packets.c
@@ -376,11 +376,13 @@ void process_pause_packet(long curr_pause, long new_pause)
   }
 }
 
-void process_camera_controls(struct Camera* cam, const struct Packet* pckt, struct PlayerInfo* player, TbBool is_local_camera)
+void process_camera_controls(struct Camera* cam, const struct Packet* pckt,
+    struct PlayerInfo* player)
 {
     if (cam == NULL) {
         return;
     }
+    const TbBool is_local_camera = cam != get_player_active_camera(player);
     long inter_val;
     int scroll_speed = cam->zoom;
     if (scroll_speed <= 0)
@@ -569,7 +571,7 @@ void process_user_dungeon_control_packet_control(NetUserId user)
         ERRORLOG("No active camera");
         return;
     }
-    process_camera_controls(cam, pckt, player, false);
+    process_camera_controls(cam, pckt, player);
     if (is_my_player(player)) {
         TbBool settings_changed = false;
         if ((pckt->control_flags & (PCtr_ViewTiltUp | PCtr_ViewTiltDown | PCtr_ViewTiltReset)) != 0) {

--- a/src/packets.c
+++ b/src/packets.c
@@ -415,7 +415,7 @@ void process_camera_controls(struct Camera* cam, const struct Packet* pckt, stru
     if (pckt->additional_packet_values & PCAdV_SpeedupPressed)
       inter_val *= 3;
 
-    if (is_local_camera && !game.packet_load_enable)
+    if (is_local_camera && !game.packet_load_enable && cam->view_mode != PVM_ParchmentView)
     {        
         // Apply same scaling as packet-based movement for consistency
         if (camera_movement_y != 0.0f) {
@@ -428,12 +428,9 @@ void process_camera_controls(struct Camera* cam, const struct Packet* pckt, stru
             long limit = (long)(camera_movement_x * inter_val);
             view_set_camera_x_inertia(cam, delta, limit);
         }
-        camera_movement_x = 0.0f;
-        camera_movement_y = 0.0f;
     }
     else
     {
-        // Packet-based movement for non-local cameras or when local camera is disabled
         if ((pckt->control_flags & PCtr_MoveUp) != 0) {
             view_set_camera_y_inertia(cam, -inter_val/4, -inter_val);
         }
@@ -446,6 +443,10 @@ void process_camera_controls(struct Camera* cam, const struct Packet* pckt, stru
         if ((pckt->control_flags & PCtr_MoveRight) != 0) {
             view_set_camera_x_inertia(cam, inter_val/4, inter_val);
         }
+    }
+    if (is_local_camera) {
+        camera_movement_x = 0.0f;
+        camera_movement_y = 0.0f;
     }
 
     const TbBool use_rotate_pos = flag_is_set(pckt->control_flags, PCtr_ViewRotatePos | PCtr_MapCoordsValid);
@@ -627,6 +628,11 @@ void process_camera_action(struct Camera cams[], const struct Packet *pckt)
     case PckA_ZoomFromMap:
         set_all_cameras_position(cams, subtile_coord_center(pckt->actn_par1), subtile_coord_center(pckt->actn_par2));
         set_all_cameras_rotation(cams, 0);
+        for (int i = 0; i < CamIV_EndList; i++) {
+            cams[i].inertia_x = 0;
+            cams[i].inertia_y = 0;
+            cams[i].inertia_rotation = 0;
+        }
         break;
     }
 }

--- a/src/packets.c
+++ b/src/packets.c
@@ -376,8 +376,7 @@ void process_pause_packet(long curr_pause, long new_pause)
   }
 }
 
-void process_camera_controls(struct Camera* cam, const struct Packet* pckt,
-    struct PlayerInfo* player)
+void process_camera_controls(struct Camera* cam, const struct Packet* pckt, struct PlayerInfo* player)
 {
     if (cam == NULL) {
         return;

--- a/src/packets.c
+++ b/src/packets.c
@@ -984,7 +984,6 @@ TbBool process_user_global_packet_action(NetUserId user)
     }
   case PckA_LoadViewType:
       set_player_mode(player, pckt->actn_par1);
-      set_engine_view(player, player->view_mode_restore);
       return false;
     case PckA_SetRoomspaceAuto:
     case PckA_SetRoomspaceMan:

--- a/src/packets.h
+++ b/src/packets.h
@@ -343,8 +343,7 @@ void process_user_creature_passenger_packet_action(NetUserId user);
 void process_user_creature_control_packet_action(NetUserId user);
 void process_map_packet_clicks(NetUserId user);
 void process_pause_packet(long a1, long a2);
-void process_camera_controls(struct Camera* cam, const struct Packet* pckt,
-    struct PlayerInfo* player);
+void process_camera_controls(struct Camera* cam, const struct Packet* pckt, struct PlayerInfo* player);
 void process_camera_action(struct Camera cams[], const struct Packet* pckt);
 void process_first_person_look(struct Thing *thing, const struct Packet *pckt, long current_horizontal, long current_vertical, long *out_horizontal, long *out_vertical, long *out_roll);
 TbBool can_process_creature_input(struct Thing *thing);

--- a/src/packets.h
+++ b/src/packets.h
@@ -343,7 +343,8 @@ void process_user_creature_passenger_packet_action(NetUserId user);
 void process_user_creature_control_packet_action(NetUserId user);
 void process_map_packet_clicks(NetUserId user);
 void process_pause_packet(long a1, long a2);
-void process_camera_controls(struct Camera* cam, const struct Packet* pckt, struct PlayerInfo* player, TbBool is_local_camera);
+void process_camera_controls(struct Camera* cam, const struct Packet* pckt,
+    struct PlayerInfo* player);
 void process_camera_action(struct Camera cams[], const struct Packet* pckt);
 void process_first_person_look(struct Thing *thing, const struct Packet *pckt, long current_horizontal, long current_vertical, long *out_horizontal, long *out_vertical, long *out_roll);
 TbBool can_process_creature_input(struct Thing *thing);

--- a/src/packets_misc.c
+++ b/src/packets_misc.c
@@ -30,6 +30,7 @@
 #include "game_saves.h"
 #include "gui_topmsg.h"
 #include "config_settings.h"
+#include "player_data.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
@@ -80,6 +81,17 @@ void set_players_packet_action(struct PlayerInfo *player, unsigned char pcktype,
     pckt->actn_par3 = par3;
     pckt->actn_par4 = par4;
     pckt->action = pcktype;
+    if (!is_my_player(player)) {
+        return;
+    }
+    if (pcktype == PckA_SaveViewType && par1 == PVT_MapScreen) {
+        local_state.view_type = PVT_MapScreen;
+        toggle_status_menu(0);
+    }
+    if ((pcktype == PckA_LoadViewType && par1 == PVT_DungeonTop) || pcktype == PckA_ZoomFromMap) {
+        local_state.view_type = PVT_DungeonTop;
+        toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
+    }
 }
 
 unsigned char get_players_packet_action(struct PlayerInfo *player)

--- a/src/packets_misc.c
+++ b/src/packets_misc.c
@@ -30,7 +30,6 @@
 #include "game_saves.h"
 #include "gui_topmsg.h"
 #include "config_settings.h"
-#include "player_data.h"
 #include "post_inc.h"
 
 #ifdef __cplusplus
@@ -81,17 +80,6 @@ void set_players_packet_action(struct PlayerInfo *player, unsigned char pcktype,
     pckt->actn_par3 = par3;
     pckt->actn_par4 = par4;
     pckt->action = pcktype;
-    if (!is_my_player(player)) {
-        return;
-    }
-    if (pcktype == PckA_SaveViewType && par1 == PVT_MapScreen) {
-        local_state.view_type = PVT_MapScreen;
-        toggle_status_menu(0);
-    }
-    if ((pcktype == PckA_LoadViewType && par1 == PVT_DungeonTop) || pcktype == PckA_ZoomFromMap) {
-        local_state.view_type = PVT_DungeonTop;
-        toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
-    }
 }
 
 unsigned char get_players_packet_action(struct PlayerInfo *player)

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -481,12 +481,10 @@ void set_player_mode(struct PlayerInfo *player, unsigned short nview)
   player->view_type = nview;
   player->allocflags &= ~PlaF_CreaturePassengerMode;
   player->first_person_unfreeze_delay = 0;
-  if (is_my_player(player))
-  {
+  if (is_my_player(player)) {
     game.view_mode_flags &= ~GNFldD_CreaturePasngr;
     game.view_mode_flags |= GNFldD_CreatureViewMode;
-    if (is_my_player(player))
-      stop_all_things_playing_samples();
+    stop_all_things_playing_samples();
   }
   switch (player->view_type)
   {
@@ -500,10 +498,9 @@ void set_player_mode(struct PlayerInfo *player, unsigned short nview)
         set_engine_view(player, PVM_IsoWibbleView);
       }
       if (is_my_player(player)) {
-        if (local_state.view_type == PVT_MapScreen)
-          toggle_status_menu(0);
-        else
+        if (local_state.view_type == PVT_None) {
           toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
+        }
         if ((game.operation_flags & GOF_ShowGui) != 0)
           setup_engine_window(status_panel_width, 0, MyScreenWidth, MyScreenHeight);
         else
@@ -521,11 +518,8 @@ void set_player_mode(struct PlayerInfo *player, unsigned short nview)
       }
       break;
   case PVT_MapScreen:
-      if (is_my_player(player)) {
-        if (local_state.view_type == PVT_DungeonTop)
-          toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
-        else
-          toggle_status_menu(0);
+      if (is_my_player(player) && local_state.view_type == PVT_None) {
+        toggle_status_menu(0);
       }
       player->continue_work_state = player->work_state;
       set_engine_view(player, PVM_ParchmentView);

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -474,6 +474,8 @@ void set_player_state(struct PlayerInfo *player, short nwrk_state, int32_t chose
  */
 void set_player_mode(struct PlayerInfo *player, unsigned short nview)
 {
+  if (is_my_player(player) && local_state.view_type == nview)
+    local_state.view_type = PVT_None;
   if (player->view_type == nview)
     return;
   player->view_type = nview;
@@ -497,9 +499,11 @@ void set_player_mode(struct PlayerInfo *player, unsigned short nview)
       } else {
         set_engine_view(player, PVM_IsoWibbleView);
       }
-      if (is_my_player(player))
-      {
-        toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
+      if (is_my_player(player)) {
+        if (local_state.view_type == PVT_MapScreen)
+          toggle_status_menu(0);
+        else
+          toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
         if ((game.operation_flags & GOF_ShowGui) != 0)
           setup_engine_window(status_panel_width, 0, MyScreenWidth, MyScreenHeight);
         else
@@ -518,7 +522,10 @@ void set_player_mode(struct PlayerInfo *player, unsigned short nview)
       break;
   case PVT_MapScreen:
       if (is_my_player(player)) {
-        toggle_status_menu(0);
+        if (local_state.view_type == PVT_DungeonTop)
+          toggle_status_menu((game.operation_flags & GOF_ShowPanel) != 0);
+        else
+          toggle_status_menu(0);
       }
       player->continue_work_state = player->work_state;
       set_engine_view(player, PVM_ParchmentView);

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -278,6 +278,7 @@ extern short local_thing_under_hand;
  * Not sync'd over the network.
  */
 extern struct LocalState {
+    unsigned char view_type;
     TbBool tooltips_restore; /**< Used to store/restore the value of settings.tooltips_on when transitioning to/from the map. */
     TbBool status_menu_restore; /**< Used to store/restore the current status menu visibility when the map is shown/hidden. */
     TbBool paused_state_restore; /**< Used to restore pause state after saving */

--- a/src/power_process.c
+++ b/src/power_process.c
@@ -252,7 +252,7 @@ void process_disease(struct Thing *creatng)
 void lightning_modify_palette(struct Thing *thing)
 {
     struct PlayerInfo* myplyr = get_my_player();
-    struct Camera* camera = get_player_active_camera(myplyr);
+    struct Camera* camera = get_local_active_camera(myplyr);
 
     if (thing->health == 0)
     {
@@ -277,7 +277,7 @@ void lightning_modify_palette(struct Thing *thing)
         }
         return;
     }
-    if ((myplyr->view_mode != PVM_ParchFadeIn) && (myplyr->view_mode != PVM_ParchFadeOut) && (myplyr->view_mode != PVM_ParchmentView))
+    if ((camera->view_mode != PVM_ParchFadeIn) && (camera->view_mode != PVM_ParchFadeOut) && (camera->view_mode != PVM_ParchmentView))
     {
         if ((myplyr->additional_flags & PlaAF_LightningPaletteIsActive) == 0)
         {
@@ -388,7 +388,7 @@ void god_lightning_choose_next_creature(struct Thing *shotng)
 void draw_god_lightning(struct Thing *shotng)
 {
     struct PlayerInfo* player = get_player(shotng->owner);
-    const struct Camera* cam = get_local_camera(get_player_active_camera(player));
+    const struct Camera* cam = get_local_active_camera(player);
     if (cam == NULL) {
         return;
     }

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -131,7 +131,7 @@ void play_sound_if_close_to_receiver(struct Coord3d *soundpos, SoundSmplTblID sm
 void play_thing_walking(struct Thing *thing)
 {
     struct PlayerInfo* myplyr = get_my_player();
-    struct Camera* cam = get_local_camera(get_player_active_camera(myplyr));
+    struct Camera* cam = get_local_active_camera(myplyr);
     struct CreatureModelConfig* crconf;
     { // Skip the thing if its distance to camera is too big
         MapSubtlDelta dist_x = coord_subtile(abs(cam->mappos.x.val - (MapCoordDelta)thing->mappos.x.val));
@@ -236,7 +236,7 @@ void find_nearest_rooms_for_ambient_sound(void)
     if ((SoundDisabled) || (GetCurrentSoundMasterVolume() <= 0))
         return;
     struct PlayerInfo* player = get_my_player();
-    struct Camera* cam = get_local_camera(get_player_active_camera(player));
+    struct Camera* cam = get_local_active_camera(player);
     if (cam == NULL || LbIsFrozenOrPaused())
     {
         if (cam == NULL)
@@ -278,7 +278,7 @@ void find_nearest_rooms_for_ambient_sound(void)
 TbBool update_3d_sound_receiver(struct PlayerInfo* player)
 {
     SYNCDBG(7, "Starting");
-    struct Camera* cam = get_local_camera(get_player_active_camera(player));
+    struct Camera* cam = get_local_active_camera(player);
     if (cam == NULL)
         return false;
     S3DSetSoundReceiverPosition(cam->mappos.x.val, cam->mappos.y.val, cam->mappos.z.val);

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -4325,7 +4325,7 @@ void draw_creature_view(struct Thing *thing)
 {
   // If no eye lens required - just draw on the screen, directly
   struct PlayerInfo* player = get_my_player();
-  struct Camera* render_cam = get_local_camera(&player->cameras[CamIV_FirstPerson]);
+  struct Camera* render_cam = get_local_active_camera(player);
   if (!lens_is_ready())
   {
       engine(player, render_cam);
@@ -5673,8 +5673,7 @@ void go_to_next_creature_of_model_and_gui_job(long crmodel, long job_idx, unsign
     struct Thing* creatng = find_players_next_creature_of_breed_and_gui_job(crmodel, job_idx, my_player_number, pick_flags);
     if (!thing_is_invalid(creatng))
     {
-        struct PlayerInfo* player = get_my_player();
-        set_players_packet_action(player, PckA_ZoomToPosition, creatng->mappos.x.val, creatng->mappos.y.val, 0, 0);
+        move_local_camera_to_position(creatng->mappos.x.val, creatng->mappos.y.val);
     }
 }
 


### PR DESCRIPTION
Fixes #5209 and changes a ton of code to make the camera even more local, so its actions aren't getting stuck between queued-up packets while you have high input lag. The parchment map is no longer delayed by input lag and you can now open and close it at the same time as right-clicking on creatures in the UI to go to them.

Pressing H to go to Dungeon Heart and right-clicking on rooms in the room panel are all no longer delayed by input lag either.

Also fixed a singleplayer bug: if you were panning the camera, then opened the parchment map and clicked to go somewhere, there was an issue where the camera would briefly continue to pan.