### PR TITLE
Direct Connect

### DIFF
--- a/lang/gtext_chi.po
+++ b/lang/gtext_chi.po
@@ -6972,3 +6972,27 @@ msgstr "请将其作为模组安装到 /mods/ 文件夹中。"
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "与服务器的连接已中断。"
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "直接连接"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "主机"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "输入主机地址"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "直接连接大厅"

--- a/lang/gtext_cht.po
+++ b/lang/gtext_cht.po
@@ -6966,3 +6966,27 @@ msgstr "請將其作為模組安裝到 /mods/ 資料夾中。"
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "與伺服器的連線已中斷。"
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "直接連線"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "主機"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "輸入主機位址"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "直接連線大廳"

--- a/lang/gtext_cze.po
+++ b/lang/gtext_cze.po
@@ -7343,3 +7343,27 @@ msgstr "Nainstalujte jej jako mod do složky /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Připojení k serveru bylo ztraceno."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "Přímá IP"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Hostitel"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Zadejte IP adresu"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Přímá IP lobby"

--- a/lang/gtext_dut.po
+++ b/lang/gtext_dut.po
@@ -7309,3 +7309,27 @@ msgstr "Installeer dit als mod in de map /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Verbinding met de server verloren."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "Direct IP"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Host"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Voer IP-adres in"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Directe IP-lobby"

--- a/lang/gtext_eng.pot
+++ b/lang/gtext_eng.pot
@@ -5936,3 +5936,23 @@ msgstr ""
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr ""
+
+#: guitext:1123
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr ""
+
+#: guitext:1124
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr ""
+
+#: guitext:1125
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr ""
+
+#: guitext:1126
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr ""

--- a/lang/gtext_fre.po
+++ b/lang/gtext_fre.po
@@ -7599,3 +7599,27 @@ msgstr "Installez-le comme mod dans le dossier /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Connexion au serveur perdue."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "IP directe"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Hôte"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Entrez l'adresse IP"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Salon IP directe"

--- a/lang/gtext_ger.po
+++ b/lang/gtext_ger.po
@@ -7627,3 +7627,27 @@ msgstr "Installiere es als Mod im Ordner /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Netzwerkverbindung zum Server verloren."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "Direkte IP"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Host"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "IP-Adresse eingeben"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Direkt-IP-Lobby"

--- a/lang/gtext_ita.po
+++ b/lang/gtext_ita.po
@@ -7472,3 +7472,27 @@ msgstr "Installalo come mod nella cartella /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Connessione al server persa."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "IP diretto"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Host"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Inserisci indirizzo IP"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Lobby IP diretto"

--- a/lang/gtext_jpn.po
+++ b/lang/gtext_jpn.po
@@ -7307,3 +7307,27 @@ msgstr "MODとして /mods/ に入れてください。"
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "サーバーへの接続が失われました。"
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "直接接続"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "ホスト"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "ホストのアドレスを入力"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "直接接続ロビー"

--- a/lang/gtext_kor.po
+++ b/lang/gtext_kor.po
@@ -7358,3 +7358,27 @@ msgstr "MOD로 /mods/에 설치하세요."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "서버 연결이 끊어졌습니다."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "직접 연결"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "호스트"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "호스트 주소 입력"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "직접 연결 로비"

--- a/lang/gtext_lat.po
+++ b/lang/gtext_lat.po
@@ -7374,3 +7374,27 @@ msgstr "Instrue ut modulum in /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Conexio ad servitorem amissa est."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "Connexio Directa"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Hospes"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Inscriptionem insere"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Vestibulum Connexionis Directae"

--- a/lang/gtext_pol.po
+++ b/lang/gtext_pol.po
@@ -7460,3 +7460,27 @@ msgstr "Zainstaluj to jako mod w folderze /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Utracono połączenie z serwerem."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "Bezpośrednie IP"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Host"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Wpisz adres IP"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Lobby bezpośredniego IP"

--- a/lang/gtext_por.po
+++ b/lang/gtext_por.po
@@ -7575,3 +7575,27 @@ msgstr "Instale-o como mod na pasta /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Conexão com o servidor perdida."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "IP Direto"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Anfitrião"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Insira o endereço IP"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Lobby de IP direto"

--- a/lang/gtext_rus.po
+++ b/lang/gtext_rus.po
@@ -6740,3 +6740,27 @@ msgstr "Распакуйте архив мода в папку /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Соединение с сервером потеряно."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "Прямой IP"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Хост"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Введите IP-адрес"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Прямое IP-лобби"

--- a/lang/gtext_spa.po
+++ b/lang/gtext_spa.po
@@ -7606,3 +7606,27 @@ msgstr "Instálalo como mod en la carpeta /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Conexión con el servidor perdida."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "IP directa"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Anfitrión"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Introduce la dirección IP"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Sala IP directa"

--- a/lang/gtext_swe.po
+++ b/lang/gtext_swe.po
@@ -7370,3 +7370,27 @@ msgstr "Installera den som mod i mappen /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "Anslutningen till servern förlorades."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "Direkt IP"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Värd"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Ange IP-adress"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Direkt-IP-lobby"

--- a/lang/gtext_ukr.po
+++ b/lang/gtext_ukr.po
@@ -7425,3 +7425,27 @@ msgstr "Установіть його як мод у папку /mods/."
 msgctxt "Network game message"
 msgid "Lost connection to server"
 msgstr "З’єднання із сервером втрачено."
+
+#: guitext:1123
+#, fuzzy
+msgctxt "Menu interface, Network service item"
+msgid "Direct IP"
+msgstr "Прямий IP"
+
+#: guitext:1124
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Host"
+msgstr "Хост"
+
+#: guitext:1125
+#, fuzzy
+msgctxt "Menu interface, Direct IP screen"
+msgid "Enter IP Address"
+msgstr "Введіть IP-адресу"
+
+#: guitext:1126
+#, fuzzy
+msgctxt "Menu Interface"
+msgid "Direct IP Lobby"
+msgstr "Пряме IP-лобі"

--- a/src/bflib_guibtns.h
+++ b/src/bflib_guibtns.h
@@ -36,7 +36,7 @@ struct GuiMenu;
 struct GuiBox;
 struct GuiBoxOption;
 
-#define INPUT_FIELD_LEN     40
+#define INPUT_FIELD_LEN     128
 #define TOOLTIP_MAX_LEN   2048
 
 /** Default button designation ID. Other designation IDs should be defined relatively to it. */

--- a/src/config_strings.h
+++ b/src/config_strings.h
@@ -475,6 +475,10 @@ enum GUIStrings {
     GUIStr_FxdataZipNotLoaded,
     GUIStr_FxdataZipInstallAsMod,
     GUIStr_NetLobbyConnectionLost,
+    GUIStr_NetDirectIp,
+    GUIStr_NetHost,
+    GUIStr_NetEnterIpAddress,
+    GUIStr_MnuDirectIpLobby,
     GuiStrEnd
 };
 

--- a/src/front_lvlstats.c
+++ b/src/front_lvlstats.c
@@ -304,7 +304,7 @@ void frontstats_draw_scrolling_stats(struct GuiButton *gbtn)
 void init_menu_state_on_net_stats_exit(void)
 {
     FrontendMenuState nstate = get_menu_state_when_back_from_substate(FeSt_LEVEL_STATS);
-    if (nstate == FeSt_NET_SESSION)
+    if ((nstate == FeSt_NET_SESSION) || (nstate == FeSt_NET_DIRECT_IP))
     {
         // If the parent state is network session state, try to stay in net service
         if (!setup_old_network_service()) {

--- a/src/front_network.c
+++ b/src/front_network.c
@@ -20,6 +20,8 @@
 #include "kfx/renderer/RendererManager.h"
 #include "front_network.h"
 
+#include <ctype.h>
+
 #include "globals.h"
 #include "bflib_basics.h"
 #include "bflib_enet.h"
@@ -78,6 +80,8 @@ struct ConfigInfo net_config_info;
 char net_service[16][NET_SERVICE_LEN];
 char net_player_name[20];
 char tmp_net_player_name[24];
+char net_directip_host[DIRECTIP_HOST_LEN];
+static enum FrontendNetService net_service_id[16];
 static TbBool attempting_to_join_cancelled = false;
 static int32_t previous_active_players = 0;
 /******************************************************************************/
@@ -668,19 +672,34 @@ void net_write_config_file(void)
     }
 }
 
+static void frontnet_add_service(enum FrontendNetService service, const char *name)
+{
+    net_service_id[net_number_of_services] = service;
+    snprintf(net_service[net_number_of_services], NET_SERVICE_LEN, "%s", name);
+    net_number_of_services++;
+}
+
 void frontnet_service_setup(void)
 {
     net_number_of_services = 0;
     memset(net_service, 0, sizeof(net_service));
-    snprintf(net_service[net_number_of_services++], NET_SERVICE_LEN, "%s", get_string(GUIStr_NetOnline));
-    snprintf(net_service[net_number_of_services++], NET_SERVICE_LEN, "%s", get_string(GUIStr_NetLan));
+    memset(net_service_id, 0, sizeof(net_service_id));
+    frontnet_add_service(FrontendNetSvc_Online, get_string(GUIStr_NetOnline));
+    frontnet_add_service(FrontendNetSvc_LAN, get_string(GUIStr_NetLan));
+    frontnet_add_service(FrontendNetSvc_DirectIP, get_string(GUIStr_NetDirectIp));
     // Create skirmish option if it should be enabled
     if ((game.system_flags & GSF_AllowOnePlayer) != 0)
     {
-        snprintf(net_service[net_number_of_services], NET_SERVICE_LEN, "%s", get_string(GUIStr_NetServiceSkirmish));
-        net_number_of_services++;
+        frontnet_add_service(FrontendNetSvc_Skirmish, get_string(GUIStr_NetServiceSkirmish));
     }
     net_load_config_file();
+}
+
+enum FrontendNetService frontnet_service_id_by_row(int row)
+{
+    if ((row < 0) || (row >= net_number_of_services))
+        return FrontendNetSvc_Invalid;
+    return net_service_id[row];
 }
 
 void frontnet_session_setup(void)
@@ -698,6 +717,155 @@ void frontnet_session_setup(void)
     if (frontnet_service_selected(FrontendNetSvc_Online)) {
         matchmaking_connect_async();
     }
+}
+
+static TbBool host_label_is_valid(const char *label, int len)
+{
+    if ((len < 1) || (len > 63))
+        return false;
+    if ((label[0] == '-') || (label[len-1] == '-'))
+        return false;
+    for (int i = 0; i < len; i++)
+    {
+        char c = label[i];
+        if (!isalnum((unsigned char)c) && (c != '-'))
+            return false;
+    }
+    return true;
+}
+
+static TbBool host_is_valid_name(const char *host, int len)
+{
+    if ((len < 1) || (len > 253))
+        return false;
+    int start = 0;
+    int last_start = 0;
+    for (int i = 0; i <= len; i++)
+    {
+        if ((i < len) && (host[i] != '.'))
+            continue;
+        if (!host_label_is_valid(&host[start], i - start))
+            return false;
+        last_start = start;
+        start = i + 1;
+    }
+    for (int i = last_start; i < len; i++)
+    {
+        if (!isdigit((unsigned char)host[i]))
+            return true;
+    }
+    return false;
+}
+
+static TbBool host_is_valid_ipv4(const char *host, int len)
+{
+    int groups = 0;
+    int start = 0;
+    for (int i = 0; i <= len; i++)
+    {
+        if ((i < len) && (host[i] != '.'))
+            continue;
+        int glen = i - start;
+        if ((glen < 1) || (glen > 3))
+            return false;
+        int value = 0;
+        for (int k = start; k < i; k++)
+        {
+            if (!isdigit((unsigned char)host[k]))
+                return false;
+            value = value * 10 + (host[k] - '0');
+        }
+        if (value > 255)
+            return false;
+        groups++;
+        start = i + 1;
+    }
+    return (groups == 4);
+}
+
+static TbBool host_is_valid_ipv6(const char *host, int len)
+{
+    if (len < 2)
+        return false;
+    int groups = 0;
+    int double_colons = 0;
+    int start = 0;
+    for (int i = 0; i <= len; i++)
+    {
+        if ((i < len) && (host[i] != ':'))
+            continue;
+        int glen = i - start;
+        if (glen == 0)
+        {
+            if ((i > 0) && (i < len) && (host[i-1] != ':'))
+                return false;
+            if ((i > 0) && (host[i-1] == ':'))
+            {
+                double_colons++;
+                if (double_colons > 1)
+                    return false;
+            }
+        }
+        else if ((i == len) && (memchr(&host[start], '.', glen) != NULL))
+        {
+            if (!host_is_valid_ipv4(&host[start], glen))
+                return false;
+            groups += 2;
+        }
+        else
+        {
+            if (glen > 4)
+                return false;
+            for (int k = start; k < i; k++)
+            {
+                if (!isxdigit((unsigned char)host[k]))
+                    return false;
+            }
+            groups++;
+        }
+        start = i + 1;
+    }
+    if (groups > 8)
+        return false;
+    return (double_colons == 1) ? (groups < 8) : (groups == 8);
+}
+
+TbBool net_directip_host_is_valid(const char *host)
+{
+    if (host == NULL)
+        return false;
+    int len = strlen(host);
+    if ((len < 1) || (len >= DIRECTIP_HOST_LEN))
+        return false;
+    if (isspace((unsigned char)host[0]) || isspace((unsigned char)host[len-1]))
+        return false;
+    if (host[0] == '[')
+    {
+        if (host[len-1] != ']')
+            return false;
+        return host_is_valid_ipv6(&host[1], len - 2);
+    }
+    int colons = 0;
+    for (int i = 0; i < len; i++)
+    {
+        if (host[i] == ':')
+            colons++;
+    }
+    if (colons == 1)
+        return false;
+    if (colons > 1)
+        return host_is_valid_ipv6(host, len);
+    if (host_is_valid_ipv4(host, len))
+        return true;
+    return host_is_valid_name(host, len);
+}
+
+void frontnet_directip_setup(void)
+{
+    frontnet_session_setup();
+    net_directip_host[0] = '\0';
+    net_number_of_sessions = 0;
+    memset(net_session, 0, sizeof(net_session));
 }
 
 void frontnet_start_setup(void)

--- a/src/front_network.h
+++ b/src/front_network.h
@@ -31,11 +31,14 @@ extern "C" {
 
 /******************************************************************************/
 #define NET_SERVICE_LEN 64
+#define DIRECTIP_HOST_LEN 128
 
 enum FrontendNetService {
+    FrontendNetSvc_Invalid = -2,
     FrontendNetSvc_Skirmish = -1,
     FrontendNetSvc_Online = 0,
     FrontendNetSvc_LAN = 1,
+    FrontendNetSvc_DirectIP = 2,
 };
 
 #pragma pack(1)
@@ -61,6 +64,7 @@ extern struct ConfigInfo net_config_info;
 extern char net_service[16][NET_SERVICE_LEN];
 extern char net_player_name[20];
 extern char tmp_net_player_name[24];
+extern char net_directip_host[DIRECTIP_HOST_LEN];
 
 #pragma pack()
 /******************************************************************************/
@@ -72,6 +76,9 @@ TbBool attempting_to_join_cancel_requested(void);
 void setup_alliances(void);
 void frontnet_service_setup(void);
 void frontnet_session_setup(void);
+void frontnet_directip_setup(void);
+enum FrontendNetService frontnet_service_id_by_row(int row);
+TbBool net_directip_host_is_valid(const char *host);
 void frontnet_start_setup(void);
 void frontnet_service_update(void);
 void frontnet_session_update(void);

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -207,6 +207,7 @@ struct GuiMenu *menu_list[] = {
     &room_menu2,
     &trap_menu2,
     &frontend_select_mp_mappack_menu,
+    &frontend_net_directip_menu,
     NULL,
 };
 
@@ -330,6 +331,8 @@ struct FrontEndButtonData frontend_button_info[FRONTEND_BUTTON_INFO_COUNT] = {
     {GUIStr_MnuMapPacks, 2},
     {GUIStr_MnuMpMapPacks, 2},
     {GUIStr_MnuReturnToLobby, 1},
+    {GUIStr_NetDirectIp, 0},
+    {GUIStr_NetHost, 1},
 };
 
 // bttn_sprite, tooltip_stridx, msg_stridx, lifespan_turns, turns_between_events, replace_event_kind_button;
@@ -1919,6 +1922,7 @@ short is_toggleable_menu(short mnu_idx)
   case GMnu_FELOAD:
   case GMnu_FENET_SERVICE:
   case GMnu_FENET_SESSION:
+  case GMnu_FENET_DIRECTIP:
   case GMnu_FENET_START:
   case GMnu_FESTATISTICS:
   case GMnu_FEHIGH_SCORE_TABLE:
@@ -2566,6 +2570,10 @@ void frontend_shutdown_state(FrontendMenuState pstate)
     case FeSt_NET_SESSION: // Network play mode
         turn_off_menu(GMnu_FENET_SESSION);
         break;
+    case FeSt_NET_DIRECT_IP:
+        LbStopTextInput();
+        turn_off_menu(GMnu_FENET_DIRECTIP);
+        break;
     case FeSt_NET_START:
         LbStopTextInput();
         turn_off_menu(GMnu_FENET_START);
@@ -2697,6 +2705,12 @@ FrontendMenuState frontend_setup_state(FrontendMenuState nstate)
           clear_flag(game.system_flags, GSF_NetworkActive);
           set_pointer_graphic_menu();
           break;
+      case FeSt_NET_DIRECT_IP:
+          turn_on_menu(GMnu_FENET_DIRECTIP);
+          frontnet_directip_setup();
+          clear_flag(game.system_flags, GSF_NetworkActive);
+          set_pointer_graphic_menu();
+          break;
       case FeSt_NET_START:
           turn_on_menu(GMnu_FENET_START);
           if (frontend_menu_state != FeSt_MP_MAPPACK_SELECT)
@@ -2808,6 +2822,7 @@ static const char * menu_state_str(FrontendMenuState state)
         case FeSt_LAND_VIEW: return "FeSt_LAND_VIEW";
         case FeSt_NET_SERVICE: return "FeSt_NET_SERVICE";
         case FeSt_NET_SESSION: return "FeSt_NET_SESSION";
+        case FeSt_NET_DIRECT_IP: return "FeSt_NET_DIRECT_IP";
         case FeSt_NET_START: return "FeSt_NET_START";
         case FeSt_START_KPRLEVEL: return "FeSt_START_KPRLEVEL";
         case FeSt_START_MPLEVEL: return "FeSt_START_MPLEVEL";
@@ -2980,6 +2995,7 @@ void frontend_input(void)
         frontmap_input();
         break;
     case FeSt_NET_SESSION:
+    case FeSt_NET_DIRECT_IP:
         get_gui_inputs(0);
         break;
     case FeSt_NET_START:
@@ -3327,6 +3343,7 @@ short frontend_draw(void)
     case FeSt_FELOAD_GAME:
     case FeSt_NET_SERVICE:
     case FeSt_NET_SESSION:
+    case FeSt_NET_DIRECT_IP:
     case FeSt_NET_START:
     case FeSt_LEVEL_STATS:
     case FeSt_HIGH_SCORES:
@@ -3547,6 +3564,8 @@ void frontend_update(short *finish_menu)
     case FeSt_NET_SESSION:
         frontnet_session_update();
         break;
+    case FeSt_NET_DIRECT_IP:
+        break;
     case FeSt_NET_START:
         frontnet_start_update();
         break;
@@ -3637,7 +3656,7 @@ FrontendMenuState get_menu_state_when_back_from_substate(FrontendMenuState subst
     case FeSt_LOAD_GAME:
         return FeSt_START_KPRLEVEL;
     case FeSt_NET_START:
-        return FeSt_NET_SESSION;
+        return frontnet_service_selected(FrontendNetSvc_DirectIP) ? FeSt_NET_DIRECT_IP : FeSt_NET_SESSION;
     case FeSt_MP_MAPPACK_SELECT:
         if (net_service_index_selected == FrontendNetSvc_Skirmish)
         {
@@ -3650,6 +3669,7 @@ FrontendMenuState get_menu_state_when_back_from_substate(FrontendMenuState subst
     case FeSt_LEVEL_SELECT:
          return FeSt_MAPPACK_SELECT;
     case FeSt_NET_SESSION:
+    case FeSt_NET_DIRECT_IP:
     case FeSt_NETLAND_VIEW:
         return FeSt_NET_SERVICE;
     case FeSt_TORTURE:
@@ -3661,7 +3681,7 @@ FrontendMenuState get_menu_state_when_back_from_substate(FrontendMenuState subst
         return FeSt_TORTURE;
     case FeSt_LEVEL_STATS:
         if (network_is_active() || skip_high_score_screen) {
-            return FeSt_NET_SESSION;
+            return frontnet_service_selected(FrontendNetSvc_DirectIP) ? FeSt_NET_DIRECT_IP : FeSt_NET_SESSION;
         }
         lvnum = get_loaded_level_number();
         if (is_multiplayer_level(lvnum))
@@ -3762,7 +3782,7 @@ FrontendMenuState get_startup_menu_state(void)
         } else
         if (setup_old_network_service())
         {
-          return FeSt_NET_SESSION;
+          return frontnet_service_selected(FrontendNetSvc_DirectIP) ? FeSt_NET_DIRECT_IP : FeSt_NET_SESSION;
         } else
         {
           return FeSt_MAIN_MENU;

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -31,8 +31,8 @@ extern "C" {
 /******************************************************************************/
 // Limits for GUI arrays
 #define ACTIVE_BUTTONS_COUNT        100
-#define MENU_LIST_ITEMS_COUNT       52
-#define FRONTEND_BUTTON_INFO_COUNT 115
+#define MENU_LIST_ITEMS_COUNT       56
+#define FRONTEND_BUTTON_INFO_COUNT 117
 #define NET_MESSAGES_COUNT           8
 #define NET_MESSAGE_LEN             64
 // Sprite limits
@@ -87,6 +87,7 @@ enum FrontendMenuStates {
   FeSt_CAMPAIGN_INTRO,
   FeSt_MAPPACK_SELECT,
   FeSt_MP_MAPPACK_SELECT,
+  FeSt_NET_DIRECT_IP,
   // Special testing states
   FeSt_FONT_TEST          = 255,
 };

--- a/src/frontmenu_net.c
+++ b/src/frontmenu_net.c
@@ -87,6 +87,11 @@ void frontnet_join_game_maintain(struct GuiButton *gbtn)
     gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * frontnet_can_join_session()) & LbBtnF_Enabled;
 }
 
+void frontnet_directip_join_maintain(struct GuiButton *gbtn)
+{
+    gbtn->flags ^= (gbtn->flags ^ LbBtnF_Enabled * net_directip_host_is_valid(net_directip_host)) & LbBtnF_Enabled;
+}
+
 void frontnet_maintain_alliance(struct GuiButton *gbtn)
 {
     long plyr_idx1;
@@ -148,8 +153,8 @@ void frontnet_draw_services_scroll_tab(struct GuiButton *gbtn)
 
 void frontnet_session_set_player_name(struct GuiButton *gbtn)
 {
-    strcpy(net_player_name, tmp_net_player_name);
-    strcpy(net_config_info.net_player_name, tmp_net_player_name);
+    snprintf(net_player_name, sizeof(net_player_name), "%s", tmp_net_player_name);
+    snprintf(net_config_info.net_player_name, sizeof(net_config_info.net_player_name), "%s", tmp_net_player_name);
     net_write_config_file();
 }
 
@@ -258,6 +263,75 @@ void frontnet_session_join(struct GuiButton *gbtn)
         return;
     frontend_set_player_number(plyr_num);
     frontend_set_state(FeSt_NET_START);
+}
+
+void frontnet_directip_join(struct GuiButton *gbtn)
+{
+    long plyr_num;
+    if (!net_directip_host_is_valid(net_directip_host))
+        return;
+    plyr_num = network_directip_join();
+    if (plyr_num < 0)
+        return;
+    frontend_set_player_number(plyr_num);
+    frontend_set_state(FeSt_NET_START);
+}
+
+void frontnet_directip_host_confirm(struct GuiButton *gbtn)
+{
+    // TODO: save host for next time
+}
+
+// Scroll to the right as needed to keep caret visible
+void frontnet_draw_host_enter_text(struct GuiButton *gbtn)
+{
+    int font_idx = 1;
+    if (gbtn == input_button) {
+        font_idx = 2;
+    } else
+    if ((gbtn->flags & LbBtnF_Enabled) == 0) {
+        font_idx = 3;
+    } else
+    if ((gbtn->content.str != NULL) && ((gbtn->btype_value & LbBFeF_IntValueMask) == frontend_mouse_over_button)) {
+        font_idx = 2;
+    }
+    int tx_units_per_px = gbtn->height * 16 / LbTextLineHeight();
+    int avail = gbtn->width * 16 / tx_units_per_px;
+    char text[DIRECTIP_HOST_LEN + 8];
+    snprintf(text, sizeof(text), "%s", gbtn->content.str);
+    if ((gbtn != input_button) && (text[0] == '\0'))
+    {
+        snprintf(text, sizeof(text), "%s", get_string(GUIStr_NetEnterIpAddress));
+        font_idx = 3;
+    }
+    else
+    {
+        TbCharCount caret_pos = input_field_pos;
+        if ((gbtn == input_button) && ((LbTimerClock() / 200 & 1) != 0))
+        {
+            if (LbLocTextStringInsert(text, "_", caret_pos, sizeof(text)) != NULL)
+                caret_pos++;
+        }
+        while (LbTextStringWidth(text) > avail)
+        {
+            if (caret_pos > 0)
+            {
+                LbLocTextStringDelete(text, 0, 1);
+                caret_pos--;
+            }
+            else
+            {
+                TbCharCount last = LbLocTextStringLength(text);
+                if (last <= 0)
+                    break;
+                LbLocTextStringDelete(text, last - 1, 1);
+            }
+        }
+    }
+    LbTextSetFont(frontend_font[font_idx]);
+    RendererSetDrawFlags(Lb_TEXT_HALIGN_LEFT);
+    LbTextSetWindow(gbtn->scr_pos_x, gbtn->scr_pos_y, gbtn->width, gbtn->height);
+    LbTextDrawResized(0, 0, tx_units_per_px, text);
 }
 
 void frontnet_return_to_main_menu(struct GuiButton *gbtn)
@@ -646,7 +720,7 @@ void frontnet_return_to_session_menu(struct GuiButton *gbtn)
     }
     FrontendMenuState nstate;
     nstate = get_menu_state_when_back_from_substate(FeSt_NET_START);
-    if (nstate == FeSt_NET_SESSION)
+    if ((nstate == FeSt_NET_SESSION) || (nstate == FeSt_NET_DIRECT_IP))
     {
         // If the parent state is network session state, try to stay in net service
         if (!setup_old_network_service()) {
@@ -717,22 +791,24 @@ void frontnet_draw_service_button(struct GuiButton *gbtn)
 
 void frontnet_service_select(struct GuiButton *gbtn)
 {
-  int srvidx;
-  srvidx = gbtn->content.lval + net_service_scroll_offset - 45;
-  if ( ((game.system_flags & GSF_AllowOnePlayer) != 0)
-     && (srvidx+1 >= net_number_of_services) )
+  int srvidx = gbtn->content.lval + net_service_scroll_offset - 45;
+  enum FrontendNetService service = frontnet_service_id_by_row(srvidx);
+  switch (service)
   {
+  case FrontendNetSvc_Skirmish:
       frontend_set_player_number(default_loc_player);
       fe_network_active = 0;
       net_service_index_selected = FrontendNetSvc_Skirmish;
       frontend_set_state(FeSt_MP_MAPPACK_SELECT);
-  } else
-  if (srvidx < 0)
-  {
+      break;
+  case FrontendNetSvc_Online:
+  case FrontendNetSvc_LAN:
+  case FrontendNetSvc_DirectIP:
+      setup_network_service(service);
+      break;
+  default:
       frontend_set_state(FeSt_NET_SERVICE);
-  } else
-  {
-      setup_network_service(srvidx);
+      break;
   }
 }
 

--- a/src/frontmenu_net.h
+++ b/src/frontmenu_net.h
@@ -39,6 +39,7 @@ struct GuiButton;
 extern struct GuiMenu frontend_net_service_menu;
 extern struct GuiMenu frontend_net_session_menu;
 extern struct GuiMenu frontend_net_start_menu;
+extern struct GuiMenu frontend_net_directip_menu;
 extern struct GuiMenu frontend_add_session_box;
 /******************************************************************************/
 void frontnet_session_up_maintain(struct GuiButton *gbtn);
@@ -47,6 +48,10 @@ void frontnet_session_maintain(struct GuiButton *gbtn);
 void frontnet_players_up_maintain(struct GuiButton *gbtn);
 void frontnet_players_down_maintain(struct GuiButton *gbtn);
 void frontnet_join_game_maintain(struct GuiButton *gbtn);
+void frontnet_directip_join_maintain(struct GuiButton *gbtn);
+void frontnet_directip_join(struct GuiButton *gbtn);
+void frontnet_directip_host_confirm(struct GuiButton *gbtn);
+void frontnet_draw_host_enter_text(struct GuiButton *gbtn);
 void frontnet_maintain_alliance(struct GuiButton *gbtn);
 void frontnet_messages_up_maintain(struct GuiButton *gbtn);
 void frontnet_messages_down_maintain(struct GuiButton *gbtn);

--- a/src/frontmenu_net_data.cpp
+++ b/src/frontmenu_net_data.cpp
@@ -92,6 +92,20 @@ struct GuiButtonInit frontend_net_session_buttons[] = {
   {-1,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   0,   0,   0,   0,  0,  0, NULL,                              0,           0,  0,       {0},            0, NULL },
 };
 
+struct GuiButtonInit frontend_net_directip_buttons[] = {
+  { LbBtnT_NormalBtn,  BID_MENU_TITLE, 0, 0, NULL,            NULL,        NULL,               0, 999,  30, 999,  30,371, 46, frontend_draw_large_menu_button,   0, GUIStr_Empty, 0,     {115},            0, NULL },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  82, 100,  82, 100,165, 29, frontnet_draw_text_bar,            0, GUIStr_Empty, 0,      {27},            0, NULL },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  95, 102,  91, 102,165, 25, frontend_draw_text,                0, GUIStr_Empty, 0,      {19},            0, NULL },
+  { 5, -1,-1, 0, frontnet_session_set_player_name,NULL,frontend_over_button,19,200,102,95,102,432, 25, frontend_draw_enter_text,          0, GUIStr_Empty, 0,{.str = tmp_net_player_name}, 20, NULL },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  82, 140,  82, 140,165, 29, frontnet_draw_text_bar,            0, GUIStr_Empty, 0,      {27},            0, NULL },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,  95, 142,  91, 142,165, 26, frontend_draw_text,                0, GUIStr_Empty, 0,     {116},            0, NULL },
+  { 5, -1,-1, 0, frontnet_directip_host_confirm,NULL,frontend_over_button,116,200,142,95,142,360, 26, frontnet_draw_host_enter_text,     0, GUIStr_Empty, 0,{.str = net_directip_host}, DIRECTIP_HOST_LEN, NULL },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, frontnet_directip_join,NULL,    frontend_over_button,0,  72, 360,  72, 360,247, 46, frontend_draw_small_menu_button,   0, GUIStr_Empty, 0,      {13},            0, frontnet_directip_join_maintain },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, frontnet_session_create,NULL,   frontend_over_button,0, 321, 360, 321, 360,247, 46, frontend_draw_small_menu_button,   0, GUIStr_Empty, 0,      {14},            0, NULL },
+  { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, frontnet_return_to_main_menu,NULL,frontend_over_button,0,999,404, 999, 404,371, 46, frontend_draw_large_menu_button,   0, GUIStr_Empty, 0,       {6},            0, NULL },
+  {-1,  BID_DEFAULT, 0, 0, NULL,               NULL,        NULL,               0,   0,   0,   0,   0,  0,  0, NULL,                              0,           0,  0,       {0},            0, NULL },
+};
+
 struct GuiButtonInit frontend_net_start_buttons[] = {
   { LbBtnT_NormalBtn,  BID_MENU_TITLE, 0, 0, NULL,               NULL,   NULL,                    0, 999,  30, 999,  30, 371, 46, frontend_draw_large_menu_button,   0, GUIStr_Empty, 0,  {11},    0, NULL },
   { LbBtnT_NormalBtn,  BID_DEFAULT, 0, 0, NULL,               NULL,   NULL,                    0,  82,  78,  82,  78, 220, 26, frontnet_draw_scroll_box_tab,      0, GUIStr_Empty, 0,  {28},    0, NULL },
@@ -150,6 +164,8 @@ struct GuiMenu frontend_net_session_menu =
  { GMnu_FENET_SESSION, 0, 1, frontend_net_session_buttons, POS_SCRCTR, POS_SCRCTR,  640, 480, NULL, 0, NULL,    NULL,                    0, 0, 0,};
 struct GuiMenu frontend_net_start_menu =
  { GMnu_FENET_START,   0, 1, frontend_net_start_buttons,   POS_SCRCTR, POS_SCRCTR,  640, 480, NULL, 0, NULL,    NULL,                    0, 0, 0,};
+struct GuiMenu frontend_net_directip_menu =
+ { GMnu_FENET_DIRECTIP,0, 1, frontend_net_directip_buttons,POS_SCRCTR, POS_SCRCTR,  640, 480, NULL, 0, NULL,    NULL,                    0, 0, 0,};
 struct GuiMenu frontend_add_session_box =
  { GMnu_FEADD_SESSION, 0, 1, frontend_add_session_buttons, POS_SCRCTR, POS_SCRCTR,  450,  92, NULL, 0, NULL,    NULL,                    0, 1, 0,};
 /******************************************************************************/

--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -712,6 +712,7 @@ static TbBool should_use_delta_time_on_menu()
         case FeSt_FELOAD_GAME:
         case FeSt_NET_SERVICE: /**< Network service selection, where player can select Serial/Modem/IPX/TCP IP/1 player. */
         case FeSt_NET_SESSION: /**< Network session selection screen, where list of games is displayed, with possibility to join or create own game. */
+        case FeSt_NET_DIRECT_IP: /**< Direct IP screen, where a host is entered by hand. */
         case FeSt_NET_START: /**< Network game start screen (the menu with chat), when created new session or joined existing session. */
         case FeSt_LEVEL_STATS:
         case FeSt_HIGH_SCORES:

--- a/src/gui_frontbtns.c
+++ b/src/gui_frontbtns.c
@@ -371,7 +371,7 @@ void kill_button(struct GuiButton *gbtn)
 void kill_button_area_input(void)
 {
   if (input_button != NULL)
-    strcpy(input_button->content.str, backup_input_field);
+    snprintf(input_button->content.str, input_button->maxval, "%s", backup_input_field);
   input_button = NULL;
   if (LbIsTextInputActive())
     LbStopTextInput();

--- a/src/gui_frontmenu.h
+++ b/src/gui_frontmenu.h
@@ -77,6 +77,7 @@ enum GUI_Menus {
   GMnu_ROOM2              = 47,
   GMnu_TRAP2              = 48,
   GMnu_MP_MAPPACK_SELECT  = 49,
+  GMnu_FENET_DIRECTIP     = 50,
 };
 
 #define MENU_INVALID_ID -1

--- a/src/net_game.c
+++ b/src/net_game.c
@@ -79,7 +79,8 @@ short setup_network_service(enum FrontendNetService service)
   SYNCMSG("Initializing 4-players type %d network", service);
   memset(net_user_info, 0, sizeof(net_user_info));
   network_lobby_ping = 0;
-  if (service != FrontendNetSvc_Online && service != FrontendNetSvc_LAN) {
+  if (service != FrontendNetSvc_Online && service != FrontendNetSvc_LAN
+   && service != FrontendNetSvc_DirectIP) {
     process_network_error(-800);
     return 0;
   }
@@ -89,14 +90,17 @@ short setup_network_service(enum FrontendNetService service)
     return 0;
   }
   net_service_index_selected = service;
-  if (service == FrontendNetSvc_LAN) {
+  if (service == FrontendNetSvc_DirectIP) {
+    frontend_button_info[11].capstr_idx = GUIStr_MnuDirectIpLobby;
+    frontend_button_info[12].capstr_idx = GUIStr_MnuOnlineLobbies;
+  } else if (service == FrontendNetSvc_LAN) {
     frontend_button_info[11].capstr_idx = GUIStr_MnuLanLobby;
     frontend_button_info[12].capstr_idx = GUIStr_MnuLanLobbies;
   } else {
     frontend_button_info[11].capstr_idx = GUIStr_MnuOnlineLobby;
     frontend_button_info[12].capstr_idx = GUIStr_MnuOnlineLobbies;
   }
-  frontend_set_state(FeSt_NET_SESSION);
+  frontend_set_state((service == FrontendNetSvc_DirectIP) ? FeSt_NET_DIRECT_IP : FeSt_NET_SESSION);
   return 1;
 }
 
@@ -648,6 +652,21 @@ long network_session_join(void)
         }
         process_network_error(-802);
     }
+    return -1;
+}
+
+long network_directip_join(void)
+{
+    int32_t plyr_num;
+    reset_attempting_to_join_cancel();
+    display_attempting_to_join_message(-1);
+    if (attempting_to_join_cancel_requested())
+        return -1;
+    join_lobby_id[0] = '\0';
+    if (LbNetwork_JoinAddress(net_directip_host, net_player_name, &plyr_num, NULL) == 0)
+        return plyr_num;
+    if (!attempting_to_join_cancel_requested())
+        process_network_error(-802);
     return -1;
 }
 

--- a/src/net_game.h
+++ b/src/net_game.h
@@ -47,6 +47,7 @@ void setup_count_players(void);
 void are_disconnect_victories_allowed(void);
 
 long network_session_join(void);
+long network_directip_join(void);
 
 TbBool network_user_active(NetUserId);
 const char *network_user_name(NetUserId);

--- a/src/net_lobby.c
+++ b/src/net_lobby.c
@@ -263,13 +263,13 @@ TbError LbNetwork_Create(char *, char *plyr_name, uint32_t *plyr_num, void *optn
     return Lb_OK;
 }
 
-TbError LbNetwork_Join(struct TbNetworkSessionNameEntry *nsname, char *plyr_name, int32_t *plyr_num, void *optns)
+TbError LbNetwork_JoinAddress(const char *address, char *plyr_name, int32_t *plyr_num, void *optns)
 {
     if (!netstate.sp) {
         ERRORLOG("No network SP selected");
         return Lb_FAIL;
     }
-    if (netstate.sp->join(nsname->text, optns) == Lb_FAIL) {
+    if (netstate.sp->join(address, optns) == Lb_FAIL) {
         return Lb_FAIL;
     }
     netstate.my_id = INVALID_USER_ID;
@@ -278,6 +278,11 @@ TbError LbNetwork_Join(struct TbNetworkSessionNameEntry *nsname, char *plyr_name
     }
     *plyr_num = netstate.my_id;
     return Lb_OK;
+}
+
+TbError LbNetwork_Join(struct TbNetworkSessionNameEntry *nsname, char *plyr_name, int32_t *plyr_num, void *optns)
+{
+    return LbNetwork_JoinAddress(nsname->text, plyr_name, plyr_num, optns);
 }
 
 TbError LbNetwork_EnableNewPlayers(TbBool allow)

--- a/src/net_lobby.h
+++ b/src/net_lobby.h
@@ -36,6 +36,7 @@ TbError process_user_update_message(NetUserId source, char *read_pos, const char
 void LbNetwork_SetServerPort(int port);
 void LbNetwork_InitSessionsFromCmdLine(const char *str);
 TbError LbNetwork_Join(struct TbNetworkSessionNameEntry *nsname, char *playr_name, int32_t *playr_num, void *optns);
+TbError LbNetwork_JoinAddress(const char *address, char *playr_name, int32_t *playr_num, void *optns);
 TbError LbNetwork_Create(char *nsname_str, char *plyr_name, uint32_t *plyr_num, void *optns);
 TbError LbNetwork_EnableNewPlayers(TbBool allow);
 TbError LbNetwork_EnumeratePlayers(struct TbNetworkSessionNameEntry *sesn, TbNetworkCallbackFunc callback, void *user_data);


### PR DESCRIPTION
Adds Direct Connect to the multiplayer menu.

Direct Connect allows entering in an IP address or hostname manually. It does not use the matchmaking server. (The hostname entered doesn't matter when creating the lobby.)

<img width="637" height="477" alt="image" src="https://github.com/user-attachments/assets/6e9a4878-7f69-4ae2-bd3d-348033422867" />

<img width="640" height="481" alt="image" src="https://github.com/user-attachments/assets/973a8c12-f08f-40d1-bdf7-8bdb9dcfe7c0" />

@Loobinex  I know there were mixed opinions about adding Direct Connect into the game. If you want to reject this PR that's fine, no hard feelings. (I mostly just wanted to prove it can be done and would not be too invasive in the code.) For what it's worth, many games have a direct connect option, including factorio, openrct2, project zomboid, palworld, minecraft, terraria..., it's a very handy feature, especially if the online matchmaking server goes down.