### PR TITLE
Port more fields to UserState

### DIFF
--- a/src/creature_instances.c
+++ b/src/creature_instances.c
@@ -867,6 +867,7 @@ long instf_first_person_do_imp_task(struct Thing *creatng, int32_t *param)
 {
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     struct PlayerInfo* player = get_player(get_appropriate_player_for_creature(creatng));
+    struct UserState* ustate = get_player_user_state(player);
     TRACE_THING(creatng);
     struct SlabMap* slb;
     MapSubtlCoord ahead_stl_x = creatng->mappos.x.stl.num;
@@ -903,7 +904,7 @@ long instf_first_person_do_imp_task(struct Thing *creatng, int32_t *param)
         ahead_stl_x++;
         ahead_slb_x++;
     }
-    if ( (player->selected_fp_thing_pickup != 0) || (cctrl->dragtng_idx != 0) )
+    if ( (ustate->selected_fp_thing_pickup != 0) || (cctrl->dragtng_idx != 0) )
     {
         set_players_packet_action(player, PckA_DirectCtrlDragDrop, 0, 0, 0, 0);
         return 1;
@@ -936,7 +937,7 @@ long instf_first_person_do_imp_task(struct Thing *creatng, int32_t *param)
     slb = get_slabmap_block(slb_x, slb_y);
     if ( check_place_to_convert_excluding(creatng, slb_x, slb_y) )
     {
-        if (!player->first_person_dig_claim_mode)
+        if (!ustate->first_person_dig_claim_mode)
         {
             struct SlabConfigStats* slabst = get_slab_stats(slb);
             instf_destroy(creatng, NULL);
@@ -973,7 +974,7 @@ long instf_first_person_do_imp_task(struct Thing *creatng, int32_t *param)
             return 1;
         }
     }
-    else if (player->first_person_dig_claim_mode)
+    else if (ustate->first_person_dig_claim_mode)
     {
         if (slabmap_owner(slb) == creatng->owner)
         {

--- a/src/cursor_tag.c
+++ b/src/cursor_tag.c
@@ -215,13 +215,14 @@ TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
 {
     SYNCDBG(7,"Starting");
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     MapSlabCoord slb_x;
     MapSlabCoord slb_y;
     slb_x = subtile_slab(stl_x);
     slb_y = subtile_slab(stl_y);
     int floor_height_z = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
     unsigned char colour = SLC_RED;
-    if(can_build_roomspace(plyr_idx, player->chosen_room_kind, player->render_roomspace) > 0)
+    if(can_build_roomspace(plyr_idx, ustate->chosen_room_kind, player->render_roomspace) > 0)
     {
         colour = SLC_GREEN;
     }
@@ -229,7 +230,7 @@ TbBool tag_cursor_blocks_place_room(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
     {
         #if (BFDEBUG_LEVEL > 7)
             struct SlabMap* slb = get_slabmap_block(slb_x, slb_y); //inside condition because otherwise it would throw a build warning for not using this variable.
-            SYNCDBG(7,"Cannot build %s on %s slabs centered at (%d,%d)", room_code_name(player->chosen_room_kind), slab_code_name(slb->kind), (int)slb_x, (int)slb_y);
+            SYNCDBG(7,"Cannot build %s on %s slabs centered at (%d,%d)", room_code_name(ustate->chosen_room_kind), slab_code_name(slb->kind), (int)slb_x, (int)slb_y);
         #endif
     }
     if (is_my_player_number(plyr_idx) && !game_is_busy_doing_gui() && (game.small_map_state != 2))
@@ -345,7 +346,7 @@ TbBool tag_cursor_blocks_steal_slab(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
     int floor_height_z = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
     unsigned char colour;
     struct PlayerInfo* player = get_player(plyr_idx);
-    if ( ( ( ((slabst->category == SlbAtCtg_FortifiedGround) || (slabst->category == SlbAtCtg_FortifiedWall) ) && (slabmap_owner(slb) != player->cheatselection.chosen_player) ) )
+    if ( ( ( ((slabst->category == SlbAtCtg_FortifiedGround) || (slabst->category == SlbAtCtg_FortifiedWall) ) && (slabmap_owner(slb) != get_player_user_state(player)->cheatselection.chosen_player) ) )
         || ( (slabst->category == SlbAtCtg_FriableDirt) || ( (slabst->category == SlbAtCtg_Unclaimed) && (slabst->is_safe_land) && (!slab_is_liquid(slb_x, slb_y) ) ) ) )
     {
         colour = SLC_GREEN;
@@ -375,8 +376,9 @@ TbBool tag_cursor_blocks_place_trap(PlayerNumber plyr_idx, MapSubtlCoord stl_x, 
     TbBool can_place = can_place_trap_on(plyr_idx, stl_x, stl_y, trpkind);
     int floor_height = floor_height_for_volume_box(plyr_idx, slb_x, slb_y);
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     TbBool full_slab = !get_trap_model_stats(trpkind)->place_on_subtile;
-    player->full_slab_cursor = full_slab;
+    ustate->full_slab_cursor = full_slab;
     if (is_my_player_number(plyr_idx) && !game_is_busy_doing_gui() && (game.small_map_state != 2)) {
         MapSubtlCoord box_size = 1;
         if (full_slab) {

--- a/src/engine_redraw.c
+++ b/src/engine_redraw.c
@@ -688,7 +688,8 @@ TbBool draw_spell_cursor(ThingIndex tng_idx, MapSubtlCoord stl_x, MapSubtlCoord 
     long i;
     long pwkind = -1;
     struct PlayerInfo* player = get_my_player();
-    pwkind = player->chosen_power_kind;
+    struct UserState* ustate = get_player_user_state(player);
+    pwkind = ustate->chosen_power_kind;
     SYNCDBG(5,"Starting for power %d",(int)pwkind);
     if (pwkind <= 0)
     {
@@ -756,7 +757,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
     // Mouse over battle message box
     if (battle_creature_over > 0)
     {
-        PowerKind pwkind = player->chosen_power_kind;
+        PowerKind pwkind = ustate->chosen_power_kind;
         thing = thing_get(battle_creature_over);
         TRACE_THING(thing);
         if (can_cast_spell(player->id_number, pwkind, thing->mappos.x.stl.num, thing->mappos.y.stl.num, thing, CastChk_Default))
@@ -829,9 +830,9 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
                 }
                 if (can_cast)
                 {
-                    player->chosen_power_kind = pwkind;
+                    ustate->chosen_power_kind = pwkind;
                     draw_spell_cursor(0, thing->mappos.x.stl.num, thing->mappos.y.stl.num);
-                    player->chosen_power_kind = 0;
+                    ustate->chosen_power_kind = 0;
                     player->thing_under_hand = thing->index;
                 } else {
                     set_pointer_graphic(MousePG_Arrow);
@@ -862,7 +863,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
         }
         break;
     case PsPg_BuildRoom:
-        i = get_place_room_pointer_graphics(player->chosen_room_kind);
+        i = get_place_room_pointer_graphics(ustate->chosen_room_kind);
         set_pointer_graphic(i);
         break;
     case PsPg_Invisible:
@@ -875,11 +876,11 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
         set_pointer_graphic(MousePG_Query);
         break;
     case PsPg_PlaceTrap:
-        i = get_place_trap_pointer_graphics(player->chosen_trap_kind);
+        i = get_place_trap_pointer_graphics(ustate->chosen_trap_kind);
         set_pointer_graphic(i);
         break;
     case PsPg_PlaceDoor:
-        i = get_place_door_pointer_graphics(player->chosen_door_kind);
+        i = get_place_door_pointer_graphics(ustate->chosen_door_kind);
         set_pointer_graphic(i);
         break;
     case PsPg_Sell:
@@ -887,7 +888,7 @@ void process_dungeon_top_pointer_graphic(struct PlayerInfo *player)
         break;
     case PsPg_PlaceTerrain:
     {
-        i = get_place_terrain_pointer_graphics(player->cheatselection.chosen_terrain_kind);
+        i = get_place_terrain_pointer_graphics(ustate->cheatselection.chosen_terrain_kind);
         set_pointer_graphic(i);
         break;
     }

--- a/src/engine_render.c
+++ b/src/engine_render.c
@@ -8939,7 +8939,8 @@ static void process_frontview_map_volume_box(struct Camera *cam, unsigned char s
 TbBool cursor_on_room(RoomIndex room_index)
 {
     struct PlayerInfo* player = get_my_player();
-    struct SlabMap* slb = get_slabmap_for_subtile(player->cursor_subtile_x, player->cursor_subtile_y);
+    struct UserState* ustate = get_player_user_state(player);
+    struct SlabMap* slb = get_slabmap_for_subtile(ustate->cursor_subtile_x, ustate->cursor_subtile_y);
     if (slabmap_block_invalid(slb)) {
         return false;
     }
@@ -8959,11 +8960,12 @@ TbBool room_is_damaged(RoomIndex room_index)
 TbBool placing_same_room_type(RoomIndex room_index)
 {
     struct PlayerInfo* player = get_my_player();
+    struct UserState* ustate = get_player_user_state(player);
     if (map_volume_box.visible == 0) {
         return false;
     }
     struct Room* room = room_get(room_index);
-    if (player->chosen_room_kind != room->kind) {
+    if (ustate->chosen_room_kind != room->kind) {
         return false;
     }
     return true;

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -1556,6 +1556,7 @@ static short get_creature_control_action_inputs(void)
 {
     SYNCDBG(6,"Starting");
     struct PlayerInfo* player = get_my_player();
+    struct UserState* ustate = get_player_user_state(player);
     if (get_players_packet_action(player) != PckA_None)
         return 1;
     if ( ((game.operation_flags & GOF_Paused) == 0) || ((game.operation_flags & GOF_WorldInfluence) != 0))
@@ -1861,14 +1862,14 @@ static short get_creature_control_action_inputs(void)
         }
         if (is_game_key_pressed(Gkey_CrtrContrlMod, false, false))
         {
-            if (!player->first_person_dig_claim_mode)
+            if (!ustate->first_person_dig_claim_mode)
             {
                 set_players_packet_action(player, PckA_SetFirstPersonDigMode, true, 0, 0, 0);
             }
         }
         else
         {
-            if (player->first_person_dig_claim_mode)
+            if (ustate->first_person_dig_claim_mode)
             {
                 set_players_packet_action(player, PckA_SetFirstPersonDigMode, false, 0, 0, 0);
             }
@@ -1938,7 +1939,7 @@ static short get_creature_control_action_inputs(void)
                 }
             }
             local_thing_under_hand = player->thing_under_hand;
-            if (player->selected_fp_thing_pickup != player->thing_under_hand)
+            if (ustate->selected_fp_thing_pickup != player->thing_under_hand)
             {
                 set_players_packet_action(player, PckA_SelectFPPickup, player->thing_under_hand, 0, 0, 0);
             }
@@ -1986,6 +1987,7 @@ static void set_packet_action_for_thing_under_hand(struct Packet* pckt)
 {
     NetUserId user = get_local_user();
     struct PlayerInfo* player = get_my_player();
+    struct UserState* ustate = get_player_user_state(player);
     if ((get_local_view_type(player) != PVT_DungeonTop) || ((pckt->control_flags & PCtr_Gui) != 0) || (local_thing_under_hand <= 0) || (pckt->action != PckA_None) || (get_gameturn() - hand_pick_pending_turn <= game.input_lag_turns)) {
         return;
     }
@@ -1997,7 +1999,7 @@ static void set_packet_action_for_thing_under_hand(struct Packet* pckt)
     if (!left_button_released) {
         return;
     }
-    PowerKind pwkind = player->chosen_power_kind;
+    PowerKind pwkind = ustate->chosen_power_kind;
     PlayerState work_state = player->work_state;
     for (GameTurnDelta i = 1; i <= game.input_lag_turns; i += 1) {
         const struct Packet* delayed_pckt = get_history_packet(user, get_gameturn() - i);
@@ -3139,12 +3141,13 @@ short get_gui_inputs(short gameplay_on)
 static void process_cheat_mode_selection_inputs(void)
 {
     struct PlayerInfo *player = get_my_player();
+    struct UserState* ustate = get_player_user_state(player);
     unsigned char new_value;
     struct CreatureModelConfig* crconf;
     // player selection
     if (player->work_state == PSt_PlaceTerrain)
     {
-        if (slab_kind_has_no_ownership(player->cheatselection.chosen_terrain_kind))
+        if (slab_kind_has_no_ownership(ustate->cheatselection.chosen_terrain_kind))
         {
             goto INPUTS;
         }
@@ -3275,7 +3278,7 @@ static void process_cheat_mode_selection_inputs(void)
             else if (is_key_pressed(KC_EQUALS, KMod_DONTCARE))
             {
 
-                new_value = player->cheatselection.chosen_experience_level;
+                new_value = ustate->cheatselection.chosen_experience_level;
                 if (new_value < 9)
                 {
                     new_value++;
@@ -3285,7 +3288,7 @@ static void process_cheat_mode_selection_inputs(void)
             }
             else if (is_key_pressed(KC_MINUS, KMod_DONTCARE))
             {
-                new_value = player->cheatselection.chosen_experience_level;
+                new_value = ustate->cheatselection.chosen_experience_level;
                 if (new_value > 0)
                 {
                     new_value--;
@@ -3297,7 +3300,7 @@ static void process_cheat_mode_selection_inputs(void)
             {
                 if (player->work_state == PSt_MkGoodCreatr)
                 {
-                    new_value = player->cheatselection.chosen_hero_kind;
+                    new_value = ustate->cheatselection.chosen_hero_kind;
                     do
                     {
                         new_value++;
@@ -3313,7 +3316,7 @@ static void process_cheat_mode_selection_inputs(void)
                 }
                 else if (player->work_state == PSt_MkBadCreatr)
                 {
-                    new_value = player->cheatselection.chosen_creature_kind;
+                    new_value = ustate->cheatselection.chosen_creature_kind;
                     do
                     {
                         new_value++;
@@ -3333,7 +3336,7 @@ static void process_cheat_mode_selection_inputs(void)
             {
                 if (player->work_state == PSt_MkGoodCreatr)
                 {
-                    new_value = player->cheatselection.chosen_hero_kind;
+                    new_value = ustate->cheatselection.chosen_hero_kind;
                     do
                     {
                         if (new_value == 0)
@@ -3355,7 +3358,7 @@ static void process_cheat_mode_selection_inputs(void)
                 }
                 else if (player->work_state == PSt_MkBadCreatr)
                 {
-                    new_value = player->cheatselection.chosen_creature_kind;
+                    new_value = ustate->cheatselection.chosen_creature_kind;
                     do
                     {
                         if (new_value == 0)
@@ -3381,7 +3384,7 @@ static void process_cheat_mode_selection_inputs(void)
         }
         case PSt_PlaceTerrain:
         {
-            new_value = player->cheatselection.chosen_terrain_kind;
+            new_value = ustate->cheatselection.chosen_terrain_kind;
             if (is_key_pressed(KC_0, KMod_NONE))
             {
                 new_value = SlbT_ROCK;
@@ -3477,7 +3480,7 @@ static void process_cheat_mode_selection_inputs(void)
                 set_players_packet_action(player, PckA_CheatSwitchTerrain, new_value, 0, 0, 0);
                 clear_key_pressed(KC_LCONTROL);
             }
-            if ( (player->cheatselection.chosen_terrain_kind >= SlbT_WALLDRAPE) && (player->cheatselection.chosen_terrain_kind <= SlbT_WALLPAIRSHR) )
+            if ( (ustate->cheatselection.chosen_terrain_kind >= SlbT_WALLDRAPE) && (ustate->cheatselection.chosen_terrain_kind <= SlbT_WALLPAIRSHR) )
             {
                 if (is_key_pressed(KC_LALT, KMod_DONTCARE))
                 {
@@ -3494,7 +3497,7 @@ static void process_cheat_mode_selection_inputs(void)
                         }
                         else
                         {
-                            id = player->cheatselection.chosen_player;
+                            id = ustate->cheatselection.chosen_player;
                         }
                         new_value = choose_pretty_type(id, slb_x, slb_y);
                         set_players_packet_action(player, PckA_CheatSwitchTerrain, new_value, 0, 0, 0);

--- a/src/frontmenu_ingame_evnt.c
+++ b/src/frontmenu_ingame_evnt.c
@@ -154,7 +154,7 @@ void gui_get_creature_in_battle(struct GuiButton *gbtn)
     if (battle_creature_over <= 0) {
         return;
     }
-    PowerKind pwkind = myplyr->chosen_power_kind;
+    PowerKind pwkind = get_player_user_state(myplyr)->chosen_power_kind;
     struct Thing* thing = thing_get(battle_creature_over);
     if (!thing_exists(thing)) {
         WARNLOG("Nonexisting thing %d in battle",(int)battle_creature_over);

--- a/src/frontmenu_ingame_tabs.c
+++ b/src/frontmenu_ingame_tabs.c
@@ -602,6 +602,7 @@ void gui_area_big_room_button(struct GuiButton *gbtn)
 {
     RoomKind rkind = gbtn->content.lval;
     struct PlayerInfo* player = get_my_player();
+    struct UserState* ustate = get_player_user_state(player);
 
     struct Dungeon* dungeon = get_players_dungeon(player);
 
@@ -628,7 +629,7 @@ void gui_area_big_room_button(struct GuiButton *gbtn)
     RendererClearDrawFlags(Lb_TEXT_ONE_COLOR);
 
     struct RoomConfigStats* roomst = get_room_kind_stats(rkind);
-    unsigned char boxsize = player->boxsize;
+    unsigned char boxsize = ustate->boxsize;
     if (boxsize == 0)
     {
         boxsize = 1;
@@ -643,7 +644,7 @@ void gui_area_big_room_button(struct GuiButton *gbtn)
     }
     if (player->render_roomspace.total_roomspace_cost <= dungeon->total_money_owned)
     {
-        if ((player->work_state == PSt_BuildRoom) && (player->chosen_room_kind == game.chosen_room_kind)
+        if ((player->work_state == PSt_BuildRoom) && (ustate->chosen_room_kind == game.chosen_room_kind)
           && ((get_gameturn() % (2 * gui_blink_rate)) < gui_blink_rate))
         {
             draw_gui_panel_sprite_rmleft(gbtn->scr_pos_x - 4*units_per_px/16, gbtn->scr_pos_y - 32*units_per_px/16, ps_units_per_px, gbtn->sprite_idx, 44);
@@ -1157,6 +1158,7 @@ void gui_area_big_trap_button(struct GuiButton *gbtn)
 {
     int manufctr_idx = gbtn->content.lval;
     struct PlayerInfo* player = get_my_player();
+    struct UserState* ustate = get_player_user_state(player);
 
     struct Dungeon* dungeon = get_players_dungeon(player);
     struct ManufactureData* manufctr = get_manufacture_data(manufctr_idx);
@@ -1204,8 +1206,8 @@ void gui_area_big_trap_button(struct GuiButton *gbtn)
         if (amount <= 0) {
             draw_gui_panel_sprite_left(gbtn->scr_pos_x - 4*units_per_px/16, gbtn->scr_pos_y - 32*units_per_px/16, ps_units_per_px, gbtn->sprite_idx + 1);
         } else
-        if ((((manufctr->tngclass == TCls_Trap) && (player->chosen_trap_kind == manufctr->tngmodel) && (player->work_state == PSt_PlaceTrap))
-        || ((manufctr->tngclass == TCls_Door) && (player->chosen_door_kind == manufctr->tngmodel) && (player->work_state == PSt_PlaceDoor)))
+        if ((((manufctr->tngclass == TCls_Trap) && (ustate->chosen_trap_kind == manufctr->tngmodel) && (player->work_state == PSt_PlaceTrap))
+        || ((manufctr->tngclass == TCls_Door) && (ustate->chosen_door_kind == manufctr->tngmodel) && (player->work_state == PSt_PlaceDoor)))
         && ((get_gameturn() % (2 * gui_blink_rate)) < gui_blink_rate) )
         {
             draw_gui_panel_sprite_rmleft(gbtn->scr_pos_x - 4*units_per_px/16, gbtn->scr_pos_y - 32*units_per_px/16, ps_units_per_px, gbtn->sprite_idx, 44);

--- a/src/gui_tooltips.c
+++ b/src/gui_tooltips.c
@@ -132,7 +132,8 @@ static inline void clear_gui_tooltip_button(void)
 
 TbBool cursor_moved_to_new_subtile(struct PlayerInfo *player)
 {
-    return ((player->cursor_subtile_x != player->previous_cursor_subtile_x) || (player->cursor_subtile_y != player->previous_cursor_subtile_y));
+    const struct UserState* ustate = get_player_user_state(player);
+    return ((ustate->cursor_subtile_x != ustate->previous_cursor_subtile_x) || (ustate->cursor_subtile_y != ustate->previous_cursor_subtile_y));
 }
 
 TbBool setup_trap_tooltips(struct Coord3d *pos)

--- a/src/lvl_script_lib.c
+++ b/src/lvl_script_lib.c
@@ -390,8 +390,8 @@ short get_chat_icon_sprite_idx_from_id(short id, char type)
 
 short get_chat_icon_sprite_idx(const char* txt)
 {
-    short id;
-    char type;
+    short id = 0;
+    char type = 0;
 
     get_chat_icon_from_value(txt, &id, &type);
 

--- a/src/magic_powers.c
+++ b/src/magic_powers.c
@@ -1842,7 +1842,8 @@ static TbResult magic_use_power_possess_thing(PowerKind power_kind, PlayerNumber
     player = get_player(plyr_idx);
     player->influenced_thing_idx = thing->index;
     player->influenced_thing_creation = thing->creation_turn;
-    player->first_person_dig_claim_mode = false;
+    struct UserState* ustate = get_player_user_state(player);
+    ustate->first_person_dig_claim_mode = false;
     player->teleport_destination = 19; // reset to default behaviour
     player->battleid = 1;
     // Note that setting Direct Control player instance requires player->influenced_thing_idx to be set correctly

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -576,9 +576,10 @@ void process_disconnected_network_players(void)
         if ((player->allocflags & PlaF_CompCtrl) == 0) {
             network_lobby_ping = GetPing(my_player_number);
             input_lag_reset_request(calculate_initial_input_lag());
-            if (!host_disconnected && player->id_number != get_net_user_player_number(SERVER_ID) && player->player_name[0] != '\0') {
-                message_add_fmt(MsgType_Blank, 0, get_string(GUIStr_NetPlayerDisconnected), player->player_name);
-                JUSTLOG("p:%d player %s departed", player->id_number, player->player_name);
+            const char* departed_name = player->player_name;
+            if (!host_disconnected && player->id_number != get_net_user_player_number(SERVER_ID) && departed_name[0] != '\0') {
+                message_add_fmt(MsgType_Blank, 0, get_string(GUIStr_NetPlayerDisconnected), departed_name);
+                JUSTLOG("p:%d player %s departed", player->id_number, departed_name);
             }
             if (player->victory_state == VicS_Undecided) {
                 replace_network_player_with_ai(player);

--- a/src/packets.c
+++ b/src/packets.c
@@ -172,15 +172,18 @@ void update_double_click_detection(NetUserId user)
 struct Room *keeper_build_room(long stl_x,long stl_y,long plyr_idx,long rkind)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     struct Dungeon* dungeon = get_players_dungeon(player);
     struct RoomConfigStats* roomst = get_room_kind_stats(rkind);
     // Take top left subtile on single subtile boundbox, take center subtile on full slab boundbox
-    MapCoord x = ((player->full_slab_cursor == 0) ? slab_subtile(subtile_slab(stl_x), 0) : slab_subtile_center(subtile_slab(stl_x)));
-    MapCoord y = ((player->full_slab_cursor == 0) ? slab_subtile(subtile_slab(stl_y), 0) : slab_subtile_center(subtile_slab(stl_y)));
-    struct Room* room = player_build_room_at(x, y, plyr_idx, rkind);
+    MapCoord x = ((ustate->full_slab_cursor == 0) ? slab_subtile(subtile_slab(stl_x), 0) : slab_subtile_center(subtile_slab(stl_x)));
+    MapCoord y = ((ustate->full_slab_cursor == 0) ? slab_subtile(subtile_slab(stl_y), 0) : slab_subtile_center(subtile_slab(stl_y)));
+    struct Room* room = player_build_room_at(x, y, plyr_idx, rkind, ustate->boxsize);
     if (!room_is_invalid(room))
     {
-        if (player->boxsize > 1)
+        if (ustate->boxsize > 0)
+            ustate->boxsize--;
+        if (ustate->boxsize > 1)
         {
             dungeon->camera_deviate_jump = 240;
         }
@@ -198,6 +201,7 @@ struct Room *keeper_build_room(long stl_x,long stl_y,long plyr_idx,long rkind)
 TbBool process_dungeon_control_packet_spell_overcharge(NetUserId user)
 {
     struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    struct UserState* ustate = get_player_user_state(player);
     const PlayerNumber plyr_idx = player->id_number;
     struct Dungeon* dungeon = get_players_dungeon(player);
     SYNCDBG(6,"Starting for player %d state %s",(int)plyr_idx,player_state_code_name(player->work_state));
@@ -205,7 +209,7 @@ TbBool process_dungeon_control_packet_spell_overcharge(NetUserId user)
 
     while (game.conf.rules[plyr_idx].magic.allow_instant_charge_up && (pckt->additional_packet_values & PCAdV_SpeedupPressed))
     {
-        struct PowerConfigStats *powerst = get_power_model_stats(player->chosen_power_kind);
+        struct PowerConfigStats *powerst = get_power_model_stats(ustate->chosen_power_kind);
 
         if (powerst->overcharge_check_idx == OcC_CallToArms_expand
             || powerst->overcharge_check_idx == OcC_SightOfEvil_expand
@@ -214,7 +218,7 @@ TbBool process_dungeon_control_packet_spell_overcharge(NetUserId user)
             if (powerst->overcharge_check_idx == OcC_CallToArms_expand && player_uses_power_call_to_arms(plyr_idx))
                 break;
 
-            while(update_power_overcharge(player, player->chosen_power_kind))
+            while(update_power_overcharge(player, ustate->chosen_power_kind))
             {}
 
             return true;
@@ -224,7 +228,7 @@ TbBool process_dungeon_control_packet_spell_overcharge(NetUserId user)
 
     if (flag_is_set(pckt->control_flags,PCtr_LBtnHeld))
     {
-        struct PowerConfigStats *powerst = get_power_model_stats(player->chosen_power_kind);
+        struct PowerConfigStats *powerst = get_power_model_stats(ustate->chosen_power_kind);
 
         switch (powerst->overcharge_check_idx)
         {
@@ -232,11 +236,11 @@ TbBool process_dungeon_control_packet_spell_overcharge(NetUserId user)
                 if (player_uses_power_call_to_arms(plyr_idx))
                     player->cast_expand_level = (dungeon->cta_power_level << 2);
                 else
-                    update_power_overcharge(player, player->chosen_power_kind);
+                    update_power_overcharge(player, ustate->chosen_power_kind);
                 break;
             case OcC_SightOfEvil_expand:
             case OcC_General_expand:
-                update_power_overcharge(player, player->chosen_power_kind);
+                update_power_overcharge(player, ustate->chosen_power_kind);
                 break;
             case OcC_do_not_expand:
             case OcC_Null:
@@ -1024,7 +1028,7 @@ TbBool process_user_global_packet_action(NetUserId user)
             // exit out of click and drag mode
             if (player->render_roomspace.drag_mode)
             {
-                player->cursor_button_down = 0;
+                get_player_user_state(player)->cursor_button_down = 0;
                 player->one_click_lock_cursor = false;
                 if ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld)
                 {
@@ -1459,6 +1463,7 @@ void process_user_creature_control_packet_action(NetUserId user)
   struct Packet *pckt;
   long i;
   player = get_player(plyr_idx);
+  struct UserState* ustate = get_player_user_state(player);
   pckt = get_packet(user);
   SYNCDBG(6,"Processing player %d action %d",(int)plyr_idx,(int)pckt->action);
   switch (pckt->action)
@@ -1542,7 +1547,7 @@ void process_user_creature_control_packet_action(NetUserId user)
       }
     case PckA_SetFirstPersonDigMode:
     {
-        player->first_person_dig_claim_mode = pckt->actn_par1;
+        ustate->first_person_dig_claim_mode = pckt->actn_par1;
         break;
     }
     case PckA_SwitchTeleportDest:
@@ -1552,7 +1557,7 @@ void process_user_creature_control_packet_action(NetUserId user)
     }
     case PckA_SelectFPPickup:
     {
-        player->selected_fp_thing_pickup = pckt->actn_par1;
+        ustate->selected_fp_thing_pickup = pckt->actn_par1;
         break;
     }
     case PckA_SetNearestTeleport:

--- a/src/packets_cheats.c
+++ b/src/packets_cheats.c
@@ -69,6 +69,7 @@ TbBool packets_process_cheats(
     PowerKind pwkind;
     struct SlabMap *slb;
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     TbBool allowed;
     char str[255] = "";
     switch (player->work_state)
@@ -76,13 +77,13 @@ TbBool packets_process_cheats(
         case PSt_MkDigger:
         player->render_roomspace = create_box_roomspace(player->render_roomspace, 1, 1, slb_x, slb_y);
         allowed = tag_cursor_blocks_place_thing(plyr_idx, stl_x, stl_y);
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-        targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, "%d", player->cheatselection.chosen_experience_level + 1);
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+        targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, "%d", ustate->cheatselection.chosen_experience_level + 1);
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
         {
             if (allowed)
             {
-                set_packet_action(pckt, PckA_CheatMakeDigger, player->cheatselection.chosen_player, player->cheatselection.chosen_experience_level, 0, 0);
+                set_packet_action(pckt, PckA_CheatMakeDigger, ustate->cheatselection.chosen_player, ustate->cheatselection.chosen_experience_level, 0, 0);
             }
             else
             {
@@ -97,24 +98,24 @@ TbBool packets_process_cheats(
         case PSt_MkGoodCreatr:
         player->render_roomspace = create_box_roomspace(player->render_roomspace, 1, 1, slb_x, slb_y);
         allowed = tag_cursor_blocks_place_thing(plyr_idx, stl_x, stl_y);
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-        if (player->cheatselection.chosen_hero_kind == 0)
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+        if (ustate->cheatselection.chosen_hero_kind == 0)
         {
             snprintf(str, sizeof(str), "?");
         }
         else
         {
-            struct CreatureModelConfig* crconf = creature_stats_get(player->cheatselection.chosen_hero_kind);
-            snprintf(str, sizeof(str), "%s %d", get_string(crconf->namestr_idx), player->cheatselection.chosen_experience_level + 1);
+            struct CreatureModelConfig* crconf = creature_stats_get(ustate->cheatselection.chosen_hero_kind);
+            snprintf(str, sizeof(str), "%s %d", get_string(crconf->namestr_idx), ustate->cheatselection.chosen_experience_level + 1);
         }
-        targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, "%s", str);
+        targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, "%s", str);
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
         {
             if (allowed)
             {
                 ThingModel crmodel;
                 unsigned char exp;
-                if (player->cheatselection.chosen_hero_kind == 0)
+                if (ustate->cheatselection.chosen_hero_kind == 0)
                 {
                     while (1)
                     {
@@ -137,10 +138,10 @@ TbBool packets_process_cheats(
                 }
                 else
                 {
-                    crmodel = player->cheatselection.chosen_hero_kind;
-                    exp = player->cheatselection.chosen_experience_level;
+                    crmodel = ustate->cheatselection.chosen_hero_kind;
+                    exp = ustate->cheatselection.chosen_experience_level;
                 }
-                unsigned short param2 = player->cheatselection.chosen_player | (exp << 8);
+                unsigned short param2 = ustate->cheatselection.chosen_player | (exp << 8);
                 set_packet_action(pckt, PckA_CheatMakeCreature, crmodel, param2, 0, 0);
             }
             else
@@ -254,24 +255,24 @@ TbBool packets_process_cheats(
         case PSt_MkBadCreatr:
         player->render_roomspace = create_box_roomspace(player->render_roomspace, 1, 1, slb_x, slb_y);
         allowed = tag_cursor_blocks_place_thing(plyr_idx, stl_x, stl_y);
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-        if (player->cheatselection.chosen_creature_kind == 0)
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+        if (ustate->cheatselection.chosen_creature_kind == 0)
         {
             snprintf(str, sizeof(str), "?");
         }
         else
         {
-            struct CreatureModelConfig* crconf = creature_stats_get(player->cheatselection.chosen_creature_kind);
-            snprintf(str, sizeof(str), "%s %d", get_string(crconf->namestr_idx), player->cheatselection.chosen_experience_level + 1);
+            struct CreatureModelConfig* crconf = creature_stats_get(ustate->cheatselection.chosen_creature_kind);
+            snprintf(str, sizeof(str), "%s %d", get_string(crconf->namestr_idx), ustate->cheatselection.chosen_experience_level + 1);
         }
-        targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, "%s", str);
+        targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, "%s", str);
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
         {
             if (allowed)
             {
                 ThingModel crmodel;
                 unsigned char exp;
-                if (player->cheatselection.chosen_creature_kind == 0)
+                if (ustate->cheatselection.chosen_creature_kind == 0)
                 {
                     while (1)
                     {
@@ -288,10 +289,10 @@ TbBool packets_process_cheats(
                 }
                 else
                 {
-                    crmodel = player->cheatselection.chosen_creature_kind;
-                    exp = player->cheatselection.chosen_experience_level;
+                    crmodel = ustate->cheatselection.chosen_creature_kind;
+                    exp = ustate->cheatselection.chosen_experience_level;
                 }
-                unsigned short param2 = player->cheatselection.chosen_player | (exp << 8);
+                unsigned short param2 = ustate->cheatselection.chosen_player | (exp << 8);
                 set_packet_action(pckt, PckA_CheatMakeCreature, crmodel, param2, 0, 0);
             }
             else
@@ -307,7 +308,7 @@ TbBool packets_process_cheats(
         case PSt_FreeDestroyWalls:
             if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
             {
-                pwkind = player->chosen_power_kind;
+                pwkind = ustate->chosen_power_kind;
                 i = get_power_overcharge_level(player);
                 magic_use_power_direct(plyr_idx,pwkind,i,stl_x, stl_y,INVALID_THING, PwMod_CastForFree);
                 unset_packet_control(pckt, PCtr_LBtnRelease);
@@ -316,7 +317,7 @@ TbBool packets_process_cheats(
         case PSt_FreeTurnChicken:
         case PSt_FreeCastDisease:
         {
-            pwkind = player->chosen_power_kind;
+            pwkind = ustate->chosen_power_kind;
             thing = get_creature_near_to_be_keeper_power_target(x, y, pwkind, plyr_idx);
             if (thing_is_invalid(thing))
             {
@@ -333,21 +334,21 @@ TbBool packets_process_cheats(
             break;
         }
         case PSt_StealRoom:
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
         slb = get_slabmap_block(slb_x, slb_y);
         room = room_get(slb->room_index);
-        allowed = ( (room_exists(room)) && (room->owner != player->cheatselection.chosen_player) );
+        allowed = ( (room_exists(room)) && (room->owner != ustate->cheatselection.chosen_player) );
         if (allowed)
         {
             snprintf(str, sizeof(str), "%s", get_string(GUIStr_MnuOk));
         }
-        targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, str);
+        targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, str);
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
         {
             if (allowed)
             {
                 TbBool effect = (is_key_pressed(KC_RALT, KMod_DONTCARE));
-                set_packet_action(pckt, PckA_CheatStealRoom, player->cheatselection.chosen_player, effect, 0, 0);
+                set_packet_action(pckt, PckA_CheatStealRoom, ustate->cheatselection.chosen_player, effect, 0, 0);
             }
             unset_packet_control(pckt, PCtr_LBtnRelease);
         }
@@ -390,10 +391,10 @@ TbBool packets_process_cheats(
             }
             break;
         case PSt_ConvertCreatr:
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-        targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, str);
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+        targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, str);
         thing = get_creature_near(x, y);
-        if ((!thing_is_creature(thing)) || (thing->owner == player->cheatselection.chosen_player))
+        if ((!thing_is_creature(thing)) || (thing->owner == ustate->cheatselection.chosen_player))
         {
             player->thing_under_hand = 0;
         }
@@ -403,15 +404,15 @@ TbBool packets_process_cheats(
         }
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
         {
-            set_packet_action(pckt, PckA_CheatConvertCreature, player->cheatselection.chosen_player, 0, 0, 0);
+            set_packet_action(pckt, PckA_CheatConvertCreature, ustate->cheatselection.chosen_player, 0, 0, 0);
             unset_packet_control(pckt, PCtr_LBtnRelease);
         }
         break;
         case PSt_StealSlab:
         player->render_roomspace = create_box_roomspace(player->render_roomspace, 1, 1, slb_x, slb_y);
         allowed = tag_cursor_blocks_steal_slab(plyr_idx, stl_x, stl_y);
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-        targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, str);
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+        targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, str);
         if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && ((pckt->control_flags & PCtr_MapCoordsValid) != 0))
         {
             if (allowed)
@@ -431,7 +432,7 @@ TbBool packets_process_cheats(
                         {
                             if (is_key_pressed(KC_RSHIFT, KMod_DONTCARE))
                             {
-                                slbkind = choose_pretty_type(player->cheatselection.chosen_player, slb_x, slb_y);
+                                slbkind = choose_pretty_type(ustate->cheatselection.chosen_player, slb_x, slb_y);
                             }
                             else
                             {
@@ -443,7 +444,7 @@ TbBool packets_process_cheats(
                         {
                             if (is_key_pressed(KC_RSHIFT, KMod_DONTCARE))
                             {
-                                slbkind = choose_pretty_type(player->cheatselection.chosen_player, slb_x, slb_y);
+                                slbkind = choose_pretty_type(ustate->cheatselection.chosen_player, slb_x, slb_y);
                             }
                             else
                             {
@@ -466,7 +467,7 @@ TbBool packets_process_cheats(
                     {
                         effect = false;
                     }
-                    unsigned short param2 = player->cheatselection.chosen_player | (effect << 8);
+                    unsigned short param2 = ustate->cheatselection.chosen_player | (effect << 8);
                     set_packet_action(pckt, PckA_CheatStealSlab, slbkind, param2, 0, 0);
                 }
             }
@@ -517,11 +518,11 @@ TbBool packets_process_cheats(
             }
             break;
         case PSt_KillPlayer:
-          clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-          struct PlayerInfo* PlayerToKill = get_player(player->cheatselection.chosen_player);
+          clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+          struct PlayerInfo* PlayerToKill = get_player(ustate->cheatselection.chosen_player);
           if (player_exists(PlayerToKill))
           {
-              targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, str);
+              targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, str);
               if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
               {
                 set_packet_action(pckt, PckA_CheatKillPlayer, PlayerToKill->id_number, 0, 0, 0);
@@ -530,8 +531,8 @@ TbBool packets_process_cheats(
           }
         break;
         case PSt_HeartHealth:
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-        thing = get_player_soul_container(player->cheatselection.chosen_player);
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+        thing = get_player_soul_container(ustate->cheatselection.chosen_player);
         struct ObjectConfigStats* objst = get_object_model_stats(thing->model);
         if (thing_exists(thing))
         {
@@ -544,7 +545,7 @@ TbBool packets_process_cheats(
         HitPoints new_health = thing->health;
         if (process_cheat_heart_health_inputs(&new_health, objst->health))
         {
-            set_packet_action(pckt, PckA_CheatHeartHealth, player->cheatselection.chosen_player, new_health, 0, 0);
+            set_packet_action(pckt, PckA_CheatHeartHealth, ustate->cheatselection.chosen_player, new_health, 0, 0);
         }
         break;
         case PSt_QueryAll:
@@ -647,11 +648,11 @@ TbBool packets_process_cheats(
             player->render_roomspace = create_box_roomspace(player->render_roomspace, 1, 1, slb_x, slb_y);
             tag_cursor_blocks_place_terrain(plyr_idx, stl_x, stl_y);
             struct SlabConfigStats* slab_cfgstats;
-            clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-            struct SlabConfigStats *slabst = get_slab_kind_stats(player->cheatselection.chosen_terrain_kind);
-            if (slab_kind_has_no_ownership(player->cheatselection.chosen_terrain_kind))
+            clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+            struct SlabConfigStats *slabst = get_slab_kind_stats(ustate->cheatselection.chosen_terrain_kind);
+            if (slab_kind_has_no_ownership(ustate->cheatselection.chosen_terrain_kind))
             {
-                player->cheatselection.chosen_player = game.neutral_player_num;
+                ustate->cheatselection.chosen_player = game.neutral_player_num;
             }
             if (slabst->tooltip_stridx <= GUI_STRINGS_COUNT)
             {
@@ -662,12 +663,12 @@ TbBool packets_process_cheats(
                 {
                     dis_msg = str;
                 }
-                targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, dis_msg);
+                targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, dis_msg);
             }
             else
             {
-                slab_cfgstats = get_slab_kind_stats(player->cheatselection.chosen_terrain_kind);
-                targeted_message_add(MsgType_Player, player->cheatselection.chosen_player, plyr_idx, 1, slab_cfgstats->code_name);
+                slab_cfgstats = get_slab_kind_stats(ustate->cheatselection.chosen_terrain_kind);
+                targeted_message_add(MsgType_Player, ustate->cheatselection.chosen_player, plyr_idx, 1, slab_cfgstats->code_name);
             }
             clear_messages_from_player(MsgType_Blank, -1);
             if (is_key_pressed(KC_RSHIFT, KMod_DONTCARE))
@@ -688,11 +689,11 @@ TbBool packets_process_cheats(
                     room = subtile_room_get(stl_x, stl_y);
                     delete_room_slab(slb_x, slb_y, true);
                 }
-                PlayerNumber id = (slab_kind_has_no_ownership(player->cheatselection.chosen_terrain_kind)) ? game.neutral_player_num : player->cheatselection.chosen_player;
-                set_packet_action(pckt, PckA_CheatPlaceTerrain, player->cheatselection.chosen_terrain_kind, id, 0, 0);
-                if ( (player->cheatselection.chosen_terrain_kind >= SlbT_WALLDRAPE) && (player->cheatselection.chosen_terrain_kind <= SlbT_WALLPAIRSHR) )
+                PlayerNumber id = (slab_kind_has_no_ownership(ustate->cheatselection.chosen_terrain_kind)) ? game.neutral_player_num : ustate->cheatselection.chosen_player;
+                set_packet_action(pckt, PckA_CheatPlaceTerrain, ustate->cheatselection.chosen_terrain_kind, id, 0, 0);
+                if ( (ustate->cheatselection.chosen_terrain_kind >= SlbT_WALLDRAPE) && (ustate->cheatselection.chosen_terrain_kind <= SlbT_WALLPAIRSHR) )
                 {
-                    player->cheatselection.chosen_terrain_kind = SlbT_WALLDRAPE + GAME_RANDOM(5);
+                    ustate->cheatselection.chosen_terrain_kind = SlbT_WALLDRAPE + GAME_RANDOM(5);
                 }
             }
             unset_packet_control(pckt, PCtr_LBtnRelease);
@@ -768,7 +769,8 @@ TbBool packets_process_cheats(
 
 TbBool process_player_global_cheats_packet_action(PlayerNumber plyr_idx, struct Packet* pckt)
 {
-  struct PlayerInfo* player;
+  struct PlayerInfo* player = get_player(plyr_idx);
+  struct UserState* ustate = get_player_user_state(player);
   switch (pckt->action)
   {
       case PckA_CheatEnter:
@@ -804,38 +806,33 @@ TbBool process_player_global_cheats_packet_action(PlayerNumber plyr_idx, struct 
           return false;
       case PckA_CheatSwitchTerrain:
         {
-            player = get_player(plyr_idx);
-            player->cheatselection.chosen_terrain_kind = pckt->actn_par1;
-            if (slab_kind_has_no_ownership(player->cheatselection.chosen_terrain_kind))
+            ustate->cheatselection.chosen_terrain_kind = pckt->actn_par1;
+            if (slab_kind_has_no_ownership(ustate->cheatselection.chosen_terrain_kind))
             {
-               clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-               player->cheatselection.chosen_player = game.neutral_player_num;
+               clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+               ustate->cheatselection.chosen_player = game.neutral_player_num;
             }
             return false;
         }
       case PckA_CheatSwitchPlayer:
         {
-            player = get_player(plyr_idx);
-            clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-            player->cheatselection.chosen_player = pckt->actn_par1;
+            clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+            ustate->cheatselection.chosen_player = pckt->actn_par1;
             return false;
         }
       case PckA_CheatSwitchCreature:
         {
-            player = get_player(plyr_idx);
-            player->cheatselection.chosen_creature_kind = pckt->actn_par1;
+            ustate->cheatselection.chosen_creature_kind = pckt->actn_par1;
             return false;
         }
       case PckA_CheatSwitchHero:
         {
-            player = get_player(plyr_idx);
-            player->cheatselection.chosen_hero_kind = pckt->actn_par1;
+            ustate->cheatselection.chosen_hero_kind = pckt->actn_par1;
             return false;
         }
       case PckA_CheatSwitchExperience:
         {
-            player = get_player(plyr_idx);
-            player->cheatselection.chosen_experience_level = pckt->actn_par1;
+            ustate->cheatselection.chosen_experience_level = pckt->actn_par1;
             return false;
         }
         case PckA_CheatAllDoors:

--- a/src/packets_input.c
+++ b/src/packets_input.c
@@ -70,17 +70,18 @@ TbBool is_mouse_on_map(struct Packet* pckt)
 void remember_cursor_subtile(struct PlayerInfo *player)
 {
     struct Packet* pckt = get_packet(player->user_id);
+    struct UserState* ustate = get_player_user_state(player);
     MapSubtlCoord cursor_subtile_x = coord_subtile(pckt->pos_x);
     MapSubtlCoord cursor_subtile_y = coord_subtile(pckt->pos_y);
-    player->previous_cursor_subtile_x = player->cursor_subtile_x;
-    player->previous_cursor_subtile_y = player->cursor_subtile_y;
+    ustate->previous_cursor_subtile_x = ustate->cursor_subtile_x;
+    ustate->previous_cursor_subtile_y = ustate->cursor_subtile_y;
     if (!player->interpolated_tagging && ((pckt->control_flags & (PCtr_LBtnHeld | PCtr_LBtnRelease)) != 0)) {
-        player->previous_cursor_subtile_x = cursor_subtile_x;
-        player->previous_cursor_subtile_y = cursor_subtile_y;
+        ustate->previous_cursor_subtile_x = cursor_subtile_x;
+        ustate->previous_cursor_subtile_y = cursor_subtile_y;
     }
-    player->cursor_subtile_x = cursor_subtile_x;
-    player->cursor_subtile_y = cursor_subtile_y;
-    if (player->mouse_on_map && ((pckt->control_flags & (PCtr_LBtnClick | PCtr_LBtnHeld)) != 0)) {
+    ustate->cursor_subtile_x = cursor_subtile_x;
+    ustate->cursor_subtile_y = cursor_subtile_y;
+    if (ustate->mouse_on_map && ((pckt->control_flags & (PCtr_LBtnClick | PCtr_LBtnHeld)) != 0)) {
         player->interpolated_tagging = true;
     } else {
         player->interpolated_tagging = false;
@@ -89,6 +90,7 @@ void remember_cursor_subtile(struct PlayerInfo *player)
 
 struct Thing *get_thing_under_hand(struct PlayerInfo *player, MapCoord x, MapCoord y)
 {
+    struct UserState* ustate = get_player_user_state(player);
     struct Thing *thing;
 
     switch (player->work_state) {
@@ -110,7 +112,7 @@ struct Thing *get_thing_under_hand(struct PlayerInfo *player, MapCoord x, MapCoo
         }
         break;
     case PST_CastPowerOnTarget:
-        return get_creature_near_to_be_keeper_power_target(x, y, player->chosen_power_kind, player->id_number);
+        return get_creature_near_to_be_keeper_power_target(x, y, ustate->chosen_power_kind, player->id_number);
     }
     return INVALID_THING;
 }
@@ -118,6 +120,7 @@ struct Thing *get_thing_under_hand(struct PlayerInfo *player, MapCoord x, MapCoo
 TbBool process_dungeon_control_packet_dungeon_build_room(NetUserId user)
 {
     struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    struct UserState* ustate = get_user_state(user);
     PlayerNumber plyr_idx = player->id_number;
     struct Packet* pckt = get_packet(user);
     MapCoord x = (pckt->pos_x);
@@ -126,9 +129,9 @@ TbBool process_dungeon_control_packet_dungeon_build_room(NetUserId user)
     MapSubtlCoord stl_y = coord_subtile(y);
     if ((pckt->control_flags & PCtr_MapCoordsValid) == 0)
     {
-        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->cursor_button_down != 0))
+        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (ustate->cursor_button_down != 0))
         {
-            player->cursor_button_down = 0;
+            ustate->cursor_button_down = 0;
             unset_packet_control(pckt, PCtr_LBtnRelease);
         }
         return false;
@@ -145,9 +148,9 @@ TbBool process_dungeon_control_packet_dungeon_build_room(NetUserId user)
     {
         if ((pckt->control_flags & PCtr_LBtnClick) == 0)
         {
-            if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->cursor_button_down != 0))
+            if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (ustate->cursor_button_down != 0))
             {
-                player->cursor_button_down = 0;
+                ustate->cursor_button_down = 0;
                 unset_packet_control(pckt, PCtr_LBtnRelease);
             }
             return false;
@@ -155,14 +158,14 @@ TbBool process_dungeon_control_packet_dungeon_build_room(NetUserId user)
     }
     else if ((pckt->control_flags & PCtr_LBtnHeld) == PCtr_LBtnHeld)
     {
-        if ( (player->boxsize == 0) || (!can_build_room_at_slab(player->id_number, player->chosen_room_kind, subtile_slab(stl_x), subtile_slab(stl_y))) )
+        if ( (ustate->boxsize == 0) || (!can_build_room_at_slab(player->id_number, ustate->chosen_room_kind, subtile_slab(stl_x), subtile_slab(stl_y))) )
         {
             return false; //stops attempts at invalid rooms, if left mouse button held (i.e. don't repeat failure sound repeatedly in paint mode)
         }
     }
     if (!can_place_room)
     {
-        if (can_build_room_at_slab(player->id_number, player->chosen_room_kind, subtile_slab(stl_x), subtile_slab(stl_y)))
+        if (can_build_room_at_slab(player->id_number, ustate->chosen_room_kind, subtile_slab(stl_x), subtile_slab(stl_y)))
         {
             struct Dungeon* dungeon = get_dungeon(player->id_number);
             if (player->render_roomspace.total_roomspace_cost > dungeon->total_money_owned)
@@ -183,7 +186,7 @@ TbBool process_dungeon_control_packet_dungeon_build_room(NetUserId user)
         unset_packet_control(pckt, PCtr_LBtnClick);
       return false;
     }
-    if (player->boxsize > 0)
+    if (ustate->boxsize > 0)
     {
         keeper_build_roomspace(plyr_idx, &player->render_roomspace);
     }
@@ -201,6 +204,7 @@ TbBool process_dungeon_control_packet_dungeon_build_room(NetUserId user)
 TbBool process_dungeon_power_hand_state(NetUserId user)
 {
     struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    struct UserState* ustate = get_player_user_state(player);
     PlayerNumber plyr_idx = player->id_number;
     struct Packet* pckt = get_packet(user);
     MapCoord x = pckt->pos_x;
@@ -236,13 +240,13 @@ TbBool process_dungeon_power_hand_state(NetUserId user)
             && (!player->one_click_lock_cursor))
         {
             player->render_roomspace = create_box_roomspace(player->render_roomspace, 1, 1, subtile_slab(stl_x), subtile_slab(stl_y));
-            player->full_slab_cursor = (player->roomspace_mode != single_subtile_mode);
-            tag_cursor_blocks_thing_in_hand(plyr_idx, stl_x, stl_y, allow_unclaimed_path, player->full_slab_cursor);
+            ustate->full_slab_cursor = (player->roomspace_mode != single_subtile_mode);
+            tag_cursor_blocks_thing_in_hand(plyr_idx, stl_x, stl_y, allow_unclaimed_path, ustate->full_slab_cursor);
         } else
         {
             player->additional_flags |= PlaAF_ChosenSubTileIsHigh;
             get_dungeon_highlight_user_roomspace(&player->render_roomspace, player, pckt, stl_x, stl_y, NULL);
-            tag_cursor_blocks_dig(player, pckt, &player->render_roomspace, stl_x, stl_y, player->full_slab_cursor);
+            tag_cursor_blocks_dig(player, pckt, &player->render_roomspace, stl_x, stl_y, ustate->full_slab_cursor);
             player->thing_under_hand = 0;
         }
     }
@@ -276,6 +280,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
 {
     struct Thing *thing;
     struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    struct UserState* ustate = get_user_state(user);
     PlayerNumber plyr_idx = player->id_number;
     struct Dungeon* dungeon = get_players_dungeon(player);
     struct Packet* pckt = get_packet(user);
@@ -291,7 +296,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
         player->secondary_cursor_state = CSt_DefaultArrow;
     player->render_roomspace.highlight_mode = settings.highlight_mode; // reset one-click highlight mode
     player->render_roomspace.drag_mode = player->one_click_lock_cursor;
-    player->pickup_all_gold = (pckt->additional_packet_values & PCAdV_RotatePressed);
+    ustate->pickup_all_gold = (pckt->additional_packet_values & PCAdV_RotatePressed);
     process_dungeon_power_hand_state(user);
     if ((pckt->control_flags & PCtr_MapCoordsValid) != 0)
     {
@@ -303,7 +308,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
                 player->render_roomspace.untag_mode = pckt->actn_par4;
                 player->render_roomspace = check_roomspace_for_diggable_slabs(player->render_roomspace, plyr_idx, NULL);
             }
-            box_colour = tag_cursor_blocks_dig(player, pckt, &player->render_roomspace, stl_x, stl_y, player->full_slab_cursor);
+            box_colour = tag_cursor_blocks_dig(player, pckt, &player->render_roomspace, stl_x, stl_y, ustate->full_slab_cursor);
             at_limit = (box_colour == SLC_REDYELLOW) || (box_colour == SLC_REDFLASH);
             if (apply_roomspace_tag) {
                 MapSlabCoord previous_slb_x = (uint16_t)pckt->actn_par3 & 0xFF;
@@ -313,9 +318,9 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
         }
         if ((pckt->control_flags & PCtr_LBtnClick) != 0)
         {
-            player->cursor_clicked_subtile_x = stl_x;
-            player->cursor_clicked_subtile_y = stl_y;
-            player->cursor_button_down = 1;
+            ustate->cursor_clicked_subtile_x = stl_x;
+            ustate->cursor_clicked_subtile_y = stl_y;
+            ustate->cursor_button_down = 1;
             player->secondary_cursor_state = player->primary_cursor_state;
             switch (player->primary_cursor_state)
             {
@@ -333,10 +338,10 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
                     }
                     break;
                 case CSt_DoorKey:
-                    thing = get_door_for_position(player->cursor_clicked_subtile_x, player->cursor_clicked_subtile_y);
+                    thing = get_door_for_position(ustate->cursor_clicked_subtile_x, ustate->cursor_clicked_subtile_y);
                     if (thing_is_invalid(thing))
                     {
-                        ERRORLOG("Door thing not found at map pos (%d,%d)",(int)player->cursor_clicked_subtile_x,(int)player->cursor_clicked_subtile_y);
+                        ERRORLOG("Door thing not found at map pos (%d,%d)",(int)ustate->cursor_clicked_subtile_x,(int)ustate->cursor_clicked_subtile_y);
                         break;
                     }
                     if (thing->door.is_locked)
@@ -366,9 +371,9 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
         }
         if ((pckt->control_flags & PCtr_RBtnClick) != 0)
         {
-            player->cursor_clicked_subtile_x = stl_x;
-            player->cursor_clicked_subtile_y = stl_y;
-            player->cursor_button_down = 1;
+            ustate->cursor_clicked_subtile_x = stl_x;
+            ustate->cursor_clicked_subtile_y = stl_y;
+            ustate->cursor_button_down = 1;
             unset_packet_control(pckt, PCtr_RBtnClick);
         }
     }
@@ -379,7 +384,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
         {
             player->secondary_cursor_state = player->primary_cursor_state;
         }
-        if (player->cursor_button_down != 0)
+        if (ustate->cursor_button_down != 0)
         {
             if (!player->render_roomspace.drag_mode) // allow drag and click to not place on LMB hold
             {
@@ -396,7 +401,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
     }
     if ((pckt->control_flags & PCtr_RBtnHeld) != 0)
     {
-        if (player->cursor_button_down != 0)
+        if (ustate->cursor_button_down != 0)
             unset_packet_control(pckt, PCtr_RBtnRelease);
     }
     if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
@@ -408,13 +413,13 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
             player->ignore_next_PCtr_LBtnRelease = false;
             if ((pckt->control_flags & PCtr_RBtnHeld) == 0)
             {
-                player->cursor_button_down = 0;
+                ustate->cursor_button_down = 0;
             }
             unset_packet_control(pckt, PCtr_LBtnRelease);
         } else
-        if (player->cursor_button_down != 0)
+        if (ustate->cursor_button_down != 0)
         {
-            TbBool direct_control_target = !thing_target_action && (player->thing_under_hand != 0) && (get_user_state(user)->input_crtr_control != 0);
+            TbBool direct_control_target = !thing_target_action && (player->thing_under_hand != 0) && (ustate->input_crtr_control != 0);
             if (direct_control_target && (dungeon->things_in_hand[0] != player->thing_under_hand)) {
                 thing = get_creature_near_for_controlling(player->id_number, x, y);
                 if (!thing_is_invalid(thing))
@@ -430,7 +435,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
                     set_player_state(player, player->continue_work_state, 0);
                 }
                 unset_packet_control(pckt, PCtr_LBtnRelease);
-            } else if (!thing_target_action && get_user_state(user)->input_crtr_query != 0) {
+            } else if (!thing_target_action && ustate->input_crtr_query != 0) {
                 thing = get_creature_near(x, y);
                 if (!can_thing_be_queried(thing, plyr_idx))
                 {
@@ -483,7 +488,7 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
             }
             if ((pckt->control_flags & PCtr_RBtnHeld) == 0)
             {
-                player->cursor_button_down = 0;
+                ustate->cursor_button_down = 0;
                 player->one_click_lock_cursor = false;
             }
             if (player->render_roomspace.drag_mode)
@@ -510,18 +515,18 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
             player->ignore_next_PCtr_RBtnRelease = false;
             if ((pckt->control_flags & PCtr_LBtnHeld) == 0)
             {
-                player->cursor_button_down = 0;
+                ustate->cursor_button_down = 0;
             }
             unset_packet_control(pckt, PCtr_RBtnRelease);
         } else
-        if (player->cursor_button_down != 0)
+        if (ustate->cursor_button_down != 0)
         {
             if (!power_hand_is_empty(player) && (!player->one_click_lock_cursor))
             {
                 if (dump_first_held_thing_on_map(player->id_number, stl_x, stl_y, 1)) {
                     if ((pckt->control_flags & PCtr_LBtnHeld) == 0)
                     {
-                        player->cursor_button_down = 0;
+                        ustate->cursor_button_down = 0;
                     }
                     unset_packet_control(pckt, PCtr_RBtnRelease);
                 }
@@ -534,18 +539,18 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
                 }
                 if ((pckt->control_flags & PCtr_LBtnHeld) == 0)
                 {
-                    player->cursor_button_down = 0;
+                    ustate->cursor_button_down = 0;
                     player->one_click_lock_cursor = false;
                 }
                 unset_packet_control(pckt, PCtr_RBtnRelease);
             }
         }
     }
-    if ((player->cursor_button_down == 0) || (!player->one_click_lock_cursor))
+    if ((ustate->cursor_button_down == 0) || (!player->one_click_lock_cursor))
     {
         //if (untag_or_tag_completed_or_cancelled)
         player->swap_to_untag_mode = 0; // no
-        if ((player->cursor_button_down == 0) && ((pckt->control_flags & PCtr_LBtnHeld) == 0))
+        if ((ustate->cursor_button_down == 0) && ((pckt->control_flags & PCtr_LBtnHeld) == 0))
         {
             player->one_click_lock_cursor = false;
         }
@@ -556,13 +561,14 @@ TbBool process_dungeon_control_packet_dungeon_control(NetUserId user)
 TbBool process_dungeon_control_packet_sell_operation(NetUserId user)
 {
     struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    struct UserState* ustate = get_player_user_state(player);
     PlayerNumber plyr_idx = player->id_number;
     struct Packet* pckt = get_packet(user);
     if ((pckt->control_flags & PCtr_MapCoordsValid) == 0)
     {
-        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->full_slab_cursor != 0))
+        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (ustate->full_slab_cursor != 0))
         {
-            player->full_slab_cursor = 0;
+            ustate->full_slab_cursor = 0;
             unset_packet_control(pckt, PCtr_LBtnRelease);
         }
         return false;
@@ -583,15 +589,15 @@ TbBool process_dungeon_control_packet_sell_operation(NetUserId user)
     {
         if ((pckt->control_flags & PCtr_LBtnClick) == 0)
         {
-            if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->full_slab_cursor != 0))
+            if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (ustate->full_slab_cursor != 0))
             {
-                player->full_slab_cursor = 0;
+                ustate->full_slab_cursor = 0;
                 unset_packet_control(pckt, PCtr_LBtnRelease);
             }
             return false;
         }
     }
-    if (player->full_slab_cursor)
+    if (ustate->full_slab_cursor)
     {
         //Slab Mode
         if (player->render_roomspace.slab_count > 0)
@@ -618,7 +624,7 @@ TbBool process_dungeon_control_packet_sell_operation(NetUserId user)
                 // Nothing to do here - door already sold
             } else
                 // Trying to sell trap
-            if (player_sell_trap_at_subtile(plyr_idx, stl_x, stl_y))
+            if (player_sell_trap_at_subtile(plyr_idx, stl_x, stl_y, ustate->full_slab_cursor != 0))
             {
                 // Nothing to do here - trap already sold
             } else
@@ -637,7 +643,7 @@ TbBool process_dungeon_control_packet_sell_operation(NetUserId user)
             return false;
         }
         // Subtile Mode
-        if (player_sell_trap_at_subtile(plyr_idx, stl_x, stl_y))
+        if (player_sell_trap_at_subtile(plyr_idx, stl_x, stl_y, ustate->full_slab_cursor != 0))
         {
             // Nothing to do here - trap already sold
         } else
@@ -661,6 +667,7 @@ TbBool process_dungeon_control_packet_sell_operation(NetUserId user)
 TbBool process_dungeon_control_packet_dungeon_place_trap(NetUserId user)
 {
     struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    struct UserState* ustate = get_user_state(user);
     PlayerNumber plyr_idx = player->id_number;
     struct Packet* pckt = get_packet(user);
     MapCoord x = (pckt->pos_x);
@@ -670,19 +677,19 @@ TbBool process_dungeon_control_packet_dungeon_place_trap(NetUserId user)
 
     if ((pckt->control_flags & PCtr_MapCoordsValid) == 0)
     {
-        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->cursor_button_down != 0))
+        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (ustate->cursor_button_down != 0))
         {
-            player->cursor_button_down = 0;
+            ustate->cursor_button_down = 0;
             unset_packet_control(pckt, PCtr_LBtnRelease);
         }
         return false;
     }
-    TbBool can_place = tag_cursor_blocks_place_trap(player->id_number, stl_x, stl_y, player->chosen_trap_kind);
+    TbBool can_place = tag_cursor_blocks_place_trap(player->id_number, stl_x, stl_y, ustate->chosen_trap_kind);
     if ((pckt->control_flags & PCtr_LBtnClick) == 0)
     {
-        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (player->cursor_button_down != 0))
+        if (((pckt->control_flags & PCtr_LBtnRelease) != 0) && (ustate->cursor_button_down != 0))
         {
-            player->cursor_button_down = 0;
+            ustate->cursor_button_down = 0;
             unset_packet_control(pckt, PCtr_LBtnRelease);
         }
         return false;
@@ -694,7 +701,7 @@ TbBool process_dungeon_control_packet_dungeon_place_trap(NetUserId user)
         unset_packet_control(pckt, PCtr_LBtnClick);
         return false;
     }
-    if (!player_place_trap_at(stl_x, stl_y, plyr_idx, player->chosen_trap_kind))
+    if (!player_place_trap_at(stl_x, stl_y, plyr_idx, ustate->chosen_trap_kind))
     {
         unset_packet_control(pckt, PCtr_LBtnClick);
         return false;
@@ -708,14 +715,15 @@ TbBool process_dungeon_control_packet_clicks(NetUserId user)
     struct Thing *thing;
     PowerKind pwkind;
     struct PlayerInfo* player = get_player(get_net_user_player_number(user));
+    struct UserState* ustate = get_user_state(user);
     const PlayerNumber plyr_idx = player->id_number;
     struct Packet* pckt = get_packet(user);
     SYNCDBG(6,"Starting for user %d state %s",user,player_state_code_name(player->work_state));
     TbBool thing_target_action = (pckt->action == PckA_UsePwrHandPick) || (pckt->action == PckA_UsePwrOnThing);
-    player->full_slab_cursor = 1;
+    ustate->full_slab_cursor = 1;
     player->primary_cursor_state = (pckt->additional_packet_values & PCAdV_ContextMask) >> 1;
     packet_left_button_double_clicked[user] = 0;
-    player->mouse_on_map = is_mouse_on_map(pckt);
+    ustate->mouse_on_map = is_mouse_on_map(pckt);
     remember_cursor_subtile(player);
     process_dungeon_control_packet_spell_overcharge(user);
     if (flag_is_set(pckt->control_flags,PCtr_Gui))
@@ -726,7 +734,7 @@ TbBool process_dungeon_control_packet_clicks(NetUserId user)
     } else
     if ((pckt->control_flags & PCtr_RBtnRelease) == 0)
     {
-        player->boxsize = 1;
+        ustate->boxsize = 1;
     }
     if (player->id_number == my_player_number)
     {
@@ -743,7 +751,7 @@ TbBool process_dungeon_control_packet_clicks(NetUserId user)
     long i;
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
-    pwkind = player->chosen_power_kind;
+    pwkind = ustate->chosen_power_kind;
     thing = get_thing_under_hand(player, x, y);
     if (!thing_is_invalid(thing)) {
         player->thing_under_hand = thing->index;
@@ -868,20 +876,20 @@ TbBool process_dungeon_control_packet_clicks(NetUserId user)
         {
             if ((pckt->control_flags & PCtr_MapCoordsValid) != 0)
             {
-                player->full_slab_cursor = 1;
+                ustate->full_slab_cursor = 1;
                 // Make the frame around active slab
                 i = tag_cursor_blocks_place_door(player->id_number, stl_x, stl_y);
                 if ((pckt->control_flags & PCtr_LBtnClick) != 0)
                 {
-                    packet_place_door(stl_x, stl_y, player->id_number, player->chosen_door_kind, i);
+                    packet_place_door(stl_x, stl_y, player->id_number, ustate->chosen_door_kind, i);
                 }
                 unset_packet_control(pckt, PCtr_LBtnClick);
             }
             if ((pckt->control_flags & PCtr_LBtnRelease) != 0)
             {
-                if (player->cursor_button_down != 0)
+                if (ustate->cursor_button_down != 0)
                 {
-                    player->cursor_button_down = 0;
+                    ustate->cursor_button_down = 0;
                     unset_packet_control(pckt, PCtr_LBtnRelease);
                 }
             }

--- a/src/player_comptask.c
+++ b/src/player_comptask.c
@@ -363,7 +363,7 @@ TbResult game_action(PlayerNumber plyr_idx, unsigned short gaction, KeepPwrLevel
     }
     case GA_Unk15:
     case GA_PlaceRoom:
-        room = player_build_room_at(stl_x, stl_y, plyr_idx, param2);
+        room = player_build_room_at(stl_x, stl_y, plyr_idx, param2, 1);
         if (room_is_invalid(room))
             break;
         return Lb_SUCCESS;
@@ -383,7 +383,7 @@ TbResult game_action(PlayerNumber plyr_idx, unsigned short gaction, KeepPwrLevel
         }
     }
     case GA_SellTrap:
-        return player_sell_trap_at_subtile(plyr_idx, stl_x, stl_y);
+        return player_sell_trap_at_subtile(plyr_idx, stl_x, stl_y, false);
     case GA_SellDoor:
         return player_sell_door_at_subtile(plyr_idx, stl_x, stl_y);
     case GA_UsePwrLightning:

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -129,7 +129,7 @@ struct UserState *get_user_state(NetUserId user)
 
 struct UserState *get_player_user_state(const struct PlayerInfo *player)
 {
-    if (player == NULL)
+    if ((player == NULL) || player_invalid(player))
         return INVALID_USER_STATE;
     return get_user_state(player->user_id);
 }

--- a/src/player_data.c
+++ b/src/player_data.c
@@ -44,12 +44,12 @@ TbPixel possession_hit_colours[] =   {133, 89, 167, 141,  31,  31, 110,  54,  46
 unsigned short const player_cubes[] = {0x00C0, 0x00C1, 0x00C2, 0x00C3, 0x00C7, 0x00C6 };
 
 struct PlayerInfo bad_player;
+short local_thing_under_hand;
 struct LocalState local_state;
 struct UserState bad_user_state;
 
 /** The current player's number. */
 unsigned char my_player_number;
-short local_thing_under_hand;
 /******************************************************************************/
 
 struct Camera *get_player_active_camera(const struct PlayerInfo *player)
@@ -125,6 +125,13 @@ struct UserState *get_user_state(NetUserId user)
     if ((user < 0) || (user >= MAX_NET_USERS))
         return INVALID_USER_STATE;
     return &game.user_states[user];
+}
+
+struct UserState *get_player_user_state(const struct PlayerInfo *player)
+{
+    if (player == NULL)
+        return INVALID_USER_STATE;
+    return get_user_state(player->user_id);
 }
 
 TbBool user_state_invalid(const struct UserState *ustate)
@@ -344,6 +351,7 @@ void set_player_ally_locked(PlayerNumber plyr_idx, PlayerNumber ally_idx, TbBool
 
 void set_player_state(struct PlayerInfo *player, short nwrk_state, int32_t chosen_kind)
 {
+  struct UserState* ustate = get_player_user_state(player);
   SYNCDBG(6,"Player %d state %s to %s",(int)player->id_number,player_state_code_name(player->work_state),player_state_code_name(nwrk_state));
   // Selecting the same state again - update only 2nd parameter
   if (player->work_state == nwrk_state)
@@ -351,35 +359,35 @@ void set_player_state(struct PlayerInfo *player, short nwrk_state, int32_t chose
     switch ( player->work_state )
     {
     case PSt_BuildRoom:
-        player->chosen_room_kind = chosen_kind;
+        ustate->chosen_room_kind = chosen_kind;
         break;
     case PSt_PlaceTrap:
-        player->chosen_trap_kind = chosen_kind;
+        ustate->chosen_trap_kind = chosen_kind;
         break;
     case PSt_PlaceDoor:
-        player->chosen_door_kind = chosen_kind;
+        ustate->chosen_door_kind = chosen_kind;
         break;
     case PSt_CastPowerOnSubtile:
     case PST_CastPowerOnTarget:
     case PSt_CreateDigger:
     case PSt_SightOfEvil:
     case PSt_CallToArms:
-        player->chosen_power_kind = chosen_kind;
+        ustate->chosen_power_kind = chosen_kind;
         break;
     case PSt_CtrlDirect:
     case PSt_CtrlPassngr:
     case PSt_FreeCtrlPassngr:
     case PSt_FreeCtrlDirect:
-        player->chosen_power_kind = PwrK_POSSESS;
+        ustate->chosen_power_kind = PwrK_POSSESS;
         break;
     case PSt_FreeDestroyWalls:
-        player->chosen_power_kind = PwrK_DESTRWALLS;
+        ustate->chosen_power_kind = PwrK_DESTRWALLS;
         break;
     case PSt_FreeCastDisease:
-        player->chosen_power_kind = PwrK_DISEASE;
+        ustate->chosen_power_kind = PwrK_DISEASE;
         break;
     case PSt_FreeTurnChicken:
-        player->chosen_power_kind = PwrK_CHICKEN;
+        ustate->chosen_power_kind = PwrK_CHICKEN;
         break;
     }
     return;
@@ -396,11 +404,11 @@ void set_player_state(struct PlayerInfo *player, short nwrk_state, int32_t chose
   switch (player->work_state)
   {
   case PSt_CtrlDungeon:
-      player->full_slab_cursor = 1;
-      player->chosen_power_kind = PwrK_None; //Cleanup for spells. Traps, doors and rooms do not require cleanup.
+      ustate->full_slab_cursor = 1;
+      ustate->chosen_power_kind = PwrK_None; //Cleanup for spells. Traps, doors and rooms do not require cleanup.
       break;
   case PSt_BuildRoom:
-      player->chosen_room_kind = chosen_kind;
+      ustate->chosen_room_kind = chosen_kind;
       break;
   case PSt_HoldInHand:
       create_power_hand(player->id_number);
@@ -425,41 +433,41 @@ void set_player_state(struct PlayerInfo *player, short nwrk_state, int32_t chose
       }
   }
   case PSt_PlaceTrap:
-      player->chosen_trap_kind = chosen_kind;
+      ustate->chosen_trap_kind = chosen_kind;
       break;
   case PSt_PlaceDoor:
-      player->chosen_door_kind = chosen_kind;
+      ustate->chosen_door_kind = chosen_kind;
       break;
   case PSt_CastPowerOnSubtile:
   case PST_CastPowerOnTarget:
   case PSt_CallToArms:
   case PSt_SightOfEvil:
   case PSt_CreateDigger:
-      player->chosen_power_kind = chosen_kind;
+      ustate->chosen_power_kind = chosen_kind;
       break;
   case PSt_MkGoodCreatr:
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-        player->cheatselection.chosen_player = PLAYER_GOOD;
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+        ustate->cheatselection.chosen_player = PLAYER_GOOD;
         break;
   case PSt_MkBadCreatr:
   case PSt_MkDigger:
-        clear_messages_from_player(MsgType_Player, player->cheatselection.chosen_player);
-        player->cheatselection.chosen_player = player->id_number;
+        clear_messages_from_player(MsgType_Player, ustate->cheatselection.chosen_player);
+        ustate->cheatselection.chosen_player = player->id_number;
         break;
   case PSt_FreeCtrlPassngr:
   case PSt_FreeCtrlDirect:
   case PSt_CtrlPassngr:
   case PSt_CtrlDirect:
-        player->chosen_power_kind = PwrK_POSSESS;
+        ustate->chosen_power_kind = PwrK_POSSESS;
         break;
   case PSt_FreeDestroyWalls:
-      player->chosen_power_kind = PwrK_DESTRWALLS;
+      ustate->chosen_power_kind = PwrK_DESTRWALLS;
       break;
   case PSt_FreeCastDisease:
-      player->chosen_power_kind = PwrK_DISEASE;
+      ustate->chosen_power_kind = PwrK_DISEASE;
       break;
   case PSt_FreeTurnChicken:
-      player->chosen_power_kind = PwrK_CHICKEN;
+      ustate->chosen_power_kind = PwrK_CHICKEN;
       break;
    default:
       break;

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -156,7 +156,6 @@ struct CheatSelection
 */
 struct PlayerInfo {
     unsigned char allocflags;
-    unsigned char boxsize; //field_2 seems to be used in DK, so now renamed and used in KeeperFX
     unsigned char additional_flags; // Uses PlayerAdditionalFlags
     unsigned char display_flags;
     NetUserId user_id; // -1 if no user
@@ -191,14 +190,6 @@ struct PlayerInfo {
     char mp_message_text[PLAYER_MP_MESSAGE_LEN];
     char mp_pending_message[PLAYER_MP_MESSAGE_LEN];
     char mp_message_text_last[PLAYER_MP_MESSAGE_LEN];
-    unsigned char chosen_room_kind;
-    unsigned char full_slab_cursor; // 0 for subtile sized cursor, 1 for slab sized cursor
-    ThingModel chosen_trap_kind;
-    ThingModel chosen_door_kind;
-    PowerKind chosen_power_kind;
-    MapSubtlCoord cursor_clicked_subtile_x; // x coord of subtile clicked by mouse cursor
-    MapSubtlCoord cursor_clicked_subtile_y; // y coord of subtile clicked by mouse cursor
-    unsigned char cursor_button_down; // left or right button down (whilst using the bounding box cursor)
     /** Player instance, from PlayerInstanceNum enum. */
     unsigned char instance_num;
     unsigned long instance_remain_turns;
@@ -215,12 +206,6 @@ struct PlayerInfo {
     uint32_t isometric_view_zoom_level;
     uint32_t frontview_zoom_level;
     unsigned char hand_idx;
-    struct CheatSelection cheatselection;
-    TbBool first_person_dig_claim_mode;
-    unsigned char teleport_destination;
-    TbBool nearest_teleport;
-    BattleIndex battleid;
-    unsigned short selected_fp_thing_pickup;
     struct RoomSpace render_roomspace;
     struct RoomSpace roomspace;
     unsigned char roomspace_mode;
@@ -235,21 +220,18 @@ struct PlayerInfo {
     char swap_to_untag_mode;
     unsigned char roomspace_highlight_mode;
     TbBool roomspace_no_default;
-    MapSubtlCoord cursor_subtile_x;
-    MapSubtlCoord cursor_subtile_y;
-    MapSubtlCoord previous_cursor_subtile_x;
-    MapSubtlCoord previous_cursor_subtile_y;
-    TbBool mouse_on_map;
     TbBool interpolated_tagging;
     TbBool roomspace_drag_paint_mode;
     unsigned char roomspace_l_shape;
     TbBool roomspace_horizontal_first;
-    TbBool pickup_all_gold;
     unsigned char player_type; //enum PlayerTypes
     ThingModel special_digger;
     int isometric_tilt;
     unsigned short generate_speed;
     int first_person_unfreeze_delay;
+    unsigned char teleport_destination;
+    TbBool nearest_teleport;
+    BattleIndex battleid;
 };
 
 /* Game state that exists per human user. Computer-controlled
@@ -262,6 +244,26 @@ struct UserState {
     unsigned char input_crtr_control;
     unsigned char input_crtr_query;
     short cursor_light_idx;
+    /** Cursor position, and the subtile it last clicked on. */
+    MapSubtlCoord cursor_subtile_x;
+    MapSubtlCoord cursor_subtile_y;
+    MapSubtlCoord previous_cursor_subtile_x;
+    MapSubtlCoord previous_cursor_subtile_y;
+    MapSubtlCoord cursor_clicked_subtile_x;
+    MapSubtlCoord cursor_clicked_subtile_y;
+    unsigned char cursor_button_down; // left or right button down (whilst using the bounding box cursor)
+    TbBool mouse_on_map;
+    /** First person (possession) controls. */
+    TbBool first_person_dig_claim_mode;
+    unsigned short selected_fp_thing_pickup;
+    struct CheatSelection cheatselection;
+    unsigned char boxsize;
+    unsigned char chosen_room_kind;
+    unsigned char full_slab_cursor; // 0 for subtile sized cursor, 1 for slab sized cursor
+    ThingModel chosen_trap_kind;
+    ThingModel chosen_door_kind;
+    PowerKind chosen_power_kind;
+    TbBool pickup_all_gold;
 };
 
 /******************************************************************************/
@@ -314,6 +316,7 @@ TbBool player_invalid(const struct PlayerInfo *player);
 TbBool player_exists(const struct PlayerInfo *player);
 TbBool is_my_player(const struct PlayerInfo *player);
 struct UserState *get_user_state(NetUserId user);
+struct UserState *get_player_user_state(const struct PlayerInfo *player);
 TbBool user_state_invalid(const struct UserState *ustate);
 TbBool is_my_player_number(PlayerNumber plyr_num);
 TbBool player_allied_with(const struct PlayerInfo *player, PlayerNumber ally_idx);

--- a/src/player_instances.c
+++ b/src/player_instances.c
@@ -1121,7 +1121,7 @@ TbBool clear_selected_thing(struct PlayerInfo *player)
  * @param rkind Kind of the room.
  * @return Returns room struct, or invalid room on error.
  */
-struct Room *player_build_room_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, RoomKind rkind)
+struct Room *player_build_room_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, RoomKind rkind, int slabs_left)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
     struct Dungeon* dungeon = get_players_dungeon(player);
@@ -1154,21 +1154,15 @@ struct Room *player_build_room_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, Play
         play_non_3d_sample(snd_refusal);
       return INVALID_ROOM;
     }
-    if (player->boxsize == 0)
-    {
-        player->boxsize++;
-    }
-    if (dungeon->total_money_owned >= roomst->cost * player->boxsize)
+    if (slabs_left < 1)
+        slabs_left = 1;
+    if (dungeon->total_money_owned >= roomst->cost * slabs_left)
     {
         if (take_money_from_dungeon(plyr_idx, roomst->cost, 1) < 0)
         {
             if (is_my_player(player))
                 output_message(SMsg_GoldNotEnough, 0);
             return INVALID_ROOM;
-        }
-        if (player->boxsize > 0)
-        {
-        player->boxsize--;
         }
     }
     else
@@ -1192,7 +1186,7 @@ struct Room *player_build_room_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, Play
       if (is_my_player(player))
       {
           play_non_3d_sample(snd_tile_place);
-          if (player->boxsize > 1)
+          if (slabs_left > 2) // more slabs follow this one
           {
               play_non_3d_sample(snd_larg_tile_down);
               play_non_3d_sample(snd_larg_tile_up);

--- a/src/player_instances.h
+++ b/src/player_instances.h
@@ -109,7 +109,7 @@ TbBool is_thing_passenger_controlled_by_player(const struct Thing *thing, Player
 
 void set_player_zoom_to_position(struct PlayerInfo *player,struct Coord3d *pos);
 
-struct Room *player_build_room_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, RoomKind rkind);
+struct Room *player_build_room_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, RoomKind rkind, int slabs_left);
 TbBool player_place_trap_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel);
 TbBool player_place_trap_without_check_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel, TbBool free);
 TbBool player_place_door_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_idx, ThingModel tngmodel);

--- a/src/player_utils.c
+++ b/src/player_utils.c
@@ -1190,7 +1190,7 @@ void process_players(void)
     SYNCDBG(17,"Finished");
 }
 
-TbBool player_sell_trap_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
+TbBool player_sell_trap_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool whole_slab)
 {
     struct Thing *thing;
     struct Coord3d pos;
@@ -1198,8 +1198,7 @@ TbBool player_sell_trap_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, M
     MapSlabCoord slb_y = subtile_slab(stl_y);
     int32_t sell_value = 0;
     unsigned long traps_sold;
-    struct PlayerInfo* player = get_player(plyr_idx);
-    if (player->full_slab_cursor == false)
+    if (!whole_slab)
     {
         thing = get_trap_for_position(stl_x, stl_y);
         if (!thing_is_sellable_trap(thing))

--- a/src/player_utils.h
+++ b/src/player_utils.h
@@ -52,7 +52,7 @@ void compute_and_update_player_payday_total(PlayerNumber plyr_idx);
 void compute_and_update_player_backpay_total(PlayerNumber plyr_idx);
 void calculate_dungeon_area_scores(void);
 
-TbBool player_sell_trap_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
+TbBool player_sell_trap_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y, TbBool whole_slab);
 TbBool player_sell_door_at_subtile(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 
 void init_players(void);

--- a/src/power_hand.c
+++ b/src/power_hand.c
@@ -84,11 +84,13 @@ struct Thing *create_gold_for_hand_grab(struct Thing *thing, long owner)
     struct Dungeon *dungeon;
     dungeon = get_players_num_dungeon(owner);
     struct PlayerInfo* player = get_player(dungeon->owner);
+    struct UserState* ustate = get_player_user_state(player);
+    TbBool pickup_all = !user_state_invalid(ustate) && ustate->pickup_all_gold;
     if (dungeon->gold_hoard_for_pickup != thing->index)
     {
         dungeon->gold_hoard_for_pickup = thing->index;
         GoldAmount gold_req;
-        if (player->pickup_all_gold)
+        if (pickup_all)
         {
             gold_req = thing->valuable.gold_stored;
         }
@@ -105,7 +107,7 @@ struct Thing *create_gold_for_hand_grab(struct Thing *thing, long owner)
     pos.y.val = thing->mappos.y.val;
     pos.z.val = thing->mappos.z.val;
 
-    if (player->pickup_all_gold)
+    if (pickup_all)
     {
         dungeon->gold_pickup_amount = thing->valuable.gold_stored;
     }

--- a/src/roomspace.c
+++ b/src/roomspace.c
@@ -536,6 +536,7 @@ void reset_dungeon_build_room_ui_variables(PlayerNumber plyr_idx)
 
 void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, struct PlayerInfo *player, const struct Packet *pckt, MapSubtlCoord stl_x, MapSubtlCoord stl_y, const unsigned char *predicted_slab_tag_modes)
 {
+    struct UserState* ustate = get_player_user_state(player);
     PlayerNumber plyr_idx = player->id_number;
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
@@ -557,7 +558,7 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, struct Pl
         current_roomspace.untag_mode = false;
         current_roomspace.one_click_mode_exclusive = false;
         current_roomspace = check_roomspace_for_diggable_slabs(current_roomspace, plyr_idx, predicted_slab_tag_modes);
-        player->boxsize = current_roomspace.slab_count;
+        ustate->boxsize = current_roomspace.slab_count;
         *roomspace = current_roomspace;
         return;
     }
@@ -655,7 +656,7 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, struct Pl
             player->swap_to_untag_mode = -1; // disable
         }
     }
-    player->boxsize = current_roomspace.slab_count;
+    ustate->boxsize = current_roomspace.slab_count;
     if (current_roomspace.slab_count > 0)
     {
         current_roomspace.tag_for_dig = true;
@@ -670,6 +671,7 @@ void get_dungeon_highlight_user_roomspace(struct RoomSpace *roomspace, struct Pl
 void get_dungeon_sell_user_roomspace(struct RoomSpace *roomspace, PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     struct RoomSpace current_roomspace;
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
@@ -689,7 +691,7 @@ void get_dungeon_sell_user_roomspace(struct RoomSpace *roomspace, PlayerNumber p
         current_roomspace.untag_mode = false;
         current_roomspace.one_click_mode_exclusive = false;
         current_roomspace = check_roomspace_for_diggable_slabs(current_roomspace, plyr_idx, NULL);
-        player->boxsize = current_roomspace.slab_count;
+        ustate->boxsize = current_roomspace.slab_count;
         *roomspace = current_roomspace;
         player->ignore_next_PCtr_LBtnRelease = false;
         return;
@@ -745,7 +747,7 @@ void get_dungeon_sell_user_roomspace(struct RoomSpace *roomspace, PlayerNumber p
         player->roomspace_width = current_roomspace.width;
         player->roomspace_height = current_roomspace.height;
     }
-    player->boxsize = current_roomspace.slab_count;
+    ustate->boxsize = current_roomspace.slab_count;
     current_roomspace.one_click_mode_exclusive = player->one_click_mode_exclusive;
     *roomspace = current_roomspace;
 }
@@ -753,6 +755,7 @@ void get_dungeon_sell_user_roomspace(struct RoomSpace *roomspace, PlayerNumber p
 void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber plyr_idx, RoomKind rkind, MapSubtlCoord stl_x, MapSubtlCoord stl_y, unsigned char mode)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     MapSlabCoord slb_x = subtile_slab(stl_x);
     MapSlabCoord slb_y = subtile_slab(stl_y);
     struct RoomSpace best_roomspace;
@@ -776,7 +779,7 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
         best_roomspace.untag_mode = false;
         best_roomspace.one_click_mode_exclusive = false;
         best_roomspace = check_roomspace_for_diggable_slabs(best_roomspace, plyr_idx, NULL);
-        player->boxsize = best_roomspace.slab_count;
+        ustate->boxsize = best_roomspace.slab_count;
         *roomspace = best_roomspace;
         player->ignore_next_PCtr_LBtnRelease = false;
         return;
@@ -795,7 +798,7 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
         best_roomspace = get_biggest_roomspace(plyr_idx, rkind, slb_x, slb_y, roomst->cost, 0, 32, player->roomspace_detection_looseness);
         slb_x = best_roomspace.centreX;
         slb_y = best_roomspace.centreY;
-        player->boxsize = best_roomspace.slab_count; // correct number of tiles always returned from get_biggest_roomspace
+        ustate->boxsize = best_roomspace.slab_count; // correct number of tiles always returned from get_biggest_roomspace
     }
     else if ( (mode == drag_placement_mode) && (player->roomspace_drag_paint_mode == false) )
     {
@@ -841,7 +844,7 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
         }
         temp_best_room = check_slabs_in_roomspace(temp_best_room, roomst->cost);
         best_roomspace = temp_best_room;
-        player->boxsize = best_roomspace.slab_count;
+        ustate->boxsize = best_roomspace.slab_count;
         player->roomspace_width = best_roomspace.width;
         player->roomspace_height = best_roomspace.height;
         best_roomspace.render_roomspace_as_box = true;
@@ -852,7 +855,7 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
         temp_best_room.drag_direction = top_left_to_bottom_right;
         temp_best_room = check_slabs_in_roomspace(temp_best_room, roomst->cost);
         best_roomspace = temp_best_room;
-        player->boxsize = best_roomspace.slab_count; // correct number of tiles returned from check_slabs_in_roomspace
+        ustate->boxsize = best_roomspace.slab_count; // correct number of tiles returned from check_slabs_in_roomspace
             // Make sure the "outer box" bounding is drawn with square room mode
             best_roomspace.width = player->roomspace_width;
             best_roomspace.height = player->roomspace_height;
@@ -869,24 +872,26 @@ void get_dungeon_build_user_roomspace(struct RoomSpace *roomspace, PlayerNumber 
 TbBool update_dungeon_build_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
     struct PlayerInfo *player = get_player(plyr_idx);
-    player->full_slab_cursor = 1;
+    struct UserState* ustate = get_player_user_state(player);
+    ustate->full_slab_cursor = 1;
     if (is_my_player(player)) {
-        gui_room_type_highlighted = player->chosen_room_kind;
+        gui_room_type_highlighted = ustate->chosen_room_kind;
     }
-    get_dungeon_build_user_roomspace(&player->render_roomspace, player->id_number, player->chosen_room_kind, stl_x, stl_y, player->roomspace_mode);
-    return tag_cursor_blocks_place_room(player->id_number, stl_x, stl_y, player->full_slab_cursor);
+    get_dungeon_build_user_roomspace(&player->render_roomspace, player->id_number, ustate->chosen_room_kind, stl_x, stl_y, player->roomspace_mode);
+    return tag_cursor_blocks_place_room(player->id_number, stl_x, stl_y, ustate->full_slab_cursor);
 }
 
 TbBool update_dungeon_sell_roomspace_preview(PlayerNumber plyr_idx, MapSubtlCoord stl_x, MapSubtlCoord stl_y)
 {
     struct PlayerInfo *player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     if (player->roomspace_mode != single_subtile_mode) {
-        player->full_slab_cursor = 1;
+        ustate->full_slab_cursor = 1;
     } else {
-        player->full_slab_cursor = 0;
+        ustate->full_slab_cursor = 0;
     }
     get_dungeon_sell_user_roomspace(&player->render_roomspace, player->id_number, stl_x, stl_y);
-    return tag_cursor_blocks_sell_area(plyr_idx, stl_x, stl_y, player->full_slab_cursor);
+    return tag_cursor_blocks_sell_area(plyr_idx, stl_x, stl_y, ustate->full_slab_cursor);
 }
 
 void apply_roomspace_packet_action(struct PlayerInfo *player, const struct Packet *pckt)
@@ -947,7 +952,8 @@ static void sell_at_point(struct RoomSpace *roomspace)
     struct SlabMap *slb = get_slabmap_block(roomspace->buildx, roomspace->buildy);
     if (slabmap_owner(slb) == roomspace->plyr_idx)
     {
-        if (player_sell_trap_at_subtile(roomspace->plyr_idx, slab_subtile_center(roomspace->buildx), slab_subtile_center(roomspace->buildy)) ||
+        if (player_sell_trap_at_subtile(roomspace->plyr_idx, slab_subtile_center(roomspace->buildx), slab_subtile_center(roomspace->buildy),
+                get_player_user_state(get_player(roomspace->plyr_idx))->full_slab_cursor != 0) ||
             player_sell_door_at_subtile(roomspace->plyr_idx, slab_subtile(roomspace->buildx, 0), slab_subtile(roomspace->buildy, 0)) ) // Trying to sell trap
         {
             // Nothing to do here - trap already sold
@@ -1136,7 +1142,7 @@ int apply_roomspace_dig_tag_selection(PlayerNumber plyr_idx, struct RoomSpace *r
 void keeper_highlight_roomspace(PlayerNumber plyr_idx, struct RoomSpace *roomspace)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
-    int dig_change_count = apply_roomspace_dig_tag_selection(plyr_idx, roomspace, player->previous_cursor_subtile_x / STL_PER_SLB, player->previous_cursor_subtile_y / STL_PER_SLB, player->roomspace_highlight_mode, NULL, NULL, NULL, NULL);
+    int dig_change_count = apply_roomspace_dig_tag_selection(plyr_idx, roomspace, get_player_user_state(player)->previous_cursor_subtile_x / STL_PER_SLB, get_player_user_state(player)->previous_cursor_subtile_y / STL_PER_SLB, player->roomspace_highlight_mode, NULL, NULL, NULL, NULL);
     if (is_my_player(player))
     {
         if (dig_change_count > 0) {
@@ -1358,8 +1364,9 @@ void update_roomspaces()
 void process_build_roomspace_inputs(PlayerNumber plyr_idx)
 {
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     struct Packet* pckt = get_packet(player->user_id);
-    if (room_role_matches(player->chosen_room_kind,RoRoF_PassLava|RoRoF_PassWater|RoRoF_PassAbyss))
+    if (room_role_matches(ustate->chosen_room_kind,RoRoF_PassLava|RoRoF_PassWater|RoRoF_PassAbyss))
     {
         TbBool drag_check = ( ( (is_game_key_pressed(Gkey_BestRoomSpace, false, true)) || (is_game_key_pressed(Gkey_SquareRoomSpace, false, true)) ) && (left_button_held));
         if (drag_check) // Enable "paint mode" if Ctrl or Shift are held

--- a/src/roomspace_prediction.c
+++ b/src/roomspace_prediction.c
@@ -130,7 +130,10 @@ static TbBool get_local_dig_prediction_roomspace(const struct Packet *pckt, stru
         predicted_player->render_roomspace.drag_start_y = local_dig_tag_prediction.drag_start_slb_y;
         predicted_player->render_roomspace.untag_mode = local_dig_tag_prediction.untag_mode;
     }
+    struct UserState *ustate = get_player_user_state(predicted_player);
+    struct UserState saved_ustate = *ustate;
     get_dungeon_highlight_user_roomspace(roomspace, predicted_player, pckt, stl_x, stl_y, local_dig_tag_prediction.slab_tag_modes);
+    *ustate = saved_ustate;
     return true;
 }
 
@@ -144,7 +147,9 @@ static TbBool update_predicted_build_or_sell_roomspace_preview(struct RoomSpace 
         return false;
     }
     struct Packet *direct_packet = get_packet(player->user_id);
+    struct UserState *ustate = get_player_user_state(player);
     struct PlayerInfo saved_player = *player;
+    struct UserState saved_ustate = *ustate;
     struct Packet saved_packet = *direct_packet;
     *direct_packet = *pckt;
     apply_roomspace_packet_action(player, pckt);
@@ -157,6 +162,7 @@ static TbBool update_predicted_build_or_sell_roomspace_preview(struct RoomSpace 
     }
     *roomspace = player->render_roomspace;
     *player = saved_player;
+    *ustate = saved_ustate;
     *direct_packet = saved_packet;
     return true;
 }

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -7167,11 +7167,12 @@ void direct_control_pick_up_or_drop(PlayerNumber plyr_idx, struct Thing *creatng
     struct CreatureControl* cctrl = creature_control_get_from_thing(creatng);
     struct Thing* dragtng = thing_get(cctrl->dragtng_idx);
     struct PlayerInfo* player = get_player(plyr_idx);
+    struct UserState* ustate = get_player_user_state(player);
     if (!thing_is_invalid(dragtng))
     {
         if (thing_is_trap_crate(dragtng))
         {
-            struct Thing *traptng = thing_get(player->selected_fp_thing_pickup);
+            struct Thing *traptng = thing_get(ustate->selected_fp_thing_pickup);
             if (!thing_is_invalid(traptng))
             {
                 if (traptng->class_id == TCls_Trap)
@@ -7186,7 +7187,7 @@ void direct_control_pick_up_or_drop(PlayerNumber plyr_idx, struct Thing *creatng
     }
     else
     {
-        struct Thing* picktng = thing_get(player->selected_fp_thing_pickup);
+        struct Thing* picktng = thing_get(ustate->selected_fp_thing_pickup);
         struct Room* room;
         if (!thing_is_invalid(picktng))
         {


### PR DESCRIPTION
Moving more fields from PlayerInfo that really belong in UserState. (Previous PR: https://github.com/dkfans/keeperfx/pull/5220).

These fields all only belong on actual human users, not computer-controlled players. Furthermore, for "archon mode," this will (eventually) allow different users to have different such states per user.

These are all pretty straightforward, there's really nothing surprising to see in this PR. I have `roomspace_prediction.c` now copy the UserState in addition to PlayerInfo.