### PR TITLE
Prevent creatures from ever voluntarily walking onto lava/abyss subtiles.

### DIFF
--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6418,6 +6418,23 @@ static void process_keeper_spell_aura(struct Thing *thing)
     create_used_effect_or_element(&pos, cctrl->spell_aura, thing->owner, thing->index);
 }
 
+static void block_voluntary_move_onto_toxic_terrain(struct Thing *thing, struct CreatureControl *cctrl)
+{
+    const struct Coord3d *pos = &thing->mappos;
+    if (flag_is_set(thing->alloc_flags, TAlF_IsControlled) || terrain_toxic_for_creature_at_position(thing, pos->x.stl.num, pos->y.stl.num)) {
+        return;
+    }
+    struct Coord3d nextpos;
+    nextpos.x.val = pos->x.val + cctrl->moveaccel.x.val;
+    nextpos.y.val = pos->y.val + cctrl->moveaccel.y.val;
+    if (terrain_toxic_for_creature_at_position(thing, nextpos.x.stl.num, pos->y.stl.num)) {
+        cctrl->moveaccel.x.val = 0;
+    }
+    if (terrain_toxic_for_creature_at_position(thing, pos->x.stl.num, nextpos.y.stl.num)) {
+        cctrl->moveaccel.y.val = 0;
+    }
+}
+
 TngUpdateRet update_creature(struct Thing *thing)
 {
     SYNCDBG(19,"Starting for %s index %d",thing_model_name(thing),(int)thing->index);
@@ -6526,6 +6543,7 @@ TngUpdateRet update_creature(struct Thing *thing)
     {
         SYNCDBG(19,"The %s index %d acceleration is (%d,%d,%d)",thing_model_name(thing),
             (int)thing->index,(int)cctrl->moveaccel.x.val,(int)cctrl->moveaccel.y.val,(int)cctrl->moveaccel.z.val);
+        block_voluntary_move_onto_toxic_terrain(thing, cctrl);
         thing->velocity.x.val += cctrl->moveaccel.x.val;
         thing->velocity.y.val += cctrl->moveaccel.y.val;
         thing->velocity.z.val += cctrl->moveaccel.z.val;

--- a/src/thing_creature.c
+++ b/src/thing_creature.c
@@ -6433,6 +6433,10 @@ static void block_voluntary_move_onto_toxic_terrain(struct Thing *thing, struct 
     if (terrain_toxic_for_creature_at_position(thing, pos->x.stl.num, nextpos.y.stl.num)) {
         cctrl->moveaccel.y.val = 0;
     }
+    if ((cctrl->moveaccel.x.val != 0) && (cctrl->moveaccel.y.val != 0) && terrain_toxic_for_creature_at_position(thing, nextpos.x.stl.num, nextpos.y.stl.num)) {
+        cctrl->moveaccel.x.val = 0;
+        cctrl->moveaccel.y.val = 0;
+    }
 }
 
 TngUpdateRet update_creature(struct Thing *thing)

--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -393,9 +393,6 @@ TbBool thing_can_traverse_abyss_at(const struct Thing *thing, MapSubtlCoord stl_
 
 TbBool position_over_floor_level(const struct Thing *thing, const struct Coord3d *pos)
 {
-    if (!thing_can_traverse_abyss_at(thing, pos->x.stl.num, pos->y.stl.num)) {
-        return true;
-    }
     struct Coord3d modpos;
     modpos.x.val = pos->x.val;
     modpos.y.val = pos->y.val;


### PR DESCRIPTION
Creatures can accidentally enter lava or the abyss because their movement acceleration and low turn speed carries them into such terrain while they navigate tight corners. It's also possible that pathfinding sometimes creates paths that are too tight, though I'm less sure of this factor, in any case you need to solve for the first factor as creature movement is messy and they bump into stuff all the time.

This blocks the affected movement axis before voluntary movement enters this terrain. Possessed movement, slaps and wind are unchanged, so creatures can still be pushed into it.

This PR solves the issue entirely, it doesn't need the other PR.