### PR TITLE
Click away to finish text entry

### DIFF
--- a/src/bflib_guibtns.h
+++ b/src/bflib_guibtns.h
@@ -63,6 +63,7 @@ enum TbButtonFlags {
     LbBtnF_Enabled    =  0x08,  /**< Informs if the button is enabled and can be clicked, or disabled and grayed out with no reaction to input. */
     LbBtnF_MouseOver  =  0x10,
     LbBtnF_Toggle     =  0x20,
+    LbBtnF_NoClickAway = 0x40,  /** Cannot click outside of entry box to finalize entry */
 };
 
 enum GBoxFlags {
@@ -119,7 +120,7 @@ struct GuiButtonInit {
     char gbtype; /**< GUI Button Type, directly copied to button instance. */
     short id_num; /**< GUI Button ID, directly copied to button instance. If there is no need of identifying the button within game code, it should be set to BID_DEFAULT.*/
     short unused_field; // unused
-    unsigned short button_flags; // two bool values; maybe convert it to flags?
+    unsigned short button_flags;
     Gf_Btn_Callback click_event;
     Gf_Btn_Callback rclick_event;
     Gf_Btn_Callback ptover_event;

--- a/src/front_input.c
+++ b/src/front_input.c
@@ -3047,6 +3047,17 @@ short get_gui_inputs(short gameplay_on)
       }
   }
   update_busy_doing_gui_on_menu();
+  
+  // click outside of edit box to end entry
+  if (game_is_busy_doing_gui_string_input()
+     && (left_button_clicked || right_button_clicked)
+     && !(input_button->flags & LbBtnF_NoClickAway)
+     && !check_if_mouse_is_over_button(input_button)
+  )
+  {
+      finish_button_area_input();
+  }
+  
   int fmmenu_idx = first_monopoly_menu();
   int gmbtn_idx = -1;
   ActiveButtonID nx_over_slider_button = -1;

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -549,6 +549,23 @@ short game_is_busy_doing_gui(void)
     return true;
 }
 
+// force finish text entry
+// (if text field is empty, reverts as though esc was pressed.)
+void finish_button_area_input(void)
+{
+    if (input_button == NULL)
+        return;
+    TbKeyCode prev_key = lbInkey;
+    lbInkey = KC_RETURN;
+    get_button_area_input(input_button, input_button->id_num);
+    if (input_button != NULL)
+    {
+        lbInkey = KC_ESCAPE;
+        get_button_area_input(input_button, input_button->id_num);
+    }
+    lbInkey = prev_key;
+}
+
 TbBool get_button_area_input(struct GuiButton *gbtn, int modifiers)
 {
     if (input_button == NULL)
@@ -1957,6 +1974,7 @@ int create_button(struct GuiMenu *gmnu, struct GuiButtonInit *gbinit, int units_
     gbtn->gbtype = gbinit->gbtype;
     gbtn->id_num = gbinit->id_num;
     gbtn->flags ^= (gbtn->flags ^ LbBtnF_Clickable * (gbinit->button_flags & 0xff)) & LbBtnF_Clickable;
+    gbtn->flags ^= (gbtn->flags ^ LbBtnF_NoClickAway * ((gbinit->button_flags >> 1) & 1)) & LbBtnF_NoClickAway;
     gbtn->click_event = gbinit->click_event;
     gbtn->rclick_event = gbinit->rclick_event;
     gbtn->ptover_event = gbinit->ptover_event;

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -330,6 +330,7 @@ void create_error_box(TextStringId msg_idx);
 void create_message_box(const char *title, const char *line1, const char *line2, const char *line3, const char *line4, const char* line5);
 void gui_area_text(struct GuiButton *gbtn);
 TbBool get_button_area_input(struct GuiButton *gbtn, int a2);
+void finish_button_area_input(void);
 const char *frontend_button_caption_text(const struct GuiButton *gbtn);
 int frontend_button_caption_font(const struct GuiButton *gbtn, long mouse_over_btn_idx);
 void maintain_loadsave(struct GuiButton *gbtn);

--- a/src/frontmenu_saves_data.cpp
+++ b/src/frontmenu_saves_data.cpp
@@ -56,14 +56,14 @@ struct GuiButtonInit load_menu_buttons[] = {
 
 struct GuiButtonInit save_menu_buttons[] = {
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,              NULL, NULL,  0, 999,  10, 999,  10,155, 32, gui_area_text,    1, GUIStr_MnuSave,0,       {0},               0, NULL },
-  { 5,                 -2,         -1, 1, gui_save_game,     NULL, NULL,  0, 999,  58, 999,  58,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[0]},SAVE_TEXTNAME_LEN, NULL },
-  { 5,                 -2,         -1, 1, gui_save_game,     NULL, NULL,  1, 999,  90, 999,  90,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[1]},SAVE_TEXTNAME_LEN, NULL },
-  { 5,                 -2,         -1, 1, gui_save_game,     NULL, NULL,  2, 999, 122, 999, 122,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[2]},SAVE_TEXTNAME_LEN, NULL },
-  { 5,                 -2,         -1, 1, gui_save_game,     NULL, NULL,  3, 999, 154, 999, 154,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[3]},SAVE_TEXTNAME_LEN, NULL },
-  { 5,                 -2,         -1, 1, gui_save_game,     NULL, NULL,  4, 999, 186, 999, 186,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[4]},SAVE_TEXTNAME_LEN, NULL },
-  { 5,                 -2,         -1, 1, gui_save_game,     NULL, NULL,  5, 999, 218, 999, 218,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[5]},SAVE_TEXTNAME_LEN, NULL },
-  { 5,                 -2,         -1, 1, gui_save_game,     NULL, NULL,  6, 999, 250, 999, 250,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[6]},SAVE_TEXTNAME_LEN, NULL },
-  { 5,                 -2,         -1, 1, gui_save_game,     NULL, NULL,  7, 999, 282, 999, 282,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[7]},SAVE_TEXTNAME_LEN, NULL },
+  { 5,                 -2,         -1, 3, gui_save_game,     NULL, NULL,  0, 999,  58, 999,  58,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[0]},SAVE_TEXTNAME_LEN, NULL },
+  { 5,                 -2,         -1, 3, gui_save_game,     NULL, NULL,  1, 999,  90, 999,  90,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[1]},SAVE_TEXTNAME_LEN, NULL },
+  { 5,                 -2,         -1, 3, gui_save_game,     NULL, NULL,  2, 999, 122, 999, 122,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[2]},SAVE_TEXTNAME_LEN, NULL },
+  { 5,                 -2,         -1, 3, gui_save_game,     NULL, NULL,  3, 999, 154, 999, 154,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[3]},SAVE_TEXTNAME_LEN, NULL },
+  { 5,                 -2,         -1, 3, gui_save_game,     NULL, NULL,  4, 999, 186, 999, 186,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[4]},SAVE_TEXTNAME_LEN, NULL },
+  { 5,                 -2,         -1, 3, gui_save_game,     NULL, NULL,  5, 999, 218, 999, 218,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[5]},SAVE_TEXTNAME_LEN, NULL },
+  { 5,                 -2,         -1, 3, gui_save_game,     NULL, NULL,  6, 999, 250, 999, 250,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[6]},SAVE_TEXTNAME_LEN, NULL },
+  { 5,                 -2,         -1, 3, gui_save_game,     NULL, NULL,  7, 999, 282, 999, 282,300, 32, gui_area_text,    1, GUIStr_Empty,  0,{.str = input_string[7]},SAVE_TEXTNAME_LEN, NULL },
   { LbBtnT_HoldableBtn,BID_DEFAULT, 0, 0, gui_vscroll_input, NULL, NULL,  0, 368,  58, 368,  58, 33,254, gui_vscroll_draw, 0, GUIStr_Empty,  0,{0},                     0,                 gui_vscroll_maintain },
   {-1,                 0,           0, 0, NULL,              NULL, NULL,  0,   0,   0,   0,   0,  0,  0, NULL,             0, 0,             0,{0},                     0,                 NULL },
 };


### PR DESCRIPTION
It's been bothering me that when entering text, the GUI becomes unresponsive to clicks until you press enter to finalize the text entry. It has left me confused about why things are not working a couple of times.

When clicking away now, the text entry finalizes (confirms). If the clicking away while the text field is empty, it cancels instead.

I left the save buttons as they were (with a new flag, `LbBtnF_NoClickAway`), because I reckon somebody might not expect that clicking away would overwrite the save data. All other text entry fields (i.e. name entry, and potentially any others in the future) can now be confirmed by clicking away.