### PR TITLE
Fix - teleport to fight not working correctly

### DIFF
--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1687,6 +1687,7 @@ void process_thing_spell_teleport_effects(struct Thing *thing, struct CastedSpel
                     if (find_first_battle_of_mine(thing->owner) != 0)
                     {
                         long count = 0;
+                        TbBool battle_found = false;
                         if (player->battleid > BATTLES_COUNT)
                         {
                             player->battleid = 1;
@@ -1709,6 +1710,7 @@ void process_thing_spell_teleport_effects(struct Thing *thing, struct CastedSpel
                                     pos.x.val = tng->mappos.x.val;
                                     pos.y.val = tng->mappos.y.val;
                                     player->battleid = i + 1;
+                                    battle_found = true;
                                     break;
                                 }
                             }
@@ -1723,6 +1725,13 @@ void process_thing_spell_teleport_effects(struct Thing *thing, struct CastedSpel
                                 player->battleid = 1;
                                 continue;
                             }
+                        }
+                        if (!battle_found)
+                        {
+                            // No battle could be reached; fall back to the default
+                            // destination instead of keeping the unset position,
+                            // which would teleport the creature into the map border.
+                            allowed = false;
                         }
                     }
                     else

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -1681,7 +1681,10 @@ void process_thing_spell_teleport_effects(struct Thing *thing, struct CastedSpel
                 }
                 case 16: // Fight
                 {
-                    if (active_battle_exists(thing->owner))
+                    // visible_battles[] is battle panel state, refilled by
+                    // maintain_my_battle_list() only for the local client's own player;
+                    // for every other player it stays zeroed. Ask the battle list itself.
+                    if (find_first_battle_of_mine(thing->owner) != 0)
                     {
                         long count = 0;
                         if (player->battleid > BATTLES_COUNT)


### PR DESCRIPTION
First commit:
- A. Fix Teleport in multiplayer: each client only maintains its own player's copy, so the clients disagree on the destination of the same cast — simulation code reading client-local interface state.
- B. Fix possessing a creature you do not own: the destination comes from the controlling player, but the guard reads thing->owner, so "Fight" always falls back to the lair/heart.

Second commit:
- If no reachable battle is found, set allowed = false so it falls back to the default destination. Previously pos kept its unset value and the creature was teleported to the map border.

I attach a savegame (KeeperFX 1.4.0.5365 Alpha) to reproduce the bug (first commit, B):
[fx1g0003.zip](https://github.com/user-attachments/files/31961056/fx1g0003.zip)

Steps to reproduce it:
- Run with -alex param to enable the cheat menus
- Numpad Enter, Direct control mode, click the thief hero
- Press the zoom-to-fight key (F key) to assign where to teleport (fight)
- Numpad Enter, Teleport, click anywhere
- The thief is landed to the dungeon heart instead of the existing battle
