### PR TITLE
Multiplayer: fix crash for rendering during startup sync

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1667,13 +1667,6 @@ void update_gameplay_delta_time()
     }
 }
 
-void gameplay_loop_draw();
-
-extern "C" void network_yield_draw_gameplay()
-{
-    gameplay_loop_draw();
-}
-
 extern "C" void update_velocity(void);
 extern "C" void check_mouse_scroll(void);
 extern "C" void fronttorture_update(void);

--- a/src/net_exchange_common.c
+++ b/src/net_exchange_common.c
@@ -23,6 +23,8 @@
 #include "front_landview.h"
 #include "frontend.h"
 #include "game_legacy.h"
+#include "keeperfx.hpp"
+#include "kjm_input.h"
 #include "net_game.h"
 #include "net_exchange_gameplay.h"
 #include "net_lobby.h"
@@ -43,7 +45,6 @@
 // 3 duplicate and 2 redundant = Micro stutter
 
 extern void network_yield_draw_frontend(void);
-extern void network_yield_draw_gameplay(void);
 extern long double host_packet_received;
 
 void send_to_active_peers(int send_count, enum NetworkPeerSendMode send_mode, const char *buffer, size_t msg_size, NetUserId first_skip_id, NetUserId second_skip_id)
@@ -371,7 +372,12 @@ TbError exchange_frame_block(enum NetMessageType msg_type, void *send_buf, void 
         if (frontend_exchange) {
             network_yield_draw_frontend();
         } else {
-            network_yield_draw_gameplay();
+            if (!poll_inputs()) {
+                exit_keeper = 1;
+            }
+            if (quit_game || exit_keeper) {
+                break;
+            }
         }
         SDL_Delay(1);
     }


### PR DESCRIPTION
Fixes https://keeperfx.net/dev/crash-report/662

Even though this crash has been around for a while, my theory is that we weren't able to detect when it first started happening because the `.map` files were missing from the alpha for a while there, so when it crashed it wasn't giving us an error in the crash log. But now we can see the errors in the log again.