### PR TITLE
Scale 'name' entry field 25->26, underline now visible

### DIFF
--- a/src/frontmenu_net_data.cpp
+++ b/src/frontmenu_net_data.cpp
@@ -67,7 +67,7 @@ struct GuiButtonInit frontend_net_session_buttons[] = {
   { LbBtnT_NormalBtn,  BID_MENU_TITLE, 0, 0, NULL,               NULL,        NULL,               0, 999,  12, 999,  12,371, 46, frontend_draw_large_menu_button,   0, GUIStr_Empty, 0,      {12},            0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  82,  61,  82,  61,165, 29, frontnet_draw_text_bar,            0, GUIStr_Empty, 0,      {27},            0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  95,  63,  91,  63,165, 25, frontend_draw_text,                0, GUIStr_Empty, 0,      {19},            0, NULL },
-  { 5, -1,-1, 0, frontnet_session_set_player_name,NULL,frontend_over_button,19,200,63,95,63,432, 25, frontend_draw_enter_text,          0, GUIStr_Empty, 0,{.str = tmp_net_player_name}, 20, NULL },
+  { 5, -1,-1, 0, frontnet_session_set_player_name,NULL,frontend_over_button,19,200,63,95,63,432, 26, frontend_draw_enter_text,          0, GUIStr_Empty, 0,{.str = tmp_net_player_name}, 20, NULL },
   //{ LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, frontnet_session_add,NULL,      frontend_over_button,0, 321,  93, 321,  93,247, 46, frontend_draw_small_menu_button,   0, GUIStr_Empty, 0,     {110},            0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  82, 112,  82, 112,220, 26, frontnet_draw_scroll_box_tab,      0, GUIStr_Empty, 0,      {28},            0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  82, 138,  82, 138,450,180, frontnet_draw_scroll_box,          0, GUIStr_Empty, 0,      {25},            0, NULL },


### PR DESCRIPTION
There are half a dozen underscores here, including the blinking on that indicates text is being entered. Can you see them?

<img width="633" height="475" alt="image" src="https://github.com/user-attachments/assets/2263f141-1702-49f5-b6d5-8e9368fee212" />

They're very dark. That's because on windowed mode, they are being very slightly down-scaled. My read is that bumping up the font size to 26 (the font's native size) should prevent them from being down-scaled on any resolution:

<img width="640" height="477" alt="image" src="https://github.com/user-attachments/assets/976fb442-0d58-4e21-a49d-c22c8765442d" />
