### PR TITLE
Make checking abyss edge collision the same as checking normal cube collision

### DIFF
--- a/src/map_blocks.c
+++ b/src/map_blocks.c
@@ -1844,7 +1844,7 @@ void create_gold_rubble_for_dug_slab(MapSlabCoord slb_x, MapSlabCoord slb_y)
  * @param floor_height Floor height value reference. Value is updated only if new one is larger.
  * @param ceiling_height Ceiling height value reference. Value is updated only if new one is smaller.
  */
-void update_floor_and_ceiling_heights_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y,
+TbBool update_floor_and_ceiling_heights_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y,
     MapSubtlCoord *floor_height, MapSubtlCoord *ceiling_height)
 {
     struct Map *mapblk;
@@ -1869,6 +1869,7 @@ void update_floor_and_ceiling_heights_at(MapSubtlCoord stl_x, MapSubtlCoord stl_
     if (*ceiling_height > height) {
         *ceiling_height = height;
     }
+    return !subtile_has_abyss_on_top(stl_x, stl_y);
 }
 
 TbBool point_in_map_is_solid(const struct Coord3d *pos)

--- a/src/map_blocks.h
+++ b/src/map_blocks.h
@@ -50,7 +50,7 @@ void dig_out_block(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber plyr_i
 void neutralise_enemy_block(MapSubtlCoord stl_x, MapSubtlCoord stl_y, PlayerNumber domn_plyr_idx);
 void check_map_explored(struct Thing* creatng, MapSubtlCoord stl_x, MapSubtlCoord stl_y);
 TbBool set_slab_explored(PlayerNumber plyr_idx, MapSlabCoord slb_x, MapSlabCoord slb_y);
-void update_floor_and_ceiling_heights_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y,
+TbBool update_floor_and_ceiling_heights_at(MapSubtlCoord stl_x, MapSubtlCoord stl_y,
     MapSubtlCoord *floor_height, MapSubtlCoord *ceiling_height);
 TbBool point_in_map_is_solid(const struct Coord3d *pos);
 TbBool point_in_map_is_solid_ignoring_door(const struct Coord3d *pos, const struct Thing *doortng);

--- a/src/map_utils.c
+++ b/src/map_utils.c
@@ -161,21 +161,24 @@ void init_spiral_steps(void)
  * @param floor_height Floor height value reference. Set to max floor height in range.
  * @param ceiling_height Ceiling height value reference. Set to min ceiling height in range.
  */
-void get_min_floor_and_ceiling_heights_for_rect(MapSubtlCoord stl_x_beg, MapSubtlCoord stl_y_beg,
+TbBool get_min_floor_and_ceiling_heights_for_rect(MapSubtlCoord stl_x_beg, MapSubtlCoord stl_y_beg,
     MapSubtlCoord stl_x_end, MapSubtlCoord stl_y_end,
     MapSubtlCoord *floor_height, MapSubtlCoord *ceiling_height)
 {
     *floor_height = 0;
     *ceiling_height = 15;
+    TbBool solid_ground = false;
     // Sweep through subtiles and select highest floor and lowest ceiling
     for (MapSubtlCoord stl_y = stl_y_beg; stl_y <= stl_y_end; stl_y++)
     {
         for (MapSubtlCoord stl_x = stl_x_beg; stl_x <= stl_x_end; stl_x++)
         {
-            update_floor_and_ceiling_heights_at(stl_x, stl_y,
-                floor_height, ceiling_height);
+            if (update_floor_and_ceiling_heights_at(stl_x, stl_y, floor_height, ceiling_height)) {
+                solid_ground = true;
+            }
         }
     }
+    return solid_ground;
 }
 
 long near_coord_filter_battle_drop_point(const struct Coord3d *pos, MaxCoordFilterParam param, long maximizer)

--- a/src/map_utils.h
+++ b/src/map_utils.h
@@ -92,7 +92,7 @@ extern struct Around const my_around_nine[];
 /******************************************************************************/
 void init_spiral_steps(void);
 
-void get_min_floor_and_ceiling_heights_for_rect(MapSubtlCoord stl_x_beg, MapSubtlCoord stl_y_beg,
+TbBool get_min_floor_and_ceiling_heights_for_rect(MapSubtlCoord stl_x_beg, MapSubtlCoord stl_y_beg,
     MapSubtlCoord stl_x_end, MapSubtlCoord stl_y_end,
     MapSubtlCoord *floor_height, MapSubtlCoord *ceiling_height);
 

--- a/src/thing_list.c
+++ b/src/thing_list.c
@@ -3386,6 +3386,9 @@ TbBool update_thing(struct Thing *thing)
     if (flag_is_set(thing->state_flags, TF1_InCtrldLimbo)) {
         return true;
     }
+    MapCoord floor_height;
+    MapCoord ceiling_height;
+    TbBool over_solid_ground = true;
     falling = flag_is_set(thing->state_flags, TF1_FallingIntoAbyss);
     if (falling) {
         thing->velocity.z.val = clamp(thing->velocity.z.val, -CREATURE_TERMINAL_VELOCITY, CREATURE_TERMINAL_VELOCITY);
@@ -3402,7 +3405,10 @@ TbBool update_thing(struct Thing *thing)
         thing->veloc_base.y.val = thing->veloc_base.y.val * (256 - thing->inertia_air) / 256;
     }
     else {
-        if ((thing->class_id != TCls_EffectElem) && !flag_is_set(thing->movement_flags, TMvF_Immobile) && (thing->fall_acceleration != 0) && (thing->mappos.z.val <= 0) && !thing_can_traverse_abyss_at(thing, thing->mappos.x.stl.num, thing->mappos.y.stl.num)) {
+        if (!flag_is_set(thing->movement_flags, TMvF_Immobile) && !flag_is_set(thing->movement_flags, TMvF_Flying) && (thing->mappos.z.val <= thing->floor_height)) {
+            over_solid_ground = get_floor_and_ceiling_height_under_thing_at(thing, &thing->mappos, &floor_height, &ceiling_height);
+        }
+        if ((thing->class_id != TCls_EffectElem) && !flag_is_set(thing->movement_flags, TMvF_Immobile) && !flag_is_set(thing->movement_flags, TMvF_Flying) && (thing->fall_acceleration != 0) && (thing->mappos.z.val <= 0) && !over_solid_ground) {
             set_flag(thing->state_flags, TF1_FallingIntoAbyss);
             falling = true;
             thing->veloc_base.x.val = thing->velocity.x.val;
@@ -3425,7 +3431,7 @@ TbBool update_thing(struct Thing *thing)
     }
     SYNCDBG(18,"Class function end ok");
     if (!falling && ((thing->movement_flags & TMvF_Immobile) == 0)) {
-        if ((thing->mappos.z.val > thing->floor_height) || !thing_can_traverse_abyss_at(thing, thing->mappos.x.stl.num, thing->mappos.y.stl.num)) {
+        if ((thing->mappos.z.val > thing->floor_height) || (!flag_is_set(thing->movement_flags, TMvF_Flying) && !over_solid_ground)) {
             if (thing->veloc_base.x.val != 0)
                 thing->veloc_base.x.val = thing->veloc_base.x.val * (256 - thing->inertia_air) / 256;
             if (thing->veloc_base.y.val != 0)

--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -393,9 +393,6 @@ TbBool thing_can_traverse_abyss_at(const struct Thing *thing, MapSubtlCoord stl_
 
 TbBool position_over_floor_level(const struct Thing *thing, const struct Coord3d *pos)
 {
-    if (!thing_can_traverse_abyss_at(thing, pos->x.stl.num, pos->y.stl.num)) {
-        return true;
-    }
     struct Coord3d modpos;
     modpos.x.val = pos->x.val;
     modpos.y.val = pos->y.val;

--- a/src/thing_physics.c
+++ b/src/thing_physics.c
@@ -76,7 +76,12 @@ void destroy_thing(struct Thing* thing)
 
 TbBool thing_touching_floor(const struct Thing *thing)
 {
-    return (thing->floor_height == thing->mappos.z.val) && !subtile_has_abyss_on_top(thing->mappos.x.stl.num, thing->mappos.y.stl.num);
+    if (thing->floor_height != thing->mappos.z.val) {
+        return false;
+    }
+    MapCoord floor_height;
+    MapCoord ceiling_height;
+    return get_floor_and_ceiling_height_under_thing_at(thing, &thing->mappos, &floor_height, &ceiling_height);
 }
 
 TbBool thing_touching_flight_altitude(const struct Thing *thing)
@@ -768,7 +773,7 @@ long get_ceiling_height_above_thing_at(const struct Thing *thing, const struct C
     return subtile_coord(ceiling_height,0);
 }
 
-void get_floor_and_ceiling_height_under_thing_at(const struct Thing *thing,
+TbBool get_floor_and_ceiling_height_under_thing_at(const struct Thing *thing,
     const struct Coord3d *pos, MapCoord *floor_height_cor, MapCoord *ceiling_height_cor)
 {
     long i;
@@ -794,10 +799,11 @@ void get_floor_and_ceiling_height_under_thing_at(const struct Thing *thing,
     // Find correct floor and ceiling plane for the area
     MapSubtlCoord floor_height;
     MapSubtlCoord ceiling_height;
-    get_min_floor_and_ceiling_heights_for_rect(coord_subtile(pos_x_beg), coord_subtile(pos_y_beg),
+    TbBool solid_ground = get_min_floor_and_ceiling_heights_for_rect(coord_subtile(pos_x_beg), coord_subtile(pos_y_beg),
         coord_subtile(pos_x_end), coord_subtile(pos_y_end), &floor_height, &ceiling_height);
     *floor_height_cor = subtile_coord(floor_height,0);
     *ceiling_height_cor = subtile_coord(ceiling_height,0);
+    return solid_ground;
 }
 
 void apply_transitive_velocity_to_thing(struct Thing *thing, struct ComponentVector *veloc)

--- a/src/thing_physics.h
+++ b/src/thing_physics.h
@@ -64,7 +64,7 @@ long thing_in_wall_at_with_radius(const struct Thing *thing, const struct Coord3
 TbBool creature_can_pass_through_wall_at(const struct Thing *thing, const struct Coord3d *pos);
 long get_floor_height_under_thing_at(const struct Thing *thing, const struct Coord3d *pos);
 long get_ceiling_height_above_thing_at(const struct Thing *thing, const struct Coord3d *pos);
-void get_floor_and_ceiling_height_under_thing_at(const struct Thing *thing,
+TbBool get_floor_and_ceiling_height_under_thing_at(const struct Thing *thing,
     const struct Coord3d *pos, MapCoord *floor_height_cor, MapCoord *ceiling_height_cor);
 TbBool thing_is_exempt_from_z_axis_clipping(const struct Thing *thing);
 MapCoord push_thingz_against_wall_at(const struct Thing *thing, const struct Coord3d *pos);


### PR DESCRIPTION
Previously, abyss cliff edges were checked only at a thing's center point, while ordinary floor and elevated-cube collisions use the thing's collision bounds.

This uses the same feet collision check for abyss edges as normal cubes do, so things can stand at abyss edges by the same amount as at other elevation edges and begin falling once their collision bounds no longer overlap solid ground.

There's a good argument to be made that this PR isn't desirable, because the gameplay can be considered worse as creatures can now overhang more easily over abyss:

<img width="1049" height="558" alt="image" src="https://github.com/user-attachments/assets/b90d2846-9528-46a0-a03b-428290ec0044" />

However with this PR, this overhang is made consistent with normal cube overhang.

This is fine to reject (if the gameplay is preferred to fall off cliff edges easier), but it first must be understood that this is inconsistent and makes no sense. (why can't you fall off normal cubes as easily?)